### PR TITLE
Move `incud recover` to `incus admin recover`

### DIFF
--- a/cmd/incus/admin.go
+++ b/cmd/incus/admin.go
@@ -24,6 +24,10 @@ func (c *cmdAdmin) Command() *cobra.Command {
 	adminInitCmd := cmdAdminInit{global: c.global}
 	cmd.AddCommand(adminInitCmd.Command())
 
+	// recover sub-command
+	adminRecoverCmd := cmdAdminRecover{global: c.global}
+	cmd.AddCommand(adminRecoverCmd.Command())
+
 	// shutdown sub-command
 	shutdownCmd := cmdAdminShutdown{global: c.global}
 	cmd.AddCommand(shutdownCmd.Command())

--- a/cmd/incus/admin_recover.go
+++ b/cmd/incus/admin_recover.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package main
 
 import (
@@ -15,11 +17,11 @@ import (
 	"github.com/lxc/incus/shared/validate"
 )
 
-type cmdRecover struct {
+type cmdAdminRecover struct {
 	global *cmdGlobal
 }
 
-func (c *cmdRecover) Command() *cobra.Command {
+func (c *cmdAdminRecover) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "recover"
 	cmd.Short = "Recover missing instances and volumes from existing and unknown storage pools"
@@ -35,7 +37,7 @@ func (c *cmdRecover) Command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdAdminRecover) Run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	if len(args) > 0 {
 		return fmt.Errorf("Invalid arguments")

--- a/cmd/incusd/main.go
+++ b/cmd/incusd/main.go
@@ -173,10 +173,6 @@ func main() {
 	netcatCmd := cmdNetcat{global: &globalCmd}
 	app.AddCommand(netcatCmd.Command())
 
-	// recover sub-command
-	recoverCmd := cmdRecover{global: &globalCmd}
-	app.AddCommand(recoverCmd.Command())
-
 	// shutdown sub-command
 	shutdownCmd := cmdShutdown{global: &globalCmd}
 	app.AddCommand(shutdownCmd.Command())

--- a/cmd/incusd/main_recover.go
+++ b/cmd/incusd/main_recover.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lxc/incus/client"
 	cli "github.com/lxc/incus/internal/cmd"
+	"github.com/lxc/incus/internal/recover"
 	"github.com/lxc/incus/shared/api"
 	"github.com/lxc/incus/shared/validate"
 )
@@ -167,7 +168,7 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 	fmt.Println("Scanning for unknown volumes...")
 
 	// Send /internal/recover/validate request to the daemon.
-	reqValidate := internalRecoverValidatePost{
+	reqValidate := recover.ValidatePost{
 		Pools: make([]api.StoragePoolsPost, 0, len(existingPools)+len(unknownPools)),
 	}
 
@@ -187,7 +188,7 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Failed validation request: %w", err)
 		}
 
-		var res internalRecoverValidateResult
+		var res recover.ValidateResult
 
 		err = resp.MetadataAsStruct(&res)
 		if err != nil {
@@ -237,9 +238,9 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 	fmt.Println("Starting recovery...")
 
 	// Send /internal/recover/import request to the daemon.
-	// Don't lint next line with gosimple. It says we should convert reqValidate directly to an internalRecoverImportPost
+	// Don't lint next line with gosimple. It says we should convert reqValidate directly to an RecoverImportPost
 	// because their types are identical. This is less clear and will not work if either type changes in the future.
-	reqImport := internalRecoverImportPost{ //nolint:gosimple
+	reqImport := recover.ImportPost{ //nolint:gosimple
 		Pools: reqValidate.Pools,
 	}
 

--- a/internal/recover/struct.go
+++ b/internal/recover/struct.go
@@ -1,0 +1,30 @@
+package recover
+
+import (
+	"github.com/lxc/incus/shared/api"
+)
+
+// ValidatePost is used to initiate a recovery validation scan.
+type ValidatePost struct {
+	Pools []api.StoragePoolsPost `json:"pools" yaml:"pools"`
+}
+
+// ValidateVolume provides info about a missing volume that the recovery validation scan found.
+type ValidateVolume struct {
+	Name          string `json:"name" yaml:"name"`                   // Name of volume.
+	Type          string `json:"type" yaml:"type"`                   // Same as Type from StorageVolumesPost (container, custom or virtual-machine).
+	SnapshotCount int    `json:"snapshotCount" yaml:"snapshotCount"` // Count of snapshots found for volume.
+	Project       string `json:"project" yaml:"project"`             // Project the volume belongs to.
+	Pool          string `json:"pool" yaml:"pool"`                   // Pool the volume belongs to.
+}
+
+// ValidateResult returns the result of the validation scan.
+type ValidateResult struct {
+	UnknownVolumes   []ValidateVolume // Volumes that could be imported.
+	DependencyErrors []string         // Errors that are preventing import from proceeding.
+}
+
+// ImportPost is used to initiate a recovert import.
+type ImportPost struct {
+	Pools []api.StoragePoolsPost `json:"pools" yaml:"pools"`
+}

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -38,7 +38,7 @@ test_storage_volume_recover() {
   fi
 
   # Recover custom block volume.
-  cat <<EOF | incusd recover
+  cat <<EOF | incus admin recover
 no
 yes
 yes
@@ -89,7 +89,7 @@ test_container_recover() {
     incus project switch test
 
     # Basic no-op check.
-    cat <<EOF | incusd recover | grep "No unknown storage pools or volumes found. Nothing to do."
+    cat <<EOF | incus admin recover | grep "No unknown storage pools or volumes found. Nothing to do."
 no
 yes
 EOF
@@ -158,7 +158,7 @@ EOF
 
     respawn_incus "${INCUS_DIR}" true
 
-    cat <<EOF | incusd recover
+    cat <<EOF | incus admin recover
 no
 yes
 yes
@@ -202,7 +202,7 @@ EOF
     shutdown_incus "${INCUS_DIR}"
     respawn_incus "${INCUS_DIR}" true
 
-    cat <<EOF | incusd recover
+    cat <<EOF | incus admin recover
 no
 yes
 yes
@@ -240,7 +240,7 @@ ceph.user.name=$(incus storage get "${poolName}" ceph.user.name)
     incus admin sql global "PRAGMA foreign_keys=ON; DELETE FROM storage_volumes WHERE name='c1'"
     incus admin sql global "PRAGMA foreign_keys=ON; DELETE FROM storage_pools WHERE name='${poolName}'"
 
-    cat <<EOF |incusd recover
+    cat <<EOF |incus admin recover
 yes
 ${poolName}
 ${poolDriver}
@@ -312,7 +312,7 @@ test_bucket_recover() {
     incus admin sql global "delete from storage_buckets where name = '${bucketName}'"
 
     # Recover bucket
-    cat <<EOF | incusd recover
+    cat <<EOF | incus admin recover
 no
 yes
 yes
@@ -982,7 +982,7 @@ test_backup_export_import_recover() {
     incus admin sql global "delete from storage_volumes where name = 'c2'"
 
     # Recover removed instance.
-    cat <<EOF | incusd recover
+    cat <<EOF | incus admin recover
 no
 yes
 yes


### PR DESCRIPTION
This change moves `incusd recover` to `incus admin recover`. A new package internal/recover is also introduced  in this change. The structures used by the internal recover api and the recover command code are moved into a common package(internal/recover). 