### PR TITLE
instance: Remove limits.network.priority

### DIFF
--- a/cmd/incusd/networks_utils.go
+++ b/cmd/incusd/networks_utils.go
@@ -3,22 +3,11 @@ package main
 import (
 	"github.com/lxc/incus/internal/server/cluster"
 	"github.com/lxc/incus/internal/server/db"
-	"github.com/lxc/incus/internal/server/network"
 	"github.com/lxc/incus/internal/server/state"
 	"github.com/lxc/incus/shared/logger"
 )
 
 var networkOVNChassis *bool
-
-func networkAutoAttach(cluster *db.Cluster, devName string) error {
-	_, dbInfo, err := cluster.GetNetworkWithInterface(devName)
-	if err != nil {
-		// No match found, move on
-		return nil
-	}
-
-	return network.AttachInterface(dbInfo.Name, devName)
-}
 
 // networkUpdateOVNChassis gets called on heartbeats to check if OVN needs reconfiguring.
 func networkUpdateOVNChassis(s *state.State, heartbeatData *cluster.APIHeartbeat, localAddress string) error {

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -442,17 +442,6 @@ Specify an integer between 0 and 10.
 The higher the value, the less likely the instance is to be swapped to disk.
 ```
 
-```{config:option} limits.network.priority instance-resource-limits
-:defaultdesc: "`0` (minimum)"
-:liveupdate: "yes"
-:shortdesc: "Priority of the instance's network requests"
-:type: "integer"
-Controls how much priority to give to the instance's network requests when under load.
-
-Specify an integer between 0 and 10.
-This option is deprecated. Use the per-NIC `limits.priority` option instead.
-```
-
 ```{config:option} limits.processes instance-resource-limits
 :condition: "container"
 :defaultdesc: "empty"

--- a/internal/instance/config.go
+++ b/internal/instance/config.go
@@ -226,18 +226,6 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 		return nil
 	},
 
-	// gendoc:generate(entity=instance, group=resource-limits, key=limits.network.priority)
-	// Controls how much priority to give to the instance's network requests when under load.
-	//
-	// Specify an integer between 0 and 10.
-	// This option is deprecated. Use the per-NIC `limits.priority` option instead.
-	// ---
-	//  type: integer
-	//  defaultdesc: `0` (minimum)
-	//  liveupdate: yes
-	//  shortdesc: Priority of the instance's network requests
-	"limits.network.priority": validate.Optional(validate.IsPriority),
-
 	// Caller is responsible for full validation of any raw.* value.
 
 	// gendoc:generate(entity=instance, group=raw, key=raw.apparmor)

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -2543,17 +2543,6 @@ func (d *lxc) onStart(_ map[string]string) error {
 	// Trigger a rebalance
 	cgroup.TaskSchedulerTrigger("container", d.name, "started")
 
-	// Apply network priority
-	if d.expandedConfig["limits.network.priority"] != "" {
-		go func(d *lxc) {
-			d.fromHook = false
-			err := d.setNetworkPriority()
-			if err != nil {
-				d.logger.Error("Failed to apply network priority", logger.Ctx{"err": err})
-			}
-		}(d)
-	}
-
 	// Record last start state.
 	err = d.recordLastState()
 	if err != nil {
@@ -4547,11 +4536,6 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 							return err
 						}
 					}
