### PR TITLE
cmd/incusd: Make sure to get ServerName prior to running patches

### DIFF
--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1207,12 +1207,6 @@ func (d *Daemon) init() error {
 		return err
 	}
 
-	// Apply all patches that need to be run after daemon storage is initialised.
-	err = patchesApply(d, patchPostDaemonStorage)
-	if err != nil {
-		return err
-	}
-
 	// Get daemon configuration.
 	bgpAddress := d.localConfig.BGPAddress()
 	bgpRouterID := d.localConfig.BGPRouterID()
@@ -1239,6 +1233,12 @@ func (d *Daemon) init() error {
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	// Apply all patches that need to be run after daemon storage is initialised.
+	err = patchesApply(d, patchPostDaemonStorage)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes cluster patch failures in both
storage_zfs_unset_invalid_block_settings and
storage_zfs_unset_invalid_block_settingsV2