### PR TITLE
doc: Remove direct from reference/network_external/

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -208,5 +208,4 @@ linkcheck_anchors_ignore_for_url = [
 # Setup redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
 redirects = {
     "howto/instances_snapshots/index": "../instances_backup/",
-    "reference/network_external/index": "../networks/",
 }


### PR DESCRIPTION
This redirect prevents for https://github.com/lxc/incus/blob/main/doc/reference/network_external.md to be displayed and causes 404 Not Found error.