### PR TITLE
Rename EventTypeOVN to EventTypeNetworkACL

### DIFF
--- a/cmd/incusd/events.go
+++ b/cmd/incusd/events.go
@@ -19,7 +19,7 @@ import (
 	"github.com/lxc/incus/shared/ws"
 )
 
-var eventTypes = []string{api.EventTypeLogging, api.EventTypeOperation, api.EventTypeLifecycle, api.EventTypeOVN}
+var eventTypes = []string{api.EventTypeLogging, api.EventTypeOperation, api.EventTypeLifecycle, api.EventTypeNetworkACL}
 var privilegedEventTypes = []string{api.EventTypeLogging}
 
 var eventsCmd = APIEndpoint{

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1610,7 +1610,7 @@ Specify a comma-separated list of values that should be used as labels for a Lok
 :shortdesc: "Events to send to the Loki server"
 :type: "string"
 Specify a comma-separated list of events to send to the Loki server.
-The events can be any combination of `lifecycle`, `logging`, and `ovn`.
+The events can be any combination of `lifecycle`, `logging`, and `network-acl`.
 ```
 
 <!-- config group server-loki end -->

--- a/doc/howto/network_ovn_setup.md
+++ b/doc/howto/network_ovn_setup.md
@@ -197,14 +197,14 @@ Complete the following steps to have the OVN controller send its logs to LXD.
 
        systemctl restart ovn-controller.service
 
-You can now use [`incus monitor`](incus_monitor.md) to see logs from the OVN controller:
+You can now use [`incus monitor`](incus_monitor.md) to see logged network ACL traffic from the OVN controller:
 
-    incus monitor --type=ovn
+    incus monitor --type=network-acls
 
 You can also send the logs to Loki.
-To do so, add the `ovn` value to the {config:option}`server-loki:loki.types` configuration key, for example:
+To do so, add the `network-acl` value to the {config:option}`server-loki:loki.types` configuration key, for example:
 
-    incus config set loki.types=ovn
+    incus config set loki.types=network-acl
 
 ```{tip}
 You can include logs for OVN `northd`, OVN north-bound `ovsdb-server`, and OVN south-bound `ovsdb-server` as well.

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -600,13 +600,13 @@ var ConfigSchema = config.Schema{
 
 	// gendoc:generate(entity=server, group=loki, key=loki.types)
 	// Specify a comma-separated list of events to send to the Loki server.
-	// The events can be any combination of `lifecycle`, `logging`, and `ovn`.
+	// The events can be any combination of `lifecycle`, `logging`, and `network-acl`.
 	// ---
 	//  type: string
 	//  scope: global
 	//  defaultdesc: `lifecycle,logging`
 	//  shortdesc: Events to send to the Loki server
-	"loki.types": {Validator: validate.Optional(validate.IsListOf(validate.IsOneOf("lifecycle", "logging", "ovn"))), Default: "lifecycle,logging"},
+	"loki.types": {Validator: validate.Optional(validate.IsListOf(validate.IsOneOf("lifecycle", "logging", "network-acl"))), Default: "lifecycle,logging"},
 
 	// gendoc:generate(entity=server, group=oidc, key=oidc.client.id)
 	//

--- a/internal/server/events/internalListener.go
+++ b/internal/server/events/internalListener.go
@@ -38,7 +38,7 @@ func (l *InternalListener) startListener() {
 	aEnd, bEnd := memorypipe.NewPipePair(l.listenerCtx)
 	listenerConnection := NewSimpleListenerConnection(aEnd)
 
-	l.listener, err = l.server.AddListener("", true, listenerConnection, []string{"lifecycle", "logging", "ovn"}, []EventSource{EventSourcePull}, nil, nil)
+	l.listener, err = l.server.AddListener("", true, listenerConnection, []string{"lifecycle", "logging", "network-acl"}, []EventSource{EventSourcePull}, nil, nil)
 	if err != nil {
 		return
 	}

--- a/internal/server/loki/loki.go
+++ b/internal/server/loki/loki.go
@@ -304,7 +304,7 @@ func (c *Client) HandleEvent(event api.Event) {
 		}
 
 		entry.Line = fmt.Sprintf("%s%s", messagePrefix, lifecycleEvent.Action)
-	} else if event.Type == api.EventTypeLogging || event.Type == api.EventTypeOVN {
+	} else if event.Type == api.EventTypeLogging || event.Type == api.EventTypeNetworkACL {
 		logEvent := api.EventLogging{}
 
 		err := json.Unmarshal(event.Metadata, &logEvent)

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -1762,7 +1762,7 @@
 					{
 						"loki.types": {
 							"defaultdesc": "`lifecycle,logging`",
-							"longdesc": "Specify a comma-separated list of events to send to the Loki server.\nThe events can be any combination of `lifecycle`, `logging`, and `ovn`.",
+							"longdesc": "Specify a comma-separated list of events to send to the Loki server.\nThe events can be any combination of `lifecycle`, `logging`, and `network-acl`.",
 							"scope": "global",
 							"shortdesc": "Events to send to the Loki server",
 							"type": "string"

--- a/internal/server/syslog/listener.go
+++ b/internal/server/syslog/listener.go
@@ -117,11 +117,14 @@ func Listen(ctx context.Context, eventServer *events.Server) error {
 			logLevel := strings.ToLower(fields[len(fields)-2])
 			message := fields[len(fields)-1]
 
+			if !strings.HasPrefix(moduleName, "acl_log") {
+				continue
+			}
+
 			event := api.EventLogging{
 				Level:   logMap[logLevel].String(),
 				Message: message,
 				Context: map[string]string{
-					"module":   moduleName,
 					"sequence": sequenceNumber,
 				},
 			}
@@ -130,7 +133,7 @@ func Listen(ctx context.Context, eventServer *events.Server) error {
 				event.Context["application"] = applicationName
 			}
 
-			err = eventServer.Send("", api.EventTypeOVN, event)
+			err = eventServer.Send("", api.EventTypeNetworkACL, event)
 			if err != nil {
 				continue
 			}

--- a/shared/api/event.go
+++ b/shared/api/event.go
@@ -8,10 +8,10 @@ import (
 
 // Event types.
 const (
-	EventTypeLifecycle = "lifecycle"
-	EventTypeLogging   = "logging"
-	EventTypeOperation = "operation"
-	EventTypeOVN       = "ovn"
+	EventTypeLifecycle  = "lifecycle"
+	EventTypeLogging    = "logging"
+	EventTypeOperation  = "operation"
+	EventTypeNetworkACL = "network-acl"
 )
 
 // Event represents an event entry (over websocket)
@@ -45,7 +45,7 @@ type Event struct {
 
 // ToLogging creates log record for the event.
 func (event *Event) ToLogging() (EventLogRecord, error) {
-	if event.Type == EventTypeLogging || event.Type == EventTypeOVN {
+	if event.Type == EventTypeLogging || event.Type == EventTypeNetworkACL {
 		e := &EventLogging{}
 		err := json.Unmarshal(event.Metadata, &e)
 		if err != nil {

--- a/test/suites/syslog.sh
+++ b/test/suites/syslog.sh
@@ -5,16 +5,17 @@ test_syslog_socket() {
   spawn_incus "${INCUS_DIR}" true
 
   incus config set core.syslog_socket=true
-  incus monitor --type=ovn > "${TEST_DIR}/ovn.log" &
+  incus monitor --type=network-acl > "${TEST_DIR}/ovn.log" &
   monitorOVNPID=$!
 
   sleep 1
-  echo "<29> ovs|ovn-controller|00017|rconn|INFO|unix:/var/run/openvswitch/br-int.mgmt: connected" | socat - unix-sendto:"${INCUS_DIR}/syslog.socket"
+  echo "<29> ovs|ovn-controller|00017|acl_log(foo)|INFO|name=\"some-acl\"" | socat - unix-sendto:"${INCUS_DIR}/syslog.socket"
+
   sleep 1
 
   kill -9 ${monitorOVNPID} || true
-  grep -qF "type: ovn" "${TEST_DIR}/ovn.log"
-  grep -qF "unix:/var/run/openvswitch/br-int.mgmt: connected" "${TEST_DIR}/ovn.log"
+  grep -qF "type: network-acl" "${TEST_DIR}/ovn.log"
+  grep -qF "name=\"some-acl\"" "${TEST_DIR}/ovn.log"
 
   shutdown_incus "${INCUS_DIR}"
 }


### PR DESCRIPTION
This replaces the OVN event type introduced in LXD 5.18 with a new NetworkACL event type and updates the receiver to filter OVN events to only those about ACL matches.

This logic could in time be applied to iptables/nft too.

Closes #114 