### PR TITLE
Move db functions to ClusterTx

### DIFF
--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -638,39 +638,43 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Get a list of projects for networks.
 		var projects []dbCluster.Project
+		networks := []api.InitNetworksProjectPost{}
 
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			projects, err = dbCluster.GetProjects(ctx, tx.Tx())
-			return err
-		})
-		if err != nil {
-			return fmt.Errorf("Failed to load projects for networks: %w", err)
-		}
-
-		networks := []api.InitNetworksProjectPost{}
-		for _, p := range projects {
-			networkNames, err := s.DB.Cluster.GetNetworks(p.Name)
-			if err != nil && !response.IsNotFoundError(err) {
-				return err
+			if err != nil {
+				return fmt.Errorf("Failed to load projects for networks: %w", err)
 			}
 
-			for _, name := range networkNames {
-				_, network, _, err := s.DB.Cluster.GetNetworkInAnyState(p.Name, name)
-				if err != nil {
+			for _, p := range projects {
+				networkNames, err := tx.GetNetworks(ctx, p.Name)
+				if err != nil && !response.IsNotFoundError(err) {
 					return err
 				}
 
-				internalNetwork := api.InitNetworksProjectPost{
-					NetworksPost: api.NetworksPost{
-						NetworkPut: network.NetworkPut,
-						Name:       network.Name,
-						Type:       network.Type,
-					},
-					Project: p.Name,
-				}
+				for _, name := range networkNames {
+					_, network, _, err := tx.GetNetworkInAnyState(ctx, p.Name, name)
+					if err != nil {
+						return err
+					}
 
-				networks = append(networks, internalNetwork)
+					internalNetwork := api.InitNetworksProjectPost{
+						NetworksPost: api.NetworksPost{
+							NetworkPut: network.NetworkPut,
+							Name:       network.Name,
+							Type:       network.Type,
+						},
+						Project: p.Name,
+					}
+
+					networks = append(networks, internalNetwork)
+				}
 			}
+
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 
 		// Now request for this node to be added to the list of cluster nodes.
@@ -2088,7 +2092,13 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		for _, networkProjectName := range networkProjectNames {
-			networks, err := s.DB.Cluster.GetNetworks(networkProjectName)
+			var networks []string
+
+			err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+				networks, err = tx.GetNetworks(ctx, networkProjectName)
+
+				return err
+			})
 			if err != nil {
 				return response.SmartError(err)
 			}
@@ -2801,52 +2811,56 @@ func clusterCheckNetworksMatch(cluster *db.Cluster, reqNetworks []api.InitNetwor
 	var networkProjectNames []string
 
 	err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		networkProjectNames, err = dbCluster.GetProjectNames(context.Background(), tx.Tx())
-		return err
+		networkProjectNames, err = dbCluster.GetProjectNames(ctx, tx.Tx())
+		if err != nil {
+			return fmt.Errorf("Failed to load projects for networks: %w", err)
+		}
+
+		for _, networkProjectName := range networkProjectNames {
+			networkNames, err := tx.GetCreatedNetworkNamesByProject(ctx, networkProjectName)
+			if err != nil && !response.IsNotFoundError(err) {
+				return err
+			}
+
+			for _, networkName := range networkNames {
+				found := false
+
+				for _, reqNetwork := range reqNetworks {
+					if reqNetwork.Name != networkName || reqNetwork.Project != networkProjectName {
+						continue
+					}
+
+					found = true
+
+					_, network, _, err := tx.GetNetworkInAnyState(ctx, networkProjectName, networkName)
+					if err != nil {
+						return err
+					}
+
+					if reqNetwork.Type != network.Type {
+						return fmt.Errorf("Mismatching type for network %q in project %q", networkName, networkProjectName)
+					}
+
+					// Exclude the keys which are node-specific.
+					exclude := db.NodeSpecificNetworkConfig
+					err = localUtil.CompareConfigs(network.Config, reqNetwork.Config, exclude)
+					if err != nil {
+						return fmt.Errorf("Mismatching config for network %q in project %q: %w", network.Name, networkProjectName, err)
+					}
+
+					break
+				}
+
+				if !found {
+					return fmt.Errorf("Missing network %q in project %q", networkName, networkProjectName)
+				}
+			}
+		}
+
+		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to load projects for networks: %w", err)
-	}
-
-	for _, networkProjectName := range networkProjectNames {
-		networkNames, err := cluster.GetCreatedNetworks(networkProjectName)
-		if err != nil && !response.IsNotFoundError(err) {
-			return err
-		}
-
-		for _, networkName := range networkNames {
-			found := false
-
-			for _, reqNetwork := range reqNetworks {
-				if reqNetwork.Name != networkName || reqNetwork.Project != networkProjectName {
-					continue
-				}
-
-				found = true
-
-				_, network, _, err := cluster.GetNetworkInAnyState(networkProjectName, networkName)
-				if err != nil {
-					return err
-				}
-
-				if reqNetwork.Type != network.Type {
-					return fmt.Errorf("Mismatching type for network %q in project %q", networkName, networkProjectName)
-				}
-
-				// Exclude the keys which are node-specific.
-				exclude := db.NodeSpecificNetworkConfig
-				err = localUtil.CompareConfigs(network.Config, reqNetwork.Config, exclude)
-				if err != nil {
-					return fmt.Errorf("Mismatching config for network %q in project %q: %w", networkName, networkProjectName, err)
-				}
-
-				break
-			}
-
-			if !found {
-				return fmt.Errorf("Missing network %q in project %q", networkName, networkProjectName)
-			}
-		}
+		return err
 	}
 
 	return nil

--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -622,18 +622,31 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Get all defined storage pools and networks, so they can be compared to the ones in the cluster.
 		pools := []api.StoragePool{}
-		poolNames, err := s.DB.Cluster.GetStoragePoolNames()
+		var poolNames []string
+
+		s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			poolNames, err = tx.GetStoragePoolNames(ctx)
+
+			return err
+		})
 		if err != nil && !response.IsNotFoundError(err) {
 			return err
 		}
 
-		for _, name := range poolNames {
-			_, pool, _, err := s.DB.Cluster.GetStoragePoolInAnyState(name)
-			if err != nil {
-				return err
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			for _, name := range poolNames {
+				_, pool, _, err := tx.GetStoragePoolInAnyState(ctx, name)
+				if err != nil {
+					return err
+				}
+
+				pools = append(pools, *pool)
 			}
 
-			pools = append(pools, *pool)
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 
 		// Get a list of projects for networks.
@@ -2111,8 +2124,14 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		// Delete all the pools on this node
-		pools, err := s.DB.Cluster.GetStoragePoolNames()
+		var pools []string
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Delete all the pools on this node
+			pools, err = tx.GetStoragePoolNames(ctx)
+
+			return err
+		})
 		if err != nil && !response.IsNotFoundError(err) {
 			return response.SmartError(err)
 		}
@@ -2766,7 +2785,14 @@ type internalClusterPostHandoverRequest struct {
 }
 
 func clusterCheckStoragePoolsMatch(cluster *db.Cluster, reqPools []api.StoragePool) error {
-	poolNames, err := cluster.GetCreatedStoragePoolNames()
+	var err error
+	var poolNames []string
+
+	err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		poolNames, err = tx.GetCreatedStoragePoolNames(ctx)
+
+		return err
+	})
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
@@ -2779,7 +2805,14 @@ func clusterCheckStoragePoolsMatch(cluster *db.Cluster, reqPools []api.StoragePo
 			}
 
 			found = true
-			_, pool, _, err := cluster.GetStoragePoolInAnyState(name)
+
+			var pool *api.StoragePool
+
+			err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				_, pool, _, err = tx.GetStoragePoolInAnyState(ctx, name)
+
+				return err
+			})
 			if err != nil {
 				return err
 			}

--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -2263,7 +2263,9 @@ func updateClusterCertificate(ctx context.Context, s *state.State, gateway *clus
 		var err error
 
 		revert.Add(func() {
-			_ = s.DB.Cluster.UpsertWarningLocalNode("", -1, -1, warningtype.UnableToUpdateClusterCertificate, err.Error())
+			_ = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpsertWarningLocalNode(ctx, "", -1, -1, warningtype.UnableToUpdateClusterCertificate, err.Error())
+			})
 		})
 
 		oldCertBytes, err := os.ReadFile(internalUtil.VarPath("cluster.crt"))

--- a/cmd/incusd/api_internal.go
+++ b/cmd/incusd/api_internal.go
@@ -185,7 +185,9 @@ func internalCreateWarning(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Invalid entity type"))
 	}
 
-	err = d.State().DB.Cluster.UpsertWarning(req.Location, req.Project, req.EntityTypeCode, req.EntityID, warningtype.Type(req.TypeCode), req.Message)
+	err = d.State().DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.UpsertWarning(ctx, req.Location, req.Project, req.EntityTypeCode, req.EntityID, warningtype.Type(req.TypeCode), req.Message)
+	})
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to create warning: %w", err))
 	}

--- a/cmd/incusd/api_internal.go
+++ b/cmd/incusd/api_internal.go
@@ -737,7 +737,13 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 		}
 	}
 
-	profiles, err := s.DB.Cluster.GetProfiles(projectName, backupConf.Container.Profiles)
+	var profiles []api.Profile
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		profiles, err = tx.GetProfiles(ctx, projectName, backupConf.Container.Profiles)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed loading profiles for instance: %w", err)
 	}
@@ -839,7 +845,11 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 			return err
 		}
 
-		profiles, err := s.DB.Cluster.GetProfiles(projectName, snap.Profiles)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			profiles, err = tx.GetProfiles(ctx, projectName, snap.Profiles)
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed loading profiles for instance snapshot %q: %w", snapInstName, err)
 		}

--- a/cmd/incusd/api_internal.go
+++ b/cmd/incusd/api_internal.go
@@ -703,8 +703,12 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 		return fmt.Errorf(`Storage volume for instance %q already exists in the database`, backupConf.Container.Name)
 	}
 
-	// Check if an entry for the instance already exists in the db.
-	_, err = s.DB.Cluster.GetInstanceID(projectName, backupConf.Container.Name)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check if an entry for the instance already exists in the db.
+		_, err := tx.GetInstanceID(ctx, projectName, backupConf.Container.Name)
+
+		return err
+	})
 	if err != nil && !response.IsNotFoundError(err) {
 		return err
 	}
@@ -813,7 +817,9 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 		}
 
 		if snapErr == nil {
-			err := s.DB.Cluster.DeleteInstance(projectName, snapInstName)
+			err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.DeleteInstance(ctx, projectName, snapInstName)
+			})
 			if err != nil {
 				return err
 			}

--- a/cmd/incusd/api_internal.go
+++ b/cmd/incusd/api_internal.go
@@ -730,8 +730,10 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 			return fmt.Errorf(`The type %q of the storage volume is not identical to the instance's type %q`, dbVolume.Type, backupConf.Volume.Type)
 		}
 
-		// Remove the storage volume db entry for the instance since force was specified.
-		err := s.DB.Cluster.RemoveStoragePoolVolume(projectName, backupConf.Container.Name, instanceDBVolType, pool.ID())
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Remove the storage volume db entry for the instance since force was specified.
+			return tx.RemoveStoragePoolVolume(ctx, projectName, backupConf.Container.Name, instanceDBVolType, pool.ID())
+		})
 		if err != nil {
 			return err
 		}
@@ -836,7 +838,9 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 		}
 
 		if dbVolume != nil {
-			err := s.DB.Cluster.RemoveStoragePoolVolume(projectName, snapInstName, instanceDBVolType, pool.ID())
+			err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.RemoveStoragePoolVolume(ctx, projectName, snapInstName, instanceDBVolType, pool.ID())
+			})
 			if err != nil {
 				return err
 			}

--- a/cmd/incusd/api_internal.go
+++ b/cmd/incusd/api_internal.go
@@ -793,8 +793,12 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 	for _, snap := range existingSnapshots {
 		snapInstName := fmt.Sprintf("%s%s%s", backupConf.Container.Name, internalInstance.SnapshotDelimiter, snap.Name)
 
-		// Check if an entry for the snapshot already exists in the db.
-		_, snapErr := s.DB.Cluster.GetInstanceSnapshotID(projectName, backupConf.Container.Name, snap.Name)
+		snapErr := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Check if an entry for the snapshot already exists in the db.
+			_, err := tx.GetInstanceSnapshotID(ctx, projectName, backupConf.Container.Name, snap.Name)
+
+			return err
+		})
 		if snapErr != nil && !response.IsNotFoundError(snapErr) {
 			return snapErr
 		}

--- a/cmd/incusd/api_metrics.go
+++ b/cmd/incusd/api_metrics.go
@@ -190,16 +190,18 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 	hostInterfaces, _ := net.Interfaces()
 
 	var instances []instance.Instance
-	err = s.DB.Cluster.InstanceList(r.Context(), func(dbInst db.InstanceArgs, p api.Project) error {
-		inst, err := instance.Load(s, dbInst, p)
-		if err != nil {
-			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
-		}
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(dbInst db.InstanceArgs, p api.Project) error {
+			inst, err := instance.Load(s, dbInst, p)
+			if err != nil {
+				return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
+			}
 
-		instances = append(instances, inst)
+			instances = append(instances, inst)
 
-		return nil
-	}, projectsToFetch...)
+			return nil
+		}, projectsToFetch...)
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/cmd/incusd/api_project.go
+++ b/cmd/incusd/api_project.go
@@ -1499,8 +1499,14 @@ func projectValidateRestrictedSubnets(s *state.State, value string) error {
 			return fmt.Errorf("Not an IP network address %q", subnetStr)
 		}
 
-		// Check uplink exists and load config to compare subnets.
-		_, uplink, _, err := s.DB.Cluster.GetNetworkInAnyState(api.ProjectDefaultName, uplinkName)
+		var uplink *api.Network
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Check uplink exists and load config to compare subnets.
+			_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, uplinkName)
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Invalid uplink network %q: %w", uplinkName, err)
 		}

--- a/cmd/incusd/backup.go
+++ b/cmd/incusd/backup.go
@@ -54,7 +54,9 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 	}
 
 	// Create the database entry.
-	err = s.DB.Cluster.CreateInstanceBackup(args)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.CreateInstanceBackup(ctx, args)
+	})
 	if err != nil {
 		if err == db.ErrAlreadyDefined {
 			return fmt.Errorf("Backup %q already exists", args.Name)
@@ -63,7 +65,11 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		return fmt.Errorf("Insert backup info into database: %w", err)
 	}
 
-	revert.Add(func() { _ = s.DB.Cluster.DeleteInstanceBackup(args.Name) })
+	revert.Add(func() {
+		_ = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.DeleteInstanceBackup(ctx, args.Name)
+		})
+	})
 
 	// Get the backup struct.
 	b, err := instance.BackupLoadByName(s, sourceInst.Project().Name, args.Name)
@@ -349,8 +355,14 @@ func pruneExpiredBackupsTask(d *Daemon) (task.Func, task.Schedule) {
 }
 
 func pruneExpiredInstanceBackups(ctx context.Context, s *state.State) error {
+	var backups []db.InstanceBackup
+
 	// Get the list of expired backups.
-	backups, err := s.DB.Cluster.GetExpiredInstanceBackups()
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		backups, err = tx.GetExpiredInstanceBackups(ctx)
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve the list of expired instance backups: %w", err)
 	}
@@ -391,7 +403,9 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 	}
 
 	// Create the database entry.
-	err = s.DB.Cluster.CreateStoragePoolVolumeBackup(args)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.CreateStoragePoolVolumeBackup(ctx, args)
+	})
 	if err != nil {
 		if err == db.ErrAlreadyDefined {
 			return fmt.Errorf("Backup %q already exists", args.Name)
@@ -400,9 +414,18 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 		return fmt.Errorf("Failed creating backup record: %w", err)
 	}
 
-	revert.Add(func() { _ = s.DB.Cluster.DeleteStoragePoolVolumeBackup(args.Name) })
+	revert.Add(func() {
+		_ = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.DeleteStoragePoolVolumeBackup(ctx, args.Name)
+		})
+	})
 
-	backupRow, err := s.DB.Cluster.GetStoragePoolVolumeBackup(projectName, poolName, args.Name)
+	var backupRow db.StoragePoolVolumeBackup
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		backupRow, err = tx.GetStoragePoolVolumeBackup(ctx, projectName, poolName, args.Name)
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed getting backup record: %w", err)
 	}

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1729,7 +1729,16 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 
 			// Unmount storage pools after instances stopped.
 			logger.Info("Stopping storage pools")
-			pools, err := s.DB.Cluster.GetStoragePoolNames()
+
+			var pools []string
+
+			err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				var err error
+
+				pools, err = tx.GetStoragePoolNames(ctx)
+
+				return err
+			})
 			if err != nil && !response.IsNotFoundError(err) {
 				logger.Error("Failed to get storage pools", logger.Ctx{"err": err})
 			}

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -257,7 +257,15 @@ func allowPermission(objectType auth.ObjectType, entitlement auth.Entitlement, m
 		// Expansion function to deal with partial fingerprints.
 		expandFingerprint := func(projectName string, fingerprint string) string {
 			if objectType == auth.ObjectTypeImage {
-				_, imgInfo, err := d.db.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &projectName})
+				var imgInfo *api.Image
+
+				err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					var err error
+
+					_, imgInfo, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
+
+					return err
+				})
 				if err != nil {
 					return fingerprint
 				}

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1532,13 +1532,17 @@ func (d *Daemon) init() error {
 
 	close(d.setupChan)
 
-	// Create warnings that have been collected
-	for _, w := range dbWarnings {
-		err := d.db.Cluster.UpsertWarningLocalNode("", -1, -1, warningtype.Type(w.TypeCode), w.LastMessage)
-		if err != nil {
-			logger.Warn("Failed to create warning", logger.Ctx{"err": err})
+	_ = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Create warnings that have been collected
+		for _, w := range dbWarnings {
+			err := tx.UpsertWarningLocalNode(ctx, "", -1, -1, warningtype.Type(w.TypeCode), w.LastMessage)
+			if err != nil {
+				logger.Warn("Failed to create warning", logger.Ctx{"err": err})
+			}
 		}
-	}
+
+		return nil
+	})
 
 	// Resolve warnings older than the daemon start time
 	err = warnings.ResolveWarningsByLocalNodeOlderThan(d.db.Cluster, d.startTime)
@@ -2195,7 +2199,9 @@ func (d *Daemon) heartbeatHandler(w http.ResponseWriter, r *http.Request, isLead
 			logger.Warn("Time skew detected between leader and local", logger.Ctx{"leaderTime": hbData.Time, "localTime": now})
 
 			if d.db.Cluster != nil {
-				err := d.db.Cluster.UpsertWarningLocalNode("", -1, -1, warningtype.ClusterTimeSkew, fmt.Sprintf("leaderTime: %s, localTime: %s", hbData.Time, now))
+				err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					return tx.UpsertWarningLocalNode(ctx, "", -1, -1, warningtype.ClusterTimeSkew, fmt.Sprintf("leaderTime: %s, localTime: %s", hbData.Time, now))
+				})
 				if err != nil {
 					logger.Warn("Failed to create cluster time skew warning", logger.Ctx{"err": err})
 				}

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1522,8 +1522,10 @@ func (d *Daemon) init() error {
 		updateCertificateCache(d)
 	}
 
-	// Remove volatile.last_state.ready key as we don't know if the instances are ready.
-	err = d.db.Cluster.DeleteReadyStateFromLocalInstances()
+	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Remove volatile.last_state.ready key as we don't know if the instances are ready.
+		return tx.DeleteReadyStateFromLocalInstances(ctx)
+	})
 	if err != nil {
 		return fmt.Errorf("Failed deleting volatile.last_state.ready: %w", err)
 	}

--- a/cmd/incusd/daemon_images.go
+++ b/cmd/incusd/daemon_images.go
@@ -157,11 +157,23 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 		}
 	}
 
-	// Check if the image already exists in this project (partial hash match).
-	_, imgInfo, err := s.DB.Cluster.GetImage(fp, cluster.ImageFilter{Project: &args.ProjectName})
+	var imgInfo *api.Image
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check if the image already exists in this project (partial hash match).
+		_, imgInfo, err = tx.GetImage(ctx, fp, cluster.ImageFilter{Project: &args.ProjectName})
+
+		return err
+	})
 	if err == nil {
-		// Check if the image is available locally or it's on another node.
-		nodeAddress, err := s.DB.Cluster.LocateImage(imgInfo.Fingerprint)
+		var nodeAddress string
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Check if the image is available locally or it's on another node.
+			nodeAddress, err = tx.LocateImage(ctx, imgInfo.Fingerprint)
+
+			return err
+		})
 		if err != nil {
 			return nil, fmt.Errorf("Failed locating image %q in the cluster: %w", imgInfo.Fingerprint, err)
 		}
@@ -173,48 +185,66 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 				return nil, fmt.Errorf("Failed transferring image %q from %q: %w", imgInfo.Fingerprint, nodeAddress, err)
 			}
 
-			// As the image record already exists in the project, just add the node ID to the image.
-			err = s.DB.Cluster.AddImageToLocalNode(args.ProjectName, imgInfo.Fingerprint)
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				// As the image record already exists in the project, just add the node ID to the image.
+				return tx.AddImageToLocalNode(ctx, args.ProjectName, imgInfo.Fingerprint)
+			})
 			if err != nil {
 				return nil, fmt.Errorf("Failed adding transferred image %q to local cluster member: %w", imgInfo.Fingerprint, err)
 			}
 		}
 	} else if response.IsNotFoundError(err) {
-		// Check if the image already exists in some other project.
-		_, imgInfo, err = s.DB.Cluster.GetImageFromAnyProject(fp)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Check if the image already exists in some other project.
+			_, imgInfo, err = tx.GetImageFromAnyProject(ctx, fp)
+
+			return err
+		})
 		if err == nil {
-			// Check if the image is available locally or it's on another node. Do this before creating
-			// the missing DB record so we don't include ourself in the search results.
-			nodeAddress, err := s.DB.Cluster.LocateImage(imgInfo.Fingerprint)
+			var nodeAddress string
+
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				// Check if the image is available locally or it's on another node. Do this before creating
+				// the missing DB record so we don't include ourself in the search results.
+				nodeAddress, err = tx.LocateImage(ctx, imgInfo.Fingerprint)
+
+				return err
+			})
 			if err != nil {
 				return nil, fmt.Errorf("Locate image %q in the cluster: %w", imgInfo.Fingerprint, err)
 			}
 
-			// We need to insert the database entry for this project, including the node ID entry.
-			err = s.DB.Cluster.CreateImage(args.ProjectName, imgInfo.Fingerprint, imgInfo.Filename, imgInfo.Size, args.Public, imgInfo.AutoUpdate, imgInfo.Architecture, imgInfo.CreatedAt, imgInfo.ExpiresAt, imgInfo.Properties, imgInfo.Type, nil)
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				// We need to insert the database entry for this project, including the node ID entry.
+				return tx.CreateImage(ctx, args.ProjectName, imgInfo.Fingerprint, imgInfo.Filename, imgInfo.Size, args.Public, imgInfo.AutoUpdate, imgInfo.Architecture, imgInfo.CreatedAt, imgInfo.ExpiresAt, imgInfo.Properties, imgInfo.Type, nil)
+			})
 			if err != nil {
 				return nil, fmt.Errorf("Failed creating image record for project: %w", err)
 			}
 
 			// Mark the image as "cached" if downloading for an instance.
 			if args.SetCached {
-				err := s.DB.Cluster.SetImageCachedAndLastUseDate(args.ProjectName, imgInfo.Fingerprint, time.Now().UTC())
+				err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					return tx.SetImageCachedAndLastUseDate(ctx, args.ProjectName, imgInfo.Fingerprint, time.Now().UTC())
+				})
 				if err != nil {
 					return nil, fmt.Errorf("Failed setting cached flag and last use date: %w", err)
 				}
 			}
 
 			var id int
-			id, imgInfo, err = s.DB.Cluster.GetImage(fp, cluster.ImageFilter{Project: &args.ProjectName})
+
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				id, imgInfo, err = tx.GetImage(ctx, fp, cluster.ImageFilter{Project: &args.ProjectName})
+				if err != nil {
+					return err
+				}
+
+				return tx.CreateImageSource(ctx, id, args.Server, args.Protocol, args.Certificate, alias)
+			})
 			if err != nil {
 				return nil, err
 			}
-
-			err = s.DB.Cluster.CreateImageSource(id, args.Server, args.Protocol, args.Certificate, alias)
-			if err != nil {
-				return nil, err
-			}
-
 			// Transfer image if needed (after database record has been created above).
 			if nodeAddress != "" {
 				// The image is available from another node, let's try to import it.
@@ -244,8 +274,14 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 			return nil, err
 		}
 
-		// Check if the image is already in the pool.
-		poolIDs, err := s.DB.Cluster.GetPoolsWithImage(info.Fingerprint)
+		var poolIDs []int64
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Check if the image is already in the pool.
+			poolIDs, err = tx.GetPoolsWithImage(ctx, info.Fingerprint)
+
+			return err
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -513,8 +549,10 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 		info.AutoUpdate = args.AutoUpdate
 	}
 
-	// Create the database entry
-	err = s.DB.Cluster.CreateImage(args.ProjectName, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, nil)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Create the database entry
+		return tx.CreateImage(ctx, args.ProjectName, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, nil)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating image record: %w", err)
 	}
@@ -540,12 +578,14 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 
 	// Record the image source
 	if alias != fp {
-		id, _, err := s.DB.Cluster.GetImage(fp, cluster.ImageFilter{Project: &args.ProjectName})
-		if err != nil {
-			return nil, err
-		}
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			id, _, err := tx.GetImage(ctx, fp, cluster.ImageFilter{Project: &args.ProjectName})
+			if err != nil {
+				return err
+			}
 
-		err = s.DB.Cluster.CreateImageSource(id, args.Server, protocol, args.Certificate, alias)
+			return tx.CreateImageSource(ctx, id, args.Server, protocol, args.Certificate, alias)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -561,7 +601,9 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 
 	// Mark the image as "cached" if downloading for an instance
 	if args.SetCached {
-		err := s.DB.Cluster.SetImageCachedAndLastUseDate(args.ProjectName, fp, time.Now().UTC())
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.SetImageCachedAndLastUseDate(ctx, args.ProjectName, fp, time.Now().UTC())
+		})
 		if err != nil {
 			return nil, fmt.Errorf("Failed setting cached flag and last use date: %w", err)
 		}

--- a/cmd/incusd/daemon_images.go
+++ b/cmd/incusd/daemon_images.go
@@ -268,8 +268,14 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 
 		ctxMap["pool"] = args.StoragePool
 
-		// Get the ID of the target storage pool.
-		poolID, err := s.DB.Cluster.GetStoragePoolID(args.StoragePool)
+		var poolID int64
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Get the ID of the target storage pool.
+			poolID, err = tx.GetStoragePoolID(ctx, args.StoragePool)
+
+			return err
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/incusd/daemon_storage.go
+++ b/cmd/incusd/daemon_storage.go
@@ -154,8 +154,14 @@ func daemonStorageValidate(s *state.State, target string) error {
 		return err
 	}
 
-	// Validate pool exists.
-	poolID, _, _, err := s.DB.Cluster.GetStoragePool(poolName)
+	var poolID int64
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Validate pool exists.
+		poolID, _, _, err = tx.GetStoragePool(ctx, poolName)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Unable to load storage pool %q: %w", poolName, err)
 	}

--- a/cmd/incusd/daemon_storage.go
+++ b/cmd/incusd/daemon_storage.go
@@ -183,7 +183,13 @@ func daemonStorageValidate(s *state.State, target string) error {
 		return err
 	}
 
-	snapshots, err := s.DB.Cluster.GetLocalStoragePoolVolumeSnapshotsWithType(api.ProjectDefaultName, volumeName, db.StoragePoolVolumeTypeCustom, poolID)
+	var snapshots []db.StorageVolumeArgs
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		snapshots, err = tx.GetLocalStoragePoolVolumeSnapshotsWithType(ctx, api.ProjectDefaultName, volumeName, db.StoragePoolVolumeTypeCustom, poolID)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Unable to load storage volume snapshots %q in %q project: %w", target, api.ProjectDefaultName, err)
 	}

--- a/cmd/incusd/images.go
+++ b/cmd/incusd/images.go
@@ -372,7 +372,11 @@ func imgPostInstanceInfo(s *state.State, r *http.Request, req api.ImagesPost, op
 	info.Fingerprint = fmt.Sprintf("%x", sha256.Sum(nil))
 	info.CreatedAt = time.Now().UTC()
 
-	_, _, err = s.DB.Cluster.GetImage(info.Fingerprint, dbCluster.ImageFilter{Project: &projectName})
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_, _, err = tx.GetImage(ctx, info.Fingerprint, dbCluster.ImageFilter{Project: &projectName})
+
+		return err
+	})
 	if !response.IsNotFoundError(err) {
 		if err != nil {
 			return nil, err
@@ -391,8 +395,10 @@ func imgPostInstanceInfo(s *state.State, r *http.Request, req api.ImagesPost, op
 	info.Architecture, _ = osarch.ArchitectureName(c.Architecture())
 	info.Properties = meta.Properties
 
-	// Create the database entry
-	err = s.DB.Cluster.CreateImage(c.Project().Name, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, nil)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Create the database entry
+		return tx.CreateImage(ctx, c.Project().Name, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, nil)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +435,13 @@ func imgPostRemoteInfo(s *state.State, r *http.Request, req api.ImagesPost, op *
 		return nil, err
 	}
 
-	id, info, err := s.DB.Cluster.GetImage(info.Fingerprint, dbCluster.ImageFilter{Project: &project})
+	var id int
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		id, info, err = tx.GetImage(ctx, info.Fingerprint, dbCluster.ImageFilter{Project: &project})
+
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +470,9 @@ func imgPostRemoteInfo(s *state.State, r *http.Request, req api.ImagesPost, op *
 
 	// Update the DB record if needed
 	if req.Public || req.AutoUpdate || req.Filename != "" || len(req.Properties) > 0 || len(req.Profiles) > 0 {
-		err = s.DB.Cluster.UpdateImage(id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, project, profileIds)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.UpdateImage(ctx, id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, project, profileIds)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -528,7 +542,13 @@ func imgPostURLInfo(s *state.State, r *http.Request, req api.ImagesPost, op *ope
 		return nil, err
 	}
 
-	id, info, err := s.DB.Cluster.GetImage(info.Fingerprint, dbCluster.ImageFilter{Project: &project})
+	var id int
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		id, info, err = tx.GetImage(ctx, info.Fingerprint, dbCluster.ImageFilter{Project: &project})
+
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +559,9 @@ func imgPostURLInfo(s *state.State, r *http.Request, req api.ImagesPost, op *ope
 	}
 
 	if req.Public || req.AutoUpdate || req.Filename != "" || len(req.Properties) > 0 {
-		err = s.DB.Cluster.UpdateImage(id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, "", nil)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.UpdateImage(ctx, id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, "", nil)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -756,8 +778,14 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 		}
 	}
 
-	// Check if the image already exists
-	exists, err := s.DB.Cluster.ImageExists(project, info.Fingerprint)
+	var exists bool
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check if the image already exists
+		exists, err = tx.ImageExists(ctx, project, info.Fingerprint)
+
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -766,7 +794,9 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 		// Do not create a database entry if the request is coming from the internal
 		// cluster communications for image synchronization
 		if isClusterNotification(r) {
-			err := s.DB.Cluster.AddImageToLocalNode(project, info.Fingerprint)
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.AddImageToLocalNode(ctx, project, info.Fingerprint)
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -779,8 +809,10 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 			info.Public = public.(bool)
 		}
 
-		// Create the database entry
-		err = s.DB.Cluster.CreateImage(project, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, profileIds)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Create the database entry
+			return tx.CreateImage(ctx, project, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, profileIds)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -1655,7 +1687,13 @@ func autoUpdateImages(ctx context.Context, s *state.State) error {
 	for fingerprint, images := range imageMap {
 		skipFingerprint := false
 
-		nodes, err := s.DB.Cluster.GetNodesWithImageAndAutoUpdate(fingerprint, true)
+		var nodes []string
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			nodes, err = tx.GetNodesWithImageAndAutoUpdate(ctx, fingerprint, true)
+
+			return err
+		})
 		if err != nil {
 			logger.Error("Error getting cluster members for image auto-update", logger.Ctx{"fingerprint": fingerprint, "err": err})
 			continue
@@ -1713,7 +1751,13 @@ func autoUpdateImages(ctx context.Context, s *state.State) error {
 				filter.Public = &image.Public
 			}
 
-			_, imageInfo, err := s.DB.Cluster.GetImage(image.Fingerprint, filter)
+			var imageInfo *api.Image
+
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				_, imageInfo, err = tx.GetImage(ctx, image.Fingerprint, filter)
+
+				return err
+			})
 			if err != nil {
 				logger.Error("Failed to get image", logger.Ctx{"err": err, "project": image.Project, "fingerprint": image.Fingerprint})
 				continue
@@ -1750,8 +1794,10 @@ func autoUpdateImages(ctx context.Context, s *state.State) error {
 			}
 
 			for _, ID := range deleteIDs {
-				// Remove the database entry for the image after distributing to cluster members.
-				err = s.DB.Cluster.DeleteImage(ID)
+				err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					// Remove the database entry for the image after distributing to cluster members.
+					return tx.DeleteImage(ctx, ID)
+				})
 				if err != nil {
 					logger.Error("Error deleting old image from database", logger.Ctx{"err": err, "fingerprint": fingerprint, "ID": ID})
 				}
@@ -1806,18 +1852,28 @@ func distributeImage(ctx context.Context, s *state.State, nodes []string, oldFin
 	// Skip own node
 	localClusterAddress := s.LocalConfig.ClusterAddress()
 
-	// Get the IDs of all storage pools on which a storage volume
-	// for the requested image currently exists.
-	poolIDs, err := s.DB.Cluster.GetPoolsWithImage(newImage.Fingerprint)
-	if err != nil {
-		logger.Error("Error getting image storage pools", logger.Ctx{"err": err, "fingerprint": oldFingerprint})
-		return err
-	}
+	var poolIDs []int64
+	var poolNames []string
 
-	// Translate the IDs to poolNames.
-	poolNames, err := s.DB.Cluster.GetPoolNamesFromIDs(poolIDs)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get the IDs of all storage pools on which a storage volume
+		// for the requested image currently exists.
+		poolIDs, err = tx.GetPoolsWithImage(ctx, newImage.Fingerprint)
+		if err != nil {
+			logger.Error("Error getting image storage pools", logger.Ctx{"err": err, "fingerprint": oldFingerprint})
+			return err
+		}
+
+		// Translate the IDs to poolNames.
+		poolNames, err = tx.GetPoolNamesFromIDs(ctx, poolIDs)
+		if err != nil {
+			logger.Error("Error getting image storage pools", logger.Ctx{"err": err, "fingerprint": oldFingerprint})
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
-		logger.Error("Error getting image storage pools", logger.Ctx{"err": err, "fingerprint": oldFingerprint})
 		return err
 	}
 
@@ -2005,18 +2061,28 @@ func autoUpdateImage(ctx context.Context, s *state.State, op *operations.Operati
 		return nil, err
 	}
 
-	// Get the IDs of all storage pools on which a storage volume
-	// for the requested image currently exists.
-	poolIDs, err := s.DB.Cluster.GetPoolsWithImage(fingerprint)
-	if err != nil {
-		logger.Error("Error getting image pools", logger.Ctx{"err": err, "fingerprint": fingerprint})
-		return nil, err
-	}
+	var poolIDs []int64
+	var poolNames []string
 
-	// Translate the IDs to poolNames.
-	poolNames, err := s.DB.Cluster.GetPoolNamesFromIDs(poolIDs)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get the IDs of all storage pools on which a storage volume
+		// for the requested image currently exists.
+		poolIDs, err = tx.GetPoolsWithImage(ctx, fingerprint)
+		if err != nil {
+			logger.Error("Error getting image pools", logger.Ctx{"err": err, "fingerprint": fingerprint})
+			return err
+		}
+
+		// Translate the IDs to poolNames.
+		poolNames, err = tx.GetPoolNamesFromIDs(ctx, poolIDs)
+		if err != nil {
+			logger.Error("Error getting image pools", logger.Ctx{"err": err, "fingerprint": fingerprint})
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
-		logger.Error("Error getting image pools", logger.Ctx{"err": err, "fingerprint": fingerprint})
 		return nil, err
 	}
 
@@ -2076,14 +2142,22 @@ func autoUpdateImage(ctx context.Context, s *state.State, op *operations.Operati
 			continue
 		}
 
-		newID, _, err := s.DB.Cluster.GetImage(hash, dbCluster.ImageFilter{Project: &projectName})
+		var newID int
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			newID, _, err = tx.GetImage(ctx, hash, dbCluster.ImageFilter{Project: &projectName})
+
+			return err
+		})
 		if err != nil {
 			logger.Error("Error loading image", logger.Ctx{"err": err, "fingerprint": hash})
 			continue
 		}
 
 		if info.Cached {
-			err = s.DB.Cluster.SetImageCachedAndLastUseDate(projectName, hash, info.LastUsedAt)
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.SetImageCachedAndLastUseDate(ctx, projectName, hash, info.LastUsedAt)
+			})
 			if err != nil {
 				logger.Error("Error setting cached flag and last use date", logger.Ctx{"err": err, "fingerprint": hash})
 				continue
@@ -2103,13 +2177,17 @@ func autoUpdateImage(ctx context.Context, s *state.State, op *operations.Operati
 			}
 		}
 
-		err = s.DB.Cluster.MoveImageAlias(id, newID)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.MoveImageAlias(ctx, id, newID)
+		})
 		if err != nil {
 			logger.Error("Error moving aliases", logger.Ctx{"err": err, "fingerprint": hash})
 			continue
 		}
 
-		err = s.DB.Cluster.CopyDefaultImageProfiles(id, newID)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.CopyDefaultImageProfiles(ctx, id, newID)
+		})
 		if err != nil {
 			logger.Error("Copying default profiles", logger.Ctx{"err": err, "fingerprint": hash})
 		}
@@ -2396,8 +2474,10 @@ func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Oper
 				continue
 			}
 
-			// Remove the database entry for the image.
-			err = s.DB.Cluster.DeleteImage(dbImage.ID)
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				// Remove the database entry for the image.
+				return tx.DeleteImage(ctx, dbImage.ID)
+			})
 			if err != nil {
 				return fmt.Errorf("Error deleting image %q in project %q from database: %w", fingerprint, dbImage.Project, err)
 			}
@@ -2415,14 +2495,24 @@ func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Oper
 			continue
 		}
 
-		// Get the IDs of all storage pools on which a storage volume for the image currently exists.
-		poolIDs, err := s.DB.Cluster.GetPoolsWithImage(fingerprint)
-		if err != nil {
-			continue
-		}
+		var poolIDs []int64
+		var poolNames []string
 
-		// Translate the IDs to poolNames.
-		poolNames, err := s.DB.Cluster.GetPoolNamesFromIDs(poolIDs)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Get the IDs of all storage pools on which a storage volume for the image currently exists.
+			poolIDs, err = tx.GetPoolsWithImage(ctx, fingerprint)
+			if err != nil {
+				return err
+			}
+
+			// Translate the IDs to poolNames.
+			poolNames, err = tx.GetPoolNamesFromIDs(ctx, poolIDs)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
 		if err != nil {
 			continue
 		}
@@ -2493,9 +2583,16 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// Use the fingerprint we received in a LIKE query and use the full
-	// fingerprint we receive from the database in all further queries.
-	imgID, imgInfo, err := s.DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &projectName})
+	var imgID int
+	var imgInfo *api.Image
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Use the fingerprint we received in a LIKE query and use the full
+		// fingerprint we receive from the database in all further queries.
+		imgID, imgInfo, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2510,9 +2607,15 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 
 		defer unlock()
 
-		// Check image still exists and another request hasn't removed it since we resolved the image
-		// fingerprint above.
-		exist, err := s.DB.Cluster.ImageExists(projectName, imgInfo.Fingerprint)
+		var exist bool
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Check image still exists and another request hasn't removed it since we resolved the image
+			// fingerprint above.
+			exist, err = tx.ImageExists(ctx, projectName, imgInfo.Fingerprint)
+
+			return err
+		})
 		if err != nil {
 			return err
 		}
@@ -2522,17 +2625,25 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if !isClusterNotification(r) {
-			// Check if the image being deleted is actually still
-			// referenced by other projects. In that case we don't want to
-			// physically delete it just yet, but just to remove the
-			// relevant database entry.
-			referenced, err := s.DB.Cluster.ImageIsReferencedByOtherProjects(projectName, imgInfo.Fingerprint)
+			var referenced bool
+
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				// Check if the image being deleted is actually still
+				// referenced by other projects. In that case we don't want to
+				// physically delete it just yet, but just to remove the
+				// relevant database entry.
+				referenced, err = tx.ImageIsReferencedByOtherProjects(ctx, projectName, imgInfo.Fingerprint)
+
+				return err
+			})
 			if err != nil {
 				return err
 			}
 
 			if referenced {
-				err := s.DB.Cluster.DeleteImage(imgID)
+				err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					return tx.DeleteImage(ctx, imgID)
+				})
 				if err != nil {
 					return fmt.Errorf("Error deleting image info from the database: %w", err)
 				}
@@ -2564,13 +2675,23 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 			}
 		}
 
-		// Delete the pool volumes.
-		poolIDs, err := s.DB.Cluster.GetPoolsWithImage(imgInfo.Fingerprint)
-		if err != nil {
-			return err
-		}
+		var poolIDs []int64
+		var poolNames []string
 
-		poolNames, err := s.DB.Cluster.GetPoolNamesFromIDs(poolIDs)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Delete the pool volumes.
+			poolIDs, err = tx.GetPoolsWithImage(ctx, imgInfo.Fingerprint)
+			if err != nil {
+				return err
+			}
+
+			poolNames, err = tx.GetPoolNamesFromIDs(ctx, poolIDs)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
 		if err != nil {
 			return err
 		}
@@ -2592,7 +2713,9 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 
 		// Remove the database entry.
 		if !isClusterNotification(r) {
-			err = s.DB.Cluster.DeleteImage(imgID)
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.DeleteImage(ctx, imgID)
+			})
 			if err != nil {
 				return fmt.Errorf("Error deleting image info from the database: %w", err)
 			}
@@ -2877,7 +3000,14 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	id, info, err := s.DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &projectName})
+	var id int
+	var info *api.Image
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		id, info, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2917,7 +3047,9 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 		profileIds[i] = profileID
 	}
 
-	err = s.DB.Cluster.UpdateImage(id, info.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, req.Properties, projectName, profileIds)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.UpdateImage(ctx, id, info.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, req.Properties, projectName, profileIds)
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2972,7 +3104,14 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	id, info, err := s.DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &projectName})
+	var id int
+	var info *api.Image
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		id, info, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3029,7 +3168,9 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 		info.Properties = properties
 	}
 
-	err = s.DB.Cluster.UpdateImage(id, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, "", nil)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.UpdateImage(ctx, id, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, "", nil)
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3623,7 +3764,7 @@ func imageAliasPatch(d *Daemon, r *http.Request) response.Response {
 			imgAlias.Description = description
 		}
 
-		imageID, _, err := s.DB.Cluster.GetImage(imgAlias.Target, dbCluster.ImageFilter{Project: &projectName})
+		imageID, _, err := tx.GetImage(ctx, imgAlias.Target, dbCluster.ImageFilter{Project: &projectName})
 		if err != nil {
 			return err
 		}
@@ -3708,12 +3849,7 @@ func imageAliasPost(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		err = s.DB.Cluster.RenameImageAlias(imgAliasID, req.Name)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return tx.RenameImageAlias(ctx, imgAliasID, req.Name)
 	})
 	if err != nil {
 		return response.SmartError(err)
@@ -3795,8 +3931,14 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// Get the image (expand the fingerprint).
-	_, imgInfo, err := s.DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &projectName})
+	var imgInfo *api.Image
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get the image (expand the fingerprint).
+		_, imgInfo, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3833,8 +3975,14 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	// Check if the image is only available on another node.
-	address, err := s.DB.Cluster.LocateImage(imgInfo.Fingerprint)
+	var address string
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check if the image is only available on another node.
+		address, err = tx.LocateImage(ctx, imgInfo.Fingerprint)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3935,8 +4083,12 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// Check if the image exists
-	_, _, err = s.DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &projectName})
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check if the image exists
+		_, _, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -4069,18 +4221,26 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func imageSecret(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	projectName := request.ProjectParam(r)
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	_, imgInfo, err := d.State().DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &projectName})
+	var imgInfo *api.Image
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_, imgInfo, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	return createTokenResponse(d.State(), r, projectName, imgInfo.Fingerprint, nil)
+	return createTokenResponse(s, r, projectName, imgInfo.Fingerprint, nil)
 }
 
 func imageImportFromNode(imagesDir string, client incus.InstanceServer, fingerprint string) error {
@@ -4188,14 +4348,27 @@ func imageRefresh(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	imageID, imageInfo, err := s.DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &projectName})
+	var imageID int
+	var imageInfo *api.Image
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		imageID, imageInfo, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &projectName})
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	// Begin background operation
 	run := func(op *operations.Operation) error {
-		nodes, err := s.DB.Cluster.GetNodesWithImageAndAutoUpdate(fingerprint, true)
+		var nodes []string
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			nodes, err = tx.GetNodesWithImageAndAutoUpdate(ctx, fingerprint, true)
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Error getting cluster members for refreshing image %q in project %q: %w", fingerprint, projectName, err)
 		}
@@ -4213,8 +4386,10 @@ func imageRefresh(d *Daemon, r *http.Request) response.Response {
 				}
 			}
 
-			// Remove the database entry for the image after distributing to cluster members.
-			err = s.DB.Cluster.DeleteImage(imageID)
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				// Remove the database entry for the image after distributing to cluster members.
+				return tx.DeleteImage(ctx, imageID)
+			})
 			if err != nil {
 				logger.Error("Error deleting old image from database", logger.Ctx{"err": err, "fingerprint": fingerprint, "ID": imageID})
 			}
@@ -4289,8 +4464,16 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 }
 
 func autoSyncImages(ctx context.Context, s *state.State) error {
-	// Get all images.
-	imageProjectInfo, err := s.DB.Cluster.GetImages()
+	var imageProjectInfo map[string][]string
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get all images.
+		imageProjectInfo, err = tx.GetImages(ctx)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to query image fingerprints: %w", err)
 	}
@@ -4341,8 +4524,14 @@ func imageSyncBetweenNodes(s *state.State, r *http.Request, project string, fing
 		return err
 	}
 
-	// Check how many nodes already have this image
-	syncNodeAddresses, err := s.DB.Cluster.GetNodesWithImage(fingerprint)
+	var syncNodeAddresses []string
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check how many nodes already have this image
+		syncNodeAddresses, err = tx.GetNodesWithImage(ctx, fingerprint)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to get nodes for the image synchronization: %w", err)
 	}
@@ -4369,8 +4558,14 @@ func imageSyncBetweenNodes(s *state.State, r *http.Request, project string, fing
 
 	source = source.UseProject(project)
 
-	// Get the image.
-	_, image, err := s.DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &project})
+	var image *api.Image
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get the image.
+		_, image, err = tx.GetImage(ctx, fingerprint, dbCluster.ImageFilter{Project: &project})
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to get image: %w", err)
 	}
@@ -4383,8 +4578,14 @@ func imageSyncBetweenNodes(s *state.State, r *http.Request, project string, fing
 
 	// Replicate on as many nodes as needed.
 	for i := 0; i < int(nodeCount); i++ {
-		// Get a list of nodes that do not have the image.
-		addresses, err := s.DB.Cluster.GetNodesWithoutImage(fingerprint)
+		var addresses []string
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Get a list of nodes that do not have the image.
+			addresses, err = tx.GetNodesWithoutImage(ctx, fingerprint)
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed to get nodes for the image synchronization: %w", err)
 		}

--- a/cmd/incusd/images.go
+++ b/cmd/incusd/images.go
@@ -457,15 +457,23 @@ func imgPostRemoteInfo(s *state.State, r *http.Request, req api.ImagesPost, op *
 	}
 
 	profileIds := make([]int64, len(req.Profiles))
-	for i, profile := range req.Profiles {
-		profileID, _, err := s.DB.Cluster.GetProfile(project, profile)
-		if response.IsNotFoundError(err) {
-			return nil, fmt.Errorf("Profile '%s' doesn't exist", profile)
-		} else if err != nil {
-			return nil, err
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		for i, profile := range req.Profiles {
+			profileID, _, err := tx.GetProfile(ctx, project, profile)
+			if response.IsNotFoundError(err) {
+				return fmt.Errorf("Profile '%s' doesn't exist", profile)
+			} else if err != nil {
+				return err
+			}
+
+			profileIds[i] = profileID
 		}
 
-		profileIds[i] = profileID
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	// Update the DB record if needed
@@ -766,15 +774,22 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 		p, _ := url.ParseQuery(profilesHeaders)
 		profileIds = make([]int64, len(p["profile"]))
 
-		for i, val := range p["profile"] {
-			profileID, _, err := s.DB.Cluster.GetProfile(project, val)
-			if response.IsNotFoundError(err) {
-				return nil, fmt.Errorf("Profile '%s' doesn't exist", val)
-			} else if err != nil {
-				return nil, err
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			for i, val := range p["profile"] {
+				profileID, _, err := tx.GetProfile(ctx, project, val)
+				if response.IsNotFoundError(err) {
+					return fmt.Errorf("Profile '%s' doesn't exist", val)
+				} else if err != nil {
+					return err
+				}
+
+				profileIds[i] = profileID
 			}
 
-			profileIds[i] = profileID
+			return nil
+		})
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -3036,15 +3051,27 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	profileIds := make([]int64, len(req.Profiles))
-	for i, profile := range req.Profiles {
-		profileID, _, err := s.DB.Cluster.GetProfile(projectName, profile)
-		if response.IsNotFoundError(err) {
-			return response.BadRequest(fmt.Errorf("Profile '%s' doesn't exist", profile))
-		} else if err != nil {
-			return response.SmartError(err)
+
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		for i, profile := range req.Profiles {
+			profileID, _, err := tx.GetProfile(ctx, projectName, profile)
+			if response.IsNotFoundError(err) {
+				return fmt.Errorf("Profile '%s' doesn't exist", profile)
+			} else if err != nil {
+				return err
+			}
+
+			profileIds[i] = profileID
 		}
 
-		profileIds[i] = profileID
+		return nil
+	})
+	if err != nil {
+		if response.IsNotFoundError(err) {
+			return response.BadRequest(err)
+		}
+
+		return response.SmartError(err)
 	}
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/cmd/incusd/images.go
+++ b/cmd/incusd/images.go
@@ -1844,7 +1844,13 @@ func distributeImage(ctx context.Context, s *state.State, nodes []string, oldFin
 		if vol != "" {
 			fields := strings.Split(vol, "/")
 
-			_, pool, _, err := s.DB.Cluster.GetStoragePool(fields[0])
+			var pool *api.StoragePool
+
+			err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+				_, pool, _, err = tx.GetStoragePool(ctx, fields[0])
+
+				return err
+			})
 			if err != nil {
 				return fmt.Errorf("Failed to get storage pool info: %w", err)
 			}

--- a/cmd/incusd/instance.go
+++ b/cmd/incusd/instance.go
@@ -451,16 +451,18 @@ func instanceLoadNodeProjectAll(ctx context.Context, s *state.State, project str
 		filter.Node = &s.ServerName
 	}
 
-	err = s.DB.Cluster.InstanceList(ctx, func(dbInst db.InstanceArgs, p api.Project) error {
-		inst, err := instance.Load(s, dbInst, p)
-		if err != nil {
-			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
-		}
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(dbInst db.InstanceArgs, p api.Project) error {
+			inst, err := instance.Load(s, dbInst, p)
+			if err != nil {
+				return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
+			}
 
-		instances = append(instances, inst)
+			instances = append(instances, inst)
 
-		return nil
-	}, filter)
+			return nil
+		}, filter)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -606,38 +608,41 @@ func pruneExpiredAndAutoCreateInstanceSnapshotsTask(d *Daemon) (task.Func, task.
 
 		// Get list of instances on the local member that are due to have snaphots creating.
 		filter := dbCluster.InstanceFilter{Node: &s.ServerName}
-		err = s.DB.Cluster.InstanceList(ctx, func(dbInst db.InstanceArgs, p api.Project) error {
-			err = project.AllowSnapshotCreation(&p)
-			if err != nil {
+
+		err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.InstanceList(ctx, func(dbInst db.InstanceArgs, p api.Project) error {
+				err = project.AllowSnapshotCreation(&p)
+				if err != nil {
+					return nil
+				}
+
+				inst, err := instance.Load(s, dbInst, p)
+				if err != nil {
+					return fmt.Errorf("Failed loading instance %q (project %q) for snapshot task: %w", dbInst.Name, dbInst.Project, err)
+				}
+
+				// Check if instance has snapshot schedule enabled.
+				schedule, ok := inst.ExpandedConfig()["snapshots.schedule"]
+				if !ok || schedule == "" {
+					return nil
+				}
+
+				// Check if snapshot is scheduled.
+				if !snapshotIsScheduledNow(schedule, int64(inst.ID())) {
+					return nil
+				}
+
+				// If snapshot should only be taken if instance is running, check if running.
+				if util.IsFalseOrEmpty(inst.ExpandedConfig()["snapshots.schedule.stopped"]) && !inst.IsRunning() {
+					return nil
+				}
+
+				logger.Debug("Scheduling auto instance snapshot", logger.Ctx{"instance": inst.Name(), "project": inst.Project().Name})
+				instances = append(instances, inst)
+
 				return nil
-			}
-
-			inst, err := instance.Load(s, dbInst, p)
-			if err != nil {
-				return fmt.Errorf("Failed loading instance %q (project %q) for snapshot task: %w", dbInst.Name, dbInst.Project, err)
-			}
-
-			// Check if instance has snapshot schedule enabled.
-			schedule, ok := inst.ExpandedConfig()["snapshots.schedule"]
-			if !ok || schedule == "" {
-				return nil
-			}
-
-			// Check if snapshot is scheduled.
-			if !snapshotIsScheduledNow(schedule, int64(inst.ID())) {
-				return nil
-			}
-
-			// If snapshot should only be taken if instance is running, check if running.
-			if util.IsFalseOrEmpty(inst.ExpandedConfig()["snapshots.schedule.stopped"]) && !inst.IsRunning() {
-				return nil
-			}
-
-			logger.Debug("Scheduling auto instance snapshot", logger.Ctx{"instance": inst.Name(), "project": inst.Project().Name})
-			instances = append(instances, inst)
-
-			return nil
-		}, filter)
+			}, filter)
+		})
 		if err != nil {
 			logger.Error("Failed getting instance snapshot schedule info", logger.Ctx{"err": err})
 			return

--- a/cmd/incusd/instance.go
+++ b/cmd/incusd/instance.go
@@ -98,7 +98,13 @@ func ensureImageIsLocallyAvailable(s *state.State, r *http.Request, img *api.Ima
 
 	defer unlock()
 
-	memberAddress, err := s.DB.Cluster.LocateImage(img.Fingerprint)
+	var memberAddress string
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		memberAddress, err = tx.LocateImage(ctx, img.Fingerprint)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed locating image %q: %w", img.Fingerprint, err)
 	}
@@ -110,8 +116,10 @@ func ensureImageIsLocallyAvailable(s *state.State, r *http.Request, img *api.Ima
 			return fmt.Errorf("Failed transferring image %q from %q: %w", img.Fingerprint, memberAddress, err)
 		}
 
-		// As the image record already exists in the project, just add the node ID to the image.
-		err = s.DB.Cluster.AddImageToLocalNode(projectName, img.Fingerprint)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// As the image record already exists in the project, just add the node ID to the image.
+			return tx.AddImageToLocalNode(ctx, projectName, img.Fingerprint)
+		})
 		if err != nil {
 			return fmt.Errorf("Failed adding transferred image %q record to local cluster member: %w", img.Fingerprint, err)
 		}

--- a/cmd/incusd/instance_post.go
+++ b/cmd/incusd/instance_post.go
@@ -346,8 +346,13 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if targetMemberInfo != nil {
+			var backups []string
+
 			// Check if instance has backups.
-			backups, err := s.DB.Cluster.GetInstanceBackups(projectName, name)
+			err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+				backups, err = tx.GetInstanceBackups(ctx, projectName, name)
+				return err
+			})
 			if err != nil {
 				err = fmt.Errorf("Failed to fetch instance's backups: %w", err)
 				return response.SmartError(err)

--- a/cmd/incusd/instance_snapshot.go
+++ b/cmd/incusd/instance_snapshot.go
@@ -732,10 +732,17 @@ func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance) r
 
 	fullName := parentName + internalInstance.SnapshotDelimiter + newName
 
-	// Check that the name isn't already in use
-	id, _ := s.DB.Cluster.GetInstanceSnapshotID(snapInst.Project().Name, parentName, newName)
-	if id > 0 {
-		return response.Conflict(fmt.Errorf("Name '%s' already in use", fullName))
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check that the name isn't already in use
+		id, _ := tx.GetInstanceSnapshotID(ctx, snapInst.Project().Name, parentName, newName)
+		if id > 0 {
+			return fmt.Errorf("Name '%s' already in use", fullName)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return response.Conflict(err)
 	}
 
 	rename := func(op *operations.Operation) error {

--- a/cmd/incusd/instance_snapshot.go
+++ b/cmd/incusd/instance_snapshot.go
@@ -156,7 +156,15 @@ func instanceSnapshotsGet(d *Daemon, r *http.Request) response.Response {
 	resultMap := []*api.InstanceSnapshot{}
 
 	if !recursion {
-		snaps, err := s.DB.Cluster.GetInstanceSnapshotsNames(projectName, cname)
+		var snaps []string
+
+		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			snaps, err = tx.GetInstanceSnapshotsNames(ctx, projectName, cname)
+
+			return err
+		})
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/cmd/incusd/instance_test.go
+++ b/cmd/incusd/instance_test.go
@@ -122,7 +122,11 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 		Name: "testFoo",
 	}
 
-	_, err := suite.d.State().DB.Cluster.CreateNetwork(api.ProjectDefaultName, "unknownbr0", "", db.NetworkTypeBridge, nil)
+	err := suite.d.State().DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_, err := tx.CreateNetwork(ctx, api.ProjectDefaultName, "unknownbr0", "", db.NetworkTypeBridge, nil)
+
+		return err
+	})
 	suite.Req.Nil(err)
 
 	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
@@ -157,7 +161,11 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 
 	state := suite.d.State()
 
-	_, err := state.DB.Cluster.CreateNetwork(api.ProjectDefaultName, "unknownbr0", "", db.NetworkTypeBridge, nil)
+	err := state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_, err := tx.CreateNetwork(ctx, api.ProjectDefaultName, "unknownbr0", "", db.NetworkTypeBridge, nil)
+
+		return err
+	})
 	suite.Req.Nil(err)
 
 	// Create the container

--- a/cmd/incusd/instance_test.go
+++ b/cmd/incusd/instance_test.go
@@ -77,7 +77,13 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 		})
 	}()
 
-	testProfiles, err := suite.d.db.Cluster.GetProfiles("default", []string{"default", "unprivileged"})
+	var testProfiles []api.Profile
+
+	err = suite.d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		testProfiles, err = tx.GetProfiles(ctx, "default", []string{"default", "unprivileged"})
+
+		return err
+	})
 	suite.Req.Nil(err)
 
 	args := db.InstanceArgs{
@@ -245,7 +251,15 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		"ipv6.gateway": "none", "nictype": "routed", "parent": "unknownbr0"}
 	eth2 := deviceConfig.Device{"name": "eth2", "type": "nic", "nictype": "bridged", "parent": "unknownbr0"}
 
-	testProfiles, err := suite.d.db.Cluster.GetProfiles("default", []string{"default"})
+	var testProfiles []api.Profile
+
+	err := suite.d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		testProfiles, err = tx.GetProfiles(ctx, "default", []string{"default"})
+
+		return err
+	})
 	suite.Req.Nil(err)
 
 	args := db.InstanceArgs{

--- a/cmd/incusd/instance_test.go
+++ b/cmd/incusd/instance_test.go
@@ -180,7 +180,11 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	pool, err := storagePools.LoadByName(state, poolName)
 	suite.Req.Nil(err)
 
-	_, err = state.DB.Cluster.CreateStoragePoolVolume(c.Project().Name, c.Name(), "", db.StoragePoolVolumeContentTypeFS, pool.ID(), nil, db.StoragePoolVolumeContentTypeFS, time.Now())
+	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_, err = tx.CreateStoragePoolVolume(ctx, c.Project().Name, c.Name(), "", db.StoragePoolVolumeContentTypeFS, pool.ID(), nil, db.StoragePoolVolumeContentTypeFS, time.Now())
+
+		return err
+	})
 	suite.Req.Nil(err)
 
 	// Load the container and trigger initLXC()

--- a/cmd/incusd/instances.go
+++ b/cmd/incusd/instances.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -228,8 +229,10 @@ func instancesStart(s *state.State, instances []instance.Instance) {
 				instLogger.Warn("Failed auto start instance attempt", logger.Ctx{"attempt": attempt, "maxAttempts": maxAttempts, "err": err})
 
 				if attempt >= maxAttempts {
-					// If unable to start after 3 tries, record a warning.
-					warnErr := s.DB.Cluster.UpsertWarningLocalNode(inst.Project().Name, cluster.TypeInstance, inst.ID(), warningtype.InstanceAutostartFailure, fmt.Sprintf("%v", err))
+					warnErr := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+						// If unable to start after 3 tries, record a warning.
+						return tx.UpsertWarningLocalNode(ctx, inst.Project().Name, cluster.TypeInstance, inst.ID(), warningtype.InstanceAutostartFailure, fmt.Sprintf("%v", err))
+					})
 					if warnErr != nil {
 						instLogger.Warn("Failed to create instance autostart failure warning", logger.Ctx{"err": warnErr})
 					}

--- a/cmd/incusd/instances_post.go
+++ b/cmd/incusd/instances_post.go
@@ -674,8 +674,14 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 			return response.InternalError(fmt.Errorf("Storage pool not found: %w", err))
 		}
 
-		// Otherwise try and restore to the project's default profile pool.
-		_, profile, err := s.DB.Cluster.GetProfile(bInfo.Project, "default")
+		var profile *api.Profile
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Otherwise try and restore to the project's default profile pool.
+			_, profile, err = tx.GetProfile(ctx, bInfo.Project, "default")
+
+			return err
+		})
 		if err != nil {
 			return response.InternalError(fmt.Errorf("Failed to get default profile: %w", err))
 		}
@@ -1161,18 +1167,25 @@ func instanceFindStoragePool(s *state.State, projectName string, req *api.Instan
 
 	// If we don't have a valid pool yet, look through profiles
 	if storagePool == "" {
-		for _, pName := range req.Profiles {
-			_, p, err := s.DB.Cluster.GetProfile(projectName, pName)
-			if err != nil {
-				return "", "", "", nil, response.SmartError(err)
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			for _, pName := range req.Profiles {
+				_, p, err := tx.GetProfile(ctx, projectName, pName)
+				if err != nil {
+					return err
+				}
+
+				k, v, _ := internalInstance.GetRootDiskDevice(p.Devices)
+				if k != "" && v["pool"] != "" {
+					// Keep going as we want the last one in the profile chain
+					storagePool = v["pool"]
+					storagePoolProfile = pName
+				}
 			}
 
-			k, v, _ := internalInstance.GetRootDiskDevice(p.Devices)
-			if k != "" && v["pool"] != "" {
-				// Keep going as we want the last one in the profile chain
-				storagePool = v["pool"]
-				storagePoolProfile = pName
-			}
+			return nil
+		})
+		if err != nil {
+			return "", "", "", nil, response.SmartError(err)
 		}
 	}
 

--- a/cmd/incusd/instances_post.go
+++ b/cmd/incusd/instances_post.go
@@ -444,7 +444,13 @@ func createFromCopy(s *state.State, r *http.Request, projectName string, profile
 				return clusterCopyContainerInternal(s, r, source, projectName, profiles, req)
 			}
 
-			_, pool, _, err := s.DB.Cluster.GetStoragePoolInAnyState(sourcePoolName)
+			var pool *api.StoragePool
+
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				_, pool, _, err = tx.GetStoragePoolInAnyState(ctx, sourcePoolName)
+
+				return err
+			})
 			if err != nil {
 				err = fmt.Errorf("Failed to fetch instance's pool info: %w", err)
 				return response.SmartError(err)
@@ -664,8 +670,12 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 		"snapshots": bInfo.Snapshots,
 	})
 
-	// Check storage pool exists.
-	_, _, _, err = s.DB.Cluster.GetStoragePoolInAnyState(bInfo.Pool)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check storage pool exists.
+		_, _, _, err = tx.GetStoragePoolInAnyState(ctx, bInfo.Pool)
+
+		return err
+	})
 	if response.IsNotFoundError(err) {
 		// The storage pool doesn't exist. If backup is in binary format (so we cannot alter
 		// the backup.yaml) or the pool has been specified directly from the user restoring
@@ -1156,7 +1166,11 @@ func instanceFindStoragePool(s *state.State, projectName string, req *api.Instan
 
 	// Handle copying/moving between two storage-api instances.
 	if storagePool != "" {
-		_, err := s.DB.Cluster.GetStoragePoolID(storagePool)
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			_, err := tx.GetStoragePoolID(ctx, storagePool)
+
+			return err
+		})
 		if response.IsNotFoundError(err) {
 			storagePool = ""
 			// Unset the local root disk device storage pool if not
@@ -1192,7 +1206,16 @@ func instanceFindStoragePool(s *state.State, projectName string, req *api.Instan
 	// If there is just a single pool in the database, use that
 	if storagePool == "" {
 		logger.Debug("No valid storage pool in the container's local root disk device and profiles found")
-		pools, err := s.DB.Cluster.GetStoragePoolNames()
+
+		var pools []string
+
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			pools, err = tx.GetStoragePoolNames(ctx)
+
+			return err
+		})
 		if err != nil {
 			if response.IsNotFoundError(err) {
 				return "", "", "", nil, response.BadRequest(fmt.Errorf("This instance does not have any storage pools configured"))

--- a/cmd/incusd/network_allocations.go
+++ b/cmd/incusd/network_allocations.go
@@ -125,7 +125,15 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 
 	// Then, get all the networks, their network forwards and their network load balancers.
 	for _, projectName := range projectNames {
-		networkNames, err := d.db.Cluster.GetNetworks(projectName)
+		var networkNames []string
+
+		err := d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			networkNames, err = tx.GetNetworks(ctx, projectName)
+
+			return err
+		})
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed loading networks: %w", err))
 		}

--- a/cmd/incusd/network_allocations.go
+++ b/cmd/incusd/network_allocations.go
@@ -179,7 +179,13 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 				}
 			}
 
-			forwards, err := d.db.Cluster.GetNetworkForwards(r.Context(), n.ID(), false)
+			var forwards map[int64]*api.NetworkForward
+
+			err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+				forwards, err = tx.GetNetworkForwards(ctx, n.ID(), false)
+
+				return err
+			})
 			if err != nil {
 				return response.SmartError(fmt.Errorf("Failed getting forwards for network %q in project %q: %w", networkName, projectName, err))
 			}

--- a/cmd/incusd/network_allocations.go
+++ b/cmd/incusd/network_allocations.go
@@ -207,7 +207,13 @@ func networkAllocationsGet(d *Daemon, r *http.Request) response.Response {
 				)
 			}
 
-			loadBalancers, err := d.db.Cluster.GetNetworkLoadBalancers(r.Context(), n.ID(), false)
+			var loadBalancers map[int64]*api.NetworkLoadBalancer
+
+			err = d.db.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+				loadBalancers, err = tx.GetNetworkLoadBalancers(ctx, n.ID(), false)
+
+				return err
+			})
 			if err != nil {
 				return response.SmartError(fmt.Errorf("Failed getting load-balancers for network %q in project %q: %w", networkName, projectName, err))
 			}

--- a/cmd/incusd/networks.go
+++ b/cmd/incusd/networks.go
@@ -177,8 +177,14 @@ func networksGet(d *Daemon, r *http.Request) response.Response {
 
 	recursion := localUtil.IsRecursionRequest(r)
 
-	// Get list of managed networks (that may or may not have network interfaces on the host).
-	networkNames, err := s.DB.Cluster.GetNetworks(projectName)
+	var networkNames []string
+
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get list of managed networks (that may or may not have network interfaces on the host).
+		networkNames, err = tx.GetNetworks(ctx, projectName)
+
+		return err
+	})
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -335,7 +341,13 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 			return response.InternalError(fmt.Errorf("Invalid project limits.network value: %w", err))
 		}
 
-		networks, err := s.DB.Cluster.GetNetworks(projectName)
+		var networks []string
+
+		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			networks, err = tx.GetNetworks(ctx, projectName)
+
+			return err
+		})
 		if err != nil {
 			return response.InternalError(fmt.Errorf("Failed loading project's networks for limits check: %w", err))
 		}
@@ -398,8 +410,14 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	// Load existing network if exists, if not don't fail.
-	_, netInfo, _, err := s.DB.Cluster.GetNetworkInAnyState(projectName, req.Name)
+	var netInfo *api.Network
+
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Load existing network if exists, if not don't fail.
+		_, netInfo, _, err = tx.GetNetworkInAnyState(ctx, projectName, req.Name)
+
+		return err
+	})
 	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 		return response.InternalError(err)
 	}
@@ -462,13 +480,21 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	// Create the database entry.
-	_, err = s.DB.Cluster.CreateNetwork(projectName, req.Name, req.Description, netType.DBType(), req.Config)
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Create the database entry.
+		_, err = tx.CreateNetwork(ctx, projectName, req.Name, req.Description, netType.DBType(), req.Config)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Error inserting %q into database: %w", req.Name, err))
 	}
 
-	revert.Add(func() { _ = s.DB.Cluster.DeleteNetwork(projectName, req.Name) })
+	revert.Add(func() {
+		_ = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.DeleteNetwork(ctx, projectName, req.Name)
+		})
+	})
 
 	n, err := network.LoadByName(s, projectName, req.Name)
 	if err != nil {
@@ -999,8 +1025,12 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	// Remove the network from the database.
-	err = s.DB.Cluster.DeleteNetwork(n.Project(), n.Name())
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Remove the network from the database.
+		err = tx.DeleteNetwork(ctx, n.Project(), n.Name())
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1115,8 +1145,14 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Network is currently in use"))
 	}
 
-	// Check that the name isn't already in used by an existing managed network.
-	networks, err := s.DB.Cluster.GetNetworks(projectName)
+	var networks []string
+
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check that the name isn't already in used by an existing managed network.
+		networks, err = tx.GetNetworks(ctx, projectName)
+
+		return err
+	})
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -1468,21 +1504,28 @@ func networkStartup(s *state.State) error {
 		networkPriorityLogical:    make(map[network.ProjectNetwork]struct{}),
 	}
 
-	for _, projectName := range projectNames {
-		networkNames, err := s.DB.Cluster.GetCreatedNetworks(projectName)
-		if err != nil {
-			return fmt.Errorf("Failed to load networks for project %q: %w", projectName, err)
-		}
-
-		for _, networkName := range networkNames {
-			pn := network.ProjectNetwork{
-				ProjectName: projectName,
-				NetworkName: networkName,
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		for _, projectName := range projectNames {
+			networkNames, err := tx.GetCreatedNetworkNamesByProject(ctx, projectName)
+			if err != nil {
+				return fmt.Errorf("Failed to load networks for project %q: %w", projectName, err)
 			}
 
-			// Assume all networks are networkPriorityStandalone initially.
-			initNetworks[networkPriorityStandalone][pn] = struct{}{}
+			for _, networkName := range networkNames {
+				pn := network.ProjectNetwork{
+					ProjectName: projectName,
+					NetworkName: networkName,
+				}
+
+				// Assume all networks are networkPriorityStandalone initially.
+				initNetworks[networkPriorityStandalone][pn] = struct{}{}
+			}
 		}
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	loadedNetworks := make(map[network.ProjectNetwork]network.Network)
@@ -1662,8 +1705,14 @@ func networkShutdown(s *state.State) {
 	}
 
 	for _, projectName := range projectNames {
-		// Get a list of managed networks.
-		networks, err := s.DB.Cluster.GetNetworks(projectName)
+		var networks []string
+
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Get a list of managed networks.
+			networks, err = tx.GetNetworks(ctx, projectName)
+
+			return err
+		})
 		if err != nil {
 			logger.Error("Failed shutting down networks, couldn't load networks for project", logger.Ctx{"project": projectName, "err": err})
 			continue
@@ -1702,7 +1751,13 @@ func networkRestartOVN(s *state.State) error {
 
 	// Go over all the networks in every project.
 	for _, projectName := range projectNames {
-		networkNames, err := s.DB.Cluster.GetCreatedNetworks(projectName)
+		var networkNames []string
+
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			networkNames, err = tx.GetCreatedNetworkNamesByProject(ctx, projectName)
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed to load networks for project %q: %w", projectName, err)
 		}

--- a/cmd/incusd/networks.go
+++ b/cmd/incusd/networks.go
@@ -1534,7 +1534,10 @@ func networkStartup(s *state.State) error {
 		err = n.Start()
 		if err != nil {
 			err = fmt.Errorf("Failed starting: %w", err)
-			_ = s.DB.Cluster.UpsertWarningLocalNode(n.Project(), dbCluster.TypeNetwork, int(n.ID()), warningtype.NetworkUnvailable, err.Error())
+
+			_ = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpsertWarningLocalNode(ctx, n.Project(), dbCluster.TypeNetwork, int(n.ID()), warningtype.NetworkUnvailable, err.Error())
+			})
 
 			return err
 		}

--- a/cmd/incusd/patches.go
+++ b/cmd/incusd/patches.go
@@ -548,7 +548,7 @@ func patchNetworkOVNRemoveRoutes(name string, d *Daemon) error {
 			return err
 		}
 
-		for _, networks := range projectNetworks {
+		for projectName, networks := range projectNetworks {
 			for networkID, network := range networks {
 				if network.Type != "ovn" {
 					continue
@@ -570,7 +570,7 @@ func patchNetworkOVNRemoveRoutes(name string, d *Daemon) error {
 				}
 
 				if modified {
-					err = tx.UpdateNetwork(networkID, network.Description, network.Config)
+					err = tx.UpdateNetwork(ctx, projectName, network.Name, network.Description, network.Config)
 					if err != nil {
 						return fmt.Errorf("Failed removing OVN external route settings for %q (%d): %w", network.Name, networkID, err)
 					}
@@ -600,7 +600,7 @@ func patchNetworkOVNEnableNAT(name string, d *Daemon) error {
 			return err
 		}
 
-		for _, networks := range projectNetworks {
+		for projectName, networks := range projectNetworks {
 			for networkID, network := range networks {
 				if network.Type != "ovn" {
 					continue
@@ -620,7 +620,7 @@ func patchNetworkOVNEnableNAT(name string, d *Daemon) error {
 				}
 
 				if modified {
-					err = tx.UpdateNetwork(networkID, network.Description, network.Config)
+					err = tx.UpdateNetwork(ctx, projectName, network.Name, network.Description, network.Config)
 					if err != nil {
 						return fmt.Errorf("Failed saving OVN NAT settings for %q (%d): %w", network.Name, networkID, err)
 					}
@@ -711,25 +711,32 @@ func patchNetworkClearBridgeVolatileHwaddr(name string, d *Daemon) error {
 	// Use api.ProjectDefaultName, as bridge networks don't support projects.
 	projectName := api.ProjectDefaultName
 
-	// Get the list of networks.
-	networks, err := d.db.Cluster.GetNetworks(projectName)
-	if err != nil {
-		return fmt.Errorf("Failed loading networks for network_clear_bridge_volatile_hwaddr patch: %w", err)
-	}
-
-	for _, networkName := range networks {
-		_, net, _, err := d.db.Cluster.GetNetworkInAnyState(projectName, networkName)
+	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get the list of networks.
+		networks, err := tx.GetNetworks(ctx, projectName)
 		if err != nil {
-			return fmt.Errorf("Failed loading network %q for network_clear_bridge_volatile_hwaddr patch: %w", networkName, err)
+			return fmt.Errorf("Failed loading networks for network_clear_bridge_volatile_hwaddr patch: %w", err)
 		}
 
-		if net.Config["volatile.bridge.hwaddr"] != "" {
-			delete(net.Config, "volatile.bridge.hwaddr")
-			err = d.db.Cluster.UpdateNetwork(projectName, net.Name, net.Description, net.Config)
+		for _, networkName := range networks {
+			_, net, _, err := tx.GetNetworkInAnyState(ctx, projectName, networkName)
 			if err != nil {
-				return fmt.Errorf("Failed updating network %q for network_clear_bridge_volatile_hwaddr patch: %w", networkName, err)
+				return fmt.Errorf("Failed loading network %q for network_clear_bridge_volatile_hwaddr patch: %w", networkName, err)
+			}
+
+			if net.Config["volatile.bridge.hwaddr"] != "" {
+				delete(net.Config, "volatile.bridge.hwaddr")
+				err = tx.UpdateNetwork(ctx, projectName, net.Name, net.Description, net.Config)
+				if err != nil {
+					return fmt.Errorf("Failed updating network %q for network_clear_bridge_volatile_hwaddr patch: %w", networkName, err)
+				}
 			}
 		}
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/incusd/patches.go
+++ b/cmd/incusd/patches.go
@@ -290,42 +290,49 @@ func patchNetworkACLRemoveDefaults(name string, d *Daemon) error {
 		return err
 	}
 
-	// Get ACLs in projects.
-	for _, projectName := range projectNames {
-		aclNames, err := d.db.Cluster.GetNetworkACLs(projectName)
-		if err != nil {
-			return err
-		}
-
-		for _, aclName := range aclNames {
-			aclID, acl, err := d.db.Cluster.GetNetworkACL(projectName, aclName)
+	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get ACLs in projects.
+		for _, projectName := range projectNames {
+			aclNames, err := tx.GetNetworkACLs(ctx, projectName)
 			if err != nil {
 				return err
 			}
 
-			modified := false
-
-			// Remove the offending keys if found.
-			_, found := acl.Config["default.action"]
-			if found {
-				delete(acl.Config, "default.action")
-				modified = true
-			}
-
-			_, found = acl.Config["default.logged"]
-			if found {
-				delete(acl.Config, "default.logged")
-				modified = true
-			}
-
-			// Write back modified config if needed.
-			if modified {
-				err = d.db.Cluster.UpdateNetworkACL(aclID, &acl.NetworkACLPut)
+			for _, aclName := range aclNames {
+				aclID, acl, err := tx.GetNetworkACL(ctx, projectName, aclName)
 				if err != nil {
-					return fmt.Errorf("Failed updating network ACL %d: %w", aclID, err)
+					return err
+				}
+
+				modified := false
+
+				// Remove the offending keys if found.
+				_, found := acl.Config["default.action"]
+				if found {
+					delete(acl.Config, "default.action")
+					modified = true
+				}
+
+				_, found = acl.Config["default.logged"]
+				if found {
+					delete(acl.Config, "default.logged")
+					modified = true
+				}
+
+				// Write back modified config if needed.
+				if modified {
+					err = tx.UpdateNetworkACL(ctx, aclID, &acl.NetworkACLPut)
+					if err != nil {
+						return fmt.Errorf("Failed updating network ACL %d: %w", aclID, err)
+					}
 				}
 			}
 		}
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/incusd/patches.go
+++ b/cmd/incusd/patches.go
@@ -1054,7 +1054,9 @@ func patchStorageZfsUnsetInvalidBlockSettings(_ string, d *Daemon) error {
 				continue
 			}
 
-			err = s.DB.Cluster.UpdateStoragePoolVolume(vol.Project, vol.Name, volType, pool, vol.Description, config)
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpdateStoragePoolVolume(ctx, vol.Project, vol.Name, volType, pool, vol.Description, config)
+			})
 			if err != nil {
 				return fmt.Errorf("Failed updating volume %q in project %q on pool %q: %w", vol.Name, vol.Project, poolIDNameMap[pool], err)
 			}
@@ -1172,7 +1174,9 @@ func patchStorageZfsUnsetInvalidBlockSettingsV2(_ string, d *Daemon) error {
 				continue
 			}
 
-			err = s.DB.Cluster.UpdateStoragePoolVolume(vol.Project, vol.Name, volType, pool, vol.Description, config)
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpdateStoragePoolVolume(ctx, vol.Project, vol.Name, volType, pool, vol.Description, config)
+			})
 			if err != nil {
 				return fmt.Errorf("Failed updating volume %q in project %q on pool %q: %w", vol.Name, vol.Project, poolIDNameMap[pool], err)
 			}

--- a/cmd/incusd/patches.go
+++ b/cmd/incusd/patches.go
@@ -413,12 +413,14 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 	oldUUIDKey := "volatile.vm.uuid"
 	newUUIDKey := "volatile.uuid"
 
-	return d.State().DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
-		if inst.Type != instancetype.VM {
-			return nil
-		}
+	s := d.State()
 
-		return d.State().DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	return s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
+			if inst.Type != instancetype.VM {
+				return nil
+			}
+
 			uuid := inst.Config[oldUUIDKey]
 			if uuid != "" {
 				changes := map[string]string{

--- a/cmd/incusd/patches.go
+++ b/cmd/incusd/patches.go
@@ -747,8 +747,16 @@ func patchNetworkClearBridgeVolatileHwaddr(name string, d *Daemon) error {
 func patchStorageRenameCustomISOBlockVolumes(name string, d *Daemon) error {
 	s := d.State()
 
-	// Get all storage pool names.
-	pools, err := s.DB.Cluster.GetStoragePoolNames()
+	var pools []string
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get all storage pool names.
+		pools, err = tx.GetStoragePoolNames(ctx)
+
+		return err
+	})
 	if err != nil {
 		// Skip the rest of the patch if no storage pools were found.
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
@@ -852,8 +860,16 @@ func patchStorageRenameCustomISOBlockVolumes(name string, d *Daemon) error {
 func patchZfsSetContentTypeUserProperty(name string, d *Daemon) error {
 	s := d.State()
 
-	// Get all storage pool names.
-	pools, err := s.DB.Cluster.GetStoragePoolNames()
+	var pools []string
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get all storage pool names.
+		pools, err = tx.GetStoragePoolNames(ctx)
+
+		return err
+	})
 	if err != nil {
 		// Skip the rest of the patch if no storage pools were found.
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
@@ -939,8 +955,16 @@ func patchSnapshotsRename(name string, d *Daemon) error {
 func patchStorageZfsUnsetInvalidBlockSettings(_ string, d *Daemon) error {
 	s := d.State()
 
-	// Get all storage pool names.
-	pools, err := s.DB.Cluster.GetStoragePoolNames()
+	var pools []string
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get all storage pool names.
+		pools, err = tx.GetStoragePoolNames(ctx)
+
+		return err
+	})
 	if err != nil {
 		// Skip the rest of the patch if no storage pools were found.
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
@@ -1047,8 +1071,16 @@ func patchStorageZfsUnsetInvalidBlockSettings(_ string, d *Daemon) error {
 func patchStorageZfsUnsetInvalidBlockSettingsV2(_ string, d *Daemon) error {
 	s := d.State()
 
-	// Get all storage pool names.
-	pools, err := s.DB.Cluster.GetStoragePoolNames()
+	var pools []string
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get all storage pool names.
+		pools, err = tx.GetStoragePoolNames(ctx)
+
+		return err
+	})
 	if err != nil {
 		// Skip the rest of the patch if no storage pools were found.
 		if api.StatusErrorCheck(err, http.StatusNotFound) {

--- a/cmd/incusd/profiles_utils.go
+++ b/cmd/incusd/profiles_utils.go
@@ -55,25 +55,32 @@ func doProfileUpdate(s *state.State, p api.Project, profileName string, id int64
 				continue
 			}
 
-			// Check what profile the device comes from by working backwards along the profiles list.
-			for i := len(inst.Profiles) - 1; i >= 0; i-- {
-				_, profile, err := s.DB.Cluster.GetProfile(p.Name, inst.Profiles[i].Name)
-				if err != nil {
-					return err
-				}
-
-				// Check if we find a match for the device.
-				_, ok := profile.Devices[oldProfileRootDiskDeviceKey]
-				if ok {
-					// Found the profile.
-					if inst.Profiles[i].Name == profileName {
-						// If it's the current profile, then we can't modify that root device.
-						return fmt.Errorf("At least one instance relies on this profile's root disk device")
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				// Check what profile the device comes from by working backwards along the profiles list.
+				for i := len(inst.Profiles) - 1; i >= 0; i-- {
+					_, profile, err := tx.GetProfile(ctx, p.Name, inst.Profiles[i].Name)
+					if err != nil {
+						return err
 					}
 
-					// If it's not, then move on to the next instance.
-					break
+					// Check if we find a match for the device.
+					_, ok := profile.Devices[oldProfileRootDiskDeviceKey]
+					if ok {
+						// Found the profile.
+						if inst.Profiles[i].Name == profileName {
+							// If it's the current profile, then we can't modify that root device.
+							return fmt.Errorf("At least one instance relies on this profile's root disk device")
+						}
+
+						// If it's not, then move on to the next instance.
+						break
+					}
 				}
+
+				return nil
+			})
+			if err != nil {
+				return err
 			}
 		}
 	}
@@ -204,7 +211,15 @@ func doProfileUpdateInstance(s *state.State, args db.InstanceArgs, p api.Project
 		profileNames = append(profileNames, profile.Name)
 	}
 
-	profiles, err := s.DB.Cluster.GetProfiles(args.Project, profileNames)
+	var profiles []api.Profile
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		profiles, err = tx.GetProfiles(ctx, args.Project, profileNames)
+
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -231,8 +246,16 @@ func doProfileUpdateInstance(s *state.State, args db.InstanceArgs, p api.Project
 
 // Query the db for information about instances associated with the given profile.
 func getProfileInstancesInfo(dbCluster *db.Cluster, projectName string, profileName string) (map[int]db.InstanceArgs, map[string]*api.Project, error) {
+	var projectInstNames map[string][]string
+
 	// Query the db for information about instances associated with the given profile.
-	projectInstNames, err := dbCluster.GetInstancesWithProfile(projectName, profileName)
+	err := dbCluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		projectInstNames, err = tx.GetInstancesWithProfile(ctx, projectName, profileName)
+
+		return err
+	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to query instances with profile %q: %w", profileName, err)
 	}

--- a/cmd/incusd/storage.go
+++ b/cmd/incusd/storage.go
@@ -88,7 +88,9 @@ func storageStartup(s *state.State, forceCheck bool) error {
 		_, err = pool.Mount()
 		if err != nil {
 			logger.Error("Failed mounting storage pool", logger.Ctx{"pool": poolName, "err": err})
-			_ = s.DB.Cluster.UpsertWarningLocalNode("", cluster.TypeStoragePool, int(pool.ID()), warningtype.StoragePoolUnvailable, err.Error())
+			_ = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpsertWarningLocalNode(ctx, "", cluster.TypeStoragePool, int(pool.ID()), warningtype.StoragePoolUnvailable, err.Error())
+			})
 
 			return false
 		}

--- a/cmd/incusd/storage.go
+++ b/cmd/incusd/storage.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/lxc/incus/internal/server/db"
 	"github.com/lxc/incus/internal/server/db/cluster"
 	"github.com/lxc/incus/internal/server/db/warningtype"
 	"github.com/lxc/incus/internal/server/instance"
@@ -46,7 +48,15 @@ func storageStartup(s *state.State, forceCheck bool) error {
 	// Update the storage drivers supported and used cache in api_1.0.go.
 	storagePoolDriversCacheUpdate(s)
 
-	poolNames, err := s.DB.Cluster.GetCreatedStoragePoolNames()
+	var poolNames []string
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		poolNames, err = tx.GetCreatedStoragePoolNames(ctx)
+
+		return err
+	})
 	if err != nil {
 		if response.IsNotFoundError(err) {
 			logger.Debug("No existing storage pools detected")
@@ -160,7 +170,16 @@ func storagePoolDriversCacheUpdate(s *state.State) {
 	// copy-on-write semantics without locking in the read case seems
 	// appropriate. (Should be cheaper then querying the db all the time,
 	// especially if we keep adding more storage drivers.)
-	drivers, err := s.DB.Cluster.GetStoragePoolDrivers()
+
+	var drivers []string
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		drivers, err = tx.GetStoragePoolDrivers(ctx)
+
+		return err
+	})
 	if err != nil && !response.IsNotFoundError(err) {
 		return
 	}

--- a/cmd/incusd/storage_volumes.go
+++ b/cmd/incusd/storage_volumes.go
@@ -2417,8 +2417,14 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 			return response.InternalError(fmt.Errorf("Storage pool not found: %w", err))
 		}
 
-		// Otherwise try and restore to the project's default profile pool.
-		_, profile, err := s.DB.Cluster.GetProfile(bInfo.Project, "default")
+		var profile *api.Profile
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Otherwise try and restore to the project's default profile pool.
+			_, profile, err = tx.GetProfile(ctx, bInfo.Project, "default")
+
+			return err
+		})
 		if err != nil {
 			return response.InternalError(fmt.Errorf("Failed to get default profile: %w", err))
 		}

--- a/cmd/incusd/storage_volumes.go
+++ b/cmd/incusd/storage_volumes.go
@@ -1374,8 +1374,12 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// Check that the name isn't already in use.
-	_, err = s.DB.Cluster.GetStoragePoolNodeVolumeID(targetProjectName, req.Name, volumeType, targetPoolID)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check that the name isn't already in use.
+		_, err = tx.GetStoragePoolNodeVolumeID(ctx, targetProjectName, req.Name, volumeType, targetPoolID)
+
+		return err
+	})
 	if !response.IsNotFoundError(err) {
 		if err != nil {
 			return response.InternalError(err)

--- a/cmd/incusd/storage_volumes.go
+++ b/cmd/incusd/storage_volumes.go
@@ -646,7 +646,13 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Currently not allowed to create storage volumes of type %q", req.Type))
 	}
 
-	poolID, err := s.DB.Cluster.GetStoragePoolID(poolName)
+	var poolID int64
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		poolID, err = tx.GetStoragePoolID(ctx, poolName)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -932,7 +938,13 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	poolID, err := s.DB.Cluster.GetStoragePoolID(poolName)
+	var poolID int64
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		poolID, err = tx.GetStoragePoolID(ctx, poolName)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1226,8 +1238,14 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			if srcPool.Driver().Info().Name == "ceph" {
-				// Load source volume.
-				srcPoolID, err := s.DB.Cluster.GetStoragePoolID(srcPoolName)
+				var srcPoolID int64
+
+				err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					// Load source volume.
+					srcPoolID, err = tx.GetStoragePoolID(ctx, srcPoolName)
+
+					return err
+				})
 				if err != nil {
 					return response.SmartError(err)
 				}
@@ -1339,12 +1357,19 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	// Retrieve ID of the storage pool (and check if the storage pool exists).
 	var targetPoolID int64
+	var targetPoolName string
+
 	if req.Pool != "" {
-		targetPoolID, err = s.DB.Cluster.GetStoragePoolID(req.Pool)
+		targetPoolName = req.Pool
 	} else {
-		targetPoolID, err = s.DB.Cluster.GetStoragePoolID(srcPoolName)
+		targetPoolName = srcPoolName
 	}
 
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		targetPoolID, err = tx.GetStoragePoolID(ctx, targetPoolName)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1369,8 +1394,14 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Volume is used by Incus itself and cannot be renamed"))
 	}
 
-	// Load source volume.
-	srcPoolID, err := s.DB.Cluster.GetStoragePoolID(srcPoolName)
+	var srcPoolID int64
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Load source volume.
+		srcPoolID, err = tx.GetStoragePoolID(ctx, srcPoolName)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1769,8 +1800,14 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	// Get the ID of the storage pool the storage volume is supposed to be attached to.
-	poolID, err := s.DB.Cluster.GetStoragePoolID(poolName)
+	var poolID int64
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get the ID of the storage pool the storage volume is supposed to be attached to.
+		poolID, err = tx.GetStoragePoolID(ctx, poolName)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -2407,8 +2444,12 @@ func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestP
 		"snapshots": bInfo.Snapshots,
 	})
 
-	// Check storage pool exists.
-	_, _, _, err = s.DB.Cluster.GetStoragePoolInAnyState(bInfo.Pool)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check storage pool exists.
+		_, _, _, err = tx.GetStoragePoolInAnyState(ctx, bInfo.Pool)
+
+		return err
+	})
 	if response.IsNotFoundError(err) {
 		// The storage pool doesn't exist. If backup is in binary format (so we cannot alter
 		// the backup.yaml) or the pool has been specified directly from the user restoring

--- a/cmd/incusd/storage_volumes_backup.go
+++ b/cmd/incusd/storage_volumes_backup.go
@@ -203,7 +203,12 @@ func storagePoolVolumeTypeCustomBackupsGet(d *Daemon, r *http.Request) response.
 
 	recursion := localUtil.IsRecursionRequest(r)
 
-	volumeBackups, err := s.DB.Cluster.GetStoragePoolVolumeBackups(projectName, volumeName, poolID)
+	var volumeBackups []db.StoragePoolVolumeBackup
+
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		volumeBackups, err = tx.GetStoragePoolVolumeBackups(ctx, projectName, volumeName, poolID)
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -366,8 +371,13 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 	}
 
 	if req.Name == "" {
+		var backups []string
+
 		// come up with a name.
-		backups, err := s.DB.Cluster.GetStoragePoolVolumeBackupsNames(projectName, volumeName, poolID)
+		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			backups, err = tx.GetStoragePoolVolumeBackupsNames(ctx, projectName, volumeName, poolID)
+			return err
+		})
 		if err != nil {
 			return response.BadRequest(err)
 		}

--- a/cmd/incusd/storage_volumes_backup.go
+++ b/cmd/incusd/storage_volumes_backup.go
@@ -190,7 +190,15 @@ func storagePoolVolumeTypeCustomBackupsGet(d *Daemon, r *http.Request) response.
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 
-	poolID, _, _, err := s.DB.Cluster.GetStoragePool(poolName)
+	var poolID int64
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		poolID, _, _, err = tx.GetStoragePool(ctx, poolName)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -326,7 +334,15 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 		return resp
 	}
 
-	poolID, _, _, err := s.DB.Cluster.GetStoragePool(poolName)
+	var poolID int64
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		poolID, _, _, err = tx.GetStoragePool(ctx, poolName)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/cmd/incusd/storage_volumes_snapshot.go
+++ b/cmd/incusd/storage_volumes_snapshot.go
@@ -169,7 +169,14 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 
 	// Get a snapshot name.
 	if req.Name == "" {
-		i := s.DB.Cluster.GetNextStorageVolumeSnapshotIndex(poolName, volumeName, volumeType, "snap%d")
+		var i int
+
+		_ = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			i = tx.GetNextStorageVolumeSnapshotIndex(ctx, poolName, volumeName, volumeType, "snap%d")
+
+			return nil
+		})
+
 		req.Name = fmt.Sprintf("snap%d", i)
 	}
 
@@ -387,21 +394,25 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 	}
 
 	var poolID int64
+	var volumes []db.StorageVolumeArgs
 
 	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		// Retrieve ID of the storage pool (and check if the storage pool exists).
 		poolID, err = tx.GetStoragePoolID(ctx, poolName)
+		if err != nil {
+			return err
+		}
 
-		return err
+		// Get the names of all storage volume snapshots of a given volume.
+		volumes, err = tx.GetLocalStoragePoolVolumeSnapshotsWithType(ctx, projectName, volumeName, volumeType, poolID)
+		if err != nil {
+			return err
+		}
+
+		return nil
 	})
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	// Get the names of all storage volume snapshots of a given volume.
-	volumes, err := s.DB.Cluster.GetLocalStoragePoolVolumeSnapshotsWithType(projectName, volumeName, volumeType, poolID)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1466,7 +1477,14 @@ func volumeDetermineNextSnapshotName(s *state.State, volume db.StorageVolumeArgs
 	if count > 1 {
 		return "", fmt.Errorf("Snapshot pattern may contain '%%d' only once")
 	} else if count == 1 {
-		i := s.DB.Cluster.GetNextStorageVolumeSnapshotIndex(volume.PoolName, volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
+		var i int
+
+		_ = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			i = tx.GetNextStorageVolumeSnapshotIndex(ctx, volume.PoolName, volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
+
+			return nil
+		})
+
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 
@@ -1506,13 +1524,20 @@ func volumeDetermineNextSnapshotName(s *state.State, volume db.StorageVolumeArgs
 			return "", err
 		}
 
-		for _, project := range projects {
-			snaps, err := s.DB.Cluster.GetLocalStoragePoolVolumeSnapshotsWithType(project, volume.Name, db.StoragePoolVolumeTypeCustom, poolID)
-			if err != nil {
-				return "", err
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			for _, project := range projects {
+				snaps, err := tx.GetLocalStoragePoolVolumeSnapshotsWithType(ctx, project, volume.Name, db.StoragePoolVolumeTypeCustom, poolID)
+				if err != nil {
+					return err
+				}
+
+				snapshots = append(snapshots, snaps...)
 			}
 
-			snapshots = append(snapshots, snaps...)
+			return nil
+		})
+		if err != nil {
+			return "", err
 		}
 	}
 
@@ -1526,7 +1551,14 @@ func volumeDetermineNextSnapshotName(s *state.State, volume db.StorageVolumeArgs
 	}
 
 	if snapshotExists {
-		i := s.DB.Cluster.GetNextStorageVolumeSnapshotIndex(volume.PoolName, volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
+		var i int
+
+		_ = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			i = tx.GetNextStorageVolumeSnapshotIndex(ctx, volume.PoolName, volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
+
+			return nil
+		})
+
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 

--- a/cmd/incusd/storage_volumes_snapshot.go
+++ b/cmd/incusd/storage_volumes_snapshot.go
@@ -711,7 +711,13 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 		return response.SmartError(err)
 	}
 
-	expiry, err := s.DB.Cluster.GetStorageVolumeSnapshotExpiry(dbVolume.ID)
+	var expiry time.Time
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		expiry, err = tx.GetStorageVolumeSnapshotExpiry(ctx, dbVolume.ID)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -840,7 +846,13 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 		return response.SmartError(err)
 	}
 
-	expiry, err := s.DB.Cluster.GetStorageVolumeSnapshotExpiry(dbVolume.ID)
+	var expiry time.Time
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		expiry, err = tx.GetStorageVolumeSnapshotExpiry(ctx, dbVolume.ID)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -971,7 +983,13 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 		return err
 	})
 
-	expiry, err := s.DB.Cluster.GetStorageVolumeSnapshotExpiry(dbVolume.ID)
+	var expiry time.Time
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		expiry, err = tx.GetStorageVolumeSnapshotExpiry(ctx, dbVolume.ID)
+
+		return err
+	})
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/cmd/incusd/storage_volumes_utils.go
+++ b/cmd/incusd/storage_volumes_utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"strings"
 
 	"github.com/lxc/incus/internal/server/backup"
@@ -134,7 +135,13 @@ func storagePoolVolumeUsedByGet(s *state.State, requestProjectName string, poolN
 }
 
 func storagePoolVolumeBackupLoadByName(s *state.State, projectName, poolName, backupName string) (*backup.VolumeBackup, error) {
-	b, err := s.DB.Cluster.GetStoragePoolVolumeBackup(projectName, poolName, backupName)
+	var b db.StoragePoolVolumeBackup
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		b, err = tx.GetStoragePoolVolumeBackup(ctx, projectName, poolName, backupName)
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/backup/backup_config_utils.go
+++ b/internal/server/backup/backup_config_utils.go
@@ -127,8 +127,14 @@ func UpdateInstanceConfig(c *db.Cluster, b Info, mountPath string) error {
 		backup.Volume.Project = b.Project
 	}
 
-	// Load the storage pool.
-	_, pool, _, err := c.GetStoragePool(b.Pool)
+	var pool *api.StoragePool
+
+	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Load the storage pool.
+		_, pool, _, err = tx.GetStoragePool(ctx, b.Pool)
+
+		return err
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/server/backup/backup_instance.go
+++ b/internal/server/backup/backup_instance.go
@@ -1,10 +1,12 @@
 package backup
 
 import (
+	"context"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/lxc/incus/internal/server/db"
 	"github.com/lxc/incus/internal/server/lifecycle"
 	"github.com/lxc/incus/internal/server/operations"
 	"github.com/lxc/incus/internal/server/project"
@@ -93,7 +95,9 @@ func (b *InstanceBackup) Rename(newName string) error {
 	}
 
 	// Rename the database record.
-	err = b.state.DB.Cluster.RenameInstanceBackup(b.name, newName)
+	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.RenameInstanceBackup(ctx, b.name, newName)
+	})
 	if err != nil {
 		return err
 	}
@@ -127,7 +131,9 @@ func (b *InstanceBackup) Delete() error {
 	}
 
 	// Remove the database record.
-	err := b.state.DB.Cluster.DeleteInstanceBackup(b.name)
+	err := b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.DeleteInstanceBackup(ctx, b.name)
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/server/cluster/heartbeat.go
+++ b/internal/server/cluster/heartbeat.go
@@ -186,7 +186,9 @@ func (hbState *APIHeartbeat) Send(ctx context.Context, networkCert *localtls.Cer
 			logger.Warn("Failed heartbeat", logger.Ctx{"remote": address, "err": err})
 
 			if ctx.Err() == nil {
-				err = hbState.cluster.UpsertWarningLocalNode("", cluster.TypeNode, int(nodeID), warningtype.OfflineClusterMember, err.Error())
+				err = hbState.cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					return tx.UpsertWarningLocalNode(ctx, "", cluster.TypeNode, int(nodeID), warningtype.OfflineClusterMember, err.Error())
+				})
 				if err != nil {
 					logger.Warn("Failed to create warning", logger.Ctx{"err": err})
 				}

--- a/internal/server/cluster/member_state.go
+++ b/internal/server/cluster/member_state.go
@@ -76,7 +76,15 @@ func MemberState(ctx context.Context, s *state.State, memberName string) (*api.C
 
 	// Get storage pool states.
 	stateCreated := db.StoragePoolCreated
-	pools, poolMembers, err := s.DB.Cluster.GetStoragePools(ctx, &stateCreated)
+
+	var pools map[int64]api.StoragePool
+	var poolMembers map[int64]map[int64]db.StoragePoolNode
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		pools, poolMembers, err = tx.GetStoragePools(ctx, &stateCreated)
+
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("Failed loading storage pools: %w", err)
 	}

--- a/internal/server/cluster/membership_test.go
+++ b/internal/server/cluster/membership_test.go
@@ -338,7 +338,12 @@ func TestJoin(t *testing.T) {
 
 	err = cluster.Bootstrap(targetState, targetGateway, "buzz")
 	require.NoError(t, err)
-	_, err = targetState.DB.Cluster.GetNetworks(api.ProjectDefaultName)
+
+	err = targetState.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_, err = tx.GetNetworks(ctx, api.ProjectDefaultName)
+
+		return err
+	})
 	require.NoError(t, err)
 
 	// Setup a joining node

--- a/internal/server/db/db_internal_test.go
+++ b/internal/server/db/db_internal_test.go
@@ -186,11 +186,15 @@ func (s *dbTestSuite) Test_deleting_an_image_cascades_on_related_tables() {
 }
 
 func (s *dbTestSuite) Test_ImageGet_finds_image_for_fingerprint() {
-	var err error
 	var result *api.Image
 	project := "default"
 
-	_, result, err = s.db.GetImage("fingerprint", cluster.ImageFilter{Project: &project})
+	err := s.db.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+		var err error
+		_, result, err = tx.GetImage(ctx, "fingerprint", cluster.ImageFilter{Project: &project})
+		return err
+	})
+
 	s.Nil(err)
 	s.NotNil(result)
 	s.Equal(result.Filename, "filename")
@@ -201,24 +205,37 @@ func (s *dbTestSuite) Test_ImageGet_finds_image_for_fingerprint() {
 
 func (s *dbTestSuite) Test_ImageGet_for_missing_fingerprint() {
 	project := "default"
-	var err error
 
-	_, _, err = s.db.GetImage("unknown", cluster.ImageFilter{Project: &project})
+	err := s.db.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+		_, _, err := tx.GetImage(ctx, "unknown", cluster.ImageFilter{Project: &project})
+		return err
+	})
+
 	s.True(api.StatusErrorCheck(err, http.StatusNotFound))
 }
 
 func (s *dbTestSuite) Test_ImageExists_true() {
-	var err error
+	var exists bool
 
-	exists, err := s.db.ImageExists("default", "fingerprint")
+	err := s.db.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+		var err error
+		exists, err = tx.ImageExists(ctx, "default", "fingerprint")
+		return err
+	})
+
 	s.Nil(err)
 	s.True(exists)
 }
 
 func (s *dbTestSuite) Test_ImageExists_false() {
-	var err error
+	var exists bool
 
-	exists, err := s.db.ImageExists("default", "foobar")
+	err := s.db.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+		var err error
+		exists, err = tx.ImageExists(ctx, "default", "foobar")
+		return err
+	})
+
 	s.Nil(err)
 	s.False(exists)
 }
@@ -257,13 +274,14 @@ func (s *dbTestSuite) Test_CreateImageAlias() {
 
 func (s *dbTestSuite) Test_GetCachedImageSourceFingerprint() {
 	project := "default"
-	imageID, _, err := s.db.GetImage("fingerprint", cluster.ImageFilter{Project: &project})
-	s.Nil(err)
-
-	err = s.db.CreateImageSource(imageID, "server.remote", "simplestreams", "", "test")
-	s.Nil(err)
 
 	_ = s.db.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+		imageID, _, err := tx.GetImage(ctx, "fingerprint", cluster.ImageFilter{Project: &project})
+		s.Nil(err)
+
+		err = tx.CreateImageSource(ctx, imageID, "server.remote", "simplestreams", "", "test")
+		s.Nil(err)
+
 		fingerprint, err := tx.GetCachedImageSourceFingerprint(ctx, "server.remote", "simplestreams", "test", "container", 0)
 		s.Nil(err)
 		s.Equal(fingerprint, "fingerprint")
@@ -273,13 +291,14 @@ func (s *dbTestSuite) Test_GetCachedImageSourceFingerprint() {
 
 func (s *dbTestSuite) Test_GetCachedImageSourceFingerprint_no_match() {
 	project := "default"
-	imageID, _, err := s.db.GetImage("fingerprint", cluster.ImageFilter{Project: &project})
-	s.Nil(err)
-
-	err = s.db.CreateImageSource(imageID, "server.remote", "simplestreams", "", "test")
-	s.Nil(err)
 
 	_ = s.db.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+		imageID, _, err := tx.GetImage(ctx, "fingerprint", cluster.ImageFilter{Project: &project})
+		s.Nil(err)
+
+		err = tx.CreateImageSource(ctx, imageID, "server.remote", "simplestreams", "", "test")
+		s.Nil(err)
+
 		_, err = tx.GetCachedImageSourceFingerprint(ctx, "server.remote", "incus", "test", "container", 0)
 		s.True(api.StatusErrorCheck(err, http.StatusNotFound))
 		return nil

--- a/internal/server/db/entity.go
+++ b/internal/server/db/entity.go
@@ -347,7 +347,13 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 
 		uri = fmt.Sprintf(cluster.EntityURIs[entityType], volume.PoolName, volume.TypeName, volume.Name, backup.Name, volume.ProjectName)
 	case cluster.TypeStorageVolumeSnapshot:
-		snapshot, err := c.GetStorageVolumeSnapshotWithID(entityID)
+		var snapshot StorageVolumeArgs
+
+		err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+			snapshot, err = tx.GetStorageVolumeSnapshotWithID(ctx, entityID)
+
+			return err
+		})
 		if err != nil {
 			return "", fmt.Errorf("Failed to get volume snapshot: %w", err)
 		}

--- a/internal/server/db/entity.go
+++ b/internal/server/db/entity.go
@@ -233,7 +233,16 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 
 		uri = fmt.Sprintf(cluster.EntityURIs[entityType], networkName, projectName)
 	case cluster.TypeNetworkACL:
-		networkACLName, projectName, err := c.GetNetworkACLNameAndProjectWithID(entityID)
+		var networkACLName string
+		var projectName string
+
+		err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+			var err error
+
+			networkACLName, projectName, err = tx.GetNetworkACLNameAndProjectWithID(ctx, entityID)
+
+			return err
+		})
 		if err != nil {
 			return "", fmt.Errorf("Failed to get network ACL name and project name: %w", err)
 		}

--- a/internal/server/db/entity.go
+++ b/internal/server/db/entity.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/lxc/incus/internal/server/db/cluster"
+	"github.com/lxc/incus/shared/api"
 )
 
 // ErrUnknownEntityID describes the unknown entity ID error.
@@ -295,7 +296,13 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 
 		uri = fmt.Sprintf(cluster.EntityURIs[entityType], op.UUID)
 	case cluster.TypeStoragePool:
-		_, pool, _, err := c.GetStoragePoolWithID(entityID)
+		var pool *api.StoragePool
+
+		err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+			_, pool, _, err = tx.GetStoragePoolWithID(ctx, entityID)
+
+			return err
+		})
 		if err != nil {
 			return "", fmt.Errorf("Failed to get storage pool: %w", err)
 		}

--- a/internal/server/db/entity.go
+++ b/internal/server/db/entity.go
@@ -226,7 +226,14 @@ func (c *Cluster) GetURIFromEntity(entityType int, entityID int) (string, error)
 		}
 
 	case cluster.TypeNetwork:
-		networkName, projectName, err := c.GetNetworkNameAndProjectWithID(entityID)
+		var networkName string
+		var projectName string
+
+		err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
+			networkName, projectName, err = tx.GetNetworkNameAndProjectWithID(ctx, entityID)
+
+			return err
+		})
 		if err != nil {
 			return "", fmt.Errorf("Failed to get network name and project name: %w", err)
 		}

--- a/internal/server/db/images.go
+++ b/internal/server/db/images.go
@@ -210,7 +210,7 @@ SELECT fingerprint
 }
 
 // CreateImageSource inserts a new image source.
-func (c *Cluster) CreateImageSource(id int, server string, protocol string, certificate string, alias string) error {
+func (c *ClusterTx) CreateImageSource(ctx context.Context, id int, server string, protocol string, certificate string, alias string) error {
 	protocolInt := -1
 	for protoInt, protoString := range ImageSourceProtocol {
 		if protoString == protocol {
@@ -222,21 +222,18 @@ func (c *Cluster) CreateImageSource(id int, server string, protocol string, cert
 		return fmt.Errorf("Invalid protocol: %s", protocol)
 	}
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := query.UpsertObject(tx.tx, "images_source", []string{
-			"image_id",
-			"server",
-			"protocol",
-			"certificate",
-			"alias",
-		}, []any{
-			id,
-			server,
-			protocolInt,
-			certificate,
-			alias,
-		})
-		return err
+	_, err := query.UpsertObject(c.tx, "images_source", []string{
+		"image_id",
+		"server",
+		"protocol",
+		"certificate",
+		"alias",
+	}, []any{
+		id,
+		server,
+		protocolInt,
+		certificate,
+		alias,
 	})
 
 	return err
@@ -294,66 +291,48 @@ func (c *ClusterTx) GetCachedImageSourceFingerprint(ctx context.Context, server 
 }
 
 // ImageExists returns whether an image with the given fingerprint exists.
-func (c *Cluster) ImageExists(project string, fingerprint string) (bool, error) {
+func (c *ClusterTx) ImageExists(ctx context.Context, project string, fingerprint string) (bool, error) {
 	table := "images JOIN projects ON projects.id = images.project_id"
 	where := "projects.name = ? AND fingerprint=?"
 
-	var exists bool
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		enabled, err := cluster.ProjectHasImages(context.Background(), tx.tx, project)
-		if err != nil {
-			return fmt.Errorf("Check if project has images: %w", err)
-		}
+	enabled, err := cluster.ProjectHasImages(ctx, c.tx, project)
+	if err != nil {
+		return false, fmt.Errorf("Check if project has images: %w", err)
+	}
 
-		if !enabled {
-			project = "default"
-		}
+	if !enabled {
+		project = "default"
+	}
 
-		count, err := query.Count(ctx, tx.tx, table, where, project, fingerprint)
-		if err != nil {
-			return err
-		}
-
-		exists = count > 0
-		return nil
-	})
+	count, err := query.Count(ctx, c.tx, table, where, project, fingerprint)
 	if err != nil {
 		return false, err
 	}
 
-	return exists, nil
+	return count > 0, nil
 }
 
 // ImageIsReferencedByOtherProjects returns true if the image with the given
 // fingerprint is referenced by projects other than the given one.
-func (c *Cluster) ImageIsReferencedByOtherProjects(project string, fingerprint string) (bool, error) {
+func (c *ClusterTx) ImageIsReferencedByOtherProjects(ctx context.Context, project string, fingerprint string) (bool, error) {
 	table := "images JOIN projects ON projects.id = images.project_id"
 	where := "projects.name != ? AND fingerprint=?"
 
-	var referenced bool
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		enabled, err := cluster.ProjectHasImages(context.Background(), tx.tx, project)
-		if err != nil {
-			return fmt.Errorf("Check if project has images: %w", err)
-		}
+	enabled, err := cluster.ProjectHasImages(ctx, c.tx, project)
+	if err != nil {
+		return false, fmt.Errorf("Check if project has images: %w", err)
+	}
 
-		if !enabled {
-			project = "default"
-		}
+	if !enabled {
+		project = "default"
+	}
 
-		count, err := query.Count(ctx, tx.tx, table, where, project, fingerprint)
-		if err != nil {
-			return err
-		}
-
-		referenced = count > 0
-		return nil
-	})
+	count, err := query.Count(ctx, c.tx, table, where, project, fingerprint)
 	if err != nil {
 		return false, err
 	}
 
-	return referenced, nil
+	return count > 0, nil
 }
 
 // GetImage gets an Image object from the database.
@@ -363,15 +342,8 @@ func (c *Cluster) ImageIsReferencedByOtherProjects(project string, fingerprint s
 // shortform matches more than one image, an error will be returned.
 // publicOnly, when true, will return the image only if it is public;
 // a false value will return any image matching the fingerprint prefix.
-func (c *Cluster) GetImage(fingerprintPrefix string, filter cluster.ImageFilter) (int, *api.Image, error) {
-	var image *api.Image
-	var id int
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		id, image, err = tx.GetImageByFingerprintPrefix(ctx, fingerprintPrefix, filter)
-
-		return err
-	})
+func (c *ClusterTx) GetImage(ctx context.Context, fingerprintPrefix string, filter cluster.ImageFilter) (int, *api.Image, error) {
+	id, image, err := c.GetImageByFingerprintPrefix(ctx, fingerprintPrefix, filter)
 	if err != nil {
 		return -1, nil, err
 	}
@@ -447,42 +419,35 @@ func (c *ClusterTx) GetImageByFingerprintPrefix(ctx context.Context, fingerprint
 
 // GetImageFromAnyProject returns an image matching the given fingerprint, if
 // it exists in any project.
-func (c *Cluster) GetImageFromAnyProject(fingerprint string) (int, *api.Image, error) {
+func (c *ClusterTx) GetImageFromAnyProject(ctx context.Context, fingerprint string) (int, *api.Image, error) {
 	// The object we'll actually return
 	var image api.Image
 	var object cluster.Image
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		images, err := tx.getImagesByFingerprintPrefix(ctx, fingerprint, cluster.ImageFilter{})
-		if err != nil {
-			return fmt.Errorf("Failed to fetch images: %w", err)
-		}
-
-		if len(images) == 0 {
-			return api.StatusErrorf(http.StatusNotFound, "Image not found")
-		}
-
-		object = images[0]
-
-		image.Fingerprint = object.Fingerprint
-		image.Filename = object.Filename
-		image.Size = object.Size
-		image.Cached = object.Cached
-		image.Public = object.Public
-		image.AutoUpdate = object.AutoUpdate
-
-		err = tx.imageFill(
-			ctx, object.ID, &image,
-			&object.CreationDate.Time, &object.ExpiryDate.Time, &object.LastUseDate.Time,
-			&object.UploadDate, object.Architecture, object.Type)
-		if err != nil {
-			return fmt.Errorf("Fill image details: %w", err)
-		}
-
-		return nil
-	})
+	images, err := c.getImagesByFingerprintPrefix(ctx, fingerprint, cluster.ImageFilter{})
 	if err != nil {
-		return -1, nil, fmt.Errorf("Get image %q: %w", fingerprint, err)
+		return -1, nil, fmt.Errorf("Get image %q: Failed to fetch images: %w", fingerprint, err)
+	}
+
+	if len(images) == 0 {
+		return -1, nil, fmt.Errorf("Get image %q: %w", fingerprint, api.StatusErrorf(http.StatusNotFound, "Image not found"))
+	}
+
+	object = images[0]
+
+	image.Fingerprint = object.Fingerprint
+	image.Filename = object.Filename
+	image.Size = object.Size
+	image.Cached = object.Cached
+	image.Public = object.Public
+	image.AutoUpdate = object.AutoUpdate
+
+	err = c.imageFill(
+		ctx, object.ID, &image,
+		&object.CreationDate.Time, &object.ExpiryDate.Time, &object.LastUseDate.Time,
+		&object.UploadDate, object.Architecture, object.Type)
+	if err != nil {
+		return -1, nil, fmt.Errorf("Get image %q: Fill image details: %w", fingerprint, err)
 	}
 
 	return object.ID, &image, nil
@@ -554,7 +519,7 @@ WHERE images.fingerprint LIKE ?
 // node.
 //
 // If the image is not available on any online node, an error is returned.
-func (c *Cluster) LocateImage(fingerprint string) (string, error) {
+func (c *ClusterTx) LocateImage(ctx context.Context, fingerprint string) (string, error) {
 	stmt := `
 SELECT nodes.address FROM nodes
   LEFT JOIN images_nodes ON images_nodes.node_id = nodes.id
@@ -564,39 +529,32 @@ WHERE images.fingerprint = ?
 	var localAddress string // Address of this node
 	var addresses []string  // Addresses of online nodes with the image
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		offlineThreshold, err := tx.GetNodeOfflineThreshold(ctx)
-		if err != nil {
-			return err
-		}
-
-		localAddress, err = tx.GetLocalNodeAddress(ctx)
-		if err != nil {
-			return err
-		}
-
-		allAddresses, err := query.SelectStrings(ctx, tx.tx, stmt, fingerprint)
-		if err != nil {
-			return err
-		}
-
-		for _, address := range allAddresses {
-			node, err := tx.GetNodeByAddress(ctx, address)
-			if err != nil {
-				return err
-			}
-
-			if address != localAddress && node.IsOffline(offlineThreshold) {
-				continue
-			}
-
-			addresses = append(addresses, address)
-		}
-
-		return err
-	})
+	offlineThreshold, err := c.GetNodeOfflineThreshold(ctx)
 	if err != nil {
 		return "", err
+	}
+
+	localAddress, err = c.GetLocalNodeAddress(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	allAddresses, err := query.SelectStrings(ctx, c.tx, stmt, fingerprint)
+	if err != nil {
+		return "", err
+	}
+
+	for _, address := range allAddresses {
+		node, err := c.GetNodeByAddress(ctx, address)
+		if err != nil {
+			return "", err
+		}
+
+		if address != localAddress && node.IsOffline(offlineThreshold) {
+			continue
+		}
+
+		addresses = append(addresses, address)
 	}
 
 	if len(addresses) == 0 {
@@ -614,33 +572,29 @@ WHERE images.fingerprint = ?
 
 // AddImageToLocalNode creates a new entry in the images_nodes table for
 // tracking that the local member has the given image.
-func (c *Cluster) AddImageToLocalNode(project, fingerprint string) error {
-	imageID, _, err := c.GetImage(fingerprint, cluster.ImageFilter{Project: &project})
+func (c *ClusterTx) AddImageToLocalNode(ctx context.Context, project, fingerprint string) error {
+	imageID, _, err := c.GetImage(ctx, fingerprint, cluster.ImageFilter{Project: &project})
 	if err != nil {
 		return err
 	}
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.Exec("INSERT INTO images_nodes(image_id, node_id) VALUES(?, ?)", imageID, c.nodeID)
-		return err
-	})
+	_, err = c.tx.ExecContext(ctx, "INSERT INTO images_nodes(image_id, node_id) VALUES(?, ?)", imageID, c.nodeID)
+
 	return err
 }
 
 // DeleteImage deletes the image with the given ID.
-func (c *Cluster) DeleteImage(id int) error {
-	return c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		deleted, err := query.DeleteObject(tx.tx, "images", int64(id))
-		if err != nil {
-			return err
-		}
+func (c *ClusterTx) DeleteImage(ctx context.Context, id int) error {
+	deleted, err := query.DeleteObject(c.tx, "images", int64(id))
+	if err != nil {
+		return err
+	}
 
-		if !deleted {
-			return fmt.Errorf("No image with ID %d", id)
-		}
+	if !deleted {
+		return fmt.Errorf("No image with ID %d", id)
+	}
 
-		return nil
-	})
+	return nil
 }
 
 // GetImageAliases returns the names of the aliases of all images.
@@ -717,12 +671,10 @@ func (c *ClusterTx) GetImageAlias(ctx context.Context, projectName string, image
 }
 
 // RenameImageAlias renames the alias with the given ID.
-func (c *Cluster) RenameImageAlias(id int, name string) error {
+func (c *ClusterTx) RenameImageAlias(ctx context.Context, id int, name string) error {
 	q := "UPDATE images_aliases SET name=? WHERE id=?"
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.Exec(q, name, id)
-		return err
-	})
+	_, err := c.tx.ExecContext(ctx, q, name, id)
+
 	return err
 }
 
@@ -751,12 +703,10 @@ DELETE
 }
 
 // MoveImageAlias changes the image ID associated with an alias.
-func (c *Cluster) MoveImageAlias(source int, destination int) error {
+func (c *ClusterTx) MoveImageAlias(ctx context.Context, source int, destination int) error {
 	q := "UPDATE images_aliases SET image_id=? WHERE image_id=?"
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.Exec(q, destination, source)
-		return err
-	})
+	_, err := c.tx.ExecContext(ctx, q, destination, source)
+
 	return err
 }
 
@@ -790,22 +740,15 @@ func (c *ClusterTx) UpdateImageAlias(ctx context.Context, aliasID int, imageID i
 }
 
 // CopyDefaultImageProfiles copies default profiles from id to new_id.
-func (c *Cluster) CopyDefaultImageProfiles(id int, newID int) error {
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		// Delete all current associations.
-		_, err := tx.tx.Exec("DELETE FROM images_profiles WHERE image_id=?", newID)
-		if err != nil {
-			return err
-		}
+func (c *ClusterTx) CopyDefaultImageProfiles(ctx context.Context, id int, newID int) error {
+	// Delete all current associations.
+	_, err := c.tx.ExecContext(ctx, "DELETE FROM images_profiles WHERE image_id=?", newID)
+	if err != nil {
+		return err
+	}
 
-		// Copy the entries over.
-		_, err = tx.tx.Exec("INSERT INTO images_profiles (image_id, profile_id) SELECT ?, profile_id FROM images_profiles WHERE image_id=?", newID, id)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
+	// Copy the entries over.
+	_, err = c.tx.ExecContext(ctx, "INSERT INTO images_profiles (image_id, profile_id) SELECT ?, profile_id FROM images_profiles WHERE image_id=?", newID, id)
 	if err != nil {
 		return err
 	}
@@ -822,93 +765,89 @@ func (c *ClusterTx) UpdateImageLastUseDate(ctx context.Context, projectName stri
 }
 
 // SetImageCachedAndLastUseDate sets the cached and last_use_date field of the image with the given fingerprint.
-func (c *Cluster) SetImageCachedAndLastUseDate(projectName string, fingerprint string, lastUsed time.Time) error {
+func (c *ClusterTx) SetImageCachedAndLastUseDate(ctx context.Context, projectName string, fingerprint string, lastUsed time.Time) error {
 	stmt := `UPDATE images SET cached=1, last_use_date=? WHERE fingerprint=? AND project_id = (SELECT id FROM projects WHERE name = ? LIMIT 1)`
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.Exec(stmt, lastUsed, fingerprint, projectName)
-		return err
-	})
+
+	_, err := c.tx.ExecContext(ctx, stmt, lastUsed, fingerprint, projectName)
+
 	return err
 }
 
 // UpdateImage updates the image with the given ID.
-func (c *Cluster) UpdateImage(id int, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string, project string, profileIds []int64) error {
+func (c *ClusterTx) UpdateImage(ctx context.Context, id int, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string, project string, profileIds []int64) error {
 	arch, err := osarch.ArchitectureId(architecture)
 	if err != nil {
 		arch = 0
 	}
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		publicInt := 0
-		if public {
-			publicInt = 1
+	publicInt := 0
+	if public {
+		publicInt = 1
+	}
+
+	autoUpdateInt := 0
+	if autoUpdate {
+		autoUpdateInt = 1
+	}
+
+	sql := `UPDATE images SET filename=?, size=?, public=?, auto_update=?, architecture=?, creation_date=?, expiry_date=? WHERE id=?`
+	_, err = c.tx.ExecContext(ctx, sql, fname, sz, publicInt, autoUpdateInt, arch, createdAt, expiresAt, id)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.tx.ExecContext(ctx, `DELETE FROM images_properties WHERE image_id=?`, id)
+	if err != nil {
+		return err
+	}
+
+	sql = `INSERT INTO images_properties (image_id, type, key, value) VALUES (?, ?, ?, ?)`
+	for key, value := range properties {
+		if value == "" {
+			continue
 		}
 
-		autoUpdateInt := 0
-		if autoUpdate {
-			autoUpdateInt = 1
+		_, err = c.tx.ExecContext(ctx, sql, id, 0, key, value)
+		if err != nil {
+			return err
 		}
+	}
 
-		sql := `UPDATE images SET filename=?, size=?, public=?, auto_update=?, architecture=?, creation_date=?, expiry_date=? WHERE id=?`
-		_, err = tx.tx.Exec(sql, fname, sz, publicInt, autoUpdateInt, arch, createdAt, expiresAt, id)
+	if project != "" && profileIds != nil {
+		enabled, err := cluster.ProjectHasProfiles(ctx, c.tx, project)
 		if err != nil {
 			return err
 		}
 
-		_, err = tx.tx.Exec(`DELETE FROM images_properties WHERE image_id=?`, id)
-		if err != nil {
-			return err
+		if !enabled {
+			project = "default"
 		}
 
-		sql = `INSERT INTO images_properties (image_id, type, key, value) VALUES (?, ?, ?, ?)`
-		for key, value := range properties {
-			if value == "" {
-				continue
-			}
-
-			_, err = tx.tx.Exec(sql, id, 0, key, value)
-			if err != nil {
-				return err
-			}
-		}
-
-		if project != "" && profileIds != nil {
-			enabled, err := cluster.ProjectHasProfiles(context.Background(), tx.tx, project)
-			if err != nil {
-				return err
-			}
-
-			if !enabled {
-				project = "default"
-			}
-
-			q := `DELETE FROM images_profiles
+		q := `DELETE FROM images_profiles
 				WHERE image_id = ? AND profile_id IN (
 					SELECT profiles.id FROM profiles
 					JOIN projects ON profiles.project_id = projects.id
 					WHERE projects.name = ?
 				)`
-			_, err = tx.tx.Exec(q, id, project)
+		_, err = c.tx.ExecContext(ctx, q, id, project)
+		if err != nil {
+			return err
+		}
+
+		sql = `INSERT INTO images_profiles (image_id, profile_id) VALUES (?, ?)`
+		for _, profileID := range profileIds {
+			_, err = c.tx.ExecContext(ctx, sql, id, profileID)
 			if err != nil {
 				return err
 			}
-
-			sql = `INSERT INTO images_profiles (image_id, profile_id) VALUES (?, ?)`
-			for _, profileID := range profileIds {
-				_, err = tx.tx.Exec(sql, id, profileID)
-				if err != nil {
-					return err
-				}
-			}
 		}
+	}
 
-		return nil
-	})
-	return err
+	return nil
 }
 
 // CreateImage creates a new image.
-func (c *Cluster) CreateImage(project string, fp string, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string, typeName string, profileIds []int64) error {
+func (c *ClusterTx) CreateImage(ctx context.Context, project string, fp string, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string, typeName string, profileIds []int64) error {
 	arch, err := osarch.ArchitectureId(architecture)
 	if err != nil {
 		arch = 0
@@ -927,85 +866,84 @@ func (c *Cluster) CreateImage(project string, fp string, fname string, sz int64,
 		return fmt.Errorf("Invalid image type: %v", typeName)
 	}
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		imageProject := project
-		enabled, err := cluster.ProjectHasImages(ctx, tx.tx, imageProject)
+	imageProject := project
+	enabled, err := cluster.ProjectHasImages(ctx, c.tx, imageProject)
+	if err != nil {
+		return fmt.Errorf("Check if project has images: %w", err)
+	}
+
+	if !enabled {
+		imageProject = "default"
+	}
+
+	publicInt := 0
+	if public {
+		publicInt = 1
+	}
+
+	autoUpdateInt := 0
+	if autoUpdate {
+		autoUpdateInt = 1
+	}
+
+	sql := `INSERT INTO images (project_id, fingerprint, filename, size, public, auto_update, architecture, creation_date, expiry_date, upload_date, type) VALUES ((SELECT id FROM projects WHERE name = ?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	result, err := c.tx.ExecContext(ctx, sql, imageProject, fp, fname, sz, publicInt, autoUpdateInt, arch, createdAt, expiresAt, time.Now().UTC(), imageType)
+	if err != nil {
+		return fmt.Errorf("Failed saving main image record: %w", err)
+	}
+
+	var id int
+	{
+		id64, err := result.LastInsertId()
 		if err != nil {
-			return fmt.Errorf("Check if project has images: %w", err)
+			return fmt.Errorf("Failed getting image ID: %w", err)
 		}
 
-		if !enabled {
-			imageProject = "default"
-		}
+		id = int(id64)
+	}
 
-		publicInt := 0
-		if public {
-			publicInt = 1
+	if len(properties) > 0 {
+		sql = `INSERT INTO images_properties (image_id, type, key, value) VALUES (?, 0, ?, ?)`
+		for k, v := range properties {
+			// we can assume, that there is just one
+			// value per key
+			_, err = c.tx.ExecContext(ctx, sql, id, k, v)
+			if err != nil {
+				return fmt.Errorf("Failed saving image properties %d: %w", id, err)
+			}
 		}
+	}
 
-		autoUpdateInt := 0
-		if autoUpdate {
-			autoUpdateInt = 1
+	if profileIds != nil {
+		sql = `INSERT INTO images_profiles (image_id, profile_id) VALUES (?, ?)`
+		for _, profileID := range profileIds {
+			_, err = c.tx.ExecContext(ctx, sql, id, profileID)
+			if err != nil {
+				return fmt.Errorf("Failed saving image profiles: %w", err)
+			}
 		}
-
-		sql := `INSERT INTO images (project_id, fingerprint, filename, size, public, auto_update, architecture, creation_date, expiry_date, upload_date, type) VALUES ((SELECT id FROM projects WHERE name = ?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-		result, err := tx.tx.Exec(sql, imageProject, fp, fname, sz, publicInt, autoUpdateInt, arch, createdAt, expiresAt, time.Now().UTC(), imageType)
+	} else {
+		dbProfiles, err := cluster.GetProfilesIfEnabled(ctx, c.tx, project, []string{"default"})
 		if err != nil {
-			return fmt.Errorf("Failed saving main image record: %w", err)
+			return err
 		}
 
-		var id int
-		{
-			id64, err := result.LastInsertId()
-			if err != nil {
-				return fmt.Errorf("Failed getting image ID: %w", err)
-			}
-
-			id = int(id64)
+		if len(dbProfiles) != 1 {
+			return fmt.Errorf("Failed to find default profile in project %q", project)
 		}
 
-		if len(properties) > 0 {
-			sql = `INSERT INTO images_properties (image_id, type, key, value) VALUES (?, 0, ?, ?)`
-			for k, v := range properties {
-				// we can assume, that there is just one
-				// value per key
-				_, err = tx.tx.Exec(sql, id, k, v)
-				if err != nil {
-					return fmt.Errorf("Failed saving image properties %d: %w", id, err)
-				}
-			}
+		_, err = c.tx.ExecContext(ctx, "INSERT INTO images_profiles(image_id, profile_id) VALUES(?, ?)", id, dbProfiles[0].ID)
+		if err != nil {
+			return fmt.Errorf("Failed saving image prfofiles: %w", err)
 		}
+	}
 
-		if profileIds != nil {
-			sql = `INSERT INTO images_profiles (image_id, profile_id) VALUES (?, ?)`
-			for _, profileID := range profileIds {
-				_, err = tx.tx.Exec(sql, id, profileID)
-				if err != nil {
-					return fmt.Errorf("Failed saving image profiles: %w", err)
-				}
-			}
-		} else {
-			dbProfiles, err := cluster.GetProfilesIfEnabled(ctx, tx.Tx(), project, []string{"default"})
-			if err != nil {
-				return err
-			}
-
-			if len(dbProfiles) != 1 {
-				return fmt.Errorf("Failed to find default profile in project %q", project)
-			}
-
-			_, err = tx.tx.Exec("INSERT INTO images_profiles(image_id, profile_id) VALUES(?, ?)", id, dbProfiles[0].ID)
-			if err != nil {
-				return fmt.Errorf("Failed saving image prfofiles: %w", err)
-			}
-		}
-
-		// All projects with features.images=false can use all images added to the "default" project.
-		// If these projects also have features.profiles=true, their default profiles should be associated
-		// with all created images.
-		if imageProject == "default" {
-			_, err = tx.tx.Exec(
-				`INSERT OR IGNORE INTO images_profiles(image_id, profile_id)
+	// All projects with features.images=false can use all images added to the "default" project.
+	// If these projects also have features.profiles=true, their default profiles should be associated
+	// with all created images.
+	if imageProject == "default" {
+		_, err = c.tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO images_profiles(image_id, profile_id)
 					SELECT ?, profiles.id FROM profiles
 						JOIN projects_config AS t1 ON t1.project_id = profiles.project_id
 							AND t1.key = "features.images"
@@ -1014,30 +952,24 @@ func (c *Cluster) CreateImage(project string, fp string, fname string, sz int64,
 							AND t2.key = "features.profiles"
 							AND t2.value = "true"
 						WHERE profiles.name = "default"`, id)
-			if err != nil {
-				return err
-			}
-		}
-
-		_, err = tx.tx.Exec("INSERT INTO images_nodes(image_id, node_id) VALUES(?, ?)", id, c.nodeID)
 		if err != nil {
-			return fmt.Errorf("Failed saving image member info: %w", err)
+			return err
 		}
+	}
 
-		return nil
-	})
-	return err
+	_, err = c.tx.ExecContext(ctx, "INSERT INTO images_nodes(image_id, node_id) VALUES(?, ?)", id, c.nodeID)
+	if err != nil {
+		return fmt.Errorf("Failed saving image member info: %w", err)
+	}
+
+	return nil
 }
 
 // GetPoolsWithImage get the IDs of all storage pools on which a given image exists.
-func (c *Cluster) GetPoolsWithImage(imageFingerprint string) ([]int64, error) {
+func (c *ClusterTx) GetPoolsWithImage(ctx context.Context, imageFingerprint string) ([]int64, error) {
 	q := "SELECT storage_pool_id FROM storage_volumes WHERE (node_id=? OR node_id IS NULL) AND name=? AND type=?"
-	var ids []int
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		ids, err = query.SelectIntegers(ctx, tx.tx, q, c.nodeID, imageFingerprint, StoragePoolVolumeTypeImage)
-		return err
-	})
+
+	ids, err := query.SelectIntegers(ctx, c.tx, q, c.nodeID, imageFingerprint, StoragePoolVolumeTypeImage)
 	if err != nil {
 		return nil, err
 	}
@@ -1051,7 +983,7 @@ func (c *Cluster) GetPoolsWithImage(imageFingerprint string) ([]int64, error) {
 }
 
 // GetPoolNamesFromIDs get the names of the storage pools with the given IDs.
-func (c *Cluster) GetPoolNamesFromIDs(poolIDs []int64) ([]string, error) {
+func (c *ClusterTx) GetPoolNamesFromIDs(ctx context.Context, poolIDs []int64) ([]string, error) {
 	params := make([]string, len(poolIDs))
 	args := make([]any, len(poolIDs))
 	for i, id := range poolIDs {
@@ -1061,13 +993,7 @@ func (c *Cluster) GetPoolNamesFromIDs(poolIDs []int64) ([]string, error) {
 
 	q := fmt.Sprintf("SELECT name FROM storage_pools WHERE id IN (%s)", strings.Join(params, ","))
 
-	var poolNames []string
-
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		poolNames, err = query.SelectStrings(ctx, tx.tx, q, args...)
-		return err
-	})
+	poolNames, err := query.SelectStrings(ctx, c.tx, q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1080,95 +1006,91 @@ func (c *Cluster) GetPoolNamesFromIDs(poolIDs []int64) ([]string, error) {
 }
 
 // GetImages returns all images.
-func (c *Cluster) GetImages() (map[string][]string, error) {
+func (c *ClusterTx) GetImages(ctx context.Context) (map[string][]string, error) {
 	images := make(map[string][]string) // key is fingerprint, value is list of projects
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		stmt := `
+
+	stmt := `
     SELECT images.fingerprint, projects.name FROM images
       LEFT JOIN projects ON images.project_id = projects.id
 		`
-		rows, err := tx.tx.QueryContext(ctx, stmt)
+	rows, err := c.tx.QueryContext(ctx, stmt)
+	if err != nil {
+		return nil, err
+	}
+
+	var fingerprint string
+	var projectName string
+	for rows.Next() {
+		err := rows.Scan(&fingerprint, &projectName)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		var fingerprint string
-		var projectName string
-		for rows.Next() {
-			err := rows.Scan(&fingerprint, &projectName)
-			if err != nil {
-				return err
-			}
+		images[fingerprint] = append(images[fingerprint], projectName)
+	}
 
-			images[fingerprint] = append(images[fingerprint], projectName)
-		}
-
-		return rows.Err()
-	})
-	return images, err
+	return images, rows.Err()
 }
 
 // GetImagesOnLocalNode returns all images that the local server holds.
-func (c *Cluster) GetImagesOnLocalNode() (map[string][]string, error) {
-	return c.GetImagesOnNode(c.nodeID)
+func (c *ClusterTx) GetImagesOnLocalNode(ctx context.Context) (map[string][]string, error) {
+	return c.GetImagesOnNode(ctx, c.nodeID)
 }
 
 // GetImagesOnNode returns all images that the node with the given id has.
-func (c *Cluster) GetImagesOnNode(id int64) (map[string][]string, error) {
+func (c *ClusterTx) GetImagesOnNode(ctx context.Context, id int64) (map[string][]string, error) {
 	images := make(map[string][]string) // key is fingerprint, value is list of projects
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		stmt := `
+
+	stmt := `
     SELECT images.fingerprint, projects.name FROM images
       LEFT JOIN images_nodes ON images.id = images_nodes.image_id
 			LEFT JOIN nodes ON images_nodes.node_id = nodes.id
 			LEFT JOIN projects ON images.project_id = projects.id
     WHERE nodes.id = ?
 		`
-		rows, err := tx.tx.QueryContext(ctx, stmt, id)
+	rows, err := c.tx.QueryContext(ctx, stmt, id)
+	if err != nil {
+		return nil, err
+	}
+
+	var fingerprint string
+	var projectName string
+	for rows.Next() {
+		err := rows.Scan(&fingerprint, &projectName)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		var fingerprint string
-		var projectName string
-		for rows.Next() {
-			err := rows.Scan(&fingerprint, &projectName)
-			if err != nil {
-				return err
-			}
+		images[fingerprint] = append(images[fingerprint], projectName)
+	}
 
-			images[fingerprint] = append(images[fingerprint], projectName)
-		}
-
-		return rows.Err()
-	})
-	return images, err
+	return images, rows.Err()
 }
 
 // GetNodesWithImage returns the addresses of online nodes which already have the image.
-func (c *Cluster) GetNodesWithImage(fingerprint string) ([]string, error) {
+func (c *ClusterTx) GetNodesWithImage(ctx context.Context, fingerprint string) ([]string, error) {
 	q := `
 SELECT DISTINCT nodes.address FROM nodes
   LEFT JOIN images_nodes ON images_nodes.node_id = nodes.id
   LEFT JOIN images ON images_nodes.image_id = images.id
 WHERE images.fingerprint = ?
 	`
-	return c.getNodesByImageFingerprint(q, fingerprint, nil)
+	return c.getNodesByImageFingerprint(ctx, q, fingerprint, nil)
 }
 
 // GetNodesWithImageAndAutoUpdate returns the addresses of online nodes which already have the image.
-func (c *Cluster) GetNodesWithImageAndAutoUpdate(fingerprint string, autoUpdate bool) ([]string, error) {
+func (c *ClusterTx) GetNodesWithImageAndAutoUpdate(ctx context.Context, fingerprint string, autoUpdate bool) ([]string, error) {
 	q := `
 SELECT DISTINCT nodes.address FROM nodes
   JOIN images_nodes ON images_nodes.node_id = nodes.id
   JOIN images ON images_nodes.image_id = images.id
 WHERE images.fingerprint = ? AND images.auto_update = ?
 	`
-	return c.getNodesByImageFingerprint(q, fingerprint, &autoUpdate)
+	return c.getNodesByImageFingerprint(ctx, q, fingerprint, &autoUpdate)
 }
 
 // GetNodesWithoutImage returns the addresses of online nodes which don't have the image.
-func (c *Cluster) GetNodesWithoutImage(fingerprint string) ([]string, error) {
+func (c *ClusterTx) GetNodesWithoutImage(ctx context.Context, fingerprint string) ([]string, error) {
 	q := `
 SELECT DISTINCT nodes.address FROM nodes WHERE nodes.address NOT IN (
   SELECT DISTINCT nodes.address FROM nodes
@@ -1176,45 +1098,43 @@ SELECT DISTINCT nodes.address FROM nodes WHERE nodes.address NOT IN (
     LEFT JOIN images ON images_nodes.image_id = images.id
   WHERE images.fingerprint = ?)
 `
-	return c.getNodesByImageFingerprint(q, fingerprint, nil)
+	return c.getNodesByImageFingerprint(ctx, q, fingerprint, nil)
 }
 
-func (c *Cluster) getNodesByImageFingerprint(stmt string, fingerprint string, autoUpdate *bool) ([]string, error) {
+func (c *ClusterTx) getNodesByImageFingerprint(ctx context.Context, stmt string, fingerprint string, autoUpdate *bool) ([]string, error) {
 	var addresses []string // Addresses of online nodes with the image
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		offlineThreshold, err := tx.GetNodeOfflineThreshold(ctx)
+
+	offlineThreshold, err := c.GetNodeOfflineThreshold(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var allAddresses []string
+
+	if autoUpdate == nil {
+		allAddresses, err = query.SelectStrings(ctx, c.tx, stmt, fingerprint)
+	} else {
+		allAddresses, err = query.SelectStrings(ctx, c.tx, stmt, fingerprint, autoUpdate)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, address := range allAddresses {
+		node, err := c.GetNodeByAddress(ctx, address)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		var allAddresses []string
-
-		if autoUpdate == nil {
-			allAddresses, err = query.SelectStrings(ctx, tx.tx, stmt, fingerprint)
-		} else {
-			allAddresses, err = query.SelectStrings(ctx, tx.tx, stmt, fingerprint, autoUpdate)
+		if node.IsOffline(offlineThreshold) {
+			continue
 		}
 
-		if err != nil {
-			return err
-		}
+		addresses = append(addresses, address)
+	}
 
-		for _, address := range allAddresses {
-			node, err := tx.GetNodeByAddress(ctx, address)
-			if err != nil {
-				return err
-			}
-
-			if node.IsOffline(offlineThreshold) {
-				continue
-			}
-
-			addresses = append(addresses, address)
-		}
-
-		return err
-	})
-	return addresses, err
+	return addresses, nil
 }
 
 // GetProjectsUsingImage get the project names using an image by fingerprint.

--- a/internal/server/db/instances.go
+++ b/internal/server/db/instances.go
@@ -221,7 +221,7 @@ var ErrInstanceListStop = fmt.Errorf("search stopped")
 
 // InstanceList loads all instances across all projects and for each instance runs the instanceFunc passing in the
 // instance and it's project and profiles. Accepts optional filter arguments to specify a subset of instances.
-func (c *Cluster) InstanceList(ctx context.Context, instanceFunc func(inst InstanceArgs, project api.Project) error, filters ...cluster.InstanceFilter) error {
+func (c *ClusterTx) InstanceList(ctx context.Context, instanceFunc func(inst InstanceArgs, project api.Project) error, filters ...cluster.InstanceFilter) error {
 	projectsByName := make(map[string]*api.Project)
 	var instances map[int]InstanceArgs
 
@@ -238,52 +238,45 @@ func (c *Cluster) InstanceList(ctx context.Context, instanceFunc func(inst Insta
 	}
 
 	// Retrieve required info from the database in single transaction for performance.
-	err := c.Transaction(ctx, func(ctx context.Context, tx *ClusterTx) error {
-		// Get all projects.
-		projects, err := cluster.GetProjects(ctx, tx.tx)
-		if err != nil {
-			return fmt.Errorf("Failed loading projects: %w", err)
+	// Get all projects.
+	projects, err := cluster.GetProjects(ctx, c.tx)
+	if err != nil {
+		return fmt.Errorf("Failed loading projects: %w", err)
+	}
+
+	// Get all instances using supplied filter.
+	dbInstances, err := cluster.GetInstances(ctx, c.tx, validFilters...)
+	if err != nil {
+		return fmt.Errorf("Failed loading instances: %w", err)
+	}
+
+	// Fill instances with config, devices and profiles.
+	instances, err = c.InstancesToInstanceArgs(ctx, true, dbInstances...)
+	if err != nil {
+		return err
+	}
+
+	// Record which projects are referenced by at least one instance in the list.
+	for _, instance := range instances {
+		_, ok := projectsByName[instance.Project]
+		if !ok {
+			projectsByName[instance.Project] = nil
+		}
+	}
+
+	// Populate projectsByName map entry for referenced projects.
+	// This way we only call ToAPI() on the projects actually referenced by the instances in
+	// the list, which can reduce the number of queries run.
+	for _, project := range projects {
+		_, ok := projectsByName[project.Name]
+		if !ok {
+			continue
 		}
 
-		// Get all instances using supplied filter.
-		dbInstances, err := cluster.GetInstances(ctx, tx.tx, validFilters...)
-		if err != nil {
-			return fmt.Errorf("Failed loading instances: %w", err)
-		}
-
-		// Fill instances with config, devices and profiles.
-		instances, err = tx.InstancesToInstanceArgs(ctx, true, dbInstances...)
+		projectsByName[project.Name], err = project.ToAPI(ctx, c.tx)
 		if err != nil {
 			return err
 		}
-
-		// Record which projects are referenced by at least one instance in the list.
-		for _, instance := range instances {
-			_, ok := projectsByName[instance.Project]
-			if !ok {
-				projectsByName[instance.Project] = nil
-			}
-		}
-
-		// Populate projectsByName map entry for referenced projects.
-		// This way we only call ToAPI() on the projects actually referenced by the instances in
-		// the list, which can reduce the number of queries run.
-		for _, project := range projects {
-			_, ok := projectsByName[project.Name]
-			if !ok {
-				continue
-			}
-
-			projectsByName[project.Name], err = project.ToAPI(ctx, tx.tx)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		return err
 	}
 
 	// Call the instanceFunc provided for each instance after the transaction has ended, as we don't know if
@@ -706,8 +699,8 @@ func (c *ClusterTx) GetLocalInstancesInProject(ctx context.Context, filter clust
 }
 
 // CreateInstanceConfig inserts a new config for the container with the given ID.
-func (c *ClusterTx) CreateInstanceConfig(id int, config map[string]string) error {
-	return CreateInstanceConfig(c.tx, id, config)
+func (c *ClusterTx) CreateInstanceConfig(ctx context.Context, id int, config map[string]string) error {
+	return CreateInstanceConfig(ctx, c.tx, id, config)
 }
 
 // UpdateInstanceConfig inserts/updates/deletes the provided keys.
@@ -768,9 +761,9 @@ func (c *ClusterTx) configUpdate(id int, values map[string]string, insertSQL, de
 
 // DeleteInstanceConfigKey removes the given key from the config of the instance
 // with the given ID.
-func (c *ClusterTx) DeleteInstanceConfigKey(id int64, key string) error {
+func (c *ClusterTx) DeleteInstanceConfigKey(ctx context.Context, id int64, key string) error {
 	q := "DELETE FROM instances_config WHERE key=? AND instance_id=?"
-	_, err := c.tx.Exec(q, key, id)
+	_, err := c.tx.ExecContext(ctx, q, key, id)
 	return err
 }
 
@@ -892,22 +885,18 @@ SELECT storage_pools.name FROM storage_pools
 }
 
 // DeleteInstance removes the instance with the given name from the database.
-func (c *Cluster) DeleteInstance(project, name string) error {
+func (c *ClusterTx) DeleteInstance(ctx context.Context, project, name string) error {
 	if strings.Contains(name, internalInstance.SnapshotDelimiter) {
 		parts := strings.SplitN(name, internalInstance.SnapshotDelimiter, 2)
-		return c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-			return cluster.DeleteInstanceSnapshot(ctx, tx.tx, project, parts[0], parts[1])
-		})
+		return cluster.DeleteInstanceSnapshot(ctx, c.tx, project, parts[0], parts[1])
 	}
 
-	return c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return cluster.DeleteInstance(ctx, tx.tx, project, name)
-	})
+	return cluster.DeleteInstance(ctx, c.tx, project, name)
 }
 
 // GetInstanceProjectAndName returns the project and the name of the instance
 // with the given ID.
-func (c *Cluster) GetInstanceProjectAndName(id int) (string, string, error) {
+func (c *ClusterTx) GetInstanceProjectAndName(ctx context.Context, id int) (string, string, error) {
 	var project string
 	var name string
 	q := `
@@ -916,10 +905,7 @@ SELECT projects.name, instances.name
   JOIN projects ON projects.id = instances.project_id
 WHERE instances.id=?
 `
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return tx.tx.QueryRowContext(ctx, q, id).Scan(&project, &name)
-	})
-
+	err := c.tx.QueryRowContext(ctx, q, id).Scan(&project, &name)
 	if err == sql.ErrNoRows {
 		return "", "", api.StatusErrorf(http.StatusNotFound, "Instance not found")
 	}
@@ -928,24 +914,19 @@ WHERE instances.id=?
 }
 
 // GetInstanceID returns the ID of the instance with the given name.
-func (c *Cluster) GetInstanceID(project, name string) (int, error) {
-	var id int64
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		id, err = cluster.GetInstanceID(ctx, tx.tx, project, name)
-		return err
-	})
+func (c *ClusterTx) GetInstanceID(ctx context.Context, project, name string) (int, error) {
+	id, err := cluster.GetInstanceID(ctx, c.tx, project, name)
+
 	return int(id), err
 }
 
 // GetInstanceConfig returns the value of the given key in the configuration
 // of the instance with the given ID.
-func (c *Cluster) GetInstanceConfig(id int, key string) (string, error) {
+func (c *ClusterTx) GetInstanceConfig(ctx context.Context, id int, key string) (string, error) {
 	q := "SELECT value FROM instances_config WHERE instance_id=? AND key=?"
 	value := ""
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return tx.tx.QueryRowContext(ctx, q, id, key).Scan(&value)
-	})
+
+	err := c.tx.QueryRowContext(ctx, q, id, key).Scan(&value)
 	if err == sql.ErrNoRows {
 		return "", api.StatusErrorf(http.StatusNotFound, "Instance config not found")
 	}
@@ -953,42 +934,38 @@ func (c *Cluster) GetInstanceConfig(id int, key string) (string, error) {
 	return value, err
 }
 
-// DeleteInstanceConfigKey removes the given key from the config of the instance
-// with the given ID.
-func (c *Cluster) DeleteInstanceConfigKey(id int, key string) error {
-	return c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return tx.DeleteInstanceConfigKey(int64(id), key)
-	})
-}
-
 // UpdateInstanceStatefulFlag toggles the stateful flag of the instance with
 // the given ID.
-func (c *Cluster) UpdateInstanceStatefulFlag(id int, stateful bool) error {
+func (c *ClusterTx) UpdateInstanceStatefulFlag(ctx context.Context, id int, stateful bool) error {
 	statefulInt := 0
 	if stateful {
 		statefulInt = 1
 	}
 
-	return c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.Exec("UPDATE instances SET stateful=? WHERE id=?", statefulInt, id)
-		return err
-	})
+	_, err := c.tx.ExecContext(ctx, "UPDATE instances SET stateful=? WHERE id=?", statefulInt, id)
+	if err != nil {
+		return fmt.Errorf("Failed updating instance stateful flag: %w", err)
+	}
+
+	return nil
 }
 
 // UpdateInstanceSnapshotCreationDate updates the creation_date field of the instance snapshot with ID.
-func (c *Cluster) UpdateInstanceSnapshotCreationDate(instanceID int, date time.Time) error {
+func (c *ClusterTx) UpdateInstanceSnapshotCreationDate(ctx context.Context, instanceID int, date time.Time) error {
 	stmt := `UPDATE instances_snapshots SET creation_date=? WHERE id=?`
 
-	return c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.ExecContext(ctx, stmt, date, instanceID)
-		return err
-	})
+	_, err := c.tx.ExecContext(ctx, stmt, date, instanceID)
+	if err != nil {
+		return fmt.Errorf("Failed updating instance snapshot creation date: %w", err)
+	}
+
+	return nil
 }
 
 // GetInstanceSnapshotsNames returns the names of all snapshots of the instance
 // in the given project with the given name.
 // Returns snapshots slice ordered by when they were created, oldest first.
-func (c *Cluster) GetInstanceSnapshotsNames(project, name string) ([]string, error) {
+func (c *ClusterTx) GetInstanceSnapshotsNames(ctx context.Context, project, name string) ([]string, error) {
 	result := []string{}
 
 	q := `
@@ -1002,13 +979,7 @@ ORDER BY instances_snapshots.creation_date, instances_snapshots.id
 	inargs := []any{project, name}
 	outfmt := []any{name}
 
-	var dbResults [][]any
-
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		dbResults, err = queryScan(ctx, tx, q, inargs, outfmt)
-		return err
-	})
+	dbResults, err := queryScan(ctx, c, q, inargs, outfmt)
 	if err != nil {
 		return result, err
 	}
@@ -1022,7 +993,7 @@ ORDER BY instances_snapshots.creation_date, instances_snapshots.id
 
 // GetNextInstanceSnapshotIndex returns the index that the next snapshot of the
 // instance with the given name and pattern should have.
-func (c *Cluster) GetNextInstanceSnapshotIndex(project string, name string, pattern string) int {
+func (c *ClusterTx) GetNextInstanceSnapshotIndex(ctx context.Context, project string, name string, pattern string) int {
 	q := `
 SELECT instances_snapshots.name
   FROM instances_snapshots
@@ -1035,13 +1006,7 @@ ORDER BY instances_snapshots.creation_date, instances_snapshots.id
 	inargs := []any{project, name}
 	outfmt := []any{numstr}
 
-	var results [][]any
-
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		results, err = queryScan(ctx, tx, q, inargs, outfmt)
-		return err
-	})
+	results, err := queryScan(ctx, c, q, inargs, outfmt)
 	if err != nil {
 		return 0
 	}
@@ -1066,26 +1031,12 @@ ORDER BY instances_snapshots.creation_date, instances_snapshots.id
 	return max
 }
 
-// GetInstancePool returns the storage pool of a given instance.
-//
-// This is a non-transactional variant of ClusterTx.GetInstancePool().
-func (c *Cluster) GetInstancePool(project, instanceName string) (string, error) {
-	var poolName string
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		poolName, err = tx.GetInstancePool(ctx, project, instanceName)
-		return err
-	})
-	return poolName, err
-}
-
 // DeleteReadyStateFromLocalInstances deletes the volatile.last_state.ready config key
 // from all local instances.
-func (c *Cluster) DeleteReadyStateFromLocalInstances() error {
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		nodeID := tx.GetNodeID()
+func (c *ClusterTx) DeleteReadyStateFromLocalInstances(ctx context.Context) error {
+	nodeID := c.GetNodeID()
 
-		_, err := tx.Tx().Exec(`
+	_, err := c.tx.ExecContext(ctx, `
 DELETE FROM instances_config
 WHERE instances_config.id IN (
 	SELECT instances_config.id FROM instances_config
@@ -1093,22 +1044,22 @@ WHERE instances_config.id IN (
 	JOIN nodes ON instances.node_id=nodes.id
 	WHERE key="volatile.last_state.ready" AND nodes.id=?
 )`, nodeID)
+	if err != nil {
+		return fmt.Errorf("Failed deleting ready state from local instances: %w", err)
+	}
 
-		return err
-	})
-
-	return err
+	return nil
 }
 
 // CreateInstanceConfig inserts a new config for the instance with the given ID.
-func CreateInstanceConfig(tx *sql.Tx, id int, config map[string]string) error {
+func CreateInstanceConfig(ctx context.Context, tx *sql.Tx, id int, config map[string]string) error {
 	sql := "INSERT INTO instances_config (instance_id, key, value) values (?, ?, ?)"
 	for k, v := range config {
 		if v == "" {
 			continue
 		}
 
-		_, err := tx.Exec(sql, id, k, v)
+		_, err := tx.ExecContext(ctx, sql, id, k, v)
 		if err != nil {
 			return fmt.Errorf("Error adding configuration item %q = %q to instance %d: %w", k, v, id, err)
 		}

--- a/internal/server/db/instances_test.go
+++ b/internal/server/db/instances_test.go
@@ -441,20 +441,17 @@ func TestGetInstancePool(t *testing.T) {
 	dbCluster, cleanup := db.NewTestCluster(t)
 	defer cleanup()
 
-	var poolID int64
-
 	err := dbCluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		var err error
+		poolID, err := tx.CreateStoragePool(ctx, "default", "", "dir", nil)
+		if err != nil {
+			return err
+		}
 
-		poolID, err = tx.CreateStoragePool(ctx, "default", "", "dir", nil)
+		_, err = tx.CreateStoragePoolVolume(ctx, "default", "c1", "", db.StoragePoolVolumeTypeContainer, poolID, nil, db.StoragePoolVolumeContentTypeFS, time.Now())
+		if err != nil {
+			return err
+		}
 
-		return err
-	})
-	require.NoError(t, err)
-	_, err = dbCluster.CreateStoragePoolVolume("default", "c1", "", db.StoragePoolVolumeTypeContainer, poolID, nil, db.StoragePoolVolumeContentTypeFS, time.Now())
-	require.NoError(t, err)
-
-	err = dbCluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		container := cluster.Instance{
 			Project: "default",
 			Name:    "c1",

--- a/internal/server/db/instances_test.go
+++ b/internal/server/db/instances_test.go
@@ -441,7 +441,15 @@ func TestGetInstancePool(t *testing.T) {
 	dbCluster, cleanup := db.NewTestCluster(t)
 	defer cleanup()
 
-	poolID, err := dbCluster.CreateStoragePool("default", "", "dir", nil)
+	var poolID int64
+
+	err := dbCluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		poolID, err = tx.CreateStoragePool(ctx, "default", "", "dir", nil)
+
+		return err
+	})
 	require.NoError(t, err)
 	_, err = dbCluster.CreateStoragePoolVolume("default", "c1", "", db.StoragePoolVolumeTypeContainer, poolID, nil, db.StoragePoolVolumeContentTypeFS, time.Now())
 	require.NoError(t, err)

--- a/internal/server/db/network_acls.go
+++ b/internal/server/db/network_acls.go
@@ -15,7 +15,7 @@ import (
 )
 
 // GetNetworkACLs returns the names of existing Network ACLs.
-func (c *Cluster) GetNetworkACLs(project string) ([]string, error) {
+func (c *ClusterTx) GetNetworkACLs(ctx context.Context, project string) ([]string, error) {
 	q := `SELECT name FROM networks_acls
 		WHERE project_id = (SELECT id FROM projects WHERE name = ? LIMIT 1)
 		ORDER BY id
@@ -23,20 +23,18 @@ func (c *Cluster) GetNetworkACLs(project string) ([]string, error) {
 
 	var aclNames []string
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
-			var aclName string
+	err := query.Scan(ctx, c.tx, q, func(scan func(dest ...any) error) error {
+		var aclName string
 
-			err := scan(&aclName)
-			if err != nil {
-				return err
-			}
+		err := scan(&aclName)
+		if err != nil {
+			return err
+		}
 
-			aclNames = append(aclNames, aclName)
+		aclNames = append(aclNames, aclName)
 
-			return nil
-		}, project)
-	})
+		return nil
+	}, project)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +43,7 @@ func (c *Cluster) GetNetworkACLs(project string) ([]string, error) {
 }
 
 // GetNetworkACLIDsByNames returns a map of names to IDs of existing Network ACLs.
-func (c *Cluster) GetNetworkACLIDsByNames(project string) (map[string]int64, error) {
+func (c *ClusterTx) GetNetworkACLIDsByNames(ctx context.Context, project string) (map[string]int64, error) {
 	q := `SELECT id, name FROM networks_acls
 		WHERE project_id = (SELECT id FROM projects WHERE name = ? LIMIT 1)
 		ORDER BY id
@@ -53,21 +51,19 @@ func (c *Cluster) GetNetworkACLIDsByNames(project string) (map[string]int64, err
 
 	acls := make(map[string]int64)
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
-			var aclID int64
-			var aclName string
+	err := query.Scan(ctx, c.tx, q, func(scan func(dest ...any) error) error {
+		var aclID int64
+		var aclName string
 
-			err := scan(&aclID, &aclName)
-			if err != nil {
-				return err
-			}
+		err := scan(&aclID, &aclName)
+		if err != nil {
+			return err
+		}
 
-			acls[aclName] = aclID
+		acls[aclName] = aclID
 
-			return nil
-		}, project)
-	})
+		return nil
+	}, project)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +72,7 @@ func (c *Cluster) GetNetworkACLIDsByNames(project string) (map[string]int64, err
 }
 
 // GetNetworkACL returns the Network ACL with the given name in the given project.
-func (c *Cluster) GetNetworkACL(projectName string, name string) (int64, *api.NetworkACL, error) {
+func (c *ClusterTx) GetNetworkACL(ctx context.Context, projectName string, name string) (int64, *api.NetworkACL, error) {
 	var id int64 = int64(-1)
 	var ingressJSON string
 	var egressJSON string
@@ -94,25 +90,22 @@ func (c *Cluster) GetNetworkACL(projectName string, name string) (int64, *api.Ne
 		LIMIT 1
 	`
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		err := tx.tx.QueryRowContext(ctx, q, projectName, name).Scan(&id, &acl.Description, &ingressJSON, &egressJSON)
-		if err != nil {
-			return err
-		}
-
-		err = networkACLConfig(ctx, tx, id, &acl)
-		if err != nil {
-			return fmt.Errorf("Failed loading config: %w", err)
-		}
-
-		return nil
-	})
+	err := c.tx.QueryRowContext(ctx, q, projectName, name).Scan(&id, &acl.Description, &ingressJSON, &egressJSON)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return -1, nil, api.StatusErrorf(http.StatusNotFound, "Network ACL not found")
 		}
 
 		return -1, nil, err
+	}
+
+	err = networkACLConfig(ctx, c, id, &acl)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return -1, nil, api.StatusErrorf(http.StatusNotFound, "Network ACL not found")
+		}
+
+		return -1, nil, fmt.Errorf("Failed loading config: %w", err)
 	}
 
 	acl.Ingress = []api.NetworkACLRule{}
@@ -135,15 +128,13 @@ func (c *Cluster) GetNetworkACL(projectName string, name string) (int64, *api.Ne
 }
 
 // GetNetworkACLNameAndProjectWithID returns the network ACL name and project name for the given ID.
-func (c *Cluster) GetNetworkACLNameAndProjectWithID(networkACLID int) (string, string, error) {
+func (c *ClusterTx) GetNetworkACLNameAndProjectWithID(ctx context.Context, networkACLID int) (string, string, error) {
 	var networkACLName string
 	var projectName string
 
 	q := `SELECT networks_acls.name, projects.name FROM networks_acls JOIN projects ON projects.id=networks.project_id WHERE networks_acls.id=?`
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return tx.tx.QueryRowContext(ctx, q, networkACLID).Scan(&networkACLName, &projectName)
-	})
+	err := c.tx.QueryRowContext(ctx, q, networkACLID).Scan(&networkACLName, &projectName)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return "", "", api.StatusErrorf(http.StatusNotFound, "Network ACL not found")
@@ -184,8 +175,7 @@ func networkACLConfig(ctx context.Context, tx *ClusterTx, id int64, acl *api.Net
 }
 
 // CreateNetworkACL creates a new Network ACL.
-func (c *Cluster) CreateNetworkACL(projectName string, info *api.NetworkACLsPost) (int64, error) {
-	var id int64
+func (c *ClusterTx) CreateNetworkACL(ctx context.Context, projectName string, info *api.NetworkACLsPost) (int64, error) {
 	var err error
 	var ingressJSON, egressJSON []byte
 
@@ -203,30 +193,23 @@ func (c *Cluster) CreateNetworkACL(projectName string, info *api.NetworkACLsPost
 		}
 	}
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		// Insert a new Network ACL record.
-		result, err := tx.tx.Exec(`
+	// Insert a new Network ACL record.
+	result, err := c.tx.ExecContext(ctx, `
 			INSERT INTO networks_acls (project_id, name, description, ingress, egress)
 			VALUES ((SELECT id FROM projects WHERE name = ? LIMIT 1), ?, ?, ?, ?)
 		`, projectName, info.Name, info.Description, string(ingressJSON), string(egressJSON))
-		if err != nil {
-			return err
-		}
-
-		id, err := result.LastInsertId()
-		if err != nil {
-			return err
-		}
-
-		err = networkACLConfigAdd(tx.tx, id, info.Config)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
 	if err != nil {
-		id = -1
+		return -1, err
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return -1, err
+	}
+
+	err = networkACLConfigAdd(c.tx, id, info.Config)
+	if err != nil {
+		return -1, err
 	}
 
 	return id, err
@@ -257,7 +240,7 @@ func networkACLConfigAdd(tx *sql.Tx, id int64, config map[string]string) error {
 }
 
 // UpdateNetworkACL updates the Network ACL with the given ID.
-func (c *Cluster) UpdateNetworkACL(id int64, config *api.NetworkACLPut) error {
+func (c *ClusterTx) UpdateNetworkACL(ctx context.Context, id int64, config *api.NetworkACLPut) error {
 	var err error
 	var ingressJSON, egressJSON []byte
 
@@ -275,44 +258,40 @@ func (c *Cluster) UpdateNetworkACL(id int64, config *api.NetworkACLPut) error {
 		}
 	}
 
-	return c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.Exec(`
+	_, err = c.tx.ExecContext(ctx, `
 			UPDATE networks_acls
 			SET description=?, ingress = ?, egress = ?
 			WHERE id=?
 		`, config.Description, ingressJSON, egressJSON, id)
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
+	}
 
-		_, err = tx.tx.Exec("DELETE FROM networks_acls_config WHERE network_acl_id=?", id)
-		if err != nil {
-			return err
-		}
+	_, err = c.tx.ExecContext(ctx, "DELETE FROM networks_acls_config WHERE network_acl_id=?", id)
+	if err != nil {
+		return err
+	}
 
-		err = networkACLConfigAdd(tx.tx, id, config.Config)
-		if err != nil {
-			return err
-		}
+	err = networkACLConfigAdd(c.tx, id, config.Config)
+	if err != nil {
+		return err
+	}
 
-		return nil
-	})
+	return nil
 }
 
 // RenameNetworkACL renames a Network ACL.
-func (c *Cluster) RenameNetworkACL(id int64, newName string) error {
-	return c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.Exec("UPDATE networks_acls SET name=? WHERE id=?", newName, id)
-		return err
-	})
+func (c *ClusterTx) RenameNetworkACL(ctx context.Context, id int64, newName string) error {
+	_, err := c.tx.ExecContext(ctx, "UPDATE networks_acls SET name=? WHERE id=?", newName, id)
+
+	return err
 }
 
 // DeleteNetworkACL deletes the Network ACL.
-func (c *Cluster) DeleteNetworkACL(id int64) error {
-	return c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.Exec("DELETE FROM networks_acls WHERE id=?", id)
-		return err
-	})
+func (c *ClusterTx) DeleteNetworkACL(ctx context.Context, id int64) error {
+	_, err := c.tx.ExecContext(ctx, "DELETE FROM networks_acls WHERE id=?", id)
+
+	return err
 }
 
 // GetNetworkACLURIs returns the URIs for the network ACLs with the given project.

--- a/internal/server/db/networks_test.go
+++ b/internal/server/db/networks_test.go
@@ -19,9 +19,13 @@ func TestGetNetworksLocalConfigs(t *testing.T) {
 	cluster, cleanup := db.NewTestCluster(t)
 	defer cleanup()
 
-	_, err := cluster.CreateNetwork(api.ProjectDefaultName, "incusbr0", "", db.NetworkTypeBridge, map[string]string{
-		"dns.mode":                   "none",
-		"bridge.external_interfaces": "vlan0",
+	err := cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_, err := tx.CreateNetwork(ctx, api.ProjectDefaultName, "incusbr0", "", db.NetworkTypeBridge, map[string]string{
+			"dns.mode":                   "none",
+			"bridge.external_interfaces": "vlan0",
+		})
+
+		return err
 	})
 	require.NoError(t, err)
 

--- a/internal/server/db/profiles.go
+++ b/internal/server/db/profiles.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetProfileNames returns the names of all profiles in the given project.
-func (c *Cluster) GetProfileNames(project string) ([]string, error) {
+func (c *ClusterTx) GetProfileNames(ctx context.Context, project string) ([]string, error) {
 	q := `
 SELECT profiles.name
  FROM profiles
@@ -21,27 +21,20 @@ WHERE projects.name = ?
 `
 	var result [][]any
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		enabled, err := cluster.ProjectHasProfiles(context.Background(), tx.tx, project)
-		if err != nil {
-			return fmt.Errorf("Check if project has profiles: %w", err)
-		}
+	enabled, err := cluster.ProjectHasProfiles(context.Background(), c.tx, project)
+	if err != nil {
+		return nil, fmt.Errorf("Check if project has profiles: %w", err)
+	}
 
-		if !enabled {
-			project = "default"
-		}
+	if !enabled {
+		project = "default"
+	}
 
-		inargs := []any{project}
-		var name string
-		outfmt := []any{name}
+	inargs := []any{project}
+	var name string
+	outfmt := []any{name}
 
-		result, err = queryScan(ctx, tx, q, inargs, outfmt)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
+	result, err = queryScan(ctx, c, q, inargs, outfmt)
 	if err != nil {
 		return nil, err
 	}
@@ -55,27 +48,20 @@ WHERE projects.name = ?
 }
 
 // GetProfile returns the profile with the given name.
-func (c *Cluster) GetProfile(project, name string) (int64, *api.Profile, error) {
-	var result *api.Profile
-	var id int64
+func (c *ClusterTx) GetProfile(ctx context.Context, project, name string) (int64, *api.Profile, error) {
+	profiles, err := cluster.GetProfilesIfEnabled(ctx, c.tx, project, []string{name})
+	if err != nil {
+		return -1, nil, err
+	}
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		profiles, err := cluster.GetProfilesIfEnabled(ctx, tx.Tx(), project, []string{name})
-		if err != nil {
-			return err
-		}
+	if len(profiles) != 1 {
+		return -1, nil, fmt.Errorf("Expected one profile with name %q, got %d profiles", name, len(profiles))
+	}
 
-		if len(profiles) != 1 {
-			return fmt.Errorf("Expected one profile with name %q, got %d profiles", name, len(profiles))
-		}
+	profile := profiles[0]
+	id := int64(profile.ID)
 
-		profile := profiles[0]
-		id = int64(profile.ID)
-		result, err = profile.ToAPI(ctx, tx.Tx())
-
-		return err
-	})
+	result, err := profile.ToAPI(ctx, c.tx)
 	if err != nil {
 		return -1, nil, err
 	}
@@ -84,28 +70,21 @@ func (c *Cluster) GetProfile(project, name string) (int64, *api.Profile, error) 
 }
 
 // GetProfiles returns the profiles with the given names in the given project.
-func (c *Cluster) GetProfiles(projectName string, profileNames []string) ([]api.Profile, error) {
+func (c *ClusterTx) GetProfiles(ctx context.Context, projectName string, profileNames []string) ([]api.Profile, error) {
 	profiles := make([]api.Profile, len(profileNames))
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		dbProfiles, err := cluster.GetProfilesIfEnabled(ctx, tx.Tx(), projectName, profileNames)
-		if err != nil {
-			return err
-		}
-
-		for i, profile := range dbProfiles {
-			apiProfile, err := profile.ToAPI(ctx, tx.Tx())
-			if err != nil {
-				return err
-			}
-
-			profiles[i] = *apiProfile
-		}
-
-		return nil
-	})
+	dbProfiles, err := cluster.GetProfilesIfEnabled(ctx, c.tx, projectName, profileNames)
 	if err != nil {
 		return nil, err
+	}
+
+	for i, profile := range dbProfiles {
+		apiProfile, err := profile.ToAPI(ctx, c.tx)
+		if err != nil {
+			return nil, err
+		}
+
+		profiles[i] = *apiProfile
 	}
 
 	return profiles, nil
@@ -113,7 +92,7 @@ func (c *Cluster) GetProfiles(projectName string, profileNames []string) ([]api.
 
 // GetInstancesWithProfile gets the names of the instance associated with the
 // profile with the given name in the given project.
-func (c *Cluster) GetInstancesWithProfile(project, profile string) (map[string][]string, error) {
+func (c *ClusterTx) GetInstancesWithProfile(ctx context.Context, project, profile string) (map[string][]string, error) {
 	q := `SELECT instances.name, projects.name FROM instances
 		JOIN instances_profiles ON instances.id == instances_profiles.instance_id
 		JOIN projects ON projects.id == instances.project_id
@@ -125,27 +104,20 @@ func (c *Cluster) GetInstancesWithProfile(project, profile string) (map[string][
 	results := map[string][]string{}
 	var output [][]any
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		enabled, err := cluster.ProjectHasProfiles(context.Background(), tx.tx, project)
-		if err != nil {
-			return fmt.Errorf("Check if project has profiles: %w", err)
-		}
+	enabled, err := cluster.ProjectHasProfiles(context.Background(), c.tx, project)
+	if err != nil {
+		return nil, fmt.Errorf("Check if project has profiles: %w", err)
+	}
 
-		if !enabled {
-			project = "default"
-		}
+	if !enabled {
+		project = "default"
+	}
 
-		inargs := []any{profile, project}
-		var name string
-		outfmt := []any{name, name}
+	inargs := []any{profile, project}
+	var name string
+	outfmt := []any{name, name}
 
-		output, err = queryScan(ctx, tx, q, inargs, outfmt)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
+	output, err = queryScan(ctx, c, q, inargs, outfmt)
 	if err != nil {
 		return nil, err
 	}
@@ -162,17 +134,16 @@ func (c *Cluster) GetInstancesWithProfile(project, profile string) (map[string][
 }
 
 // RemoveUnreferencedProfiles removes unreferenced profiles.
-func (c *Cluster) RemoveUnreferencedProfiles() error {
+func (c *ClusterTx) RemoveUnreferencedProfiles(ctx context.Context) error {
 	stmt := `
 DELETE FROM profiles_config WHERE profile_id NOT IN (SELECT id FROM profiles);
 DELETE FROM profiles_devices WHERE profile_id NOT IN (SELECT id FROM profiles);
 DELETE FROM profiles_devices_config WHERE profile_device_id NOT IN (SELECT id FROM profiles_devices);
 `
 
-	return c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.ExecContext(ctx, stmt)
-		return err
-	})
+	_, err := c.tx.ExecContext(ctx, stmt)
+
+	return err
 }
 
 // ExpandInstanceConfig expands the given instance config with the config

--- a/internal/server/db/snapshots.go
+++ b/internal/server/db/snapshots.go
@@ -92,12 +92,7 @@ func (c *ClusterTx) GetLocalExpiredInstanceSnapshots(ctx context.Context) ([]clu
 }
 
 // GetInstanceSnapshotID returns the ID of the snapshot with the given name.
-func (c *Cluster) GetInstanceSnapshotID(project, instance, name string) (int, error) {
-	var id int64
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		id, err = cluster.GetInstanceSnapshotID(ctx, tx.tx, project, instance, name)
-		return err
-	})
+func (c *ClusterTx) GetInstanceSnapshotID(ctx context.Context, project, instance, name string) (int, error) {
+	id, err := cluster.GetInstanceSnapshotID(ctx, c.tx, project, instance, name)
 	return int(id), err
 }

--- a/internal/server/db/storage_pools.go
+++ b/internal/server/db/storage_pools.go
@@ -429,7 +429,7 @@ func (c *ClusterTx) storagePoolNodeState(poolID int64, state StoragePoolState) e
 // GetStoragePools returns map of Storage Pools keyed on ID and Storage Pool member info keyed on ID and Member ID.
 // Can optionally accept a state filter, if nil, then pools in any state are returned.
 // Can optionally accept one or more poolNames to further filter the returned pools.
-func (c *Cluster) GetStoragePools(ctx context.Context, state *StoragePoolState, poolNames ...string) (map[int64]api.StoragePool, map[int64]map[int64]StoragePoolNode, error) {
+func (c *ClusterTx) GetStoragePools(ctx context.Context, state *StoragePoolState, poolNames ...string) (map[int64]api.StoragePool, map[int64]map[int64]StoragePoolNode, error) {
 	var q *strings.Builder = &strings.Builder{}
 	var args []any
 
@@ -456,52 +456,45 @@ func (c *Cluster) GetStoragePools(ctx context.Context, state *StoragePoolState, 
 	pools := make(map[int64]api.StoragePool)
 	memberInfo := make(map[int64]map[int64]StoragePoolNode)
 
-	err = c.Transaction(ctx, func(ctx context.Context, tx *ClusterTx) error {
-		err = query.Scan(ctx, tx.Tx(), q.String(), func(scan func(dest ...any) error) error {
-			var poolID int64 = int64(-1)
-			var poolState StoragePoolState
-			var pool api.StoragePool
+	err = query.Scan(ctx, c.tx, q.String(), func(scan func(dest ...any) error) error {
+		var poolID int64 = int64(-1)
+		var poolState StoragePoolState
+		var pool api.StoragePool
 
-			err := scan(&poolID, &pool.Name, &pool.Driver, &pool.Description, &poolState)
-			if err != nil {
-				return err
-			}
-
-			pool.Status = StoragePoolStateToAPIStatus(poolState)
-
-			pools[poolID] = pool
-
-			return nil
-		}, args...)
+		err := scan(&poolID, &pool.Name, &pool.Driver, &pool.Description, &poolState)
 		if err != nil {
 			return err
 		}
 
-		for poolID := range pools {
-			pool := pools[poolID]
+		pool.Status = StoragePoolStateToAPIStatus(poolState)
 
-			err = c.getStoragePoolConfig(ctx, tx, poolID, &pool)
-			if err != nil {
-				return err
-			}
-
-			memberInfo[poolID], err = tx.storagePoolNodes(ctx, poolID)
-			if err != nil {
-				return err
-			}
-
-			pool.Locations = make([]string, 0, len(memberInfo[poolID]))
-			for _, node := range memberInfo[poolID] {
-				pool.Locations = append(pool.Locations, node.Name)
-			}
-
-			pools[poolID] = pool
-		}
+		pools[poolID] = pool
 
 		return nil
-	})
+	}, args...)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	for poolID := range pools {
+		pool := pools[poolID]
+
+		err = c.getStoragePoolConfig(ctx, c, poolID, &pool)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		memberInfo[poolID], err = c.storagePoolNodes(ctx, poolID)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		pool.Locations = make([]string, 0, len(memberInfo[poolID]))
+		for _, node := range memberInfo[poolID] {
+			pool.Locations = append(pool.Locations, node.Name)
+		}
+
+		pools[poolID] = pool
 	}
 
 	return pools, memberInfo, nil
@@ -556,17 +549,17 @@ WHERE storage_pools.id = ? AND storage_pools.state = ?
 }
 
 // GetStoragePoolNames returns the names of all storage pools.
-func (c *Cluster) GetStoragePoolNames() ([]string, error) {
-	return c.storagePools("")
+func (c *ClusterTx) GetStoragePoolNames(ctx context.Context) ([]string, error) {
+	return c.storagePools(ctx, "")
 }
 
 // GetCreatedStoragePoolNames returns the names of all storage pools that are created.
-func (c *Cluster) GetCreatedStoragePoolNames() ([]string, error) {
-	return c.storagePools("state=?", StoragePoolCreated)
+func (c *ClusterTx) GetCreatedStoragePoolNames(ctx context.Context) ([]string, error) {
+	return c.storagePools(ctx, "state=?", StoragePoolCreated)
 }
 
 // Get all storage pools matching the given WHERE filter (if given).
-func (c *Cluster) storagePools(where string, args ...any) ([]string, error) {
+func (c *ClusterTx) storagePools(ctx context.Context, where string, args ...any) ([]string, error) {
 	var name string
 	stmt := "SELECT name FROM storage_pools"
 	inargs := []any{}
@@ -577,13 +570,7 @@ func (c *Cluster) storagePools(where string, args ...any) ([]string, error) {
 		inargs = append(inargs, args...)
 	}
 
-	var result [][]any
-
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		result, err = queryScan(ctx, tx, stmt, inargs, outargs)
-		return err
-	})
+	result, err := queryScan(ctx, c, stmt, inargs, outargs)
 	if err != nil {
 		return []string{}, err
 	}
@@ -602,19 +589,13 @@ func (c *Cluster) storagePools(where string, args ...any) ([]string, error) {
 
 // GetStoragePoolDrivers returns the names of all storage drivers currently
 // being used by at least one storage pool.
-func (c *Cluster) GetStoragePoolDrivers() ([]string, error) {
+func (c *ClusterTx) GetStoragePoolDrivers(ctx context.Context) ([]string, error) {
 	var poolDriver string
 	query := "SELECT DISTINCT driver FROM storage_pools"
 	inargs := []any{}
 	outargs := []any{poolDriver}
 
-	var result [][]any
-
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		result, err = queryScan(ctx, tx, query, inargs, outargs)
-		return err
-	})
+	result, err := queryScan(ctx, c, query, inargs, outargs)
 	if err != nil {
 		return []string{}, err
 	}
@@ -631,31 +612,12 @@ func (c *Cluster) GetStoragePoolDrivers() ([]string, error) {
 	return drivers, nil
 }
 
-// GetStoragePoolID returns the id of a single storage pool.
-func (c *Cluster) GetStoragePoolID(poolName string) (int64, error) {
-	poolID := int64(-1)
-	query := "SELECT id FROM storage_pools WHERE name=?"
-	inargs := []any{poolName}
-	outargs := []any{&poolID}
-
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return dbQueryRowScan(ctx, tx, query, inargs, outargs)
-	})
-	if err != nil {
-		if err == sql.ErrNoRows {
-			return -1, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
-		}
-	}
-
-	return poolID, nil
-}
-
 // GetStoragePool returns a single storage pool.
 //
 // The pool must be in the created stated, not pending.
-func (c *Cluster) GetStoragePool(poolName string) (int64, *api.StoragePool, map[int64]StoragePoolNode, error) {
+func (c *ClusterTx) GetStoragePool(ctx context.Context, poolName string) (int64, *api.StoragePool, map[int64]StoragePoolNode, error) {
 	stateCreated := StoragePoolCreated
-	pools, poolMembers, err := c.GetStoragePools(context.TODO(), &stateCreated, poolName)
+	pools, poolMembers, err := c.GetStoragePools(ctx, &stateCreated, poolName)
 	if (err == nil && len(pools) <= 0) || errors.Is(err, sql.ErrNoRows) {
 		return -1, nil, nil, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 	} else if err == nil && len(pools) > 1 {
@@ -674,8 +636,8 @@ func (c *Cluster) GetStoragePool(poolName string) (int64, *api.StoragePool, map[
 // GetStoragePoolInAnyState returns the storage pool with the given name.
 //
 // The pool can be in any state.
-func (c *Cluster) GetStoragePoolInAnyState(poolName string) (int64, *api.StoragePool, map[int64]StoragePoolNode, error) {
-	pools, poolMembers, err := c.GetStoragePools(context.TODO(), nil, poolName)
+func (c *ClusterTx) GetStoragePoolInAnyState(ctx context.Context, poolName string) (int64, *api.StoragePool, map[int64]StoragePoolNode, error) {
+	pools, poolMembers, err := c.GetStoragePools(ctx, nil, poolName)
 	if (err == nil && len(pools) <= 0) || errors.Is(err, sql.ErrNoRows) {
 		return -1, nil, nil, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 	} else if err == nil && len(pools) > 1 {
@@ -692,12 +654,12 @@ func (c *Cluster) GetStoragePoolInAnyState(poolName string) (int64, *api.Storage
 }
 
 // GetStoragePoolWithID returns the storage pool with the given ID.
-func (c *Cluster) GetStoragePoolWithID(poolID int) (int64, *api.StoragePool, map[int64]StoragePoolNode, error) {
-	return c.getStoragePool(true, "id=?", poolID)
+func (c *ClusterTx) GetStoragePoolWithID(ctx context.Context, poolID int) (int64, *api.StoragePool, map[int64]StoragePoolNode, error) {
+	return c.getStoragePool(ctx, true, "id=?", poolID)
 }
 
 // GetStoragePool returns a single storage pool.
-func (c *Cluster) getStoragePool(onlyCreated bool, where string, args ...any) (int64, *api.StoragePool, map[int64]StoragePoolNode, error) {
+func (c *ClusterTx) getStoragePool(ctx context.Context, onlyCreated bool, where string, args ...any) (int64, *api.StoragePool, map[int64]StoragePoolNode, error) {
 	var err error
 	var q *strings.Builder = &strings.Builder{}
 	q.WriteString("SELECT id, name, driver, description, state FROM storage_pools WHERE ")
@@ -712,33 +674,42 @@ func (c *Cluster) getStoragePool(onlyCreated bool, where string, args ...any) (i
 	var pool api.StoragePool
 	var nodes map[int64]StoragePoolNode
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var state StoragePoolState
+	var state StoragePoolState
 
-		err = tx.tx.QueryRowContext(ctx, q.String(), args...).Scan(&poolID, &pool.Name, &pool.Driver, &pool.Description, &state)
-		if err != nil {
-			return err
+	err = c.tx.QueryRowContext(ctx, q.String(), args...).Scan(&poolID, &pool.Name, &pool.Driver, &pool.Description, &state)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return -1, nil, nil, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 		}
 
-		pool.Status = StoragePoolStateToAPIStatus(state)
+		return -1, nil, nil, err
+	}
 
-		err = c.getStoragePoolConfig(ctx, tx, poolID, &pool)
-		if err != nil {
-			return err
+	pool.Status = StoragePoolStateToAPIStatus(state)
+
+	err = c.getStoragePoolConfig(ctx, c, poolID, &pool)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return -1, nil, nil, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 		}
 
-		nodes, err = tx.storagePoolNodes(ctx, poolID)
-		if err != nil {
-			return err
+		return -1, nil, nil, err
+	}
+
+	nodes, err = c.storagePoolNodes(ctx, poolID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return -1, nil, nil, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
 		}
 
-		pool.Locations = make([]string, 0, len(nodes))
-		for _, node := range nodes {
-			pool.Locations = append(pool.Locations, node.Name)
-		}
+		return -1, nil, nil, err
+	}
 
-		return nil
-	})
+	pool.Locations = make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		pool.Locations = append(pool.Locations, node.Name)
+	}
+
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return -1, nil, nil, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
@@ -765,12 +736,12 @@ func StoragePoolStateToAPIStatus(state StoragePoolState) string {
 }
 
 // getStoragePoolConfig populates the config map of the Storage pool with the given ID.
-func (c *Cluster) getStoragePoolConfig(ctx context.Context, tx *ClusterTx, poolID int64, pool *api.StoragePool) error {
+func (c *ClusterTx) getStoragePoolConfig(ctx context.Context, tx *ClusterTx, poolID int64, pool *api.StoragePool) error {
 	q := "SELECT key, value FROM storage_pools_config WHERE storage_pool_id=? AND (node_id=? OR node_id IS NULL)"
 
 	pool.Config = map[string]string{}
 
-	return query.Scan(ctx, tx.Tx(), q, func(scan func(dest ...any) error) error {
+	return query.Scan(ctx, c.tx, q, func(scan func(dest ...any) error) error {
 		var key, value string
 
 		err := scan(&key, &value)
@@ -790,36 +761,29 @@ func (c *Cluster) getStoragePoolConfig(ctx context.Context, tx *ClusterTx, poolI
 }
 
 // CreateStoragePool creates new storage pool. Also creates a local member entry with state storagePoolPending.
-func (c *Cluster) CreateStoragePool(poolName string, poolDescription string, poolDriver string, poolConfig map[string]string) (int64, error) {
+func (c *ClusterTx) CreateStoragePool(ctx context.Context, poolName string, poolDescription string, poolDriver string, poolConfig map[string]string) (int64, error) {
 	var id int64
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		result, err := tx.tx.Exec("INSERT INTO storage_pools (name, description, driver, state) VALUES (?, ?, ?, ?)", poolName, poolDescription, poolDriver, StoragePoolCreated)
-		if err != nil {
-			return err
-		}
-
-		id, err = result.LastInsertId()
-		if err != nil {
-			return err
-		}
-
-		// Insert a node-specific entry pointing to ourselves with state storagePoolPending.
-		columns := []string{"storage_pool_id", "node_id", "state"}
-		values := []any{id, c.nodeID, StoragePoolPending}
-		_, err = query.UpsertObject(tx.tx, "storage_pools_nodes", columns, values)
-		if err != nil {
-			return err
-		}
-
-		err = storagePoolConfigAdd(tx.tx, id, c.nodeID, poolConfig)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
+	result, err := c.tx.ExecContext(ctx, "INSERT INTO storage_pools (name, description, driver, state) VALUES (?, ?, ?, ?)", poolName, poolDescription, poolDriver, StoragePoolCreated)
 	if err != nil {
-		id = -1
+		return -1, err
+	}
+
+	id, err = result.LastInsertId()
+	if err != nil {
+		return -1, err
+	}
+
+	// Insert a node-specific entry pointing to ourselves with state storagePoolPending.
+	columns := []string{"storage_pool_id", "node_id", "state"}
+	values := []any{id, c.nodeID, StoragePoolPending}
+	_, err = query.UpsertObject(c.tx, "storage_pools_nodes", columns, values)
+	if err != nil {
+		return -1, err
+	}
+
+	err = storagePoolConfigAdd(c.tx, id, c.nodeID, poolConfig)
+	if err != nil {
+		return -1, err
 	}
 
 	return id, nil
@@ -857,32 +821,28 @@ func storagePoolConfigAdd(tx *sql.Tx, poolID, nodeID int64, poolConfig map[strin
 }
 
 // UpdateStoragePool updates a storage pool.
-func (c *Cluster) UpdateStoragePool(poolName, description string, poolConfig map[string]string) error {
-	poolID, _, _, err := c.GetStoragePoolInAnyState(poolName)
+func (c *ClusterTx) UpdateStoragePool(ctx context.Context, poolName, description string, poolConfig map[string]string) error {
+	poolID, _, _, err := c.GetStoragePoolInAnyState(ctx, poolName)
 	if err != nil {
 		return err
 	}
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		err = updateStoragePoolDescription(tx.tx, poolID, description)
-		if err != nil {
-			return err
-		}
+	err = updateStoragePoolDescription(c.tx, poolID, description)
+	if err != nil {
+		return err
+	}
 
-		err = clearStoragePoolConfig(tx.tx, poolID, c.nodeID)
-		if err != nil {
-			return err
-		}
+	err = clearStoragePoolConfig(c.tx, poolID, c.nodeID)
+	if err != nil {
+		return err
+	}
 
-		err = storagePoolConfigAdd(tx.tx, poolID, c.nodeID, poolConfig)
-		if err != nil {
-			return err
-		}
+	err = storagePoolConfigAdd(c.tx, poolID, c.nodeID, poolConfig)
+	if err != nil {
+		return err
+	}
 
-		return nil
-	})
-
-	return err
+	return nil
 }
 
 // Uupdate the storage pool description.
@@ -902,16 +862,13 @@ func clearStoragePoolConfig(tx *sql.Tx, poolID, nodeID int64) error {
 }
 
 // RemoveStoragePool deletes storage pool.
-func (c *Cluster) RemoveStoragePool(poolName string) (*api.StoragePool, error) {
-	poolID, pool, _, err := c.GetStoragePoolInAnyState(poolName)
+func (c *ClusterTx) RemoveStoragePool(ctx context.Context, poolName string) (*api.StoragePool, error) {
+	poolID, pool, _, err := c.GetStoragePoolInAnyState(ctx, poolName)
 	if err != nil {
 		return nil, err
 	}
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		_, err := tx.tx.ExecContext(ctx, "DELETE FROM storage_pools WHERE id=?", poolID)
-		return err
-	})
+	_, err = c.tx.ExecContext(ctx, "DELETE FROM storage_pools WHERE id=?", poolID)
 	if err != nil {
 		return nil, err
 	}
@@ -931,19 +888,13 @@ var NodeSpecificStorageConfig = []string{
 }
 
 // IsRemoteStorage return whether a given pool is backed by remote storage.
-func (c *Cluster) IsRemoteStorage(poolID int64) (bool, error) {
-	isRemoteStorage := false
+func (c *ClusterTx) IsRemoteStorage(ctx context.Context, poolID int64) (bool, error) {
+	driver, err := c.GetStoragePoolDriver(ctx, poolID)
+	if err != nil {
+		return false, err
+	}
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		driver, err := tx.GetStoragePoolDriver(ctx, poolID)
-		if err != nil {
-			return err
-		}
+	isRemoteStorage := util.ValueInSlice(driver, StorageRemoteDriverNames())
 
-		isRemoteStorage = util.ValueInSlice(driver, StorageRemoteDriverNames())
-
-		return nil
-	})
-
-	return isRemoteStorage, err
+	return isRemoteStorage, nil
 }

--- a/internal/server/db/storage_pools_test.go
+++ b/internal/server/db/storage_pools_test.go
@@ -25,27 +25,31 @@ func TestGetStoragePoolsLocalConfigs(t *testing.T) {
 	cluster, cleanup := db.NewTestCluster(t)
 	defer cleanup()
 
-	// Create a storage pool named "local" (like the default clustering one), then delete it and create another one.
-	_, err := cluster.CreateStoragePool("local", "", "dir", map[string]string{
-		"rsync.bwlimit": "1",
-		"source":        "/foo/bar",
-	})
-	require.NoError(t, err)
+	_ = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Create a storage pool named "local" (like the default clustering one), then delete it and create another one.
+		_, err := tx.CreateStoragePool(ctx, "local", "", "dir", map[string]string{
+			"rsync.bwlimit": "1",
+			"source":        "/foo/bar",
+		})
+		require.NoError(t, err)
 
-	_, err = cluster.RemoveStoragePool("local")
-	require.NoError(t, err)
+		_, err = tx.RemoveStoragePool(ctx, "local")
+		require.NoError(t, err)
 
-	_, err = cluster.CreateStoragePool("BTRFS", "", "dir", map[string]string{
-		"rsync.bwlimit": "1",
-		"source":        "/egg/baz",
+		_, err = tx.CreateStoragePool(ctx, "BTRFS", "", "dir", map[string]string{
+			"rsync.bwlimit": "1",
+			"source":        "/egg/baz",
+		})
+		require.NoError(t, err)
+
+		return nil
 	})
-	require.NoError(t, err)
 
 	// Check that the config map returned by StoragePoolsConfigs actually
 	// contains the value of the "BTRFS" storage pool.
 	var config map[string]map[string]string
 
-	err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err := cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 		config, err = tx.GetStoragePoolsLocalConfig(ctx)
 		return err
@@ -172,8 +176,14 @@ func TestStoragePoolVolume_Ceph(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	poolID, err := cluster.CreateStoragePool("p1", "", "ceph", nil)
-	require.NoError(t, err)
+	var poolID int64
+
+	_ = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		poolID, err = tx.CreateStoragePool(ctx, "p1", "", "ceph", nil)
+		require.NoError(t, err)
+
+		return nil
+	})
 
 	config := map[string]string{"k": "v"}
 	volumeID, err := cluster.CreateStoragePoolVolume("default", "v1", "", 1, poolID, config, db.StoragePoolVolumeContentTypeFS, time.Now())
@@ -228,14 +238,23 @@ func TestCreateStoragePoolVolume_Snapshot(t *testing.T) {
 	cluster, cleanup := db.NewTestCluster(t)
 	defer cleanup()
 
-	poolID, err := cluster.CreateStoragePool("p1", "", "dir", nil)
-	require.NoError(t, err)
+	var poolID int64
+	var poolID1 int64
 
-	poolID1, err := cluster.CreateStoragePool("p2", "", "dir", nil)
-	require.NoError(t, err)
+	_ = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		poolID, err = tx.CreateStoragePool(ctx, "p1", "", "dir", nil)
+		require.NoError(t, err)
+
+		poolID1, err = tx.CreateStoragePool(ctx, "p2", "", "dir", nil)
+		require.NoError(t, err)
+
+		return nil
+	})
 
 	config := map[string]string{"k": "v"}
-	_, err = cluster.CreateStoragePoolVolume("default", "v1", "", 1, poolID, config, db.StoragePoolVolumeContentTypeFS, time.Now())
+	_, err := cluster.CreateStoragePoolVolume("default", "v1", "", 1, poolID, config, db.StoragePoolVolumeContentTypeFS, time.Now())
 	require.NoError(t, err)
 
 	_, err = cluster.CreateStoragePoolVolume("default", "v1", "", 1, poolID1, config, db.StoragePoolVolumeContentTypeFS, time.Now())

--- a/internal/server/db/storage_pools_test.go
+++ b/internal/server/db/storage_pools_test.go
@@ -186,7 +186,13 @@ func TestStoragePoolVolume_Ceph(t *testing.T) {
 	})
 
 	config := map[string]string{"k": "v"}
-	volumeID, err := cluster.CreateStoragePoolVolume("default", "v1", "", 1, poolID, config, db.StoragePoolVolumeContentTypeFS, time.Now())
+	var volumeID int64
+
+	_ = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		volumeID, err = tx.CreateStoragePoolVolume(ctx, "default", "v1", "", 1, poolID, config, db.StoragePoolVolumeContentTypeFS, time.Now())
+
+		return err
+	})
 	require.NoError(t, err)
 
 	getStoragePoolVolume := func(volumeProjectName string, volumeName string, volumeType int, poolID int64) (*db.StorageVolume, error) {
@@ -212,21 +218,27 @@ func TestStoragePoolVolume_Ceph(t *testing.T) {
 
 	// Update the volume
 	config["k"] = "v2"
-	err = cluster.UpdateStoragePoolVolume("default", "v1", 1, poolID, "volume 1", config)
+	err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.UpdateStoragePoolVolume(ctx, "default", "v1", 1, poolID, "volume 1", config)
+	})
 	require.NoError(t, err)
 	volume, err := getStoragePoolVolume("default", "v1", 1, poolID)
 	require.NoError(t, err)
 	assert.Equal(t, "volume 1", volume.Description)
 	assert.Equal(t, config, volume.Config)
 
-	err = cluster.RenameStoragePoolVolume("default", "v1", "v1-new", 1, poolID)
+	err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.RenameStoragePoolVolume(ctx, "default", "v1", "v1-new", 1, poolID)
+	})
 	require.NoError(t, err)
 	volume, err = getStoragePoolVolume("default", "v1-new", 1, poolID)
 	require.NoError(t, err)
 	assert.NotNil(t, volume)
 
 	// Delete the volume
-	err = cluster.RemoveStoragePoolVolume("default", "v1-new", 1, poolID)
+	err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.RemoveStoragePoolVolume(ctx, "default", "v1-new", 1, poolID)
+	})
 	require.NoError(t, err)
 	volume, err = getStoragePoolVolume("default", "v1-new", 1, poolID)
 	assert.True(t, response.IsNotFoundError(err))
@@ -250,27 +262,24 @@ func TestCreateStoragePoolVolume_Snapshot(t *testing.T) {
 		poolID1, err = tx.CreateStoragePool(ctx, "p2", "", "dir", nil)
 		require.NoError(t, err)
 
+		config := map[string]string{"k": "v"}
+
+		_, err = tx.CreateStoragePoolVolume(ctx, "default", "v1", "", 1, poolID, config, db.StoragePoolVolumeContentTypeFS, time.Now())
+		require.NoError(t, err)
+
+		_, err = tx.CreateStoragePoolVolume(ctx, "default", "v1", "", 1, poolID1, config, db.StoragePoolVolumeContentTypeFS, time.Now())
+		require.NoError(t, err)
+
+		config = map[string]string{"k": "v"}
+		_, err = tx.CreateStorageVolumeSnapshot(ctx, "default", "v1/snap0", "", 1, poolID, config, time.Now(), time.Time{})
+		require.NoError(t, err)
+
+		n := tx.GetNextStorageVolumeSnapshotIndex(ctx, "p1", "v1", 1, "snap%d")
+		assert.Equal(t, n, 1)
+
+		n = tx.GetNextStorageVolumeSnapshotIndex(ctx, "p2", "v1", 1, "snap%d")
+		assert.Equal(t, n, 0)
+
 		return nil
 	})
-
-	config := map[string]string{"k": "v"}
-	_, err := cluster.CreateStoragePoolVolume("default", "v1", "", 1, poolID, config, db.StoragePoolVolumeContentTypeFS, time.Now())
-	require.NoError(t, err)
-
-	_, err = cluster.CreateStoragePoolVolume("default", "v1", "", 1, poolID1, config, db.StoragePoolVolumeContentTypeFS, time.Now())
-	require.NoError(t, err)
-
-	config = map[string]string{"k": "v"}
-	err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		_, err = tx.CreateStorageVolumeSnapshot(ctx, "default", "v1/snap0", "", 1, poolID, config, time.Now(), time.Time{})
-
-		return err
-	})
-	require.NoError(t, err)
-
-	n := cluster.GetNextStorageVolumeSnapshotIndex("p1", "v1", 1, "snap%d")
-	assert.Equal(t, n, 1)
-
-	n = cluster.GetNextStorageVolumeSnapshotIndex("p2", "v1", 1, "snap%d")
-	assert.Equal(t, n, 0)
 }

--- a/internal/server/db/storage_pools_test.go
+++ b/internal/server/db/storage_pools_test.go
@@ -261,7 +261,11 @@ func TestCreateStoragePoolVolume_Snapshot(t *testing.T) {
 	require.NoError(t, err)
 
 	config = map[string]string{"k": "v"}
-	_, err = cluster.CreateStorageVolumeSnapshot("default", "v1/snap0", "", 1, poolID, config, time.Now(), time.Time{})
+	err = cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_, err = tx.CreateStorageVolumeSnapshot(ctx, "default", "v1/snap0", "", 1, poolID, config, time.Now(), time.Time{})
+
+		return err
+	})
 	require.NoError(t, err)
 
 	n := cluster.GetNextStorageVolumeSnapshotIndex("p1", "v1", 1, "snap%d")

--- a/internal/server/db/storage_volume_snapshots.go
+++ b/internal/server/db/storage_volume_snapshots.go
@@ -17,7 +17,7 @@ import (
 
 // CreateStorageVolumeSnapshot creates a new storage volume snapshot attached to a given
 // storage pool.
-func (c *Cluster) CreateStorageVolumeSnapshot(projectName string, volumeName string, volumeDescription string, volumeType int, poolID int64, volumeConfig map[string]string, creationDate time.Time, expiryDate time.Time) (int64, error) {
+func (c *ClusterTx) CreateStorageVolumeSnapshot(ctx context.Context, projectName string, volumeName string, volumeDescription string, volumeType int, poolID int64, volumeConfig map[string]string, creationDate time.Time, expiryDate time.Time) (int64, error) {
 	var volumeID int64
 
 	var snapshotName string
@@ -25,85 +25,74 @@ func (c *Cluster) CreateStorageVolumeSnapshot(projectName string, volumeName str
 	volumeName = parts[0]
 	snapshotName = parts[1]
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		// Figure out the volume ID of the parent.
-		parentID, err := tx.storagePoolVolumeGetTypeID(ctx, projectName, volumeName, volumeType, poolID, c.nodeID)
-		if err != nil {
-			return fmt.Errorf("Failed finding parent volume record for snapshot: %w", err)
-		}
-
-		_, err = tx.tx.Exec("UPDATE sqlite_sequence SET seq = seq + 1 WHERE name = 'storage_volumes'")
-		if err != nil {
-			return fmt.Errorf("Failed incrementing storage volumes sequence: %w", err)
-		}
-
-		row := tx.tx.QueryRowContext(ctx, "SELECT seq FROM sqlite_sequence WHERE name = 'storage_volumes' LIMIT 1")
-		err = row.Scan(&volumeID)
-		if err != nil {
-			return fmt.Errorf("Failed getting storage volumes sequence: %w", err)
-		}
-
-		_, err = tx.tx.Exec("INSERT INTO storage_volumes_snapshots (id, storage_volume_id, name, description, creation_date, expiry_date) VALUES (?, ?, ?, ?, ?, ?)", volumeID, parentID, snapshotName, volumeDescription, creationDate, expiryDate)
-		if err != nil {
-			return fmt.Errorf("Failed creating volume snapshot record: %w", err)
-		}
-
-		err = storageVolumeConfigAdd(tx.tx, volumeID, volumeConfig, true)
-		if err != nil {
-			return fmt.Errorf("Failed inserting storage volume snapshot record configuration: %w", err)
-		}
-
-		return nil
-	})
+	// Figure out the volume ID of the parent.
+	parentID, err := c.storagePoolVolumeGetTypeID(ctx, projectName, volumeName, volumeType, poolID, c.nodeID)
 	if err != nil {
-		volumeID = -1
+		return -1, fmt.Errorf("Failed finding parent volume record for snapshot: %w", err)
 	}
 
-	return volumeID, err
+	_, err = c.tx.ExecContext(ctx, "UPDATE sqlite_sequence SET seq = seq + 1 WHERE name = 'storage_volumes'")
+	if err != nil {
+		return -1, fmt.Errorf("Failed incrementing storage volumes sequence: %w", err)
+	}
+
+	row := c.tx.QueryRowContext(ctx, "SELECT seq FROM sqlite_sequence WHERE name = 'storage_volumes' LIMIT 1")
+	err = row.Scan(&volumeID)
+	if err != nil {
+		return -1, fmt.Errorf("Failed getting storage volumes sequence: %w", err)
+	}
+
+	_, err = c.tx.ExecContext(ctx, "INSERT INTO storage_volumes_snapshots (id, storage_volume_id, name, description, creation_date, expiry_date) VALUES (?, ?, ?, ?, ?, ?)", volumeID, parentID, snapshotName, volumeDescription, creationDate, expiryDate)
+	if err != nil {
+		return -1, fmt.Errorf("Failed creating volume snapshot record: %w", err)
+	}
+
+	err = storageVolumeConfigAdd(c.tx, volumeID, volumeConfig, true)
+	if err != nil {
+		return -1, fmt.Errorf("Failed inserting storage volume snapshot record configuration: %w", err)
+	}
+
+	return volumeID, nil
 }
 
 // UpdateStorageVolumeSnapshot updates the storage volume snapshot attached to a given storage pool.
-func (c *Cluster) UpdateStorageVolumeSnapshot(projectName string, volumeName string, volumeType int, poolID int64, volumeDescription string, volumeConfig map[string]string, expiryDate time.Time) error {
+func (c *ClusterTx) UpdateStorageVolumeSnapshot(ctx context.Context, projectName string, volumeName string, volumeType int, poolID int64, volumeDescription string, volumeConfig map[string]string, expiryDate time.Time) error {
 	var err error
 
 	if !strings.Contains(volumeName, internalInstance.SnapshotDelimiter) {
 		return fmt.Errorf("Volume is not a snapshot")
 	}
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		volume, err := tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, volumeName, true)
-		if err != nil {
-			return err
-		}
+	volume, err := c.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, volumeName, true)
+	if err != nil {
+		return err
+	}
 
-		err = storageVolumeConfigClear(tx.tx, volume.ID, true)
-		if err != nil {
-			return err
-		}
+	err = storageVolumeConfigClear(c.tx, volume.ID, true)
+	if err != nil {
+		return err
+	}
 
-		err = storageVolumeConfigAdd(tx.tx, volume.ID, volumeConfig, true)
-		if err != nil {
-			return err
-		}
+	err = storageVolumeConfigAdd(c.tx, volume.ID, volumeConfig, true)
+	if err != nil {
+		return err
+	}
 
-		err = storageVolumeDescriptionUpdate(tx.tx, volume.ID, volumeDescription, true)
-		if err != nil {
-			return err
-		}
+	err = storageVolumeDescriptionUpdate(c.tx, volume.ID, volumeDescription, true)
+	if err != nil {
+		return err
+	}
 
-		err = storageVolumeSnapshotExpiryDateUpdate(tx.tx, volume.ID, expiryDate)
-		if err != nil {
-			return err
-		}
+	err = storageVolumeSnapshotExpiryDateUpdate(c.tx, volume.ID, expiryDate)
+	if err != nil {
+		return err
+	}
 
-		return nil
-	})
-
-	return err
+	return nil
 }
 
 // GetStorageVolumeSnapshotWithID returns the volume snapshot with the given ID.
-func (c *Cluster) GetStorageVolumeSnapshotWithID(snapshotID int) (StorageVolumeArgs, error) {
+func (c *ClusterTx) GetStorageVolumeSnapshotWithID(ctx context.Context, snapshotID int) (StorageVolumeArgs, error) {
 	args := StorageVolumeArgs{}
 	q := `
 SELECT
@@ -121,9 +110,7 @@ WHERE volumes.id=?
 	arg1 := []any{snapshotID}
 	outfmt := []any{&args.ID, &args.Name, &args.CreationDate, &args.PoolName, &args.Type, &args.ProjectName}
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return dbQueryRowScan(ctx, tx, q, arg1, outfmt)
-	})
+	err := dbQueryRowScan(ctx, c, q, arg1, outfmt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return args, api.StatusErrorf(http.StatusNotFound, "Storage pool volume snapshot not found")
@@ -142,16 +129,14 @@ WHERE volumes.id=?
 }
 
 // GetStorageVolumeSnapshotExpiry gets the expiry date of a storage volume snapshot.
-func (c *Cluster) GetStorageVolumeSnapshotExpiry(volumeID int64) (time.Time, error) {
+func (c *ClusterTx) GetStorageVolumeSnapshotExpiry(ctx context.Context, volumeID int64) (time.Time, error) {
 	var expiry time.Time
 
 	query := "SELECT expiry_date FROM storage_volumes_snapshots WHERE id=?"
 	inargs := []any{volumeID}
 	outargs := []any{&expiry}
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		return dbQueryRowScan(ctx, tx, query, inargs, outargs)
-	})
+	err := dbQueryRowScan(ctx, c, query, inargs, outargs)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return expiry, api.StatusErrorf(http.StatusNotFound, "Storage pool volume snapshot not found")

--- a/internal/server/db/storage_volumes.go
+++ b/internal/server/db/storage_volumes.go
@@ -264,7 +264,7 @@ func (c *ClusterTx) GetStoragePoolVolume(ctx context.Context, poolID int64, proj
 // GetLocalStoragePoolVolumeSnapshotsWithType get all snapshots of a storage volume
 // attached to a given storage pool of a given volume type, on the local member.
 // Returns snapshots slice ordered by when they were created, oldest first.
-func (c *Cluster) GetLocalStoragePoolVolumeSnapshotsWithType(projectName string, volumeName string, volumeType int, poolID int64) ([]StorageVolumeArgs, error) {
+func (c *ClusterTx) GetLocalStoragePoolVolumeSnapshotsWithType(ctx context.Context, projectName string, volumeName string, volumeType int, poolID int64) ([]StorageVolumeArgs, error) {
 	remoteDrivers := StorageRemoteDriverNames()
 
 	// ORDER BY creation_date and then id is important here as the users of this function can expect that the
@@ -292,52 +292,44 @@ func (c *Cluster) GetLocalStoragePoolVolumeSnapshotsWithType(projectName string,
 		args = append(args, driver)
 	}
 
-	var err error
 	var snapshots []StorageVolumeArgs
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		err = query.Scan(ctx, tx.Tx(), queryStr, func(scan func(dest ...any) error) error {
-			var s StorageVolumeArgs
-			var snapName string
-			var expiryDate sql.NullTime
-			var contentType int
+	err := query.Scan(ctx, c.Tx(), queryStr, func(scan func(dest ...any) error) error {
+		var s StorageVolumeArgs
+		var snapName string
+		var expiryDate sql.NullTime
+		var contentType int
 
-			err := scan(&s.ID, &snapName, &s.Description, &s.CreationDate, &expiryDate, &contentType)
-			if err != nil {
-				return err
-			}
-
-			s.Name = volumeName + internalInstance.SnapshotDelimiter + snapName
-			s.PoolID = poolID
-			s.ProjectName = projectName
-			s.Snapshot = true
-			s.ExpiryDate = expiryDate.Time // Convert null to zero.
-
-			s.ContentType, err = storagePoolVolumeContentTypeToName(contentType)
-			if err != nil {
-				return err
-			}
-
-			snapshots = append(snapshots, s)
-
-			return nil
-		}, args...)
+		err := scan(&s.ID, &snapName, &s.Description, &s.CreationDate, &expiryDate, &contentType)
 		if err != nil {
 			return err
 		}
 
-		// Populate config.
-		for i := range snapshots {
-			err := storageVolumeSnapshotConfig(ctx, tx, snapshots[i].ID, &snapshots[i])
-			if err != nil {
-				return err
-			}
+		s.Name = volumeName + internalInstance.SnapshotDelimiter + snapName
+		s.PoolID = poolID
+		s.ProjectName = projectName
+		s.Snapshot = true
+		s.ExpiryDate = expiryDate.Time // Convert null to zero.
+
+		s.ContentType, err = storagePoolVolumeContentTypeToName(contentType)
+		if err != nil {
+			return err
 		}
 
+		snapshots = append(snapshots, s)
+
 		return nil
-	})
+	}, args...)
 	if err != nil {
 		return nil, err
+	}
+
+	// Populate config.
+	for i := range snapshots {
+		err := storageVolumeSnapshotConfig(ctx, c, snapshots[i].ID, &snapshots[i])
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return snapshots, nil
@@ -368,43 +360,35 @@ func storageVolumeSnapshotConfig(ctx context.Context, tx *ClusterTx, volumeSnaps
 }
 
 // UpdateStoragePoolVolume updates the storage volume attached to a given storage pool.
-func (c *Cluster) UpdateStoragePoolVolume(projectName string, volumeName string, volumeType int, poolID int64, volumeDescription string, volumeConfig map[string]string) error {
-	var err error
-
+func (c *ClusterTx) UpdateStoragePoolVolume(ctx context.Context, projectName string, volumeName string, volumeType int, poolID int64, volumeDescription string, volumeConfig map[string]string) error {
 	isSnapshot := strings.Contains(volumeName, internalInstance.SnapshotDelimiter)
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		volume, err := tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, volumeName, true)
-		if err != nil {
-			return err
-		}
+	volume, err := c.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, volumeName, true)
+	if err != nil {
+		return err
+	}
 
-		err = storageVolumeConfigClear(tx.tx, volume.ID, isSnapshot)
-		if err != nil {
-			return err
-		}
+	err = storageVolumeConfigClear(c.tx, volume.ID, isSnapshot)
+	if err != nil {
+		return err
+	}
 
-		err = storageVolumeConfigAdd(tx.tx, volume.ID, volumeConfig, isSnapshot)
-		if err != nil {
-			return err
-		}
+	err = storageVolumeConfigAdd(c.tx, volume.ID, volumeConfig, isSnapshot)
+	if err != nil {
+		return err
+	}
 
-		err = storageVolumeDescriptionUpdate(tx.tx, volume.ID, volumeDescription, isSnapshot)
-		if err != nil {
-			return err
-		}
+	err = storageVolumeDescriptionUpdate(c.tx, volume.ID, volumeDescription, isSnapshot)
+	if err != nil {
+		return err
+	}
 
-		return nil
-	})
-
-	return err
+	return nil
 }
 
 // RemoveStoragePoolVolume deletes the storage volume attached to a given storage
 // pool.
-func (c *Cluster) RemoveStoragePoolVolume(projectName string, volumeName string, volumeType int, poolID int64) error {
-	var err error
-
+func (c *ClusterTx) RemoveStoragePoolVolume(ctx context.Context, projectName string, volumeName string, volumeType int, poolID int64) error {
 	isSnapshot := strings.Contains(volumeName, internalInstance.SnapshotDelimiter)
 	var stmt string
 	if isSnapshot {
@@ -413,27 +397,21 @@ func (c *Cluster) RemoveStoragePoolVolume(projectName string, volumeName string,
 		stmt = "DELETE FROM storage_volumes WHERE id=?"
 	}
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		volume, err := tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, volumeName, true)
-		if err != nil {
-			return err
-		}
+	volume, err := c.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, volumeName, true)
+	if err != nil {
+		return err
+	}
 
-		_, err = tx.tx.Exec(stmt, volume.ID)
-		if err != nil {
-			return err
-		}
+	_, err = c.tx.ExecContext(ctx, stmt, volume.ID)
+	if err != nil {
+		return err
+	}
 
-		return nil
-	})
-
-	return err
+	return nil
 }
 
 // RenameStoragePoolVolume renames the storage volume attached to a given storage pool.
-func (c *Cluster) RenameStoragePoolVolume(projectName string, oldVolumeName string, newVolumeName string, volumeType int, poolID int64) error {
-	var err error
-
+func (c *ClusterTx) RenameStoragePoolVolume(ctx context.Context, projectName string, oldVolumeName string, newVolumeName string, volumeType int, poolID int64) error {
 	isSnapshot := strings.Contains(oldVolumeName, internalInstance.SnapshotDelimiter)
 	var stmt string
 	if isSnapshot {
@@ -444,25 +422,21 @@ func (c *Cluster) RenameStoragePoolVolume(projectName string, oldVolumeName stri
 		stmt = "UPDATE storage_volumes SET name=? WHERE id=?"
 	}
 
-	err = c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		volume, err := tx.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, oldVolumeName, true)
-		if err != nil {
-			return err
-		}
+	volume, err := c.GetStoragePoolVolume(ctx, poolID, projectName, volumeType, oldVolumeName, true)
+	if err != nil {
+		return err
+	}
 
-		_, err = tx.tx.Exec(stmt, newVolumeName, volume.ID)
-		if err != nil {
-			return err
-		}
+	_, err = c.tx.ExecContext(ctx, stmt, newVolumeName, volume.ID)
+	if err != nil {
+		return err
+	}
 
-		return nil
-	})
-
-	return err
+	return nil
 }
 
 // CreateStoragePoolVolume creates a new storage volume attached to a given storage pool.
-func (c *Cluster) CreateStoragePoolVolume(projectName string, volumeName string, volumeDescription string, volumeType int, poolID int64, volumeConfig map[string]string, contentType int, creationDate time.Time) (int64, error) {
+func (c *ClusterTx) CreateStoragePoolVolume(ctx context.Context, projectName string, volumeName string, volumeDescription string, volumeType int, poolID int64, volumeConfig map[string]string, contentType int, creationDate time.Time) (int64, error) {
 	var volumeID int64
 
 	if internalInstance.IsSnapshot(volumeName) {
@@ -471,46 +445,39 @@ func (c *Cluster) CreateStoragePoolVolume(projectName string, volumeName string,
 
 	remoteDrivers := StorageRemoteDriverNames()
 
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		driver, err := tx.GetStoragePoolDriver(ctx, poolID)
-		if err != nil {
-			return err
-		}
+	driver, err := c.GetStoragePoolDriver(ctx, poolID)
+	if err != nil {
+		return -1, err
+	}
 
-		var result sql.Result
+	var result sql.Result
 
-		if util.ValueInSlice(driver, remoteDrivers) {
-			result, err = tx.tx.Exec(`
+	if util.ValueInSlice(driver, remoteDrivers) {
+		result, err = c.tx.ExecContext(ctx, `
 INSERT INTO storage_volumes (storage_pool_id, type, name, description, project_id, content_type, creation_date)
  VALUES (?, ?, ?, ?, (SELECT id FROM projects WHERE name = ?), ?, ?)
 `,
-				poolID, volumeType, volumeName, volumeDescription, projectName, contentType, creationDate)
-		} else {
-			result, err = tx.tx.Exec(`
+			poolID, volumeType, volumeName, volumeDescription, projectName, contentType, creationDate)
+	} else {
+		result, err = c.tx.ExecContext(ctx, `
 INSERT INTO storage_volumes (storage_pool_id, node_id, type, name, description, project_id, content_type, creation_date)
  VALUES (?, ?, ?, ?, ?, (SELECT id FROM projects WHERE name = ?), ?, ?)
 `,
-				poolID, c.nodeID, volumeType, volumeName, volumeDescription, projectName, contentType, creationDate)
-		}
+			poolID, c.nodeID, volumeType, volumeName, volumeDescription, projectName, contentType, creationDate)
+	}
 
-		if err != nil {
-			return err
-		}
-
-		volumeID, err = result.LastInsertId()
-		if err != nil {
-			return err
-		}
-
-		err = storageVolumeConfigAdd(tx.tx, volumeID, volumeConfig, false)
-		if err != nil {
-			return fmt.Errorf("Failed inserting storage volume record configuration: %w", err)
-		}
-
-		return nil
-	})
 	if err != nil {
-		volumeID = -1
+		return -1, err
+	}
+
+	volumeID, err = result.LastInsertId()
+	if err != nil {
+		return -1, err
+	}
+
+	err = storageVolumeConfigAdd(c.tx, volumeID, volumeConfig, false)
+	if err != nil {
+		return -1, fmt.Errorf("Failed inserting storage volume record configuration: %w", err)
 	}
 
 	return volumeID, err
@@ -518,20 +485,6 @@ INSERT INTO storage_volumes (storage_pool_id, node_id, type, name, description, 
 
 // Return the ID of a storage volume on a given storage pool of a given storage
 // volume type, on the given node.
-func (c *Cluster) storagePoolVolumeGetTypeID(project string, volumeName string, volumeType int, poolID, nodeID int64) (int64, error) {
-	var id int64
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		id, err = tx.storagePoolVolumeGetTypeID(ctx, project, volumeName, volumeType, poolID, nodeID)
-		return err
-	})
-	if err != nil {
-		return -1, err
-	}
-
-	return id, nil
-}
-
 func (c *ClusterTx) storagePoolVolumeGetTypeID(ctx context.Context, project string, volumeName string, volumeType int, poolID, nodeID int64) (int64, error) {
 	remoteDrivers := StorageRemoteDriverNames()
 
@@ -566,8 +519,8 @@ SELECT storage_volumes_all.id
 
 // GetStoragePoolNodeVolumeID gets the ID of a storage volume on a given storage pool
 // of a given storage volume type and project, on the current node.
-func (c *Cluster) GetStoragePoolNodeVolumeID(projectName string, volumeName string, volumeType int, poolID int64) (int64, error) {
-	return c.storagePoolVolumeGetTypeID(projectName, volumeName, volumeType, poolID, c.nodeID)
+func (c *ClusterTx) GetStoragePoolNodeVolumeID(ctx context.Context, projectName string, volumeName string, volumeType int, poolID int64) (int64, error) {
+	return c.storagePoolVolumeGetTypeID(ctx, projectName, volumeName, volumeType, poolID, c.nodeID)
 }
 
 // XXX: this was extracted from storage_volume_utils.go, we find a way to
@@ -743,7 +696,7 @@ func (c *ClusterTx) storageVolumeConfigGet(ctx context.Context, volumeID int64, 
 //
 // Note, the code below doesn't deal with snapshots of snapshots.
 // To do that, we'll need to weed out based on # slashes in names.
-func (c *Cluster) GetNextStorageVolumeSnapshotIndex(pool, name string, typ int, pattern string) int {
+func (c *ClusterTx) GetNextStorageVolumeSnapshotIndex(ctx context.Context, pool, name string, typ int, pattern string) int {
 	remoteDrivers := StorageRemoteDriverNames()
 
 	q := fmt.Sprintf(`
@@ -763,13 +716,7 @@ SELECT storage_volumes_snapshots.name FROM storage_volumes_snapshots
 		inargs = append(inargs, driver)
 	}
 
-	var results [][]any
-
-	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		var err error
-		results, err = queryScan(ctx, tx, q, inargs, outfmt)
-		return err
-	})
+	results, err := queryScan(ctx, c, q, inargs, outfmt)
 	if err != nil {
 		return 0
 	}

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -1730,7 +1730,9 @@ func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName st
 	// Update last idmap.
 	poolVolumePut.Config["volatile.idmap.last"] = jsonIdmap
 
-	err = d.state.DB.Cluster.UpdateStoragePoolVolume(projectName, volumeName, volumeType, d.pool.ID(), poolVolumePut.Description, poolVolumePut.Config)
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.UpdateStoragePoolVolume(ctx, projectName, volumeName, volumeType, d.pool.ID(), poolVolumePut.Description, poolVolumePut.Config)
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -964,7 +964,9 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 							d.logger.Warn("Unable to use virtio-fs for device, using 9p as a fallback", logger.Ctx{"err": errUnsupported})
 
 							if errUnsupported == ErrMissingVirtiofsd {
-								_ = d.state.DB.Cluster.UpsertWarningLocalNode(d.inst.Project().Name, cluster.TypeInstance, d.inst.ID(), warningtype.MissingVirtiofsd, "Using 9p as a fallback")
+								_ = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+									return tx.UpsertWarningLocalNode(ctx, d.inst.Project().Name, cluster.TypeInstance, d.inst.ID(), warningtype.MissingVirtiofsd, "Using 9p as a fallback")
+								})
 							} else {
 								// Resolve previous warning.
 								_ = warnings.ResolveWarningsByLocalNodeAndProjectAndType(d.state.DB.Cluster, d.inst.Project().Name, warningtype.MissingVirtiofsd)

--- a/internal/server/device/nic_bridged.go
+++ b/internal/server/device/nic_bridged.go
@@ -3,6 +3,7 @@ package device
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -611,7 +612,13 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 		}
 
 		if brNetfilterEnabled {
-			listenAddresses, err := d.state.DB.Cluster.GetNetworkForwardListenAddresses(d.network.ID(), true)
+			var listenAddresses map[int64]string
+
+			err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				listenAddresses, err = tx.GetNetworkForwardListenAddresses(ctx, d.network.ID(), true)
+
+				return err
+			})
 			if err != nil {
 				return nil, fmt.Errorf("Failed loading network forwards: %w", err)
 			}

--- a/internal/server/device/nic_ovn.go
+++ b/internal/server/device/nic_ovn.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -393,7 +394,14 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 
 	// Load uplink network config.
 	uplinkNetworkName := d.network.Config()["network"]
-	_, uplink, _, err := d.state.DB.Cluster.GetNetworkInAnyState(api.ProjectDefaultName, uplinkNetworkName)
+
+	var uplink *api.Network
+
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, uplinkNetworkName)
+
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load uplink network %q: %w", uplinkNetworkName, err)
 	}
@@ -751,7 +759,16 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 		if isRunning {
 			// Load uplink network config.
 			uplinkNetworkName := d.network.Config()["network"]
-			_, uplink, _, err := d.state.DB.Cluster.GetNetworkInAnyState(api.ProjectDefaultName, uplinkNetworkName)
+
+			var uplink *api.Network
+
+			err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				var err error
+
+				_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, uplinkNetworkName)
+
+				return err
+			})
 			if err != nil {
 				return fmt.Errorf("Failed to load uplink network %q: %w", uplinkNetworkName, err)
 			}

--- a/internal/server/device/nictype/nictype.go
+++ b/internal/server/device/nictype/nictype.go
@@ -3,11 +3,14 @@
 package nictype
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/lxc/incus/internal/server/db"
 	deviceConfig "github.com/lxc/incus/internal/server/device/config"
 	"github.com/lxc/incus/internal/server/project"
 	"github.com/lxc/incus/internal/server/state"
+	"github.com/lxc/incus/shared/api"
 )
 
 // NICType resolves the NIC Type for the supplied NIC device config.
@@ -24,7 +27,13 @@ func NICType(s *state.State, deviceProjectName string, d deviceConfig.Device) (s
 				return "", fmt.Errorf("Failed to translate device project %q into network project: %w", deviceProjectName, err)
 			}
 
-			_, netInfo, _, err := s.DB.Cluster.GetNetworkInAnyState(networkProjectName, d["network"])
+			var netInfo *api.Network
+
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				_, netInfo, _, err = tx.GetNetworkInAnyState(ctx, networkProjectName, d["network"])
+
+				return err
+			})
 			if err != nil {
 				return "", fmt.Errorf("Failed to load network %q for project %q: %w", d["network"], networkProjectName, err)
 			}

--- a/internal/server/device/proxy.go
+++ b/internal/server/device/proxy.go
@@ -447,7 +447,9 @@ func (d *proxy) setupNAT() error {
 	if err != nil {
 		msg := fmt.Sprintf("IPv%d bridge netfilter not enabled. Instances using the bridge will not be able to connect to the proxy listen IP", ipVersion)
 		d.logger.Warn(msg, logger.Ctx{"err": err})
-		err := d.state.DB.Cluster.UpsertWarningLocalNode(d.inst.Project().Name, cluster.TypeInstance, d.inst.ID(), warningtype.ProxyBridgeNetfilterNotEnabled, fmt.Sprintf("%s: %v", msg, err))
+		err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.UpsertWarningLocalNode(ctx, d.inst.Project().Name, cluster.TypeInstance, d.inst.ID(), warningtype.ProxyBridgeNetfilterNotEnabled, fmt.Sprintf("%s: %v", msg, err))
+		})
 		if err != nil {
 			logger.Warn("Failed to create warning", logger.Ctx{"err": err})
 		}

--- a/internal/server/dns/server.go
+++ b/internal/server/dns/server.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"sync"
 
 	"github.com/miekg/dns"
@@ -162,8 +163,16 @@ func (s *Server) updateTSIG() error {
 		return nil
 	}
 
-	// Get all the secrets.
-	secrets, err := s.db.GetNetworkZoneKeys()
+	var secrets map[string]string
+
+	err := s.db.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get all the secrets.
+		secrets, err = tx.GetNetworkZoneKeys(ctx)
+
+		return err
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -2,7 +2,6 @@ package drivers
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,7 +18,6 @@ import (
 	"github.com/lxc/incus/internal/server/backup"
 	"github.com/lxc/incus/internal/server/db"
 	dbCluster "github.com/lxc/incus/internal/server/db/cluster"
-	"github.com/lxc/incus/internal/server/db/query"
 	"github.com/lxc/incus/internal/server/device"
 	deviceConfig "github.com/lxc/incus/internal/server/device/config"
 	"github.com/lxc/incus/internal/server/device/nictype"
@@ -767,19 +765,19 @@ func (d *common) updateProgress(progress string) {
 // unpopulated then the insert querty is retried until it succeeds or a retry limit is reached.
 // If the insert succeeds or the key is found to have been populated then the value of the key is returned.
 func (d *common) insertConfigkey(key string, value string) (string, error) {
-	err := query.Retry(context.TODO(), func(ctx context.Context) error {
-		err := query.Transaction(ctx, d.state.DB.Cluster.DB(), func(ctx context.Context, tx *sql.Tx) error {
-			return db.CreateInstanceConfig(tx, d.id, map[string]string{key: value})
-		})
-		if err != nil {
-			// Check if something else filled it in behind our back.
-			existingValue, errCheckExists := d.state.DB.Cluster.GetInstanceConfig(d.id, key)
-			if errCheckExists != nil {
-				return err
-			}
-
-			value = existingValue
+	err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err := tx.CreateInstanceConfig(ctx, d.id, map[string]string{key: value})
+		if err == nil {
+			return nil
 		}
+
+		// Check if something else filled it in behind our back.
+		existingValue, errCheckExists := tx.GetInstanceConfig(ctx, d.id, key)
+		if errCheckExists != nil {
+			return err
+		}
+
+		value = existingValue
 
 		return nil
 	})
@@ -1106,7 +1104,18 @@ func (d *common) getStoragePool() (storagePools.Pool, error) {
 		return d.storagePool, nil
 	}
 
-	poolName, err := d.state.DB.Cluster.GetInstancePool(d.Project().Name, d.Name())
+	var poolName string
+
+	err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		poolName, err = tx.GetInstancePool(ctx, d.Project().Name, d.Name())
+		if err != nil {
+			return fmt.Errorf("Failed getting instance pool: %w", err)
+		}
+
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -210,8 +210,14 @@ func (d *common) Operation() *operations.Operation {
 
 // Backups returns a list of backups.
 func (d *common) Backups() ([]backup.InstanceBackup, error) {
+	var backupNames []string
+
 	// Get all the backups
-	backupNames, err := d.state.DB.Cluster.GetInstanceBackups(d.project.Name, d.name)
+	err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		backupNames, err = tx.GetInstanceBackups(ctx, d.project.Name, d.name)
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -2448,7 +2448,9 @@ func (d *lxc) Start(stateful bool) error {
 		_ = os.RemoveAll(d.StatePath())
 		d.stateful = false
 
-		err = d.state.DB.Cluster.UpdateInstanceStatefulFlag(d.id, false)
+		err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.UpdateInstanceStatefulFlag(ctx, d.id, false)
+		})
 		if err != nil {
 			op.Done(err)
 			return fmt.Errorf("Failed clearing instance stateful flag: %w", err)
@@ -2469,7 +2471,9 @@ func (d *lxc) Start(stateful bool) error {
 		}
 
 		d.stateful = false
-		err = d.state.DB.Cluster.UpdateInstanceStatefulFlag(d.id, false)
+		err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.UpdateInstanceStatefulFlag(ctx, d.id, false)
+		})
 		if err != nil {
 			op.Done(err)
 			return fmt.Errorf("Failed clearing instance stateful flag: %w", err)
@@ -2581,8 +2585,10 @@ func (d *lxc) onStart(_ map[string]string) error {
 			return err
 		}
 
-		// Remove the volatile key from the DB
-		err := d.state.DB.Cluster.DeleteInstanceConfigKey(d.id, key)
+		err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Remove the volatile key from the DB
+			return tx.DeleteInstanceConfigKey(ctx, int64(d.id), key)
+		})
 		if err != nil {
 			_ = apparmor.InstanceUnload(d.state.OS, d)
 			return err
@@ -2704,7 +2710,10 @@ func (d *lxc) Stop(stateful bool) error {
 		}
 
 		d.stateful = true
-		err = d.state.DB.Cluster.UpdateInstanceStatefulFlag(d.id, true)
+
+		err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.UpdateInstanceStatefulFlag(ctx, d.id, true)
+		})
 		if err != nil {
 			return fmt.Errorf("Failed updating instance stateful flag: %w", err)
 		}
@@ -3809,8 +3818,10 @@ func (d *lxc) delete(force bool) error {
 		d.cleanup()
 	}
 
-	// Remove the database record of the instance or snapshot instance.
-	err = d.state.DB.Cluster.DeleteInstance(d.project.Name, d.Name())
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Remove the database record of the instance or snapshot instance.
+		return tx.DeleteInstance(ctx, d.project.Name, d.Name())
+	})
 	if err != nil {
 		d.logger.Error("Failed deleting instance entry", logger.Ctx{"err": err})
 		return err
@@ -3893,8 +3904,19 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 	}
 
 	if !d.IsSnapshot() {
-		// Rename all the instance snapshot database entries.
-		results, err := d.state.DB.Cluster.GetInstanceSnapshotsNames(d.project.Name, oldName)
+		var results []string
+
+		err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			// Rename all the instance snapshot database entries.
+			results, err = tx.GetInstanceSnapshotsNames(ctx, d.project.Name, oldName)
+			if err != nil {
+				return fmt.Errorf("Failed getting instance snapshot names: %w", err)
+			}
+
+			return nil
+		})
 		if err != nil {
 			d.logger.Error("Failed to get instance snapshots", ctxMap)
 			return fmt.Errorf("Failed to get instance snapshots: %w", err)

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -4107,8 +4107,14 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 	}
 
-	// Validate the new profiles
-	profiles, err := d.state.DB.Cluster.GetProfileNames(args.Project)
+	var profiles []string
+
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Validate the new profiles
+		profiles, err = tx.GetProfileNames(ctx, args.Project)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to get profiles: %w", err)
 	}

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -1365,8 +1365,10 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 			d.logger.Warn("Unable to use virtio-fs for config drive, using 9p as a fallback", logger.Ctx{"err": errUnsupported})
 
 			if errUnsupported == device.ErrMissingVirtiofsd {
-				// Create a warning if virtiofsd is missing.
-				_ = d.state.DB.Cluster.UpsertWarning(d.node, d.project.Name, dbCluster.TypeInstance, d.ID(), warningtype.MissingVirtiofsd, "Using 9p as a fallback")
+				_ = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					// Create a warning if virtiofsd is missing.
+					return tx.UpsertWarning(ctx, d.node, d.project.Name, dbCluster.TypeInstance, d.ID(), warningtype.MissingVirtiofsd, "Using 9p as a fallback")
+				})
 			} else {
 				// Resolve previous warning.
 				_ = warnings.ResolveWarningsByNodeAndProjectAndType(d.state.DB.Cluster, d.node, d.project.Name, warningtype.MissingVirtiofsd)

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -5217,8 +5217,14 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 	}
 
-	// Validate the new profiles.
-	profiles, err := d.state.DB.Cluster.GetProfileNames(args.Project)
+	var profiles []string
+
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Validate the new profiles.
+		profiles, err = tx.GetProfileNames(ctx, args.Project)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to get profiles: %w", err)
 	}

--- a/internal/server/instance/instance_utils.go
+++ b/internal/server/instance/instance_utils.go
@@ -279,8 +279,20 @@ func AllowedUnprivilegedOnlyMap(rawIdmap string) error {
 
 // LoadByID loads an instance by ID.
 func LoadByID(s *state.State, id int) (Instance, error) {
-	// Get the DB record
-	project, name, err := s.DB.Cluster.GetInstanceProjectAndName(id)
+	var project string
+	var name string
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get the DB record
+		project, name, err = tx.GetInstanceProjectAndName(ctx, id)
+		if err != nil {
+			return fmt.Errorf("Failed getting instance project and name: %w", err)
+		}
+
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -372,16 +384,18 @@ func LoadNodeAll(s *state.State, instanceType instancetype.Type) ([]Instance, er
 		filter.Node = &s.ServerName
 	}
 
-	err = s.DB.Cluster.InstanceList(context.TODO(), func(dbInst db.InstanceArgs, p api.Project) error {
-		inst, err := Load(s, dbInst, p)
-		if err != nil {
-			return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
-		}
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(dbInst db.InstanceArgs, p api.Project) error {
+			inst, err := Load(s, dbInst, p)
+			if err != nil {
+				return fmt.Errorf("Failed loading instance %q in project %q: %w", dbInst.Name, dbInst.Project, err)
+			}
 
-		instances = append(instances, inst)
+			instances = append(instances, inst)
 
-		return nil
-	}, filter)
+			return nil
+		}, filter)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -970,7 +984,11 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool) (Ins
 		return nil, nil, nil, err
 	}
 
-	revert.Add(func() { _ = s.DB.Cluster.DeleteInstance(dbInst.Project, dbInst.Name) })
+	revert.Add(func() {
+		_ = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.DeleteInstance(ctx, dbInst.Project, dbInst.Name)
+		})
+	})
 	inst, cleanup, err := Create(s, args, *p)
 	if err != nil {
 		logger.Error("Failed initialising instance", logger.Ctx{"project": args.Project, "instance": args.Name, "type": args.Type, "err": err})
@@ -1009,7 +1027,14 @@ func NextSnapshotName(s *state.State, inst Instance, defaultPattern string) (str
 	if count > 1 {
 		return "", fmt.Errorf("Snapshot pattern may contain '%%d' only once")
 	} else if count == 1 {
-		i := s.DB.Cluster.GetNextInstanceSnapshotIndex(inst.Project().Name, inst.Name(), pattern)
+		var i int
+
+		_ = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			i = tx.GetNextInstanceSnapshotIndex(ctx, inst.Project().Name, inst.Name(), pattern)
+
+			return nil
+		})
+
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 
@@ -1031,7 +1056,14 @@ func NextSnapshotName(s *state.State, inst Instance, defaultPattern string) (str
 	// Append '-0', '-1', etc. if the actual pattern/snapshot name already exists
 	if snapshotExists {
 		pattern = fmt.Sprintf("%s-%%d", pattern)
-		i := s.DB.Cluster.GetNextInstanceSnapshotIndex(inst.Project().Name, inst.Name(), pattern)
+
+		var i int
+
+		_ = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			i = tx.GetNextInstanceSnapshotIndex(ctx, inst.Project().Name, inst.Name(), pattern)
+
+			return nil
+		})
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 

--- a/internal/server/instance/instance_utils.go
+++ b/internal/server/instance/instance_utils.go
@@ -731,7 +731,11 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool) (Ins
 	}
 
 	if args.Profiles == nil {
-		args.Profiles, err = s.DB.Cluster.GetProfiles(args.Project, []string{"default"})
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			args.Profiles, err = tx.GetProfiles(ctx, args.Project, []string{"default"})
+
+			return err
+		})
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("Failed to get default profile for new instance")
 		}
@@ -797,8 +801,14 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool) (Ins
 		return nil, nil, nil, fmt.Errorf("Requested architecture isn't supported by this host")
 	}
 
-	// Validate profiles.
-	profiles, err := s.DB.Cluster.GetProfileNames(args.Project)
+	var profiles []string
+
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Validate profiles.
+		profiles, err = tx.GetProfileNames(ctx, args.Project)
+
+		return err
+	})
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1206,7 +1216,15 @@ func SnapshotProtobufToInstanceArgs(s *state.State, inst Instance, snap *migrati
 		devices[ent.GetName()] = props
 	}
 
-	profiles, err := s.DB.Cluster.GetProfiles(inst.Project().Name, snap.Profiles)
+	var profiles []api.Profile
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		profiles, err = tx.GetProfiles(ctx, inst.Project().Name, snap.Profiles)
+
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/instance/instance_utils.go
+++ b/internal/server/instance/instance_utils.go
@@ -462,8 +462,14 @@ func DeviceNextInterfaceHWAddr() (string, error) {
 
 // BackupLoadByName load an instance backup from the database.
 func BackupLoadByName(s *state.State, project, name string) (*backup.InstanceBackup, error) {
+	var args db.InstanceBackup
+
 	// Get the backup database record
-	args, err := s.DB.Cluster.GetInstanceBackup(project, name)
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		args, err = tx.GetInstanceBackup(ctx, project, name)
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("Load backup from database: %w", err)
 	}

--- a/internal/server/network/acl/acl_firewall.go
+++ b/internal/server/network/acl/acl_firewall.go
@@ -1,8 +1,10 @@
 package acl
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/lxc/incus/internal/server/db"
 	firewallDrivers "github.com/lxc/incus/internal/server/firewall/drivers"
 	"github.com/lxc/incus/internal/server/state"
 	"github.com/lxc/incus/shared/api"
@@ -60,7 +62,15 @@ func FirewallApplyACLRules(s *state.State, logger logger.Logger, aclProjectName 
 
 	// Load ACLs specified by network.
 	for _, aclName := range util.SplitNTrimSpace(aclNet.Config["security.acls"], ",", -1, true) {
-		_, aclInfo, err := s.DB.Cluster.GetNetworkACL(aclProjectName, aclName)
+		var aclInfo *api.NetworkACL
+
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			_, aclInfo, err = tx.GetNetworkACL(ctx, aclProjectName, aclName)
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed loading ACL %q for network %q: %w", aclName, aclNet.Name, err)
 		}

--- a/internal/server/network/acl/acl_load.go
+++ b/internal/server/network/acl/acl_load.go
@@ -105,33 +105,40 @@ func UsedBy(s *state.State, aclProjectName string, usageFunc func(matchedACLName
 		return nil
 	}
 
-	// Find networks using the ACLs. Cheapest to do.
-	networkNames, err := s.DB.Cluster.GetCreatedNetworks(aclProjectName)
-	if err != nil && !response.IsNotFoundError(err) {
-		return fmt.Errorf("Failed loading networks for project %q: %w", aclProjectName, err)
-	}
-
-	for _, networkName := range networkNames {
-		_, network, _, err := s.DB.Cluster.GetNetworkInAnyState(aclProjectName, networkName)
-		if err != nil {
-			return fmt.Errorf("Failed to get network config for %q: %w", networkName, err)
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Find networks using the ACLs. Cheapest to do.
+		networkNames, err := tx.GetCreatedNetworkNamesByProject(ctx, aclProjectName)
+		if err != nil && !response.IsNotFoundError(err) {
+			return fmt.Errorf("Failed loading networks for project %q: %w", aclProjectName, err)
 		}
 
-		netACLNames := util.SplitNTrimSpace(network.Config["security.acls"], ",", -1, true)
-		matchedACLNames := []string{}
-		for _, netACLName := range netACLNames {
-			if util.ValueInSlice(netACLName, matchACLNames) {
-				matchedACLNames = append(matchedACLNames, netACLName)
-			}
-		}
-
-		if len(matchedACLNames) > 0 {
-			// Call usageFunc with a list of matched ACLs and info about the network.
-			err := usageFunc(matchedACLNames, network, "", nil)
+		for _, networkName := range networkNames {
+			_, network, _, err := tx.GetNetworkInAnyState(ctx, aclProjectName, networkName)
 			if err != nil {
-				return err
+				return fmt.Errorf("Failed to get network config for %q: %w", networkName, err)
+			}
+
+			netACLNames := util.SplitNTrimSpace(network.Config["security.acls"], ",", -1, true)
+			matchedACLNames := []string{}
+			for _, netACLName := range netACLNames {
+				if util.ValueInSlice(netACLName, matchACLNames) {
+					matchedACLNames = append(matchedACLNames, netACLName)
+				}
+			}
+
+			if len(matchedACLNames) > 0 {
+				// Call usageFunc with a list of matched ACLs and info about the network.
+				err := usageFunc(matchedACLNames, network, "", nil)
+				if err != nil {
+					return err
+				}
 			}
 		}
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	// Look for profiles. Next cheapest to do.
@@ -305,7 +312,16 @@ func NetworkUsage(s *state.State, aclProjectName string, aclNames []string, aclN
 	err := UsedBy(s, aclProjectName, func(matchedACLNames []string, usageType any, _ string, nicConfig map[string]string) error {
 		switch u := usageType.(type) {
 		case db.InstanceArgs, cluster.Profile:
-			networkID, network, _, err := s.DB.Cluster.GetNetworkInAnyState(aclProjectName, nicConfig["network"])
+			var networkID int64
+			var network *api.Network
+
+			err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				var err error
+
+				networkID, network, _, err = tx.GetNetworkInAnyState(ctx, aclProjectName, nicConfig["network"])
+
+				return err
+			})
 			if err != nil {
 				return fmt.Errorf("Failed to load network %q: %w", nicConfig["network"], err)
 			}
@@ -326,7 +342,16 @@ func NetworkUsage(s *state.State, aclProjectName string, aclNames []string, aclN
 			if util.ValueInSlice(u.Type, supportedNetTypes) {
 				_, found := aclNets[u.Name]
 				if !found {
-					networkID, network, _, err := s.DB.Cluster.GetNetworkInAnyState(aclProjectName, u.Name)
+					var networkID int64
+					var network *api.Network
+
+					err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+						var err error
+
+						networkID, network, _, err = tx.GetNetworkInAnyState(ctx, aclProjectName, u.Name)
+
+						return err
+					})
 					if err != nil {
 						return fmt.Errorf("Failed to load network %q: %w", u.Name, err)
 					}

--- a/internal/server/network/acl/acl_ovn.go
+++ b/internal/server/network/acl/acl_ovn.go
@@ -133,8 +133,14 @@ func OVNEnsureACLs(s *state.State, l logger.Logger, client *ovn.NB, aclProjectNa
 		}
 
 		if portGroupUUID == "" {
-			// Load the config we'll need to create the port group with ACL rules.
-			_, aclInfo, err := s.DB.Cluster.GetNetworkACL(aclProjectName, aclName)
+			var aclInfo *api.NetworkACL
+
+			err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				// Load the config we'll need to create the port group with ACL rules.
+				_, aclInfo, err = tx.GetNetworkACL(ctx, aclProjectName, aclName)
+
+				return err
+			})
 			if err != nil {
 				return nil, fmt.Errorf("Failed loading Network ACL %q: %w", aclName, err)
 			}
@@ -164,7 +170,11 @@ func OVNEnsureACLs(s *state.State, l logger.Logger, client *ovn.NB, aclProjectNa
 			// the default rule we add. We also need to reapply the rules if we are adding any
 			// new per-ACL-per-network port groups.
 			if reapplyRules || !portGroupHasACLs || len(addACLNets) > 0 {
-				_, aclInfo, err = s.DB.Cluster.GetNetworkACL(aclProjectName, aclName)
+				err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					_, aclInfo, err = tx.GetNetworkACL(ctx, aclProjectName, aclName)
+
+					return err
+				})
 				if err != nil {
 					return nil, fmt.Errorf("Failed loading Network ACL %q: %w", aclName, err)
 				}
@@ -747,8 +757,16 @@ func OVNApplyNetworkBaselineRules(client *ovn.NB, switchName ovn.OVNSwitch, rout
 // the desired ACLs are considered unused by the usage type even if the referring config has not yet been removed
 // from the database.
 func OVNPortGroupDeleteIfUnused(s *state.State, l logger.Logger, client *ovn.NB, aclProjectName string, ignoreUsageType any, ignoreUsageNicName string, keepACLs ...string) error {
-	// Get map of ACL names to DB IDs (used for generating OVN port group names).
-	aclNameIDs, err := s.DB.Cluster.GetNetworkACLIDsByNames(aclProjectName)
+	var aclNameIDs map[string]int64
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get map of ACL names to DB IDs (used for generating OVN port group names).
+		aclNameIDs, err = tx.GetNetworkACLIDsByNames(ctx, aclProjectName)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed getting network ACL IDs for security ACL port group removal: %w", err)
 	}

--- a/internal/server/network/acl/acl_ovn.go
+++ b/internal/server/network/acl/acl_ovn.go
@@ -847,7 +847,14 @@ func OVNPortGroupDeleteIfUnused(s *state.State, l logger.Logger, client *ovn.NB,
 				return nil
 			}
 
-			netID, network, _, err := s.DB.Cluster.GetNetworkInAnyState(aclProjectName, nicConfig["network"])
+			var netID int64
+			var network *api.Network
+
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				netID, network, _, err = tx.GetNetworkInAnyState(ctx, aclProjectName, nicConfig["network"])
+
+				return err
+			})
 			if err != nil {
 				return fmt.Errorf("Failed to load network %q: %w", nicConfig["network"], err)
 			}
@@ -876,7 +883,13 @@ func OVNPortGroupDeleteIfUnused(s *state.State, l logger.Logger, client *ovn.NB,
 			}
 
 			if u.Type == "ovn" {
-				netID, _, _, err := s.DB.Cluster.GetNetworkInAnyState(aclProjectName, u.Name)
+				var netID int64
+
+				err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					netID, _, _, err = tx.GetNetworkInAnyState(ctx, aclProjectName, u.Name)
+
+					return err
+				})
 				if err != nil {
 					return fmt.Errorf("Failed to load network %q: %w", nicConfig["network"], err)
 				}
@@ -903,7 +916,14 @@ func OVNPortGroupDeleteIfUnused(s *state.State, l logger.Logger, client *ovn.NB,
 				return nil
 			}
 
-			netID, network, _, err := s.DB.Cluster.GetNetworkInAnyState(aclProjectName, nicConfig["network"])
+			var netID int64
+			var network *api.Network
+
+			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				netID, network, _, err = tx.GetNetworkInAnyState(ctx, aclProjectName, nicConfig["network"])
+
+				return err
+			})
 			if err != nil {
 				return fmt.Errorf("Failed to load network %q: %w", nicConfig["network"], err)
 			}

--- a/internal/server/network/acl/driver_common.go
+++ b/internal/server/network/acl/driver_common.go
@@ -2,6 +2,7 @@ package acl
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -299,8 +300,16 @@ func (d *common) validateRule(direction ruleDirection, rule api.NetworkACLRule) 
 		return fmt.Errorf("State must be one of: %s", strings.Join(validStates, ", "))
 	}
 
-	// Get map of ACL names to DB IDs (used for generating OVN port group names).
-	acls, err := d.state.DB.Cluster.GetNetworkACLIDsByNames(d.Project())
+	var acls map[string]int64
+
+	err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get map of ACL names to DB IDs (used for generating OVN port group names).
+		acls, err = tx.GetNetworkACLIDsByNames(ctx, d.Project())
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed getting network ACLs for security ACL subject validation: %w", err)
 	}
@@ -583,9 +592,11 @@ func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType
 	if clientType == request.ClientTypeNormal {
 		oldConfig := d.info.NetworkACLPut
 
-		// Update database. Its important this occurs before we attempt to apply to networks using the ACL
-		// as usage functions will inspect the database.
-		err = d.state.DB.Cluster.UpdateNetworkACL(d.id, config)
+		err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Update database. Its important this occurs before we attempt to apply to networks using the ACL
+			// as usage functions will inspect the database.
+			return tx.UpdateNetworkACL(ctx, d.id, config)
+		})
 		if err != nil {
 			return err
 		}
@@ -595,7 +606,10 @@ func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType
 		d.init(d.state, d.id, d.projectName, d.info)
 
 		revert.Add(func() {
-			_ = d.state.DB.Cluster.UpdateNetworkACL(d.id, &oldConfig)
+			_ = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpdateNetworkACL(ctx, d.id, &oldConfig)
+			})
+
 			d.info.NetworkACLPut = oldConfig
 			d.init(d.state, d.id, d.projectName, d.info)
 		})
@@ -636,8 +650,14 @@ func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType
 			return fmt.Errorf("Failed to get OVN client: %w", err)
 		}
 
-		// Get map of ACL names to DB IDs (used for generating OVN port group names).
-		aclNameIDs, err := d.state.DB.Cluster.GetNetworkACLIDsByNames(d.Project())
+		var aclNameIDs map[string]int64
+
+		err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Get map of ACL names to DB IDs (used for generating OVN port group names).
+			aclNameIDs, err = tx.GetNetworkACLIDsByNames(ctx, d.Project())
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed getting network ACL IDs for security ACL update: %w", err)
 		}
@@ -704,7 +724,9 @@ func (d *common) Rename(newName string) error {
 		return err
 	}
 
-	err = d.state.DB.Cluster.RenameNetworkACL(d.id, newName)
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.RenameNetworkACL(ctx, d.id, newName)
+	})
 	if err != nil {
 		return err
 	}
@@ -726,7 +748,9 @@ func (d *common) Delete() error {
 		return fmt.Errorf("Cannot delete an ACL that is in use")
 	}
 
-	return d.state.DB.Cluster.DeleteNetworkACL(d.id)
+	return d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.DeleteNetworkACL(ctx, d.id)
+	})
 }
 
 // GetLog gets the ACL log.

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -1000,7 +1000,9 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		if subnetSize > 64 {
 			n.logger.Warn("IPv6 networks with a prefix larger than 64 aren't properly supported by dnsmasq")
 
-			err = n.state.DB.Cluster.UpsertWarningLocalNode(n.project, dbCluster.TypeNetwork, int(n.id), warningtype.LargerIPv6PrefixThanSupported, "")
+			err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpsertWarningLocalNode(ctx, n.project, dbCluster.TypeNetwork, int(n.id), warningtype.LargerIPv6PrefixThanSupported, "")
+			})
 			if err != nil {
 				n.logger.Warn("Failed to create warning", logger.Ctx{"err": err})
 			}
@@ -1332,7 +1334,9 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 		} else {
 			n.logger.Warn("Skipping AppArmor for dnsmasq due to raw.dnsmasq being set", logger.Ctx{"name": n.name})
 
-			err = n.state.DB.Cluster.UpsertWarningLocalNode(n.project, dbCluster.TypeNetwork, int(n.id), warningtype.AppArmorDisabledDueToRawDnsmasq, "")
+			err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpsertWarningLocalNode(ctx, n.project, dbCluster.TypeNetwork, int(n.id), warningtype.AppArmorDisabledDueToRawDnsmasq, "")
+			})
 			if err != nil {
 				n.logger.Warn("Failed to create warning", logger.Ctx{"err": err})
 			}
@@ -2371,7 +2375,9 @@ func (n *bridge) forwardSetupFirewall() error {
 				brNetfilterWarning = true
 				msg := fmt.Sprintf("IPv%d bridge netfilter not enabled. Instances using the bridge will not be able to connect to the forward listen IPs", ipVersion)
 				n.logger.Warn(msg, logger.Ctx{"err": err})
-				err = n.state.DB.Cluster.UpsertWarningLocalNode(n.project, dbCluster.TypeNetwork, int(n.id), warningtype.ProxyBridgeNetfilterNotEnabled, fmt.Sprintf("%s: %v", msg, err))
+				err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					return tx.UpsertWarningLocalNode(ctx, n.project, dbCluster.TypeNetwork, int(n.id), warningtype.ProxyBridgeNetfilterNotEnabled, fmt.Sprintf("%s: %v", msg, err))
+				})
 				if err != nil {
 					n.logger.Warn("Failed to create warning", logger.Ctx{"err": err})
 				}

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -1864,52 +1864,54 @@ func (n *bridge) bridgeNetworkExternalSubnets(bridgeProjectNetworks map[string][
 func (n *bridge) bridgedNICExternalRoutes(bridgeProjectNetworks map[string][]*api.Network) ([]externalSubnetUsage, error) {
 	externalRoutes := make([]externalSubnetUsage, 0)
 
-	err := n.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
-		// Get the instance's effective network project name.
-		instNetworkProject := project.NetworkProjectFromRecord(&p)
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
+			// Get the instance's effective network project name.
+			instNetworkProject := project.NetworkProjectFromRecord(&p)
 
-		if instNetworkProject != api.ProjectDefaultName {
-			return nil // Managed bridge networks can only exist in default project.
-		}
-
-		devices := db.ExpandInstanceDevices(inst.Devices, inst.Profiles)
-
-		// Iterate through each of the instance's devices, looking for bridged NICs that are linked to
-		// networks specified.
-		for devName, devConfig := range devices {
-			if devConfig["type"] != "nic" {
-				continue
+			if instNetworkProject != api.ProjectDefaultName {
+				return nil // Managed bridge networks can only exist in default project.
 			}
 
-			// Check whether the NIC device references one of the networks supplied.
-			if !NICUsesNetwork(devConfig, bridgeProjectNetworks[instNetworkProject]...) {
-				continue
-			}
+			devices := db.ExpandInstanceDevices(inst.Devices, inst.Profiles)
 
-			// For bridged NICs that are connected to networks specified, check if they have any
-			// routes or external routes configured, and if so add them to the list to return.
-			for _, key := range []string{"ipv4.routes", "ipv6.routes", "ipv4.routes.external", "ipv6.routes.external"} {
-				for _, cidr := range util.SplitNTrimSpace(devConfig[key], ",", -1, true) {
-					_, ipNet, _ := net.ParseCIDR(cidr)
-					if ipNet == nil {
-						// Skip if NIC device doesn't have a valid route.
-						continue
+			// Iterate through each of the instance's devices, looking for bridged NICs that are linked to
+			// networks specified.
+			for devName, devConfig := range devices {
+				if devConfig["type"] != "nic" {
+					continue
+				}
+
+				// Check whether the NIC device references one of the networks supplied.
+				if !NICUsesNetwork(devConfig, bridgeProjectNetworks[instNetworkProject]...) {
+					continue
+				}
+
+				// For bridged NICs that are connected to networks specified, check if they have any
+				// routes or external routes configured, and if so add them to the list to return.
+				for _, key := range []string{"ipv4.routes", "ipv6.routes", "ipv4.routes.external", "ipv6.routes.external"} {
+					for _, cidr := range util.SplitNTrimSpace(devConfig[key], ",", -1, true) {
+						_, ipNet, _ := net.ParseCIDR(cidr)
+						if ipNet == nil {
+							// Skip if NIC device doesn't have a valid route.
+							continue
+						}
+
+						externalRoutes = append(externalRoutes, externalSubnetUsage{
+							subnet:          *ipNet,
+							networkProject:  instNetworkProject,
+							networkName:     devConfig["network"],
+							instanceProject: inst.Project,
+							instanceName:    inst.Name,
+							instanceDevice:  devName,
+							usageType:       subnetUsageInstance,
+						})
 					}
-
-					externalRoutes = append(externalRoutes, externalSubnetUsage{
-						subnet:          *ipNet,
-						networkProject:  instNetworkProject,
-						networkName:     devConfig["network"],
-						instanceProject: inst.Project,
-						instanceName:    inst.Name,
-						instanceDevice:  devName,
-						usageType:       subnetUsageInstance,
-					})
 				}
 			}
-		}
 
-		return nil
+			return nil
+		})
 	})
 	if err != nil {
 		return nil, err
@@ -1968,35 +1970,37 @@ func (n *bridge) getExternalSubnetInUse() ([]externalSubnetUsage, error) {
 	externalSubnets = append(externalSubnets, bridgeNetworkExternalSubnets...)
 	externalSubnets = append(externalSubnets, bridgedNICExternalRoutes...)
 
-	// Detect if there are any conflicting proxy devices on all instances with the to be created network forward
-	err = n.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
-		devices := db.ExpandInstanceDevices(inst.Devices, inst.Profiles)
+	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Detect if there are any conflicting proxy devices on all instances with the to be created network forward
+		return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
+			devices := db.ExpandInstanceDevices(inst.Devices, inst.Profiles)
 
-		for devName, devConfig := range devices {
-			if devConfig["type"] != "proxy" {
-				continue
+			for devName, devConfig := range devices {
+				if devConfig["type"] != "proxy" {
+					continue
+				}
+
+				proxyListenAddr, err := ProxyParseAddr(devConfig["listen"])
+				if err != nil {
+					return err
+				}
+
+				proxySubnet, err := ParseIPToNet(proxyListenAddr.Address)
+				if err != nil {
+					continue // If proxy listen isn't a valid IP it can't conflict.
+				}
+
+				externalSubnets = append(externalSubnets, externalSubnetUsage{
+					usageType:       subnetUsageProxy,
+					subnet:          *proxySubnet,
+					instanceProject: inst.Project,
+					instanceName:    inst.Name,
+					instanceDevice:  devName,
+				})
 			}
 
-			proxyListenAddr, err := ProxyParseAddr(devConfig["listen"])
-			if err != nil {
-				return err
-			}
-
-			proxySubnet, err := ParseIPToNet(proxyListenAddr.Address)
-			if err != nil {
-				continue // If proxy listen isn't a valid IP it can't conflict.
-			}
-
-			externalSubnets = append(externalSubnets, externalSubnetUsage{
-				usageType:       subnetUsageProxy,
-				subnet:          *proxySubnet,
-				instanceProject: inst.Project,
-				instanceName:    inst.Name,
-				instanceDevice:  devName,
-			})
-		}
-
-		return nil
+			return nil
+		})
 	})
 	if err != nil {
 		return nil, err
@@ -2115,42 +2119,45 @@ func (n *bridge) ForwardCreate(forward api.NetworkForwardsPost, clientType reque
 			// If we are the first forward on this bridge, enable hairpin mode on active NIC ports.
 			if len(listenAddresses) <= 1 {
 				filter := dbCluster.InstanceFilter{Node: &n.state.ServerName}
-				err = n.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
-					// Get the instance's effective network project name.
-					instNetworkProject := project.NetworkProjectFromRecord(&p)
 
-					if instNetworkProject != api.ProjectDefaultName {
-						return nil // Managed bridge networks can only exist in default project.
-					}
+				err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
+						// Get the instance's effective network project name.
+						instNetworkProject := project.NetworkProjectFromRecord(&p)
 
-					devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
-
-					// Iterate through each of the instance's devices, looking for bridged NICs
-					// that are linked to this network.
-					for devName, devConfig := range devices {
-						if devConfig["type"] != "nic" {
-							continue
+						if instNetworkProject != api.ProjectDefaultName {
+							return nil // Managed bridge networks can only exist in default project.
 						}
 
-						// Check whether the NIC device references our network..
-						if !NICUsesNetwork(devConfig, &api.Network{Name: n.Name()}) {
-							continue
-						}
+						devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
 
-						hostName := inst.Config[fmt.Sprintf("volatile.%s.host_name", devName)]
-						if InterfaceExists(hostName) {
-							link := &ip.Link{Name: hostName}
-							err = link.BridgeLinkSetHairpin(true)
-							if err != nil {
-								return fmt.Errorf("Error enabling hairpin mode on bridge port %q: %w", link.Name, err)
+						// Iterate through each of the instance's devices, looking for bridged NICs
+						// that are linked to this network.
+						for devName, devConfig := range devices {
+							if devConfig["type"] != "nic" {
+								continue
 							}
 
-							n.logger.Debug("Enabled hairpin mode on NIC bridge port", logger.Ctx{"inst": inst.Name, "project": inst.Project, "device": devName, "dev": link.Name})
-						}
-					}
+							// Check whether the NIC device references our network..
+							if !NICUsesNetwork(devConfig, &api.Network{Name: n.Name()}) {
+								continue
+							}
 
-					return nil
-				}, filter)
+							hostName := inst.Config[fmt.Sprintf("volatile.%s.host_name", devName)]
+							if InterfaceExists(hostName) {
+								link := &ip.Link{Name: hostName}
+								err = link.BridgeLinkSetHairpin(true)
+								if err != nil {
+									return fmt.Errorf("Error enabling hairpin mode on bridge port %q: %w", link.Name, err)
+								}
+
+								n.logger.Debug("Enabled hairpin mode on NIC bridge port", logger.Ctx{"inst": inst.Name, "project": inst.Project, "device": devName, "dev": link.Name})
+							}
+						}
+
+						return nil
+					}, filter)
+				})
 				if err != nil {
 					return err
 				}

--- a/internal/server/network/driver_common.go
+++ b/internal/server/network/driver_common.go
@@ -998,8 +998,16 @@ func (n *common) ForwardDelete(listenAddress string, clientType request.ClientTy
 
 // forwardBGPSetupPrefixes exports external forward addresses as prefixes.
 func (n *common) forwardBGPSetupPrefixes() error {
-	// Retrieve network forwards before clearing existing prefixes, and separate them by IP family.
-	fwdListenAddresses, err := n.state.DB.Cluster.GetNetworkForwardListenAddresses(n.ID(), true)
+	var fwdListenAddresses map[int64]string
+
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Retrieve network forwards before clearing existing prefixes, and separate them by IP family.
+		fwdListenAddresses, err = tx.GetNetworkForwardListenAddresses(ctx, n.ID(), true)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed loading network forwards: %w", err)
 	}

--- a/internal/server/network/driver_common.go
+++ b/internal/server/network/driver_common.go
@@ -1460,14 +1460,28 @@ func (n *common) peerUsedBy(peerName string, firstOnly bool) ([]string, error) {
 		return false
 	}
 
-	// Find ACLs that have rules that reference the peer connection.
-	aclNames, err := n.state.DB.Cluster.GetNetworkACLs(n.Project())
+	var aclNames []string
+
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Find ACLs that have rules that reference the peer connection.
+		aclNames, err = tx.GetNetworkACLs(ctx, n.Project())
+
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	for _, aclName := range aclNames {
-		_, aclInfo, err := n.state.DB.Cluster.GetNetworkACL(n.Project(), aclName)
+		var aclInfo *api.NetworkACL
+
+		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			_, aclInfo, err = tx.GetNetworkACL(ctx, n.Project(), aclName)
+
+			return err
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/network/driver_common.go
+++ b/internal/server/network/driver_common.go
@@ -1311,8 +1311,16 @@ func (n *common) LoadBalancerDelete(listenAddress string, clientType request.Cli
 
 // loadBalancerBGPSetupPrefixes exports external load balancer addresses as prefixes.
 func (n *common) loadBalancerBGPSetupPrefixes() error {
-	// Retrieve network forwards before clearing existing prefixes, and separate them by IP family.
-	listenAddresses, err := n.state.DB.Cluster.GetNetworkLoadBalancerListenAddresses(n.ID(), true)
+	var listenAddresses map[int64]string
+
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Retrieve network forwards before clearing existing prefixes, and separate them by IP family.
+		listenAddresses, err = tx.GetNetworkLoadBalancerListenAddresses(ctx, n.ID(), true)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed loading network forwards: %w", err)
 	}

--- a/internal/server/network/driver_common.go
+++ b/internal/server/network/driver_common.go
@@ -391,8 +391,10 @@ func (n *common) update(applyNetwork api.NetworkPut, targetNode string, clientTy
 			}
 		}
 
-		// Update the database.
-		err := n.state.DB.Cluster.UpdateNetwork(n.project, n.name, applyNetwork.Description, applyNetwork.Config)
+		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Update the database.
+			return tx.UpdateNetwork(ctx, n.project, n.name, applyNetwork.Description, applyNetwork.Config)
+		})
 		if err != nil {
 			return err
 		}
@@ -464,8 +466,10 @@ func (n *common) rename(newName string) error {
 		}
 	}
 
-	// Rename the database entry.
-	err := n.state.DB.Cluster.RenameNetwork(n.project, n.name, newName)
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Rename the database entry.
+		return tx.RenameNetwork(ctx, n.project, n.name, newName)
+	})
 	if err != nil {
 		return err
 	}
@@ -544,8 +548,14 @@ func (n *common) notifyDependentNetworks(changedKeys []string) {
 	}
 
 	for _, projectName := range projectNames {
-		// Get a list of managed networks in project.
-		depNets, err := n.state.DB.Cluster.GetCreatedNetworks(projectName)
+		var depNets []string
+
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Get a list of managed networks in project.
+			depNets, err = tx.GetCreatedNetworkNamesByProject(ctx, projectName)
+
+			return err
+		})
 		if err != nil {
 			n.logger.Error("Failed to load networks in project", logger.Ctx{"project": projectName, "err": err})
 			continue // Continue to next project.

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -2447,8 +2447,16 @@ func (n *ovn) setup(update bool) error {
 	// Ensure any network assigned security ACL port groups are created ready for instance NICs to use.
 	securityACLS := util.SplitNTrimSpace(n.config["security.acls"], ",", -1, true)
 	if len(securityACLS) > 0 {
-		// Get map of ACL names to DB IDs (used for generating OVN port group names).
-		aclNameIDs, err := n.state.DB.Cluster.GetNetworkACLIDsByNames(n.Project())
+		var aclNameIDs map[string]int64
+
+		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			// Get map of ACL names to DB IDs (used for generating OVN port group names).
+			aclNameIDs, err = tx.GetNetworkACLIDsByNames(ctx, n.Project())
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed getting network ACL IDs for security ACL setup: %w", err)
 		}
@@ -3033,8 +3041,14 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 			}
 		}
 
-		// Get map of ACL names to DB IDs (used for generating OVN port group names).
-		aclNameIDs, err := n.state.DB.Cluster.GetNetworkACLIDsByNames(n.Project())
+		var aclNameIDs map[string]int64
+
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Get map of ACL names to DB IDs (used for generating OVN port group names).
+			aclNameIDs, err = tx.GetNetworkACLIDsByNames(ctx, n.Project())
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed getting network ACL IDs for security ACL update: %w", err)
 		}
@@ -3885,8 +3899,14 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 	n.logger.Debug("Scheduled logical port for network port group addition", logger.Ctx{"portGroup": acl.OVNIntSwitchPortGroupName(n.ID()), "port": instancePortName})
 
 	if len(nicACLNames) > 0 || len(securityACLsRemove) > 0 {
-		// Get map of ACL names to DB IDs (used for generating OVN port group names).
-		aclNameIDs, err := n.state.DB.Cluster.GetNetworkACLIDsByNames(n.Project())
+		var aclNameIDs map[string]int64
+
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Get map of ACL names to DB IDs (used for generating OVN port group names).
+			aclNameIDs, err = tx.GetNetworkACLIDsByNames(ctx, n.Project())
+
+			return err
+		})
 		if err != nil {
 			return "", nil, fmt.Errorf("Failed getting network ACL IDs for security ACL setup: %w", err)
 		}

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -4302,47 +4302,49 @@ func (n *ovn) ovnNetworkExternalSubnets(ovnProjectNetworksWithOurUplink map[stri
 func (n *ovn) ovnNICExternalRoutes(ovnProjectNetworksWithOurUplink map[string][]*api.Network) ([]externalSubnetUsage, error) {
 	externalRoutes := make([]externalSubnetUsage, 0)
 
-	err := n.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
-		// Get the instance's effective network project name.
-		instNetworkProject := project.NetworkProjectFromRecord(&p)
-		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
+			// Get the instance's effective network project name.
+			instNetworkProject := project.NetworkProjectFromRecord(&p)
+			devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
 
-		// Iterate through each of the instance's devices, looking for OVN NICs that are linked to networks
-		// that use our uplink.
-		for devName, devConfig := range devices {
-			if devConfig["type"] != "nic" {
-				continue
-			}
+			// Iterate through each of the instance's devices, looking for OVN NICs that are linked to networks
+			// that use our uplink.
+			for devName, devConfig := range devices {
+				if devConfig["type"] != "nic" {
+					continue
+				}
 
-			// Check whether the NIC device references one of the OVN networks supplied.
-			if !NICUsesNetwork(devConfig, ovnProjectNetworksWithOurUplink[instNetworkProject]...) {
-				continue
-			}
+				// Check whether the NIC device references one of the OVN networks supplied.
+				if !NICUsesNetwork(devConfig, ovnProjectNetworksWithOurUplink[instNetworkProject]...) {
+					continue
+				}
 
-			// For OVN NICs that are connected to networks that use the same uplink as we do, check
-			// if they have any external routes configured, and if so add them to the list to return.
-			for _, key := range []string{"ipv4.routes.external", "ipv6.routes.external"} {
-				for _, cidr := range util.SplitNTrimSpace(devConfig[key], ",", -1, true) {
-					_, ipNet, _ := net.ParseCIDR(cidr)
-					if ipNet == nil {
-						// Sip if NIC device doesn't have a valid route.
-						continue
+				// For OVN NICs that are connected to networks that use the same uplink as we do, check
+				// if they have any external routes configured, and if so add them to the list to return.
+				for _, key := range []string{"ipv4.routes.external", "ipv6.routes.external"} {
+					for _, cidr := range util.SplitNTrimSpace(devConfig[key], ",", -1, true) {
+						_, ipNet, _ := net.ParseCIDR(cidr)
+						if ipNet == nil {
+							// Sip if NIC device doesn't have a valid route.
+							continue
+						}
+
+						externalRoutes = append(externalRoutes, externalSubnetUsage{
+							subnet:          *ipNet,
+							networkProject:  instNetworkProject,
+							networkName:     devConfig["network"],
+							instanceProject: inst.Project,
+							instanceName:    inst.Name,
+							instanceDevice:  devName,
+							usageType:       subnetUsageInstance,
+						})
 					}
-
-					externalRoutes = append(externalRoutes, externalSubnetUsage{
-						subnet:          *ipNet,
-						networkProject:  instNetworkProject,
-						networkName:     devConfig["network"],
-						instanceProject: inst.Project,
-						instanceName:    inst.Name,
-						instanceDevice:  devName,
-						usageType:       subnetUsageInstance,
-					})
 				}
 			}
-		}
 
-		return nil
+			return nil
+		})
 	})
 	if err != nil {
 		return nil, err
@@ -4420,54 +4422,56 @@ func (n *ovn) handleDependencyChange(uplinkName string, uplinkConfig map[string]
 
 			// Find all instance NICs that use this network, and re-add the logical OVN instance port.
 			// This will restore the l2proxy DNAT_AND_SNAT rules.
-			err = n.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
-				// Get the instance's effective network project name.
-				instNetworkProject := project.NetworkProjectFromRecord(&p)
+			err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
+					// Get the instance's effective network project name.
+					instNetworkProject := project.NetworkProjectFromRecord(&p)
 
-				// Skip instances who's effective network project doesn't match this network's
-				// project.
-				if n.Project() != instNetworkProject {
+					// Skip instances who's effective network project doesn't match this network's
+					// project.
+					if n.Project() != instNetworkProject {
+						return nil
+					}
+
+					devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
+
+					// Iterate through each of the instance's devices, looking for NICs that are linked
+					// this network.
+					for devName, devConfig := range devices {
+						if devConfig["type"] != "nic" || n.Name() != devConfig["network"] {
+							continue
+						}
+
+						// Check if instance port exists, if not then we can skip.
+						instanceUUID := inst.Config["volatile.uuid"]
+						instancePortName := n.getInstanceDevicePortName(instanceUUID, devName)
+						_, found := activePorts[instancePortName]
+						if !found {
+							continue // No need to update a port that isn't started yet.
+						}
+
+						if devConfig["hwaddr"] == "" {
+							// Load volatile MAC if no static MAC specified.
+							devConfig["hwaddr"] = inst.Config[fmt.Sprintf("volatile.%s.hwaddr", devName)]
+						}
+
+						// Re-add logical switch port to apply the l2proxy DNAT_AND_SNAT rules.
+						n.logger.Debug("Re-adding instance OVN NIC port to apply ingress mode changes", logger.Ctx{"project": inst.Project, "instance": inst.Name, "device": devName})
+						_, _, err = n.InstanceDevicePortStart(&OVNInstanceNICSetupOpts{
+							InstanceUUID: instanceUUID,
+							DNSName:      inst.Name,
+							DeviceName:   devName,
+							DeviceConfig: devConfig,
+							UplinkConfig: uplinkConfig,
+						}, nil)
+						if err != nil {
+							n.logger.Error("Failed re-adding instance OVN NIC port", logger.Ctx{"project": inst.Project, "instance": inst.Name, "err": err})
+							continue
+						}
+					}
+
 					return nil
-				}
-
-				devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
-
-				// Iterate through each of the instance's devices, looking for NICs that are linked
-				// this network.
-				for devName, devConfig := range devices {
-					if devConfig["type"] != "nic" || n.Name() != devConfig["network"] {
-						continue
-					}
-
-					// Check if instance port exists, if not then we can skip.
-					instanceUUID := inst.Config["volatile.uuid"]
-					instancePortName := n.getInstanceDevicePortName(instanceUUID, devName)
-					_, found := activePorts[instancePortName]
-					if !found {
-						continue // No need to update a port that isn't started yet.
-					}
-
-					if devConfig["hwaddr"] == "" {
-						// Load volatile MAC if no static MAC specified.
-						devConfig["hwaddr"] = inst.Config[fmt.Sprintf("volatile.%s.hwaddr", devName)]
-					}
-
-					// Re-add logical switch port to apply the l2proxy DNAT_AND_SNAT rules.
-					n.logger.Debug("Re-adding instance OVN NIC port to apply ingress mode changes", logger.Ctx{"project": inst.Project, "instance": inst.Name, "device": devName})
-					_, _, err = n.InstanceDevicePortStart(&OVNInstanceNICSetupOpts{
-						InstanceUUID: instanceUUID,
-						DNSName:      inst.Name,
-						DeviceName:   devName,
-						DeviceConfig: devConfig,
-						UplinkConfig: uplinkConfig,
-					}, nil)
-					if err != nil {
-						n.logger.Error("Failed re-adding instance OVN NIC port", logger.Ctx{"project": inst.Project, "instance": inst.Name, "err": err})
-						continue
-					}
-				}
-
-				return nil
+				})
 			})
 			if err != nil {
 				return fmt.Errorf("Failed adding instance NIC ingress mode l2proxy rules: %w", err)

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -578,8 +578,14 @@ func (n *ovn) Validate(config map[string]string) error {
 		}
 	}
 
-	// Check any existing network load balancer backend addresses are suitable for this network's subnet.
-	loadBalancers, err := n.state.DB.Cluster.GetNetworkLoadBalancers(context.TODO(), n.ID(), memberSpecific)
+	var loadBalancers map[int64]*api.NetworkLoadBalancer
+
+	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check any existing network load balancer backend addresses are suitable for this network's subnet.
+		loadBalancers, err = tx.GetNetworkLoadBalancers(ctx, n.ID(), memberSpecific)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed loading network load balancers: %w", err)
 	}
@@ -2762,7 +2768,13 @@ func (n *ovn) Delete(clientType request.ClientType) error {
 			return fmt.Errorf("Failed loading network forwards: %w", err)
 		}
 
-		loadBalancerListenAddresses, err := n.state.DB.Cluster.GetNetworkLoadBalancerListenAddresses(n.ID(), memberSpecific)
+		var loadBalancerListenAddresses map[int64]string
+
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			loadBalancerListenAddresses, err = tx.GetNetworkLoadBalancerListenAddresses(ctx, n.ID(), memberSpecific)
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed loading network forwards: %w", err)
 		}
@@ -4924,8 +4936,12 @@ func (n *ovn) LoadBalancerCreate(loadBalancer api.NetworkLoadBalancersPost, clie
 	if clientType == request.ClientTypeNormal {
 		memberSpecific := false // OVN doesn't support per-member load balancers.
 
-		// Check if there is an existing load balancer using the same listen address.
-		_, _, err := n.state.DB.Cluster.GetNetworkLoadBalancer(context.TODO(), n.ID(), memberSpecific, loadBalancer.ListenAddress)
+		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Check if there is an existing load balancer using the same listen address.
+			_, _, err := tx.GetNetworkLoadBalancer(ctx, n.ID(), memberSpecific, loadBalancer.ListenAddress)
+
+			return err
+		})
 		if err == nil {
 			return api.StatusErrorf(http.StatusConflict, "A load balancer for that listen address already exists")
 		}
@@ -5009,14 +5025,23 @@ func (n *ovn) LoadBalancerCreate(loadBalancer api.NetworkLoadBalancersPost, clie
 			return fmt.Errorf("Failed to get OVN client: %w", err)
 		}
 
-		// Create load balancer DB record.
-		loadBalancerID, err := n.state.DB.Cluster.CreateNetworkLoadBalancer(n.ID(), memberSpecific, &loadBalancer)
+		var loadBalancerID int64
+
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Create load balancer DB record.
+			loadBalancerID, err = tx.CreateNetworkLoadBalancer(ctx, n.ID(), memberSpecific, &loadBalancer)
+
+			return err
+		})
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			_ = n.state.DB.Cluster.DeleteNetworkLoadBalancer(n.ID(), loadBalancerID)
+			_ = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.DeleteNetworkLoadBalancer(ctx, n.ID(), loadBalancerID)
+			})
+
 			_ = ovnnb.LoadBalancerDelete(n.getLoadBalancerName(loadBalancer.ListenAddress))
 			_ = n.loadBalancerBGPSetupPrefixes()
 		})
@@ -5059,7 +5084,17 @@ func (n *ovn) LoadBalancerUpdate(listenAddress string, req api.NetworkLoadBalanc
 
 	if clientType == request.ClientTypeNormal {
 		memberSpecific := false // OVN doesn't support per-member load balancers.
-		curLoadBalancerID, curLoadBalancer, err := n.state.DB.Cluster.GetNetworkLoadBalancer(context.TODO(), n.ID(), memberSpecific, listenAddress)
+
+		var curLoadBalancerID int64
+		var curLoadBalancer *api.NetworkLoadBalancer
+
+		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			curLoadBalancerID, curLoadBalancer, err = tx.GetNetworkLoadBalancer(ctx, n.ID(), memberSpecific, listenAddress)
+
+			return err
+		})
 		if err != nil {
 			return err
 		}
@@ -5110,13 +5145,17 @@ func (n *ovn) LoadBalancerUpdate(listenAddress string, req api.NetworkLoadBalanc
 			}
 		})
 
-		err = n.state.DB.Cluster.UpdateNetworkLoadBalancer(n.ID(), curLoadBalancerID, &newLoadBalancer.NetworkLoadBalancerPut)
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.UpdateNetworkLoadBalancer(ctx, n.ID(), curLoadBalancerID, &newLoadBalancer.NetworkLoadBalancerPut)
+		})
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			_ = n.state.DB.Cluster.UpdateNetworkLoadBalancer(n.ID(), curLoadBalancerID, &curLoadBalancer.NetworkLoadBalancerPut)
+			_ = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpdateNetworkLoadBalancer(ctx, n.ID(), curLoadBalancerID, &curLoadBalancer.NetworkLoadBalancerPut)
+			})
 		})
 
 		// Notify all other members to refresh their BGP prefixes.
@@ -5147,7 +5186,17 @@ func (n *ovn) LoadBalancerUpdate(listenAddress string, req api.NetworkLoadBalanc
 func (n *ovn) LoadBalancerDelete(listenAddress string, clientType request.ClientType) error {
 	if clientType == request.ClientTypeNormal {
 		memberSpecific := false // OVN doesn't support per-member forwards.
-		loadBalancerID, forward, err := n.state.DB.Cluster.GetNetworkLoadBalancer(context.TODO(), n.ID(), memberSpecific, listenAddress)
+
+		var loadBalancerID int64
+		var forward *api.NetworkLoadBalancer
+
+		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			loadBalancerID, forward, err = tx.GetNetworkLoadBalancer(ctx, n.ID(), memberSpecific, listenAddress)
+
+			return err
+		})
 		if err != nil {
 			return err
 		}
@@ -5162,7 +5211,9 @@ func (n *ovn) LoadBalancerDelete(listenAddress string, clientType request.Client
 			return fmt.Errorf("Failed deleting OVN load balancer: %w", err)
 		}
 
-		err = n.state.DB.Cluster.DeleteNetworkLoadBalancer(n.ID(), loadBalancerID)
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.DeleteNetworkLoadBalancer(ctx, n.ID(), loadBalancerID)
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mdlayher/netx/eui64"
 	ovsClient "github.com/ovn-org/libovsdb/client"
 
-	"github.com/lxc/incus/client"
+	incus "github.com/lxc/incus/client"
 	"github.com/lxc/incus/internal/iprange"
 	"github.com/lxc/incus/internal/revert"
 	"github.com/lxc/incus/internal/server/cluster"
@@ -538,7 +538,14 @@ func (n *ovn) Validate(config map[string]string) error {
 
 	// Check any existing network forward target addresses are suitable for this network's subnet.
 	memberSpecific := false // OVN doesn't support per-member forwards.
-	forwards, err := n.state.DB.Cluster.GetNetworkForwards(context.TODO(), n.ID(), memberSpecific)
+
+	var forwards map[int64]*api.NetworkForward
+
+	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		forwards, err = tx.GetNetworkForwards(ctx, n.ID(), memberSpecific)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed loading network forwards: %w", err)
 	}
@@ -2743,7 +2750,14 @@ func (n *ovn) Delete(clientType request.ClientType) error {
 
 		// Delete any network forwards and load balancers.
 		memberSpecific := false // OVN doesn't support per-member forwards.
-		forwardListenAddresses, err := n.state.DB.Cluster.GetNetworkForwardListenAddresses(n.ID(), memberSpecific)
+
+		var forwardListenAddresses map[int64]string
+
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			forwardListenAddresses, err = tx.GetNetworkForwardListenAddresses(ctx, n.ID(), memberSpecific)
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed loading network forwards: %w", err)
 		}
@@ -4560,8 +4574,12 @@ func (n *ovn) ForwardCreate(forward api.NetworkForwardsPost, clientType request.
 	if clientType == request.ClientTypeNormal {
 		memberSpecific := false // OVN doesn't support per-member forwards.
 
-		// Check if there is an existing forward using the same listen address.
-		_, _, err := n.state.DB.Cluster.GetNetworkForward(context.TODO(), n.ID(), memberSpecific, forward.ListenAddress)
+		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Check if there is an existing forward using the same listen address.
+			_, _, err := tx.GetNetworkForward(ctx, n.ID(), memberSpecific, forward.ListenAddress)
+
+			return err
+		})
 		if err == nil {
 			return api.StatusErrorf(http.StatusConflict, "A forward for that listen address already exists")
 		}
@@ -4645,14 +4663,23 @@ func (n *ovn) ForwardCreate(forward api.NetworkForwardsPost, clientType request.
 			return fmt.Errorf("Failed to get OVN client: %w", err)
 		}
 
-		// Create forward DB record.
-		forwardID, err := n.state.DB.Cluster.CreateNetworkForward(n.ID(), memberSpecific, &forward)
+		var forwardID int64
+
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Create forward DB record.
+			forwardID, err = tx.CreateNetworkForward(ctx, n.ID(), memberSpecific, &forward)
+
+			return err
+		})
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			_ = n.state.DB.Cluster.DeleteNetworkForward(n.ID(), forwardID)
+			_ = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.DeleteNetworkForward(ctx, n.ID(), forwardID)
+			})
+
 			_ = ovnnb.LoadBalancerDelete(n.getLoadBalancerName(forward.ListenAddress))
 			_ = n.forwardBGPSetupPrefixes()
 		})
@@ -4695,7 +4722,17 @@ func (n *ovn) ForwardUpdate(listenAddress string, req api.NetworkForwardPut, cli
 
 	if clientType == request.ClientTypeNormal {
 		memberSpecific := false // OVN doesn't support per-member forwards.
-		curForwardID, curForward, err := n.state.DB.Cluster.GetNetworkForward(context.TODO(), n.ID(), memberSpecific, listenAddress)
+
+		var curForwardID int64
+		var curForward *api.NetworkForward
+
+		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			curForwardID, curForward, err = tx.GetNetworkForward(ctx, n.ID(), memberSpecific, listenAddress)
+
+			return err
+		})
 		if err != nil {
 			return err
 		}
@@ -4745,13 +4782,17 @@ func (n *ovn) ForwardUpdate(listenAddress string, req api.NetworkForwardPut, cli
 			}
 		})
 
-		err = n.state.DB.Cluster.UpdateNetworkForward(n.ID(), curForwardID, &newForward.NetworkForwardPut)
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.UpdateNetworkForward(ctx, n.ID(), curForwardID, &newForward.NetworkForwardPut)
+		})
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
-			_ = n.state.DB.Cluster.UpdateNetworkForward(n.ID(), curForwardID, &curForward.NetworkForwardPut)
+			_ = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				return tx.UpdateNetworkForward(ctx, n.ID(), curForwardID, &curForward.NetworkForwardPut)
+			})
 		})
 
 		// Notify all other members to refresh their BGP prefixes.
@@ -4782,7 +4823,17 @@ func (n *ovn) ForwardUpdate(listenAddress string, req api.NetworkForwardPut, cli
 func (n *ovn) ForwardDelete(listenAddress string, clientType request.ClientType) error {
 	if clientType == request.ClientTypeNormal {
 		memberSpecific := false // OVN doesn't support per-member forwards.
-		forwardID, forward, err := n.state.DB.Cluster.GetNetworkForward(context.TODO(), n.ID(), memberSpecific, listenAddress)
+
+		var forwardID int64
+		var forward *api.NetworkForward
+
+		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+
+			forwardID, forward, err = tx.GetNetworkForward(ctx, n.ID(), memberSpecific, listenAddress)
+
+			return err
+		})
 		if err != nil {
 			return err
 		}
@@ -4797,7 +4848,9 @@ func (n *ovn) ForwardDelete(listenAddress string, clientType request.ClientType)
 			return fmt.Errorf("Failed deleting OVN load balancer: %w", err)
 		}
 
-		err = n.state.DB.Cluster.DeleteNetworkForward(n.ID(), forwardID)
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.DeleteNetworkForward(ctx, n.ID(), forwardID)
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -392,8 +392,14 @@ func (n *ovn) Validate(config map[string]string) error {
 		return err
 	}
 
-	// Get uplink routes.
-	_, uplink, _, err := n.state.DB.Cluster.GetNetworkInAnyState(api.ProjectDefaultName, uplinkNetworkName)
+	var uplink *api.Network
+
+	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get uplink routes.
+		_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, uplinkNetworkName)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to load uplink network %q: %w", uplinkNetworkName, err)
 	}
@@ -1057,7 +1063,7 @@ func (n *ovn) allocateUplinkPortIPs(uplinkNet Network, routerMAC net.HardwareAdd
 				n.config[ovnVolatileUplinkIPv6] = routerExtPortIPv6.String()
 			}
 
-			err = tx.UpdateNetwork(n.id, n.description, n.config)
+			err = tx.UpdateNetwork(ctx, n.project, n.name, n.description, n.config)
 			if err != nil {
 				return fmt.Errorf("Failed saving allocated uplink network IPs: %w", err)
 			}
@@ -1974,7 +1980,7 @@ func (n *ovn) setup(update bool) error {
 		}
 
 		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			err = tx.UpdateNetwork(n.id, n.description, n.config)
+			err = tx.UpdateNetwork(ctx, n.project, n.name, n.description, n.config)
 			if err != nil {
 				return fmt.Errorf("Failed saving updated network config: %w", err)
 			}
@@ -3312,11 +3318,17 @@ func (n *ovn) instanceDevicePortRoutesParse(deviceConfig map[string]string) ([]*
 
 // InstanceDevicePortValidateExternalRoutes validates the external routes for an OVN instance port.
 func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, portExternalRoutes []*net.IPNet) error {
-	var err error
 	var p *api.Project
+	var uplink *api.Network
 
-	// Get uplink routes.
-	_, uplink, _, err := n.state.DB.Cluster.GetNetworkInAnyState(api.ProjectDefaultName, n.config["network"])
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get uplink routes.
+		_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, n.config["network"])
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to load uplink network %q: %w", n.config["network"], err)
 	}
@@ -4096,8 +4108,14 @@ func (n *ovn) InstanceDevicePortStop(ovsExternalOVNPort networkOVN.OVNSwitchPort
 		return fmt.Errorf("Failed parsing NIC device routes: %w", err)
 	}
 
-	// Load uplink network config.
-	_, uplink, _, err := n.state.DB.Cluster.GetNetworkInAnyState(api.ProjectDefaultName, n.config["network"])
+	var uplink *api.Network
+
+	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Load uplink network config.
+		_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, n.config["network"])
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Failed to load uplink network %q: %w", n.config["network"], err)
 	}
@@ -4623,8 +4641,14 @@ func (n *ovn) ForwardCreate(forward api.NetworkForwardsPost, clientType request.
 			return fmt.Errorf("Failed to load network restrictions from project %q: %w", n.project, err)
 		}
 
-		// Get uplink routes.
-		_, uplink, _, err := n.state.DB.Cluster.GetNetworkInAnyState(api.ProjectDefaultName, n.config["network"])
+		var uplink *api.Network
+
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Get uplink routes.
+			_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, n.config["network"])
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed to load uplink network %q: %w", n.config["network"], err)
 		}
@@ -4973,8 +4997,14 @@ func (n *ovn) LoadBalancerCreate(loadBalancer api.NetworkLoadBalancersPost, clie
 			return fmt.Errorf("Failed to load network restrictions from project %q: %w", n.project, err)
 		}
 
-		// Get uplink routes.
-		_, uplink, _, err := n.state.DB.Cluster.GetNetworkInAnyState(api.ProjectDefaultName, n.config["network"])
+		var uplink *api.Network
+
+		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Get uplink routes.
+			_, uplink, _, err = tx.GetNetworkInAnyState(ctx, api.ProjectDefaultName, n.config["network"])
+
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("Failed to load uplink network %q: %w", n.config["network"], err)
 		}

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -5325,9 +5325,17 @@ func (n *ovn) PeerCreate(peer api.NetworkPeersPost) error {
 		return api.StatusErrorf(http.StatusBadRequest, "Target network is required")
 	}
 
-	// Check if there is an existing peer using the same name, or whether there is already a peering (in any
-	// state) to the target network.
-	peers, err := n.state.DB.Cluster.GetNetworkPeers(n.ID())
+	var peers map[int64]*api.NetworkPeer
+
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Check if there is an existing peer using the same name, or whether there is already a peering (in any
+		// state) to the target network.
+		peers, err = tx.GetNetworkPeers(ctx, n.ID())
+
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -5348,8 +5356,14 @@ func (n *ovn) PeerCreate(peer api.NetworkPeersPost) error {
 		return err
 	}
 
-	// Create peer DB record.
-	peerID, mutualExists, err := n.state.DB.Cluster.CreateNetworkPeer(n.ID(), &peer)
+	var peerID int64
+	var mutualExists bool
+
+	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error { // Create peer DB record.
+		peerID, mutualExists, err = tx.CreateNetworkPeer(ctx, n.ID(), &peer)
+
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -5359,8 +5373,14 @@ func (n *ovn) PeerCreate(peer api.NetworkPeersPost) error {
 	})
 
 	if mutualExists {
-		// Load peering to get mutual peering info.
-		_, peerInfo, err := n.state.DB.Cluster.GetNetworkPeer(n.ID(), peer.Name)
+		var peerInfo *api.NetworkPeer
+
+		err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Load peering to get mutual peering info.
+			_, peerInfo, err = tx.GetNetworkPeer(ctx, n.ID(), peer.Name)
+
+			return err
+		})
 		if err != nil {
 			return err
 		}
@@ -5572,7 +5592,16 @@ func (n *ovn) PeerUpdate(peerName string, req api.NetworkPeerPut) error {
 	revert := revert.New()
 	defer revert.Fail()
 
-	curPeerID, curPeer, err := n.state.DB.Cluster.GetNetworkPeer(n.ID(), peerName)
+	var curPeerID int64
+	var curPeer *api.NetworkPeer
+
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		curPeerID, curPeer, err = tx.GetNetworkPeer(ctx, n.ID(), peerName)
+
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -5601,7 +5630,9 @@ func (n *ovn) PeerUpdate(peerName string, req api.NetworkPeerPut) error {
 		return nil // Nothing has changed.
 	}
 
-	err = n.state.DB.Cluster.UpdateNetworkPeer(n.ID(), curPeerID, &newPeer.NetworkPeerPut)
+	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.UpdateNetworkPeer(ctx, n.ID(), curPeerID, &newPeer.NetworkPeerPut)
+	})
 	if err != nil {
 		return err
 	}
@@ -5612,7 +5643,16 @@ func (n *ovn) PeerUpdate(peerName string, req api.NetworkPeerPut) error {
 
 // PeerDelete deletes a network peering.
 func (n *ovn) PeerDelete(peerName string) error {
-	peerID, peer, err := n.state.DB.Cluster.GetNetworkPeer(n.ID(), peerName)
+	var peerID int64
+	var peer *api.NetworkPeer
+
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		peerID, peer, err = tx.GetNetworkPeer(ctx, n.ID(), peerName)
+
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -5675,7 +5715,15 @@ func (n *ovn) PeerDelete(peerName string) error {
 
 // forPeers runs f for each target peer network that this network is connected to.
 func (n *ovn) forPeers(f func(targetOVNNet *ovn) error) error {
-	peers, err := n.state.DB.Cluster.GetNetworkPeers(n.ID())
+	var peers map[int64]*api.NetworkPeer
+
+	err := n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		peers, err = tx.GetNetworkPeers(ctx, n.ID())
+
+		return err
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/server/network/driver_physical.go
+++ b/internal/server/network/driver_physical.go
@@ -208,7 +208,7 @@ func (n *physical) setup(oldConfig map[string]string) error {
 	if util.IsFalseOrEmpty(n.config["volatile.last_state.created"]) {
 		n.config["volatile.last_state.created"] = fmt.Sprintf("%t", created)
 		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			return tx.UpdateNetwork(n.id, n.description, n.config)
+			return tx.UpdateNetwork(ctx, n.project, n.name, n.description, n.config)
 		})
 		if err != nil {
 			return fmt.Errorf("Failed saving volatile config: %w", err)
@@ -258,7 +258,7 @@ func (n *physical) Stop() error {
 	// Remove last state config.
 	delete(n.config, "volatile.last_state.created")
 	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		return tx.UpdateNetwork(n.id, n.description, n.config)
+		return tx.UpdateNetwork(ctx, n.project, n.name, n.description, n.config)
 	})
 	if err != nil {
 		return fmt.Errorf("Failed removing volatile config: %w", err)

--- a/internal/server/network/network_load.go
+++ b/internal/server/network/network_load.go
@@ -1,9 +1,11 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
+	"github.com/lxc/incus/internal/server/db"
 	"github.com/lxc/incus/internal/server/state"
 	"github.com/lxc/incus/shared/api"
 )
@@ -40,7 +42,17 @@ func LoadByType(driverType string) (Type, error) {
 
 // LoadByName loads an instantiated network from the database by project and name.
 func LoadByName(s *state.State, projectName string, name string) (Network, error) {
-	id, netInfo, netNodes, err := s.DB.Cluster.GetNetworkInAnyState(projectName, name)
+	var id int64
+	var netInfo *api.Network
+	var netNodes map[int64]db.NetworkNode
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		id, netInfo, netNodes, err = tx.GetNetworkInAnyState(ctx, projectName, name)
+
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/network/network_utils.go
+++ b/internal/server/network/network_utils.go
@@ -113,7 +113,13 @@ func UsedBy(s *state.State, networkProjectName string, networkID int64, networkN
 
 	// If managed network being passed in, check if it has any peerings in a created state.
 	if networkID > 0 {
-		peers, err := s.DB.Cluster.GetNetworkPeers(networkID)
+		var peers map[int64]*api.NetworkPeer
+
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			peers, err = tx.GetNetworkPeers(ctx, networkID)
+
+			return err
+		})
 		if err != nil {
 			return nil, fmt.Errorf("Failed getting network peers: %w", err)
 		}

--- a/internal/server/network/network_utils.go
+++ b/internal/server/network/network_utils.go
@@ -385,8 +385,12 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 	if networkName == "" {
 		var err error
 
-		// Pass api.ProjectDefaultName here, as currently dnsmasq (bridged) networks do not support projects.
-		networks, err = s.DB.Cluster.GetNetworks(api.ProjectDefaultName)
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Pass api.ProjectDefaultName here, as currently dnsmasq (bridged) networks do not support projects.
+			networks, err = tx.GetNetworks(ctx, api.ProjectDefaultName)
+
+			return err
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/server/network/network_utils.go
+++ b/internal/server/network/network_utils.go
@@ -79,28 +79,30 @@ func MACDevName(mac net.HardwareAddr) string {
 // UsedByInstanceDevices looks for instance NIC devices using the network and runs the supplied usageFunc for each.
 // Accepts optional filter arguments to specify a subset of instances.
 func UsedByInstanceDevices(s *state.State, networkProjectName string, networkName string, networkType string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error, filters ...cluster.InstanceFilter) error {
-	return s.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
-		// Get the instance's effective network project name.
-		instNetworkProject := project.NetworkProjectFromRecord(&p)
+	return s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
+			// Get the instance's effective network project name.
+			instNetworkProject := project.NetworkProjectFromRecord(&p)
 
-		// Skip instances who's effective network project doesn't match this Network's project.
-		if instNetworkProject != networkProjectName {
-			return nil
-		}
+			// Skip instances who's effective network project doesn't match this Network's project.
+			if instNetworkProject != networkProjectName {
+				return nil
+			}
 
-		// Look for NIC devices using this network.
-		devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
-		for devName, devConfig := range devices {
-			if isInUseByDevice(networkName, networkType, devConfig) {
-				err := usageFunc(inst, devName, devConfig)
-				if err != nil {
-					return err
+			// Look for NIC devices using this network.
+			devices := db.ExpandInstanceDevices(inst.Devices.Clone(), inst.Profiles)
+			for devName, devConfig := range devices {
+				if isInUseByDevice(networkName, networkType, devConfig) {
+					err := usageFunc(inst, devName, devConfig)
+					if err != nil {
+						return err
+					}
 				}
 			}
-		}
 
-		return nil
-	}, filters...)
+			return nil
+		}, filters...)
+	})
 }
 
 // UsedBy returns list of API resources using network. Accepts firstOnly argument to indicate that only the first

--- a/internal/server/network/network_utils_sriov.go
+++ b/internal/server/network/network_utils_sriov.go
@@ -59,27 +59,29 @@ func SRIOVGetHostDevicesInUse(s *state.State) (map[string]struct{}, error) {
 	reservedDevices := map[string]struct{}{}
 
 	// Check if any instances are using the VF device.
-	err = s.DB.Cluster.InstanceList(context.TODO(), func(dbInst db.InstanceArgs, p api.Project) error {
-		// Expand configs so we take into account profile devices.
-		dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
-		dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(dbInst db.InstanceArgs, p api.Project) error {
+			// Expand configs so we take into account profile devices.
+			dbInst.Config = db.ExpandInstanceConfig(dbInst.Config, dbInst.Profiles)
+			dbInst.Devices = db.ExpandInstanceDevices(dbInst.Devices, dbInst.Profiles)
 
-		for name, dev := range dbInst.Devices {
-			// If device references a parent host interface name, mark that as reserved.
-			parent := dev["parent"]
-			if parent != "" {
-				reservedDevices[parent] = struct{}{}
+			for name, dev := range dbInst.Devices {
+				// If device references a parent host interface name, mark that as reserved.
+				parent := dev["parent"]
+				if parent != "" {
+					reservedDevices[parent] = struct{}{}
+				}
+
+				// If device references a volatile host interface name, mark that as reserved.
+				hostName := dbInst.Config[fmt.Sprintf("volatile.%s.host_name", name)]
+				if hostName != "" {
+					reservedDevices[hostName] = struct{}{}
+				}
 			}
 
-			// If device references a volatile host interface name, mark that as reserved.
-			hostName := dbInst.Config[fmt.Sprintf("volatile.%s.host_name", name)]
-			if hostName != "" {
-				reservedDevices[hostName] = struct{}{}
-			}
-		}
-
-		return nil
-	}, filter)
+			return nil
+		}, filter)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/network/zone/record.go
+++ b/internal/server/network/zone/record.go
@@ -1,11 +1,13 @@
 package zone
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/miekg/dns"
 
 	"github.com/lxc/incus/internal/server/cluster/request"
+	"github.com/lxc/incus/internal/server/db"
 	"github.com/lxc/incus/shared/api"
 	"github.com/lxc/incus/shared/util"
 )
@@ -23,8 +25,12 @@ func (d *zone) AddRecord(req api.NetworkZoneRecordsPost) error {
 		return err
 	}
 
-	// Add the new record.
-	_, err = d.state.DB.Cluster.CreateNetworkZoneRecord(d.id, req)
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Add the new record.
+		_, err = tx.CreateNetworkZoneRecord(ctx, d.id, req)
+
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -33,16 +39,32 @@ func (d *zone) AddRecord(req api.NetworkZoneRecordsPost) error {
 }
 
 func (d *zone) GetRecords() ([]api.NetworkZoneRecord, error) {
-	// Get the record names.
-	names, err := d.state.DB.Cluster.GetNetworkZoneRecordNames(d.id)
+	s := d.state
+
+	var names []string
+
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get the record names.
+		names, err = tx.GetNetworkZoneRecordNames(ctx, d.id)
+
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	// Load all the records.
 	records := []api.NetworkZoneRecord{}
+	var record *api.NetworkZoneRecord
+
 	for _, name := range names {
-		_, record, err := d.state.DB.Cluster.GetNetworkZoneRecord(d.id, name)
+		err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			_, record, err = tx.GetNetworkZoneRecord(ctx, d.id, name)
+
+			return err
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -54,8 +76,16 @@ func (d *zone) GetRecords() ([]api.NetworkZoneRecord, error) {
 }
 
 func (d *zone) GetRecord(name string) (*api.NetworkZoneRecord, error) {
-	// Get the record.
-	_, record, err := d.state.DB.Cluster.GetNetworkZoneRecord(d.id, name)
+	var record *api.NetworkZoneRecord
+
+	err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get the record.
+		_, record, err = tx.GetNetworkZoneRecord(ctx, d.id, name)
+
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -64,6 +94,8 @@ func (d *zone) GetRecord(name string) (*api.NetworkZoneRecord, error) {
 }
 
 func (d *zone) UpdateRecord(name string, req api.NetworkZoneRecordPut, clientType request.ClientType) error {
+	s := d.state
+
 	// Validate.
 	err := d.validateRecordConfig(req)
 	if err != nil {
@@ -76,14 +108,21 @@ func (d *zone) UpdateRecord(name string, req api.NetworkZoneRecordPut, clientTyp
 		return err
 	}
 
-	// Get the record.
-	id, _, err := d.state.DB.Cluster.GetNetworkZoneRecord(d.id, name)
-	if err != nil {
-		return err
-	}
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get the record.
+		id, _, err := tx.GetNetworkZoneRecord(ctx, d.id, name)
+		if err != nil {
+			return err
+		}
 
-	// Update the record.
-	err = d.state.DB.Cluster.UpdateNetworkZoneRecord(id, req)
+		// Update the record.
+		err = tx.UpdateNetworkZoneRecord(ctx, id, req)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
 		return err
 	}
@@ -92,14 +131,23 @@ func (d *zone) UpdateRecord(name string, req api.NetworkZoneRecordPut, clientTyp
 }
 
 func (d *zone) DeleteRecord(name string) error {
-	// Get the record.
-	id, _, err := d.state.DB.Cluster.GetNetworkZoneRecord(d.id, name)
-	if err != nil {
-		return err
-	}
+	s := d.state
 
-	// Delete the record.
-	err = d.state.DB.Cluster.DeleteNetworkZoneRecord(id)
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get the record.
+		id, _, err := tx.GetNetworkZoneRecord(ctx, d.id, name)
+		if err != nil {
+			return err
+		}
+
+		// Delete the record.
+		err = tx.DeleteNetworkZoneRecord(ctx, id)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/server/network/zone/zone.go
+++ b/internal/server/network/zone/zone.go
@@ -283,8 +283,12 @@ func (d *zone) Delete() error {
 		return fmt.Errorf("Cannot delete a zone that is in use")
 	}
 
-	// Delete the database record.
-	err = d.state.DB.Cluster.DeleteNetworkZone(d.id)
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Delete the database record.
+		err = tx.DeleteNetworkZone(ctx, d.id)
+
+		return err
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/server/network/zone/zone.go
+++ b/internal/server/network/zone/zone.go
@@ -90,26 +90,41 @@ func (d *zone) networkUsesZone(netConfig map[string]string) bool {
 func (d *zone) usedBy(firstOnly bool) ([]string, error) {
 	usedBy := []string{}
 
-	// Find networks using the zone.
-	networkNames, err := d.state.DB.Cluster.GetCreatedNetworks(d.projectName)
+	var networkNames []string
+
+	err := d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Find networks using the zone.
+		networkNames, err = tx.GetCreatedNetworkNamesByProject(ctx, d.projectName)
+
+		return err
+	})
 	if err != nil && !response.IsNotFoundError(err) {
 		return nil, fmt.Errorf("Failed loading networks for project %q: %w", d.projectName, err)
 	}
 
-	for _, networkName := range networkNames {
-		_, network, _, err := d.state.DB.Cluster.GetNetworkInAnyState(d.projectName, networkName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get network config for %q: %w", networkName, err)
-		}
+	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		for _, networkName := range networkNames {
+			_, network, _, err := tx.GetNetworkInAnyState(ctx, d.projectName, networkName)
+			if err != nil {
+				return fmt.Errorf("Failed to get network config for %q: %w", networkName, err)
+			}
 
-		// Check if the network is using this zone.
-		if d.networkUsesZone(network.Config) {
-			u := api.NewURL().Path(version.APIVersion, "networks", networkName)
-			usedBy = append(usedBy, u.String())
-			if firstOnly {
-				return usedBy, nil
+			// Check if the network is using this zone.
+			if d.networkUsesZone(network.Config) {
+				u := api.NewURL().Path(version.APIVersion, "networks", networkName)
+				usedBy = append(usedBy, u.String())
+				if firstOnly {
+					return nil
+				}
 			}
 		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return usedBy, nil

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -5378,7 +5378,13 @@ func (b *backend) UpdateCustomVolumeSnapshot(projectName string, volName string,
 		return err
 	}
 
-	curExpiryDate, err := b.state.DB.Cluster.GetStorageVolumeSnapshotExpiry(curVol.ID)
+	var curExpiryDate time.Time
+
+	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		curExpiryDate, err = tx.GetStorageVolumeSnapshotExpiry(ctx, curVol.ID)
+
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -5392,7 +5398,9 @@ func (b *backend) UpdateCustomVolumeSnapshot(projectName string, volName string,
 
 	// Update the database if description changed. Use current config.
 	if newDesc != curVol.Description || newExpiryDate != curExpiryDate {
-		err = b.state.DB.Cluster.UpdateStorageVolumeSnapshot(projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID(), newDesc, curVol.Config, newExpiryDate)
+		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.UpdateStorageVolumeSnapshot(ctx, projectName, volName, db.StoragePoolVolumeTypeCustom, b.ID(), newDesc, curVol.Config, newExpiryDate)
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -2017,8 +2017,12 @@ func (b *backend) CreateInstanceFromMigration(inst instance.Instance, conn io.Re
 			imageExists := false
 
 			if fingerprint != "" {
-				// Confirm that the image is present in the project.
-				_, _, err = b.state.DB.Cluster.GetImage(fingerprint, cluster.ImageFilter{Project: &projectName})
+				err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+					// Confirm that the image is present in the project.
+					_, _, err = tx.GetImage(ctx, fingerprint, cluster.ImageFilter{Project: &projectName})
+
+					return err
+				})
 				if err != nil && !response.IsNotFoundError(err) {
 					return err
 				}
@@ -3305,8 +3309,14 @@ func (b *backend) EnsureImage(fingerprint string, op *operations.Operation) erro
 
 	defer unlock()
 
-	// Load image info from database.
-	_, image, err := b.state.DB.Cluster.GetImageFromAnyProject(fingerprint)
+	var image *api.Image
+
+	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Load image info from database.
+		_, image, err = tx.GetImageFromAnyProject(ctx, fingerprint)
+
+		return err
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -5129,8 +5129,14 @@ func (b *backend) RenameCustomVolume(projectName string, volName string, newVolN
 		})
 	}
 
+	var backups []db.StoragePoolVolumeBackup
+
 	// Rename each backup to have the new parent volume prefix.
-	backups, err := b.state.DB.Cluster.GetStoragePoolVolumeBackups(projectName, volName, b.ID())
+	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		backups, err = tx.GetStoragePoolVolumeBackups(ctx, projectName, volName, b.ID())
+		return err
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -310,7 +310,9 @@ func (b *backend) Update(clientType request.ClientType, newDesc string, newConfi
 
 	// Update the database if something changed and we're in ClientTypeNormal mode.
 	if clientType == request.ClientTypeNormal && (len(changedConfig) > 0 || newDesc != b.db.Description) {
-		err = b.state.DB.Cluster.UpdateStoragePool(b.name, newDesc, newConfig)
+		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			return tx.UpdateStoragePool(ctx, b.name, newDesc, newConfig)
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/server/storage/backend_patches.go
+++ b/internal/server/storage/backend_patches.go
@@ -49,79 +49,81 @@ func patchMissingSnapshotRecords(b *backend) error {
 	// Get instances on this local server (as the DB helper functions return volumes on local server), also
 	// avoids running the same queries on every cluster member for instances on shared storage.
 	filter := cluster.InstanceFilter{Node: &localNode}
-	err = b.state.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
-		// Check we can convert the instance to the volume type needed.
-		volType, err := InstanceTypeToVolumeType(inst.Type)
-		if err != nil {
-			return err
-		}
-
-		contentType := drivers.ContentTypeFS
-		if inst.Type == instancetype.VM {
-			contentType = drivers.ContentTypeBlock
-		}
-
-		// Get all the instance snapshot DB records.
-		var instPoolName string
-		var snapshots []cluster.Instance
-		err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			instPoolName, err = tx.GetInstancePool(ctx, p.Name, inst.Name)
-			if err != nil {
-				if api.StatusErrorCheck(err, http.StatusNotFound) {
-					// If the instance cannot be associated to a pool its got bigger problems
-					// outside the scope of this patch. Will skip due to empty instPoolName.
-					return nil
-				}
-
-				return fmt.Errorf("Failed finding pool for instance %q in project %q: %w", inst.Name, p.Name, err)
-			}
-
-			snapshots, err = tx.GetInstanceSnapshotsWithName(ctx, p.Name, inst.Name)
+	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
+			// Check we can convert the instance to the volume type needed.
+			volType, err := InstanceTypeToVolumeType(inst.Type)
 			if err != nil {
 				return err
 			}
 
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-
-		if instPoolName != b.Name() {
-			return nil // This instance isn't hosted on this storage pool, skip.
-		}
-
-		dbVol, err := VolumeDBGet(b, p.Name, inst.Name, volType)
-		if err != nil {
-			return fmt.Errorf("Failed loading storage volume record %q: %w", inst.Name, err)
-		}
-
-		// Get all the instance volume snapshot DB records.
-		dbVolSnaps, err := VolumeDBSnapshotsGet(b, p.Name, inst.Name, volType)
-		if err != nil {
-			return fmt.Errorf("Failed loading storage volume snapshot records %q: %w", inst.Name, err)
-		}
-
-		for i := range snapshots {
-			foundVolumeSnapshot := false
-			for _, dbVolSnap := range dbVolSnaps {
-				if dbVolSnap.Name == snapshots[i].Name {
-					foundVolumeSnapshot = true
-					break
-				}
+			contentType := drivers.ContentTypeFS
+			if inst.Type == instancetype.VM {
+				contentType = drivers.ContentTypeBlock
 			}
 
-			if !foundVolumeSnapshot {
-				b.logger.Info("Creating missing volume snapshot record", logger.Ctx{"project": snapshots[i].Project, "instance": snapshots[i].Name})
-				err = VolumeDBCreate(b, snapshots[i].Project, snapshots[i].Name, "Auto repaired", volType, true, dbVol.Config, snapshots[i].CreationDate, time.Time{}, contentType, false, true)
+			// Get all the instance snapshot DB records.
+			var instPoolName string
+			var snapshots []cluster.Instance
+			err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+				instPoolName, err = tx.GetInstancePool(ctx, p.Name, inst.Name)
+				if err != nil {
+					if api.StatusErrorCheck(err, http.StatusNotFound) {
+						// If the instance cannot be associated to a pool its got bigger problems
+						// outside the scope of this patch. Will skip due to empty instPoolName.
+						return nil
+					}
+
+					return fmt.Errorf("Failed finding pool for instance %q in project %q: %w", inst.Name, p.Name, err)
+				}
+
+				snapshots, err = tx.GetInstanceSnapshotsWithName(ctx, p.Name, inst.Name)
 				if err != nil {
 					return err
 				}
-			}
-		}
 
-		return nil
-	}, filter)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			if instPoolName != b.Name() {
+				return nil // This instance isn't hosted on this storage pool, skip.
+			}
+
+			dbVol, err := VolumeDBGet(b, p.Name, inst.Name, volType)
+			if err != nil {
+				return fmt.Errorf("Failed loading storage volume record %q: %w", inst.Name, err)
+			}
+
+			// Get all the instance volume snapshot DB records.
+			dbVolSnaps, err := VolumeDBSnapshotsGet(b, p.Name, inst.Name, volType)
+			if err != nil {
+				return fmt.Errorf("Failed loading storage volume snapshot records %q: %w", inst.Name, err)
+			}
+
+			for i := range snapshots {
+				foundVolumeSnapshot := false
+				for _, dbVolSnap := range dbVolSnaps {
+					if dbVolSnap.Name == snapshots[i].Name {
+						foundVolumeSnapshot = true
+						break
+					}
+				}
+
+				if !foundVolumeSnapshot {
+					b.logger.Info("Creating missing volume snapshot record", logger.Ctx{"project": snapshots[i].Project, "instance": snapshots[i].Name})
+					err = VolumeDBCreate(b, snapshots[i].Project, snapshots[i].Name, "Auto repaired", volType, true, dbVol.Config, snapshots[i].CreationDate, time.Time{}, contentType, false, true)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			return nil
+		}, filter)
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/utils.go
+++ b/internal/server/storage/utils.go
@@ -285,7 +285,11 @@ func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDesc
 
 	// Create the database entry for the storage volume.
 	if snapshot {
-		_, err = p.state.DB.Cluster.CreateStorageVolumeSnapshot(projectName, volumeName, volumeDescription, volDBType, pool.ID(), vol.Config(), creationDate, expiryDate)
+		err = p.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			_, err = tx.CreateStorageVolumeSnapshot(ctx, projectName, volumeName, volumeDescription, volDBType, pool.ID(), vol.Config(), creationDate, expiryDate)
+
+			return err
+		})
 	} else {
 		_, err = p.state.DB.Cluster.CreateStoragePoolVolume(projectName, volumeName, volumeDescription, volDBType, pool.ID(), vol.Config(), volDBContentType, creationDate)
 	}

--- a/internal/server/storage/utils.go
+++ b/internal/server/storage/utils.go
@@ -403,8 +403,14 @@ func BucketDBCreate(ctx context.Context, pool Pool, projectName string, memberSp
 		return -1, err
 	}
 
-	// Create the database entry for the storage bucket.
-	bucketID, err := p.state.DB.Cluster.CreateStoragePoolBucket(ctx, p.ID(), projectName, memberSpecific, *bucket)
+	var bucketID int64
+
+	err = p.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		// Create the database entry for the storage bucket.
+		bucketID, err = tx.CreateStoragePoolBucket(ctx, p.ID(), projectName, memberSpecific, *bucket)
+
+		return err
+	})
 	if err != nil {
 		return -1, fmt.Errorf("Failed inserting storage bucket %q for project %q in pool %q into database: %w", bucket.Name, projectName, pool.Name(), err)
 	}
@@ -419,7 +425,9 @@ func BucketDBDelete(ctx context.Context, pool Pool, bucketID int64) error {
 		return fmt.Errorf("Pool is not a backend")
 	}
 
-	err := p.state.DB.Cluster.DeleteStoragePoolBucket(ctx, p.ID(), bucketID)
+	err := p.state.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.DeleteStoragePoolBucket(ctx, p.ID(), bucketID)
+	})
 	if err != nil && !response.IsNotFoundError(err) {
 		return fmt.Errorf("Failed deleting storage bucket from database: %w", err)
 	}

--- a/internal/server/storage/utils.go
+++ b/internal/server/storage/utils.go
@@ -283,17 +283,16 @@ func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDesc
 		return err
 	}
 
-	// Create the database entry for the storage volume.
-	if snapshot {
-		err = p.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = p.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		// Create the database entry for the storage volume.
+		if snapshot {
 			_, err = tx.CreateStorageVolumeSnapshot(ctx, projectName, volumeName, volumeDescription, volDBType, pool.ID(), vol.Config(), creationDate, expiryDate)
+		} else {
+			_, err = tx.CreateStoragePoolVolume(ctx, projectName, volumeName, volumeDescription, volDBType, pool.ID(), vol.Config(), volDBContentType, creationDate)
+		}
 
-			return err
-		})
-	} else {
-		_, err = p.state.DB.Cluster.CreateStoragePoolVolume(projectName, volumeName, volumeDescription, volDBType, pool.ID(), vol.Config(), volDBContentType, creationDate)
-	}
-
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("Error inserting volume %q for project %q in pool %q of type %q into database %q", volumeName, projectName, pool.Name(), volumeType, err)
 	}
@@ -314,7 +313,9 @@ func VolumeDBDelete(pool Pool, projectName string, volumeName string, volumeType
 		return err
 	}
 
-	err = p.state.DB.Cluster.RemoveStoragePoolVolume(projectName, volumeName, volDBType, pool.ID())
+	err = p.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.RemoveStoragePoolVolume(ctx, projectName, volumeName, volDBType, pool.ID())
+	})
 	if err != nil && !response.IsNotFoundError(err) {
 		return fmt.Errorf("Error deleting storage volume from database: %w", err)
 	}
@@ -334,7 +335,13 @@ func VolumeDBSnapshotsGet(pool Pool, projectName string, volume string, volumeTy
 		return nil, err
 	}
 
-	snapshots, err := p.state.DB.Cluster.GetLocalStoragePoolVolumeSnapshotsWithType(projectName, volume, volDBType, pool.ID())
+	var snapshots []db.StorageVolumeArgs
+
+	err = p.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		snapshots, err = tx.GetLocalStoragePoolVolumeSnapshotsWithType(ctx, projectName, volume, volDBType, pool.ID())
+
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/storage/utils.go
+++ b/internal/server/storage/utils.go
@@ -846,59 +846,61 @@ func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName st
 		return err
 	}
 
-	return s.DB.Cluster.InstanceList(context.TODO(), func(inst db.InstanceArgs, p api.Project) error {
-		// If the volume has a specific cluster member which is different than the instance then skip as
-		// instance cannot be using this volume.
-		if vol.Location != "" && inst.Node != vol.Location {
-			return nil
-		}
-
-		instStorageProject := project.StorageVolumeProjectFromRecord(&p, volumeType)
-		if err != nil {
-			return err
-		}
-
-		// Check instance's storage project is the same as the volume's project.
-		// If not then the volume names mentioned in the instance's config cannot be referring to volumes
-		// in the volume's project we are trying to match, and this instance cannot possibly be using it.
-		if projectName != instStorageProject {
-			return nil
-		}
-
-		// Use local devices for usage check by if expandDevices is false (but don't modify instance).
-		devices := inst.Devices
-
-		// Expand devices for usage check if expandDevices is true.
-		if expandDevices {
-			devices = db.ExpandInstanceDevices(devices.Clone(), inst.Profiles)
-		}
-
-		var usedByDevices []string
-
-		// Iterate through each of the instance's devices, looking for disks in the same pool as volume.
-		// Then try and match the volume name against the instance device's "source" property.
-		for devName, dev := range devices {
-			if dev["type"] != "disk" {
-				continue
+	return s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
+			// If the volume has a specific cluster member which is different than the instance then skip as
+			// instance cannot be using this volume.
+			if vol.Location != "" && inst.Node != vol.Location {
+				return nil
 			}
 
-			if dev["pool"] != poolName {
-				continue
-			}
-
-			if dev["source"] == vol.Name {
-				usedByDevices = append(usedByDevices, devName)
-			}
-		}
-
-		if len(usedByDevices) > 0 {
-			err = instanceFunc(inst, p, usedByDevices)
+			instStorageProject := project.StorageVolumeProjectFromRecord(&p, volumeType)
 			if err != nil {
 				return err
 			}
-		}
 
-		return nil
+			// Check instance's storage project is the same as the volume's project.
+			// If not then the volume names mentioned in the instance's config cannot be referring to volumes
+			// in the volume's project we are trying to match, and this instance cannot possibly be using it.
+			if projectName != instStorageProject {
+				return nil
+			}
+
+			// Use local devices for usage check by if expandDevices is false (but don't modify instance).
+			devices := inst.Devices
+
+			// Expand devices for usage check if expandDevices is true.
+			if expandDevices {
+				devices = db.ExpandInstanceDevices(devices.Clone(), inst.Profiles)
+			}
+
+			var usedByDevices []string
+
+			// Iterate through each of the instance's devices, looking for disks in the same pool as volume.
+			// Then try and match the volume name against the instance device's "source" property.
+			for devName, dev := range devices {
+				if dev["type"] != "disk" {
+					continue
+				}
+
+				if dev["pool"] != poolName {
+					continue
+				}
+
+				if dev["source"] == vol.Name {
+					usedByDevices = append(usedByDevices, devName)
+				}
+			}
+
+			if len(usedByDevices) > 0 {
+				err = instanceFunc(inst, p, usedByDevices)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
 	})
 }
 


### PR DESCRIPTION
This moves db functions from Cluster to ClusterTx.

Progress:
- [x] `internal/server/db/backup.go`
- [x] `internal/server/db/images.go`
- [x] `internal/server/db/instances.go`
- [x] `internal/server/db/network_acls.go`
- [x] `internal/server/db/network_forwards.go`
- [x] `internal/server/db/network_load_balancers.go`
- [x] `internal/server/db/network_peers.go`
- [x] `internal/server/db/network_zones.go`
- [x] `internal/server/db/networks.go`
- [x] `internal/server/db/profiles.go`
- [x] `internal/server/db/snapshots.go`
- [x] `internal/server/db/storage_buckets.go`
- [x] `internal/server/db/storage_pools.go`
- [x] `internal/server/db/storage_volume_snapshots.go`
- [x] `internal/server/db/storage_volumes.go`
- [x] `internal/server/db/warnings.go`