### PR TITLE
cmd/incusd: Drop instance type check for containers and VMs

### DIFF
--- a/cmd/incusd/instances_get.go
+++ b/cmd/incusd/instances_get.go
@@ -7,11 +7,8 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/lxc/incus/internal/filter"
 	"github.com/lxc/incus/internal/server/auth"
@@ -35,11 +32,7 @@ import (
 // explicitly via the instance-type query param or implicitly via the endpoint URL used.
 func urlInstanceTypeDetect(r *http.Request) (instancetype.Type, error) {
 	reqInstanceType := r.URL.Query().Get("instance-type")
-	if strings.HasPrefix(mux.CurrentRoute(r).GetName(), "container") {
-		return instancetype.Container, nil
-	} else if strings.HasPrefix(mux.CurrentRoute(r).GetName(), "vm") {
-		return instancetype.VM, nil
-	} else if reqInstanceType != "" {
+	if reqInstanceType != "" {
 		instanceType, err := instancetype.New(reqInstanceType)
 		if err != nil {
 			return instancetype.Any, err
@@ -497,14 +490,7 @@ func doInstancesGet(s *state.State, r *http.Request) (any, error) {
 	if recursion == 0 {
 		resultList := make([]string, 0, len(resultFullList))
 		for i := range resultFullList {
-			instancePath := "instances"
-			if strings.HasPrefix(mux.CurrentRoute(r).GetName(), "container") {
-				instancePath = "containers"
-			} else if strings.HasPrefix(mux.CurrentRoute(r).GetName(), "vm") {
-				instancePath = "virtual-machines"
-			}
-
-			url := api.NewURL().Path(version.APIVersion, instancePath, resultFullList[i].Name).Project(resultFullList[i].Project)
+			url := api.NewURL().Path(version.APIVersion, "instances", resultFullList[i].Name).Project(resultFullList[i].Project)
 			resultList = append(resultList, url.String())
 		}
 


### PR DESCRIPTION
This removes the instance type checks for containers and VMs based on
the route name. Since the route aliases for containers and VMs have been
removed, these checks are obsolete.

With this change, the `Name` field in the `APIEndpoint` struct is not used
anymore. This field could be removed in a future PR as well.
