### PR TITLE
Fix missing VM metrics

### DIFF
--- a/internal/server/metrics/api.go
+++ b/internal/server/metrics/api.go
@@ -2,17 +2,18 @@ package metrics
 
 // Metrics represents instance metrics.
 type Metrics struct {
-	CPU            map[string]CPUMetrics        `json:"cpu_seconds_total" yaml:"cpu_seconds_total"`
-	CPUs           int                          `json:"cpus" yaml:"cpus"`
-	Disk           map[string]DiskMetrics       `json:"disk" yaml:"disk"`
-	Filesystem     map[string]FilesystemMetrics `json:"filesystem" yaml:"filesystem"`
-	Memory         MemoryMetrics                `json:"memory" yaml:"memory"`
-	Network        map[string]NetworkMetrics    `json:"network" yaml:"network"`
-	ProcessesTotal uint64                       `json:"procs_total" yaml:"procs_total"`
+	CPU            []CPUMetrics        `json:"cpu_seconds_total" yaml:"cpu_seconds_total"`
+	CPUs           int                 `json:"cpus" yaml:"cpus"`
+	Disk           []DiskMetrics       `json:"disk" yaml:"disk"`
+	Filesystem     []FilesystemMetrics `json:"filesystem" yaml:"filesystem"`
+	Memory         MemoryMetrics       `json:"memory" yaml:"memory"`
+	Network        []NetworkMetrics    `json:"network" yaml:"network"`
+	ProcessesTotal uint64              `json:"procs_total" yaml:"procs_total"`
 }
 
 // CPUMetrics represents CPU metrics for an instance.
 type CPUMetrics struct {
+	CPU            string  `json:"cpu" yaml:"cpu"`
 	SecondsUser    float64 `json:"cpu_seconds_user" yaml:"cpu_seconds_user"`
 	SecondsNice    float64 `json:"cpu_seconds_nice" yaml:"cpu_seconds_nice"`
 	SecondsSystem  float64 `json:"cpu_seconds_system" yaml:"cpu_seconds_system"`
@@ -25,6 +26,7 @@ type CPUMetrics struct {
 
 // DiskMetrics represents disk metrics for an instance.
 type DiskMetrics struct {
+	Device          string `json:"device" yaml:"device"`
 	ReadBytes       uint64 `json:"disk_read_bytes" yaml:"disk_read_bytes"`
 	ReadsCompleted  uint64 `json:"disk_reads_completed" yaml:"disk_reads_completes"`
 	WrittenBytes    uint64 `json:"disk_written_bytes" yaml:"disk_written_bytes"`
@@ -33,6 +35,7 @@ type DiskMetrics struct {
 
 // FilesystemMetrics represents filesystem metrics for an instance.
 type FilesystemMetrics struct {
+	Device         string `json:"device" yaml:"device"`
 	Mountpoint     string `json:"mountpoint" yaml:"mountpoint"`
 	FSType         string `json:"fstype" yaml:"fstype"`
 	AvailableBytes uint64 `json:"filesystem_avail_bytes" yaml:"filesystem_avail_bytes"`
@@ -66,6 +69,7 @@ type MemoryMetrics struct {
 
 // NetworkMetrics represents network metrics for an instance.
 type NetworkMetrics struct {
+	Device          string `json:"device" yaml:"device"`
 	ReceiveBytes    uint64 `json:"network_receive_bytes" yaml:"network_receive_bytes"`
 	ReceiveDrop     uint64 `json:"network_receive_drop" yaml:"network_receive_drop"`
 	ReceiveErrors   uint64 `json:"network_receive_errs" yaml:"network_receive_errs"`

--- a/internal/server/metrics/metrics.go
+++ b/internal/server/metrics/metrics.go
@@ -167,13 +167,13 @@ func MetricSetFromAPI(metrics *Metrics, labels map[string]string) (*MetricSet, e
 	set := NewMetricSet(labels)
 
 	// CPU stats
-	for dev, stats := range metrics.CPU {
+	for _, stats := range metrics.CPU {
 		getLabels := func(mode string) map[string]string {
 			labels := map[string]string{"mode": mode}
 			cpu := ""
 
-			if dev != "cpu" {
-				_, _ = fmt.Sscanf(dev, "cpu%s", &cpu)
+			if stats.CPU != "cpu" {
+				_, _ = fmt.Sscanf(stats.CPU, "cpu%s", &cpu)
 			}
 
 			if cpu != "" {
@@ -223,8 +223,8 @@ func MetricSetFromAPI(metrics *Metrics, labels map[string]string) (*MetricSet, e
 	set.AddSamples(CPUs, Sample{Value: float64(metrics.CPUs)})
 
 	// Disk stats
-	for dev, stats := range metrics.Disk {
-		labels := map[string]string{"device": dev}
+	for _, stats := range metrics.Disk {
+		labels := map[string]string{"device": stats.Device}
 
 		set.AddSamples(DiskReadBytesTotal, Sample{Value: float64(stats.ReadBytes), Labels: labels})
 		set.AddSamples(DiskReadsCompletedTotal, Sample{Value: float64(stats.ReadsCompleted), Labels: labels})
@@ -233,8 +233,8 @@ func MetricSetFromAPI(metrics *Metrics, labels map[string]string) (*MetricSet, e
 	}
 
 	// Filesystem stats
-	for dev, stats := range metrics.Filesystem {
-		labels := map[string]string{"device": dev, "fstype": stats.FSType, "mountpoint": stats.Mountpoint}
+	for _, stats := range metrics.Filesystem {
+		labels := map[string]string{"device": stats.Device, "fstype": stats.FSType, "mountpoint": stats.Mountpoint}
 
 		set.AddSamples(FilesystemAvailBytes, Sample{Value: float64(stats.AvailableBytes), Labels: labels})
 		set.AddSamples(FilesystemFreeBytes, Sample{Value: float64(stats.FreeBytes), Labels: labels})
@@ -264,8 +264,8 @@ func MetricSetFromAPI(metrics *Metrics, labels map[string]string) (*MetricSet, e
 	set.AddSamples(MemoryOOMKillsTotal, Sample{Value: float64(metrics.Memory.OOMKills)})
 
 	// Network stats
-	for dev, stats := range metrics.Network {
-		labels := map[string]string{"device": dev}
+	for _, stats := range metrics.Network {
+		labels := map[string]string{"device": stats.Device}
 
 		set.AddSamples(NetworkReceiveBytesTotal, Sample{Value: float64(stats.ReceiveBytes), Labels: labels})
 		set.AddSamples(NetworkReceiveDropTotal, Sample{Value: float64(stats.ReceiveDrop), Labels: labels})


### PR DESCRIPTION
The internal agent API was using maps rather than slices for a variety of metrics.

The problem with that approach is that if the key of that map happens to be present multiple times, as is the case with filesystem mounts, only the last record would be sent through...