### PR TITLE
shared/termios: Use golang.org/x/term instead of golang.org/x/crypto/ssh/terminal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Rican7/retry v0.3.1
 	github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a
 	github.com/canonical/candid v1.12.2
-	github.com/cowsql/go-cowsql v1.21.0
 	github.com/checkpoint-restore/go-criu/v6 v6.3.0
+	github.com/cowsql/go-cowsql v1.21.0
 	github.com/digitalocean/go-qemu v0.0.0-20230711162256-2e3d0186973e
 	github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e
 	github.com/dustinkirkland/golang-petname v0.0.0-20230626224747-e794b9370d49

--- a/go.sum
+++ b/go.sum
@@ -62,14 +62,11 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/canonical/candid v1.12.2 h1:0hfZZ1qBpFCoCrirSeSdxmOWvQnCs+1cjpft9yRs0so=
 github.com/canonical/candid v1.12.2/go.mod h1:NiCD+Go6m2oxWcsfntU9t2Cs6uZbs8UaTRt3ySubaXU=
-github.com/canonical/go-dqlite v1.20.0 h1:pnkn0oS0hPXWeODjvjWONKGb5KYh8kK0aruDPzZLwmU=
-github.com/canonical/go-dqlite v1.20.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
-github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/checkpoint-restore/go-criu/v6 v6.3.0 h1:mIdrSO2cPNWQY1truPg6uHLXyKHk3Z5Odx4wjKOASzA=
 github.com/checkpoint-restore/go-criu/v6 v6.3.0/go.mod h1:rrRTN/uSwY2X+BPRl/gkulo9gsKOSAeVp9/K2tv7xZI=
@@ -254,7 +251,6 @@ github.com/grafana/dskit v0.0.0-20230808152345-e772133474bd h1:nsjY1yHyUVAkDLDwh
 github.com/grafana/dskit v0.0.0-20230808152345-e772133474bd/go.mod h1:hbcgTCAMxGfZmjbieS4VZpnJjzvcWlI8V7/uTJ9nTMM=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
-github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
@@ -618,7 +614,6 @@ github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6
 github.com/xdg-go/stringprep v1.0.3 h1:kdwGpVNwPFtjs98xCGkHjQtGKh86rDcRZN17QEMCOIs=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
-github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yohcop/openid-go v1.0.0 h1:EciJ7ZLETHR3wOtxBvKXx9RV6eyHZpCaSZ1inbBaUXE=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/shared/termios/termios_other.go
+++ b/shared/termios/termios_other.go
@@ -3,20 +3,20 @@
 package termios
 
 import (
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // State contains the state of a terminal.
-type State terminal.State
+type State term.State
 
 // IsTerminal returns true if the given file descriptor is a terminal.
 func IsTerminal(fd int) bool {
-	return terminal.IsTerminal(fd)
+	return term.IsTerminal(fd)
 }
 
 // GetState returns the current state of a terminal which may be useful to restore the terminal after a signal.
 func GetState(fd int) (*State, error) {
-	state, err := terminal.GetState(fd)
+	state, err := term.GetState(fd)
 	if err != nil {
 		return nil, err
 	}
@@ -27,12 +27,12 @@ func GetState(fd int) (*State, error) {
 
 // GetSize returns the dimensions of the given terminal.
 func GetSize(fd int) (int, int, error) {
-	return terminal.GetSize(fd)
+	return term.GetSize(fd)
 }
 
 // MakeRaw put the terminal connected to the given file descriptor into raw mode and returns the previous state of the terminal so that it can be restored.
 func MakeRaw(fd int) (*State, error) {
-	state, err := terminal.MakeRaw(fd)
+	state, err := term.MakeRaw(fd)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func MakeRaw(fd int) (*State, error) {
 
 // Restore restores the terminal connected to the given file descriptor to a previous state.
 func Restore(fd int, state *State) error {
-	newState := terminal.State(*state)
+	newState := term.State(*state)
 
-	return terminal.Restore(fd, &newState)
+	return term.Restore(fd, &newState)
 }


### PR DESCRIPTION
## Summary

Since `golang.org/x/crypto/ssh/terminal` is deprecated, modify it to use `golang.org/x/term`.

## Links

- https://pkg.go.dev/golang.org/x/crypto/ssh/terminal
- https://pkg.go.dev/golang.org/x/term