### PR TITLE
doc: Remove "Configure a network section" in howto/network_create

### DIFF
--- a/doc/howto/network_create.md
+++ b/doc/howto/network_create.md
@@ -1,4 +1,4 @@
-# How to create and configure a network
+# How to create a network
 
 To create a managed network, use the [`incus network`](incus_network.md) command and its subcommands.
 Append `--help` to any command to see more information about its usage and available flags.
@@ -96,26 +96,3 @@ Alternatively, you can add a NIC device based on the network configuration in th
 
 When using this way, you can add further configuration to the command to override the default settings for the network if needed.
 See {ref}`NIC device <devices-nic>` for all available device options.
-
-## Configure a network
-
-To configure an existing network, use either the `incus network set` and `incus network unset` commands (to configure single settings) or the `incus network edit` command (to edit the full configuration).
-To configure settings for specific cluster members, add the `--target` flag.
-
-For example, the following command configures a DNS server for a physical network:
-
-```bash
-incus network set UPLINK dns.nameservers=8.8.8.8
-```
-
-The available configuration options differ depending on the network type.
-See {ref}`network-types` for links to the configuration options for each network type.
-
-There are separate commands to configure advanced networking features.
-See the following documentation:
-
-- {doc}`/howto/network_acls`
-- {doc}`/howto/network_forwards`
-- {doc}`/howto/network_load_balancers`
-- {doc}`/howto/network_zones`
-- {doc}`/howto/network_ovn_peers` (OVN only)


### PR DESCRIPTION
Duplicated since it was moved to howto/network_configure.