### PR TITLE
ci: Update cowsql ppa

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo add-apt-repository ppa:ubuntu-lxc/lxc-git-master -y --no-update
-          sudo add-apt-repository ppa:cowsql/master -y --no-update
+          sudo add-apt-repository ppa:cowsql/main -y --no-update
           sudo apt-get update
 
           sudo apt-get install --no-install-recommends -y \
@@ -127,7 +127,7 @@ jobs:
         run: |
           set -x
           sudo add-apt-repository ppa:ubuntu-lxc/lxc-git-master -y --no-update
-          sudo add-apt-repository ppa:cowsql/master -y --no-update
+          sudo add-apt-repository ppa:cowsql/main -y --no-update
           sudo apt-get update
 
           sudo snap remove lxd --purge


### PR DESCRIPTION
The ppa name has been updated to match the master->main branch name switch.