### PR TITLE
Added publishing to Github pages to for better docs experience

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,66 @@
+name: Pages
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/**
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  documentation:
+    name: Documentation Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install aspell aspell-en
+          sudo snap install mdl
+
+      - name: Run markdown linter
+        run: |
+          make doc-lint
+
+      - name: Run spell checker
+        run: |
+          make doc-spellcheck
+
+      - name: Run inclusive naming checker
+        uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: true
+          woke-args: "*.md **/*.md -c https://github.com/canonical-web-and-design/Inclusive-naming/raw/main/config.yml"
+
+      - name: Run link checker
+        run: |
+          make doc-linkcheck
+
+      - name: Build docs (Sphinx)
+        run: make doc
+
+      - name: Print warnings (Sphinx)
+        run: if [ -s doc/.sphinx/warnings.txt ]; then cat doc/.sphinx/warnings.txt; exit 1; fi
+
+      - name: Upload documentation artifacts
+        if: always()
+        uses: actions/upload-pages-artifact@v1
+        with:
+          name: documentation
+          path: doc/html
+
+      - name: Deploy to GitHub Pages
+        id: documentation
+        uses: actions/deploy-pages@v2
+        with:
+          artifact_name: documentation

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Consider the following aspects to ensure that your Incus installation is secure:
 - Configure your network interfaces to be secure.
 <!-- Include end security -->
 
