### PR TITLE
lxd-to-incus: query systemd instead of assuming service file path

### DIFF
--- a/cmd/lxd-to-incus/targets.go
+++ b/cmd/lxd-to-incus/targets.go
@@ -25,7 +25,8 @@ func (s *targetSystemd) Present() bool {
 		return false
 	}
 
-	if !util.PathExists("/lib/systemd/system/incus.service") {
+	_, err := subprocess.RunCommand("systemctl", "list-unit-files", "incus.service")
+	if err != nil {
 		return false
 	}
 


### PR DESCRIPTION
systemd supports multiple paths, so rely on its detection logic instead of checking a specific path.
