### PR TITLE
doc: Add start-after to include CONTRIBUTING.md from contributing.md

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -2,6 +2,7 @@
 
 % Include content from [../CONTRIBUTING.md](../CONTRIBUTING.md)
 ```{include} ../CONTRIBUTING.md
+    :start-after: <!-- Include start contributing -->
     :end-before: <!-- Include end contributing -->
 ```
 


### PR DESCRIPTION
To avoid duplicate of links to contributing in doc/general.md.