### PR TITLE
First attempt at importing LXD commits

### DIFF
--- a/client/incus_server.go
+++ b/client/incus_server.go
@@ -56,6 +56,7 @@ func (r *ProtocolIncus) UpdateServer(server api.ServerPut, ETag string) error {
 }
 
 // HasExtension returns true if the server supports a given API extension.
+// Deprecated: Use CheckExtension instead.
 func (r *ProtocolIncus) HasExtension(extension string) bool {
 	// If no cached API information, just assume we're good
 	// This is needed for those rare cases where we must avoid a GetServer call

--- a/client/incus_storage_volumes.go
+++ b/client/incus_storage_volumes.go
@@ -533,6 +533,7 @@ func (r *ProtocolIncus) CopyStoragePoolVolume(pool string, source InstanceServer
 		return nil, fmt.Errorf("Failed to get destination connection info: %w", err)
 	}
 
+	// Copy the storage pool volume locally.
 	if destInfo.URL == sourceInfo.URL && destInfo.SocketPath == sourceInfo.SocketPath && (volume.Location == r.clusterTarget || (volume.Location == "none" && r.clusterTarget == "")) {
 		// Project handling
 		if destInfo.Project != sourceInfo.Project {

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -635,7 +635,7 @@ func (c *cmdStorageVolumeDelete) Run(cmd *cobra.Command, args []string) error {
 	// Parse the input
 	volName, volType := c.storageVolume.parseVolume("custom", args[1])
 
-	// If a target was specified, create the volume on the given member.
+	// If a target was specified, delete the volume on the given member.
 	if c.storage.flagTarget != "" {
 		client = client.UseTarget(c.storage.flagTarget)
 	}

--- a/internal/server/cluster/membership.go
+++ b/internal/server/cluster/membership.go
@@ -469,23 +469,23 @@ func Join(state *state.State, gateway *Gateway, networkCert *localtls.CertInfo, 
 				return fmt.Errorf("Failed to get storage pool driver: %w", err)
 			}
 
+			// For all pools we add the config provided by the joining node.
+			config, ok := pools[name]
+			if !ok {
+				return fmt.Errorf("Joining member has no config for pool %s", name)
+			}
+
+			err = tx.CreateStoragePoolConfig(id, node.ID, config)
+			if err != nil {
+				return fmt.Errorf("Failed to add joining node's pool config: %w", err)
+			}
+
 			if util.ValueInSlice(driver, []string{"ceph", "cephfs"}) {
 				// For ceph pools we have to create volume
 				// entries for the joining node.
 				err := tx.UpdateCephStoragePoolAfterNodeJoin(ctx, id, node.ID)
 				if err != nil {
 					return fmt.Errorf("Failed to create ceph volumes for joining node: %w", err)
-				}
-			} else {
-				// For other pools we add the config provided by the joining node.
-				config, ok := pools[name]
-				if !ok {
-					return fmt.Errorf("Joining member has no config for pool %s", name)
-				}
-
-				err = tx.CreateStoragePoolConfig(id, node.ID, config)
-				if err != nil {
-					return fmt.Errorf("Failed to add joining node's pool config: %w", err)
 				}
 			}
 		}

--- a/internal/server/device/device_utils_generic.go
+++ b/internal/server/device/device_utils_generic.go
@@ -1,7 +1,11 @@
 package device
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/lxc/incus/shared/util"
@@ -20,4 +24,40 @@ func validatePCIDevice(address string) error {
 	}
 
 	return nil
+}
+
+// checkAttachedRunningProcess checks if a device is tied to running processes.
+func checkAttachedRunningProcesses(devicePath string) ([]string, error) {
+	var processes []string
+	procDir := "/proc"
+	files, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read /proc directory: %w", err)
+	}
+
+	for _, file := range files {
+		// Check if the directory name is a number (i.e., a PID).
+		_, err := strconv.Atoi(file.Name())
+		if err != nil {
+			continue
+		}
+
+		mapsFile := filepath.Join(procDir, file.Name(), "maps")
+		f, err := os.Open(mapsFile)
+		if err != nil {
+			continue // If we can't read a process's maps file, skip it.
+		}
+
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), devicePath) {
+				processes = append(processes, file.Name())
+				break
+			}
+		}
+	}
+
+	return processes, nil
 }

--- a/internal/server/device/gpu_physical.go
+++ b/internal/server/device/gpu_physical.go
@@ -225,6 +225,24 @@ func (d *gpuPhysical) startVM() (*deviceConfig.RunConfig, error) {
 			continue
 		}
 
+		// Check for existing running processes tied to the GPU.
+		// Failing early here in case of attached running processes to the card
+		// avoids a blocking call to os.WriteFile() when unbinding the device.
+		if gpu.Nvidia != nil && gpu.Nvidia.CardName != "" && util.PathExists(filepath.Join("/dev", gpu.Nvidia.CardName)) {
+			devPath := filepath.Join("/dev", gpu.Nvidia.CardName)
+			runningProcs, err := checkAttachedRunningProcesses(devPath)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(runningProcs) > 0 {
+				return nil, fmt.Errorf(
+					"Cannot use device %q, %d processes are still attached to it:\n\t%s",
+					devPath, len(runningProcs), strings.Join(runningProcs, "\n\t"),
+				)
+			}
+		}
+
 		if pciAddress != "" {
 			return nil, fmt.Errorf("VMs cannot match multiple GPUs per device")
 		}


### PR DESCRIPTION
This is a small set of automatically imported commits from the LXD repository.

The tool I wrote for this task can compare the two repositories for changes that haven't made it to Incus yet.
Currently we're looking at a bit over 400 commits to catch up to LXD 5.18.

Making this work involves a lot of path and function/struct rewriting, mostly through a long list of sed patterns, as well as careful review and occasional manual edit of the commits being processed to make sure they make sense and that everything is still buildable.

To make it clear that those commits originated from outside of Incus, the commit message gets a `[lxd-import]` prefix added.