-See [Security](https://github.com/cyphar/incus/blob/main/doc/explanation/security.md) for detailed information.
+See [Security](https://cyphar.github.io/incus/explanation/security/) for detailed information.
 
 **IMPORTANT:**
 <!-- Include start security note -->
@@ -74,7 +74,7 @@ You can file bug reports and feature requests at: [`https://github.com/cyphar/in
 
 ## Documentation
 
-The official documentation is available at: [`https://github.com/cyphar/incus/tree/main/doc`](https://github.com/cyphar/incus/tree/main/doc)
+The official documentation is available at: [`https://cyphar.github.io/incus`](https://cyphar.github.io/incus)
 
 <!-- Include end support -->
 

--- a/doc/.sphinx/_templates/header.html
+++ b/doc/.sphinx/_templates/header.html
@@ -177,13 +177,13 @@
       <li>
         <a class="p-logo" href="https://ubuntu.com/lxd" aria-current="page">
           <img src="{{ pathto('_static/tag.png', 1) }}" alt="LXD-UI logo" class="p-logo-image">
-          <div class="p-logo-text p-heading--4">Canonical LXD
+          <div class="p-logo-text p-heading--4">Incus
           </div>
         </a>
       </li>
 
       <li class="nav-ubuntu-com">
-        <a href="https://ubuntu.com/lxd" class="p-navigation__link">ubuntu.com/lxd</a>
+        <a href="https://github.com/cyphar/incus" class="p-navigation__link">github.com/cyphar/incus</a>
       </li>
 
       <li>
@@ -191,19 +191,11 @@
         <ul class="more-links-dropdown">
 
           <li>
-            <a href="https://ubuntu.com/lxd/install/" class="p-navigation__sub-link p-dropdown__link">Install LXD</a>
+            <a href="https://cyphar.github.io/incus/installing/" class="p-navigation__sub-link p-dropdown__link">Install Incus</a>
           </li>
 
           <li>
-            <a href="https://ubuntu.com/lxd/manage/" class="p-navigation__sub-link p-dropdown__link">Manage LXD</a>
-          </li>
-
-          <li>
-            <a href="https://discourse.ubuntu.com/c/lxd" class="p-navigation__sub-link p-dropdown__link">Forum</a>
-          </li>
-
-          <li>
-            <a href="https://github.com/canonical/lxd" class="p-navigation__sub-link p-dropdown__link">GitHub</a>
+            <a href="https://github.com/cyphar/incus" class="p-navigation__sub-link p-dropdown__link">GitHub</a>
           </li>
 
         </ul>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,8 +19,8 @@ if not os.path.islink('.sphinx/_static/swagger-ui/swagger-ui.css'):
     os.symlink('../../deps/swagger-ui/dist/swagger-ui.css', '.sphinx/_static/swagger-ui/swagger-ui.css')
 
 # Project config.
-project = "LXD"
-author = "LXD contributors"
+project = "Incus"
+author = "Incus contributors"
 copyright = "2014-%s %s" % (datetime.date.today().year, author)
 
 with open("../shared/version/flex.go") as fd:
@@ -132,7 +132,7 @@ html_theme_options = {
 }
 
 html_context = {
-    "github_url": "https://github.com/canonical/lxd",
+    "github_url": "https://github.com/cyphar/incus",
     "github_version": "main",
     "github_folder": "/doc/",
     "github_filetype": "md",
@@ -148,8 +148,8 @@ exclude_patterns = ['html', 'README.md', '.sphinx', 'config_options_cheat_sheet.
 
 # Open Graph configuration
 
-ogp_site_url = "https://documentation.ubuntu.com/lxd/en/latest/"
-ogp_site_name = "LXD documentation"
+ogp_site_url = "https://cyphar.github.io/incus/"
+ogp_site_name = "Incus documentation"
 ogp_image = "https://documentation.ubuntu.com/lxd/en/latest/_static/tag.png"
 
 # Links to ignore when checking links

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -19,7 +19,7 @@ To build the dependencies, follow the instructions in {ref}`installing_from_sour
 
 After building your dependencies, you can now add your GitHub fork as a remote:
 
-    git remote add myfork git@github.com:<your_username>/lxd.git
+    git remote add myfork git@github.com:<your_username>/incus.git
     git remote update
 
 Then switch to it:

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -108,9 +108,8 @@ against the local or global database, you can use the `lxd sql` command (run
 `lxd sql --help` for details).
 
 You should only need to do that in order to recover from broken updates or bugs.
-Please consult the LXD team first (creating a [GitHub
-issue](https://github.com/canonical/lxd/issues/new) or
-[forum](https://discourse.ubuntu.com/c/lxd/) post).
+Please consult the Incus team first (creating a [GitHub
+issue](https://github.com/cyphar/incus/issues/new)
 
 ### Running custom queries at LXD daemon startup
 

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -12,7 +12,7 @@
 
 See the following sections for detailed information.
 
-If you discover a security issue, see the [LXD security policy](https://github.com/canonical/lxd/blob/main/SECURITY.md) for information on how to report the issue.
+If you discover a security issue, see the [LXD security policy](https://github.com/cyphar/incus/blob/main/SECURITY.md) for information on how to report the issue.
 
 ## Supported versions
 

--- a/doc/external_resources.md
+++ b/doc/external_resources.md
@@ -3,6 +3,6 @@
 ```{toctree}
 :maxdepth: 1
 
-Project repository <https://github.com/canonical/lxd>
+Project repository <https://github.com/cyphar/incus>
 Community image server <https://images.linuxcontainers.org>
 ```

--- a/doc/index.md
+++ b/doc/index.md
@@ -2,9 +2,9 @@
 relatedlinks: https://ubuntu.com/lxd, https://ubuntu.com/blog/open-source-for-beginners-dev-environment-with-lxd
 ---
 
-# LXD
+# Incus
 
-LXD (<a href="#" title="Listen" onclick="document.getElementById('player').play();return false;">`[lɛks'di:]`&#128264;</a>) is a modern, secure and powerful system container and virtual machine manager.
+Incus (<a href="#" title="Listen" onclick="document.getElementById('player').play();return false;">`[lɛks'di:]`&#128264;</a>) is a modern, secure and powerful system container and virtual machine manager.
 
 <audio id="player">  <source src="_static/lxd.mp3" type="audio/mpeg">  <source src="_static/lxd.ogg" type="audio/ogg">  <source src="_static/lxd.wav" type="audio/wav"></audio>
 
@@ -39,10 +39,10 @@ It’s an open source project that warmly welcomes community projects, contribut
 
 The LXD project is sponsored by [Canonical Ltd](https://www.canonical.com).
 
-- [Code of Conduct](https://github.com/canonical/lxd/blob/main/CODE_OF_CONDUCT.md)
+- [Code of Conduct](https://github.com/cyphar/incus/blob/main/CODE_OF_CONDUCT.md)
 - [Contribute to the project](contributing.md)
 - [Release announcements](https://discourse.ubuntu.com/c/lxd/news/)
-- [Release tarballs](https://github.com/canonical/lxd/releases/)
+- [Release tarballs](https://github.com/cyphar/incus/releases/)
 - [Get support](support.md)
 - [Watch tutorials and announcements on YouTube](https://www.youtube.com/c/LXDvideos)
 - [Discuss on IRC](https://web.libera.chat/#lxd) (see [Getting started with IRC](https://discuss.linuxcontainers.org/t/getting-started-with-irc/11920) if needed)

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -138,7 +138,7 @@ To install it:
 
 ````
 
-You can also find native builds of the LXD client on [GitHub](https://github.com/canonical/lxd/actions).
+You can also find native builds of the LXD client on [GitHub](https://github.com/cyphar/incus/actions).
 To download a specific build:
 
 1. Make sure that you are logged into your GitHub account.
@@ -182,7 +182,7 @@ integration into Linux distributions are not covered here and may be covered in 
 future.
 
 ```bash
-git clone https://github.com/canonical/lxd
+git clone git@github.com:cyphar/incus.git
 cd lxd
 ```
 

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -247,5 +247,5 @@ much like `/1.0/containers` will only show you instances of that type.
 ## API structure
 
 LXD has an auto-generated [Swagger](https://swagger.io/) specification describing its API endpoints.
-The YAML version of this API specification can be found in [`rest-api.yaml`](https://github.com/canonical/lxd/blob/main/doc/rest-api.yaml).
+The YAML version of this API specification can be found in [`rest-api.yaml`](https://github.com/cyphar/incus/blob/main/doc/rest-api.yaml).
 See {doc}`api` for a convenient web rendering of it.


### PR DESCRIPTION
I like being able to click links and Im sure others are too. I figured a good starting point was to ensure Pages is enabled and then do something like this.

A few things I am not sure of and would appreciate some feedback on:

1. How much do we want to replace links/references to LXD *now*? Shall we wait until the first release of Incus?
1. For things like forums/discussion topics, how we do want to link stuff like that in the docs?

Example of the [action](https://github.com/MrDaGree/incus/actions/runs/5768247372) in my fork as well as a [preview](https://mrdagree.github.io/incus/)

Checks for Documentation will fail due to [pages not being created yet](https://github.com/cyphar/incus/actions/runs/5768416085/job/15639375367?pr=26#step:7:393)