-				}
-			} else if key == "limits.network.priority" {
-				err := d.setNetworkPriority()
-				if err != nil {
-					return err
 				}
 			} else if key == "limits.cpu" || key == "limits.cpu.nodes" {
 				// Trigger a scheduler re-run
@@ -7862,66 +7846,6 @@ func (d *lxc) removeDiskDevices() error {
 		if err != nil {
 			d.logger.Error("Failed to remove disk device path", logger.Ctx{"err": err, "path": diskPath})
 		}
-	}
-
-	return nil
-}
-
-// Network I/O limits.
-func (d *lxc) setNetworkPriority() error {
-	// Load the go-lxc struct.
-	cc, err := d.initLXC(false)
-	if err != nil {
-		return err
-	}
-
-	// Load the cgroup struct.
-	cg, err := d.cgroup(cc, true)
-	if err != nil {
-		return err
-	}
-
-	// Check that the container is running
-	if d.InitPID() <= 0 {
-		return fmt.Errorf("Can't set network priority on stopped container")
-	}
-
-	// Don't bother if the cgroup controller doesn't exist
-	if !d.state.OS.CGInfo.Supports(cgroup.NetPrio, cg) {
-		return nil
-	}
-
-	// Extract the current priority
-	networkPriority := d.expandedConfig["limits.network.priority"]
-	if networkPriority == "" {
-		networkPriority = "0"
-	}
-
-	networkInt, err := strconv.Atoi(networkPriority)
-	if err != nil {
-		return err
-	}
-
-	// Get all the interfaces
-	netifs, err := net.Interfaces()
-	if err != nil {
-		return err
-	}
-
-	// Check that we at least succeeded to set an entry
-	success := false
-	var lastError error
-	for _, netif := range netifs {
-		err = cg.SetNetIfPrio(fmt.Sprintf("%s %d", netif.Name, networkInt))
-		if err == nil {
-			success = true
-		} else {
-			lastError = err
-		}
-	}
-
-	if !success {
-		return fmt.Errorf("Failed to set network device priority: %s", lastError)
 	}
 
 	return nil

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -460,15 +460,6 @@
 						}
 					},
 					{
-						"limits.network.priority": {
-							"defaultdesc": "`0` (minimum)",
-							"liveupdate": "yes",
-							"longdesc": "Controls how much priority to give to the instance's network requests when under load.\n\nSpecify an integer between 0 and 10.\nThis option is deprecated. Use the per-NIC `limits.priority` option instead.",
-							"shortdesc": "Priority of the instance's network requests",
-							"type": "integer"
-						}
-					},
-					{
 						"limits.processes": {
 							"condition": "container",
 							"defaultdesc": "empty",

--- a/scripts/bash/incus
+++ b/scripts/bash/incus
@@ -94,7 +94,7 @@ _have incus && {
       limits.cpu limits.cpu.allowance limits.cpu.priority \
       limits.disk.priority limits.memory limits.memory.enforce \
       limits.memory.hugepages limits.kernel \
-      limits.memory.swap limits.memory.swap.priority limits.network.priority \
+      limits.memory.swap limits.memory.swap.priority \
       limits.processes linux.kernel_modules migration.incremental.memory \
       migration.incremental.memory.goal nvidia.runtime \
       nvidia.driver.capabilities nvidia.require.cuda nvidia.require.driver \

--- a/test/suites/storage_volume_initial_config.sh
+++ b/test/suites/storage_volume_initial_config.sh
@@ -128,13 +128,13 @@ test_storage_volume_initial_config() {
     # Custom blocksize.
     incus init "${image}" c --no-profiles --storage "${pool}" --device root,initial.zfs.blocksize=64KiB
     [ "$(incus storage volume get "${pool}" container/c zfs.blocksize)" = "64KiB" ]
-    [ "$(zfs get volblocksize ${pool}/containers/c -H -o value)" = "64K" ]
+    [ "$(zfs get volblocksize "${pool}/containers/c" -H -o value)" = "64K" ]
     incus delete c --force
 
     # Custom blocksize that exceeds maximum allowed blocksize.
     incus init "${image}" c --no-profiles --storage "${pool}" --device root,initial.zfs.blocksize=512KiB
     [ "$(incus storage volume get "${pool}" container/c zfs.blocksize)" = "512KiB" ]
-    [ "$(zfs get volblocksize ${pool}/containers/c -H -o value)" = "128K" ]
+    [ "$(zfs get volblocksize "${pool}/containers/c" -H -o value)" = "128K" ]
     incus delete c --force
   fi
 


### PR DESCRIPTION
This option only ever worked on CGroup1 and had quite a few limitations. It's now being replaced by `limits.priority` set directly on the nic devices.

Closes #113