### PR TITLE
incusd/device: The MTU can always be controlled

### DIFF
--- a/internal/server/device/nic_physical.go
+++ b/internal/server/device/nic_physical.go
@@ -40,10 +40,11 @@ func (d *nicPhysical) validateConfig(instConf instance.ConfigReader) error {
 		"name",
 		"boot.priority",
 		"gvrp",
+		"mtu",
 	}
 
 	if instConf.Type() == instancetype.Container || instConf.Type() == instancetype.Any {
-		optionalFields = append(optionalFields, "mtu", "hwaddr", "vlan")
+		optionalFields = append(optionalFields, "hwaddr", "vlan")
 	}
 
 	if d.config["network"] != "" {

--- a/internal/server/device/nic_sriov.go
+++ b/internal/server/device/nic_sriov.go
@@ -41,6 +41,7 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 		"network",
 		"parent",
 		"hwaddr",
+		"mtu",
 		"vlan",
 		"security.mac_filtering",
 		"boot.priority",
@@ -89,11 +90,6 @@ func (d *nicSRIOV) validateConfig(instConf instance.ConfigReader) error {
 	} else {
 		// If no network property supplied, then parent property is required.
 		requiredFields = append(requiredFields, "parent")
-	}
-
-	// For VMs only NIC properties that can be specified on the parent's VF settings are controllable.
-	if instConf.Type() == instancetype.Container || instConf.Type() == instancetype.Any {
-		optionalFields = append(optionalFields, "mtu")
 	}
 
 	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields, instConf))


### PR DESCRIPTION
In VMs, the MTU can be set through the agent, so it should always be allowed as a user configurable property.

Reported-at: https://discuss.linuxcontainers.org/t/incus-and-sriov-issue-error-no-value-found-in-sriov/18273/3