### PR TITLE
incusd/instance/qemu: Support LXD virtual machines

### DIFF
--- a/incusd/instance/drivers/driver_qemu.go
+++ b/incusd/instance/drivers/driver_qemu.go
@@ -2454,6 +2454,11 @@ func (d *qemu) generateConfigShare() error {
 		} else {
 			d.logger.Debug("Skipping incus-agent install as unchanged", logger.Ctx{"srcPath": agentSrcPath, "installPath": agentInstallPath})
 		}
+
+		err = os.Symlink("incus-agent", filepath.Join(configDrivePath, "lxd-agent"))
+		if err != nil && !os.IsExist(err) {
+			return err
+		}
 	}
 
 	agentCert, agentKey, clientCert, _, err := d.generateAgentCert()

--- a/incusd/instance/drivers/driver_qemu_config_test.go
+++ b/incusd/instance/drivers/driver_qemu_config_test.go
@@ -136,6 +136,11 @@ func TestQemuConfigTemplates(t *testing.T) {
 			chardev = "qemu_serial-chardev"
 			bus = "dev-qemu_serial.0"
 
+			[device "qemu_serial_legacy"]
+			driver = "virtserialport"
+			name = "org.linuxcontainers.lxd"
+			bus = "dev-qemu_serial.0"
+
 			# Spice agent
 			[chardev "qemu_spice-chardev"]
 			backend = "spicevmc"

--- a/incusd/instance/drivers/driver_qemu_templates.go
+++ b/incusd/instance/drivers/driver_qemu_templates.go
@@ -191,6 +191,13 @@ func qemuSerial(opts *qemuSerialOpts) []cfgSection {
 			{key: "bus", value: "dev-qemu_serial.0"},
 		},
 	}, {
+		name: `device "qemu_serial_legacy"`,
+		entries: []cfgEntry{
+			{key: "driver", value: "virtserialport"},
+			{key: "name", value: "org.linuxcontainers.lxd"},
+			{key: "bus", value: "dev-qemu_serial.0"},
+		},
+	}, {
 		name:    `chardev "qemu_spice-chardev"`,
 		comment: "Spice agent",
 		entries: []cfgEntry{


### PR DESCRIPTION
This adds support for the LXD virtio-serial device and agent symlink to allow existing virtual machines to function properly when imported into Incus.