### PR TITLE
Add "btrfs.nodatacow" config option

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -325,6 +325,13 @@ This introduces the `btrfs.mount_options` property for Btrfs storage pools.
 
 This key controls what mount options will be used for the Btrfs storage pool.
 
+## `storage_btrfs_nodatacow`
+
+This introduces the `btrfs.nodatacow` property for Btrfs storage pools.
+
+This key controls if `chattr +C` will be invoked for storage volumes on Btrfs
+storage pools. The default value is `true`.
+
 ## `entity_description`
 
 This adds descriptions to entities like containers, snapshots, networks, storage pools and volumes.

--- a/doc/reference/storage_btrfs.md
+++ b/doc/reference/storage_btrfs.md
@@ -62,6 +62,7 @@ The following configuration options are available for storage pools that use the
 Key                             | Type      | Default                    | Description
 :--                             | :---      | :------                    | :----------
 `btrfs.mount_options`           | string    | `user_subvol_rm_allowed`   | Mount options for block devices
+`btrfs.nodatacow`               | bool      | `true`                     | Enable `nodatacow` on the storage volume/directory for VMs
 `size`                          | string    | auto (20% of free disk space, >= 5 GiB and <= 30 GiB) | Size of the storage pool when creating loop-based pools (in bytes, suffixes supported, can be increased to grow storage pool)
 `source`                        | string    | -                          | Path to an existing block device, loop file or Btrfs subvolume
 `source.wipe`                   | bool      | `false`                    | Wipe the block device specified in `source` prior to creating the storage pool

--- a/internal/server/storage/drivers/driver_btrfs.go
+++ b/internal/server/storage/drivers/driver_btrfs.go
@@ -318,6 +318,7 @@ func (d *btrfs) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
 		"size":                validate.Optional(validate.IsSize),
 		"btrfs.mount_options": validate.IsAny,
+		"btrfs.nodatacow":     validate.Optional(validate.IsBool),
 	}
 
 	return d.validatePool(config, rules, nil)
@@ -342,6 +343,11 @@ func (d *btrfs) Update(changedConfig map[string]string) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	nodatacow, ok := changedConfig["btrfs.nodatacow"]
+	if ok {
+		d.config["btrfs.nodatacow"] = nodatacow
 	}
 
 	size, ok := changedConfig["size"]

--- a/internal/server/storage/drivers/driver_btrfs_volumes.go
+++ b/internal/server/storage/drivers/driver_btrfs_volumes.go
@@ -62,18 +62,26 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 			return err
 		}
 
-		// Enable nodatacow on the parent directory so that when the root disk file is created the setting
-		// is inherited and random writes don't cause fragmentation and old extents to be kept.
-		// BTRFS extents are immutable so when blocks are written they end up in new extents and the old
-		// ones remains until all of its data is dereferenced or rewritten. These old extents are counted
-		// in the quota, and so leaving CoW enabled can cause the BTRFS subvolume quota to be reached even
-		// before the block file itself is full. This setting does not totally prevents CoW from happening
-		// as when a snapshot is taken, writes that happen on the original volume necessarily create a CoW
-		// in order to track the difference between original and snapshot. This will increase the size of
-		// data being referenced.
-		_, err = subprocess.RunCommand("chattr", "+C", volPath)
-		if err != nil {
-			return fmt.Errorf("Failed setting nodatacow on %q: %w", volPath, err)
+		// use true as the default for "nodatacow"
+		nodatacow := true
+		if util.IsFalse(d.config["btrfs.nodatacow"]) {
+			nodatacow = false
+		}
+
+		if nodatacow {
+			// Enable nodatacow on the parent directory so that when the root disk file is created the setting
+			// is inherited and random writes don't cause fragmentation and old extents to be kept.
+			// BTRFS extents are immutable so when blocks are written they end up in new extents and the old
+			// ones remains until all of its data is dereferenced or rewritten. These old extents are counted
+			// in the quota, and so leaving CoW enabled can cause the BTRFS subvolume quota to be reached even
+			// before the block file itself is full. This setting does not totally prevents CoW from happening
+			// as when a snapshot is taken, writes that happen on the original volume necessarily create a CoW
+			// in order to track the difference between original and snapshot. This will increase the size of
+			// data being referenced.
+			_, err = subprocess.RunCommand("chattr", "+C", volPath)
+			if err != nil {
+				return fmt.Errorf("Failed setting nodatacow on %q: %w", volPath, err)
+			}
 		}
 	}
 

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -64,6 +64,7 @@ var APIExtensions = []string{
 	"storage_rsync_bwlimit",
 	"network_vxlan_interface",
 	"storage_btrfs_mount_options",
+	"storage_btrfs_nodatacow",
 	"entity_description",
 	"image_force_refresh",
 	"storage_lvm_lv_resizing",

--- a/scripts/bash/incus
+++ b/scripts/bash/incus
@@ -148,7 +148,7 @@ _have incus && {
       restricted.devices.gpu restricted.devices.usb restricted.devices.nic restricted.devices.disk \
       restricted.devices.pci restricted.devices.proxy"
 
-    storage_pool_keys="source size btrfs.mount_options ceph.cluster_name \
+    storage_pool_keys="source size btrfs.mount_options btrfs.nodatacow ceph.cluster_name \
       ceph.osd.pg_num ceph.osd.pool_name ceph.osd.data_pool_name \
       ceph.rbd.clone_copy ceph.rbd.du ceph.rbd.features ceph.user.name cephfs.cluster_name cephfs.path \
       cephfs.fscache cephfs.vg_name lvm.thinpool_name lvm.thinpool_metadata_size lvm.use_thinpool \


### PR DESCRIPTION
This options is added to btrfs storage pools to control the "nodatacow" attribute of the volume/directory containing VM images. The default value is true for compatibility with previous versions.

As explained in [this post](https://discuss.linuxcontainers.org/t/nodatacow-on-btrfs-storage-breaks-compression/18224), the default "nodatacow" option appears to break compression, so this is likely necessary for anyone using `compress-force`  in `btrfs.mount_options` or in the host Btrfs mount options.