### PR TITLE
Add keepalive support in the client

### DIFF
--- a/cmd/incus/remote.go
+++ b/cmd/incus/remote.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -47,6 +48,12 @@ func (c *cmdRemote) Command() *cobra.Command {
 	// List
 	remoteListCmd := cmdRemoteList{global: c.global, remote: c}
 	cmd.AddCommand(remoteListCmd.Command())
+
+	if runtime.GOOS != "windows" {
+		// Proxy
+		remoteProxyCmd := cmdRemoteProxy{global: c.global, remote: c}
+		cmd.AddCommand(remoteProxyCmd.Command())
+	}
 
 	// Rename
 	remoteRenameCmd := cmdRemoteRename{global: c.global, remote: c}

--- a/cmd/incus/remote_unix.go
+++ b/cmd/incus/remote_unix.go
@@ -1,0 +1,271 @@
+//go:build !windows
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lxc/incus/client"
+	cli "github.com/lxc/incus/internal/cmd"
+	"github.com/lxc/incus/internal/i18n"
+	"github.com/lxc/incus/shared/api"
+)
+
+type cmdRemoteProxy struct {
+	global *cmdGlobal
+	remote *cmdRemote
+
+	flagTimeout int
+}
+
+func (c *cmdRemoteProxy) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("proxy", i18n.G("<remote>: <path>"))
+	cmd.Short = i18n.G("Run a local API proxy")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Run a local API proxy for the remote`))
+
+	cmd.RunE = c.Run
+
+	cmd.Flags().IntVar(&c.flagTimeout, "timeout", 0, i18n.G("Proxy timeout (exits when no connections)")+"``")
+
+	return cmd
+}
+
+func (c *cmdRemoteProxy) Run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	if exit {
+		return err
+	}
+
+	// Detect remote name.
+	remoteName := args[0]
+	if !strings.HasSuffix(remoteName, ":") {
+		remoteName = remoteName + ":"
+	}
+
+	path := args[1]
+
+	resources, err := c.global.ParseServers(remoteName)
+	if err != nil {
+		return err
+	}
+
+	s := resources[0].server
+
+	// Create proxy socket.
+	err = os.Remove(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("Failed to delete pre-existing unix socket: %w", err)
+	}
+
+	unixAddr, err := net.ResolveUnixAddr("unix", path)
+	if err != nil {
+		return fmt.Errorf("Unable to resolve unix socket: %w", err)
+	}
+
+	server, err := net.ListenUnix("unix", unixAddr)
+	if err != nil {
+		return fmt.Errorf("Unable to setup unix socket: %w", err)
+	}
+
+	err = os.Chmod(path, 0600)
+	if err != nil {
+		return fmt.Errorf("Unable to set socket permissions: %w", err)
+	}
+
+	// Get the connection info.
+	info, err := s.GetConnectionInfo()
+	if err != nil {
+		return err
+	}
+
+	uri, err := url.Parse(info.URL)
+	if err != nil {
+		return err
+	}
+
+	// Enable keep-alive for proxied connections.
+	httpClient, err := s.GetHTTPClient()
+	if err != nil {
+		return err
+	}
+
+	httpTransport, ok := httpClient.Transport.(*http.Transport)
+	if ok {
+		httpTransport.DisableKeepAlives = false
+	}
+
+	// Get server info.
+	api10, api10Etag, err := s.GetServer()
+	if err != nil {
+		return err
+	}
+
+	// Handle inbound connections.
+	transport := remoteProxyTransport{
+		s:       s,
+		baseURL: uri,
+	}
+
+	connections := uint64(0)
+	transactions := uint64(0)
+
+	handler := remoteProxyHandler{
+		s:         s,
+		transport: transport,
+		api10:     api10,
+		api10Etag: api10Etag,
+
+		mu:           &sync.RWMutex{},
+		connections:  &connections,
+		transactions: &transactions,
+	}
+
+	// Handle the timeout.
+	if c.flagTimeout > 0 {
+		go func() {
+			for {
+				time.Sleep(time.Duration(c.flagTimeout) * time.Second)
+
+				// Check for active connections.
+				handler.mu.RLock()
+				if *handler.connections > 0 {
+					handler.mu.RUnlock()
+					continue
+				}
+
+				// Look for recent activity
+				oldCount := uint64(*handler.transactions)
+				handler.mu.RUnlock()
+
+				time.Sleep(5 * time.Second)
+
+				handler.mu.RLock()
+				if oldCount == *handler.transactions {
+					handler.mu.RUnlock()
+
+					// Daemon has been inactive for 10s, exit.
+					os.Exit(0)
+				}
+
+				handler.mu.RUnlock()
+			}
+		}()
+	}
+
+	// Start the server.
+	err = http.Serve(server, handler)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type remoteProxyTransport struct {
+	s incus.InstanceServer
+
+	baseURL *url.URL
+}
+
+func (t remoteProxyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Fix the request.
+	r.URL.Scheme = t.baseURL.Scheme
+	r.URL.Host = t.baseURL.Host
+	r.RequestURI = ""
+
+	return t.s.DoHTTP(r)
+}
+
+type remoteProxyHandler struct {
+	s         incus.InstanceServer
+	transport http.RoundTripper
+
+	mu           *sync.RWMutex
+	connections  *uint64
+	transactions *uint64
+
+	api10     *api.Server
+	api10Etag string
+}
+
+func (h remoteProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Increase counters.
+	defer func() {
+		h.mu.Lock()
+		*h.connections -= 1
+		h.mu.Unlock()
+	}()
+
+	h.mu.Lock()
+	*h.transactions += 1
+	*h.connections += 1
+	h.mu.Unlock()
+
+	// Handle /1.0 internally (saves a round-trip).
+	if r.RequestURI == "/1.0" || strings.HasPrefix(r.RequestURI, "/1.0?project=") {
+		// Parse query URL.
+		values, err := url.ParseQuery(r.URL.RawQuery)
+		if err != nil {
+			return
+		}
+
+		// Update project name to match.
+		projectName := values.Get("project")
+		if projectName == "" {
+			projectName = api.ProjectDefaultName
+		}
+
+		api10 := api.Server(*h.api10)
+		api10.Environment.Project = projectName
+
+		// Set the request headers.
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", h.api10Etag)
+		w.WriteHeader(http.StatusOK)
+
+		// Generate a body from the cached data.
+		serverBody, err := json.Marshal(api10)
+		if err != nil {
+			return
+		}
+
+		apiResponse := api.Response{
+			Type:       "sync",
+			Status:     "success",
+			StatusCode: 200,
+			Metadata:   serverBody,
+		}
+
+		body, err := json.Marshal(apiResponse)
+		if err != nil {
+			return
+		}
+
+		_, _ = w.Write(body)
+
+		return
+	}
+
+	// Forward everything else.
+	proxy := httputil.ReverseProxy{
+		Transport: h.transport,
+		Director:  func(*http.Request) {},
+	}
+
+	proxy.ServeHTTP(w, r)
+}

--- a/cmd/incus/remote_unix.go
+++ b/cmd/incus/remote_unix.go
@@ -59,6 +59,10 @@ func (c *cmdRemoteProxy) Run(cmd *cobra.Command, args []string) error {
 
 	path := args[1]
 
+	remote := c.global.conf.Remotes[strings.TrimSuffix(remoteName, ":")]
+	remote.KeepAlive = 0
+	c.global.conf.Remotes[strings.TrimSuffix(remoteName, ":")] = remote
+
 	resources, err := c.global.ParseServers(remoteName)
 	if err != nil {
 		return err

--- a/cmd/incus/remote_windows.go
+++ b/cmd/incus/remote_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type cmdRemoteProxy struct {
+	global *cmdGlobal
+	remote *cmdRemote
+}
+
+func (c *cmdRemoteProxy) Command() *cobra.Command {
+	return nil
+}

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -700,17 +700,26 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
 msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+#, fuzzy
+msgid "<remote>: <path>"
+msgstr ""
+"Löscht einen Container oder Container Sicherungspunkt.\n"
+"\n"
+"Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
+"Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: cmd/incus/file.go:456
 #, fuzzy
@@ -760,11 +769,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
@@ -833,11 +842,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -966,7 +975,7 @@ msgstr ""
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1048,7 +1057,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1071,7 +1080,7 @@ msgstr "automatisches Update: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 #, fuzzy
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1248,7 +1257,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1341,7 +1350,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1353,7 +1362,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
@@ -1377,7 +1386,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1657,12 +1666,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1691,7 +1700,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -2118,15 +2127,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2818,7 +2827,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2837,7 +2846,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2867,7 +2876,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2877,7 +2886,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2897,7 +2906,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -3010,7 +3019,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3105,7 +3114,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -3145,7 +3154,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -3161,7 +3170,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -3596,7 +3605,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid URL %q: %w"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3702,7 +3711,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -4104,7 +4113,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -4452,7 +4461,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4516,12 +4525,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4832,7 +4841,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4865,8 +4874,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -5176,7 +5185,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -5249,11 +5258,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5301,7 +5310,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
@@ -5311,7 +5320,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Please provide join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5465,7 +5474,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5583,7 +5592,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5698,37 +5711,37 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5809,7 +5822,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5873,7 +5886,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5986,6 +5999,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -6039,7 +6060,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -6080,15 +6101,15 @@ msgstr "Erstellt: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -6099,7 +6120,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -6325,7 +6346,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6557,7 +6578,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6825,7 +6846,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -7254,7 +7275,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -7298,7 +7319,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -7332,7 +7353,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
@@ -7792,8 +7813,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -9013,7 +9034,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -9030,7 +9051,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -9344,7 +9365,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -9356,7 +9377,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9393,7 +9414,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -501,11 +505,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -569,11 +573,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -697,7 +701,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -772,7 +776,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -795,7 +799,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -960,7 +964,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1049,7 +1053,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1061,7 +1065,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1085,7 +1089,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1356,12 +1360,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1390,7 +1394,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1795,15 +1799,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2462,7 +2466,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2481,7 +2485,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2511,7 +2515,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2521,7 +2525,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2541,7 +2545,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2654,7 +2658,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2745,7 +2749,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2785,7 +2789,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2801,7 +2805,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3220,7 +3224,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3322,7 +3326,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3691,7 +3695,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -4012,7 +4016,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4076,12 +4080,12 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4373,7 +4377,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4406,8 +4410,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4469,7 +4473,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4711,7 +4715,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4784,11 +4788,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4835,7 +4839,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4844,7 +4848,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr "  Χρήση δικτύου:"
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4993,7 +4997,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5110,7 +5114,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "  Χρήση δικτύου:"
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5219,37 +5227,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5324,7 +5332,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5383,7 +5391,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5489,6 +5497,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5541,7 +5557,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5582,15 +5598,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5599,7 +5615,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5815,7 +5831,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6036,7 +6052,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6293,7 +6309,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6712,7 +6728,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6755,7 +6771,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6789,7 +6805,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7229,8 +7245,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7857,7 +7873,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7865,7 +7881,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8175,7 +8191,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8187,7 +8203,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8224,7 +8240,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -684,17 +684,22 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
 msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+#, fuzzy
+msgid "<remote>: <path>"
+msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/file.go:456
 #, fuzzy
@@ -740,11 +745,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
@@ -809,11 +814,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -938,7 +943,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1015,7 +1020,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1038,7 +1043,7 @@ msgstr "Auto actualización: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -1206,7 +1211,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1296,7 +1301,7 @@ msgstr "Cacheado: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1308,7 +1313,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
@@ -1332,7 +1337,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1609,12 +1614,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1643,7 +1648,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -2053,15 +2058,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2724,7 +2729,7 @@ msgstr "Acepta certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2743,7 +2748,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2773,7 +2778,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2783,7 +2788,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
@@ -2803,7 +2808,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2916,7 +2921,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -3008,7 +3013,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -3048,7 +3053,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -3064,7 +3069,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3491,7 +3496,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid URL %q: %w"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3594,7 +3599,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3974,7 +3979,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -4297,7 +4302,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4360,12 +4365,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4668,7 +4673,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4701,8 +4706,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4764,7 +4769,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -5004,7 +5009,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -5077,11 +5082,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5128,7 +5133,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -5137,7 +5142,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5290,7 +5295,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5407,7 +5412,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5518,37 +5527,37 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5624,7 +5633,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5685,7 +5694,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5795,6 +5804,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5848,7 +5865,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5889,15 +5906,15 @@ msgstr "Creado: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5906,7 +5923,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -6122,7 +6139,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6343,7 +6360,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6601,7 +6618,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -7022,7 +7039,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Contraseña admin para %s: "
@@ -7067,7 +7084,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -7101,7 +7118,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7542,8 +7559,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -8307,7 +8324,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8317,7 +8334,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8627,7 +8644,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8639,7 +8656,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8676,7 +8693,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -691,19 +691,31 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
 msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+#, fuzzy
+msgid "<remote>: <path>"
+msgstr ""
+"Supprimer des conteneurs ou des instantanés.\n"
+"\n"
+"lxc delete [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
+"<snapshot>]...]\n"
+"\n"
+"Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
+"(configuration, instantanés, …)."
 
 #: cmd/incus/file.go:456
 #, fuzzy
@@ -758,12 +770,12 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
@@ -830,11 +842,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Alias :"
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 #, fuzzy
 msgid ""
 "Add new remote servers\n"
@@ -972,7 +984,7 @@ msgstr ""
 msgid "All projects"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1053,7 +1065,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1076,7 +1088,7 @@ msgstr "Mise à jour auto. : %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 #, fuzzy
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
@@ -1245,7 +1257,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1337,7 +1349,7 @@ msgstr "Créé : %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1349,7 +1361,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
@@ -1373,7 +1385,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1662,12 +1674,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1696,7 +1708,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -2144,15 +2156,15 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2851,7 +2863,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 #, fuzzy
 msgid "Failed to add remote"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2871,7 +2883,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2901,7 +2913,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, fuzzy, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2911,7 +2923,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2931,7 +2943,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -3044,7 +3056,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -3139,7 +3151,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -3179,7 +3191,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -3195,7 +3207,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -3642,7 +3654,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Invalid URL %q: %w"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3747,7 +3759,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -4192,7 +4204,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -4534,7 +4546,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4600,12 +4612,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -4920,7 +4932,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4953,8 +4965,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr "NON"
 
@@ -5019,7 +5031,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -5271,7 +5283,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -5349,11 +5361,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5402,7 +5414,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
@@ -5412,7 +5424,7 @@ msgstr "Chemin vers un dossier de configuration serveur alternatif"
 msgid "Please provide join token:"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5567,7 +5579,7 @@ msgstr "Profil %s supprimé"
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5684,7 +5696,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
@@ -5802,37 +5818,37 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Ajouter de nouveaux clients de confiance"
@@ -5914,7 +5930,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5978,7 +5994,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -6108,6 +6124,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -6161,7 +6185,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -6205,15 +6229,15 @@ msgstr "Créé : %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -6224,7 +6248,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 #, fuzzy
 msgid "Server protocol (incus or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
@@ -6449,7 +6473,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6686,7 +6710,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6957,7 +6981,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -7392,7 +7416,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -7437,7 +7461,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr "URL"
 
@@ -7471,7 +7495,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
@@ -7931,8 +7955,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr "OUI"
 
@@ -9254,7 +9278,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -9274,7 +9298,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -9607,7 +9631,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -9620,7 +9644,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9658,7 +9682,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr "o"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -447,16 +447,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -501,11 +505,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -567,11 +571,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -694,7 +698,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -769,7 +773,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -792,7 +796,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -956,7 +960,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1045,7 +1049,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1057,7 +1061,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1081,7 +1085,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1352,12 +1356,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1386,7 +1390,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1782,15 +1786,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2440,7 +2444,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2459,7 +2463,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2489,7 +2493,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2499,7 +2503,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2519,7 +2523,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2632,7 +2636,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2723,7 +2727,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2763,7 +2767,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2779,7 +2783,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3185,7 +3189,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3287,7 +3291,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3654,7 +3658,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3962,7 +3966,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4024,12 +4028,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4315,7 +4319,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4348,8 +4352,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4411,7 +4415,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4651,7 +4655,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4724,11 +4728,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4775,7 +4779,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4783,7 +4787,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4932,7 +4936,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5049,7 +5053,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5158,37 +5166,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5259,7 +5267,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5317,7 +5325,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5421,6 +5429,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5473,7 +5489,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5514,15 +5530,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5531,7 +5547,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5740,7 +5756,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5946,7 +5962,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6201,7 +6217,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6619,7 +6635,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6662,7 +6678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6695,7 +6711,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7116,8 +7132,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7744,7 +7760,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7752,7 +7768,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8062,7 +8078,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8074,7 +8090,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8111,7 +8127,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2023-12-06 16:49-0500\n"
+        "POT-Creation-Date: 2023-12-10 17:31-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -420,16 +420,20 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid   "<remote>"
 msgstr  ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid   "<remote> <new-name>"
+msgstr  ""
+
+#: cmd/incus/remote_unix.go:35
+msgid   "<remote>: <path>"
 msgstr  ""
 
 #: cmd/incus/file.go:456
@@ -473,11 +477,11 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid   "Accept certificate"
 msgstr  ""
 
@@ -539,11 +543,11 @@ msgstr  ""
 msgid   "Add new aliases"
 msgstr  ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -657,7 +661,7 @@ msgstr  ""
 msgid   "All projects"
 msgstr  ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
@@ -731,7 +735,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -754,7 +758,7 @@ msgstr  ""
 msgid   "Automatic (non-interactive) mode"
 msgstr  ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid   "Available projects:"
 msgstr  ""
 
@@ -912,7 +916,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -998,7 +1002,7 @@ msgstr  ""
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
@@ -1008,7 +1012,7 @@ msgstr  ""
 msgid   "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr  ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
@@ -1032,7 +1036,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1250,12 +1254,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1284,7 +1288,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1560,7 +1564,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:53 cmd/incus/action.go:75 cmd/incus/action.go:98 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:160 cmd/incus/alias.go:215 cmd/incus/cluster.go:29 cmd/incus/cluster.go:122 cmd/incus/cluster.go:206 cmd/incus/cluster.go:255 cmd/incus/cluster.go:306 cmd/incus/cluster.go:367 cmd/incus/cluster.go:439 cmd/incus/cluster.go:471 cmd/incus/cluster.go:521 cmd/incus/cluster.go:604 cmd/incus/cluster.go:689 cmd/incus/cluster.go:802 cmd/incus/cluster.go:866 cmd/incus/cluster.go:968 cmd/incus/cluster.go:1047 cmd/incus/cluster.go:1154 cmd/incus/cluster.go:1175 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:157 cmd/incus/cluster_group.go:214 cmd/incus/cluster_group.go:266 cmd/incus/cluster_group.go:382 cmd/incus/cluster_group.go:456 cmd/incus/cluster_group.go:529 cmd/incus/cluster_group.go:577 cmd/incus/cluster_group.go:631 cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:106 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:380 cmd/incus/config.go:505 cmd/incus/config.go:719 cmd/incus/config.go:843 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:208 cmd/incus/config_device.go:285 cmd/incus/config_device.go:356 cmd/incus/config_device.go:450 cmd/incus/config_device.go:548 cmd/incus/config_device.go:555 cmd/incus/config_device.go:668 cmd/incus/config_device.go:741 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:179 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:109 cmd/incus/config_template.go:151 cmd/incus/config_template.go:239 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:90 cmd/incus/config_trust.go:170 cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:388 cmd/incus/config_trust.go:470 cmd/incus/config_trust.go:572 cmd/incus/config_trust.go:618 cmd/incus/config_trust.go:689 cmd/incus/console.go:36 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120 cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458 cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:220 cmd/incus/network.go:293 cmd/incus/network.go:372 cmd/incus/network.go:422 cmd/incus/network.go:507 cmd/incus/network.go:592 cmd/incus/network.go:720 cmd/incus/network.go:789 cmd/incus/network.go:912 cmd/incus/network.go:1005 cmd/incus/network.go:1076 cmd/incus/network.go:1128 cmd/incus/network.go:1216 cmd/incus/network.go:1280 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:164 cmd/incus/network_acl.go:217 cmd/incus/network_acl.go:265 cmd/incus/network_acl.go:326 cmd/incus/network_acl.go:411 cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:652 cmd/incus/network_acl.go:701 cmd/incus/network_acl.go:750 cmd/incus/network_acl.go:765 cmd/incus/network_acl.go:886 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:166 cmd/incus/network_forward.go:230 cmd/incus/network_forward.go:328 cmd/incus/network_forward.go:397 cmd/incus/network_forward.go:495 cmd/incus/network_forward.go:525 cmd/incus/network_forward.go:667 cmd/incus/network_forward.go:729 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:809 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:169 cmd/incus/network_load_balancer.go:233 cmd/incus/network_load_balancer.go:331 cmd/incus/network_load_balancer.go:399 cmd/incus/network_load_balancer.go:497 cmd/incus/network_load_balancer.go:527 cmd/incus/network_load_balancer.go:670 cmd/incus/network_load_balancer.go:731 cmd/incus/network_load_balancer.go:746 cmd/incus/network_load_balancer.go:810 cmd/incus/network_load_balancer.go:896 cmd/incus/network_load_balancer.go:911 cmd/incus/network_load_balancer.go:972 cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:80 cmd/incus/network_peer.go:157 cmd/incus/network_peer.go:214 cmd/incus/network_peer.go:330 cmd/incus/network_peer.go:398 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:642 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84 cmd/incus/network_zone.go:155 cmd/incus/network_zone.go:210 cmd/incus/network_zone.go:270 cmd/incus/network_zone.go:353 cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:464 cmd/incus/network_zone.go:583 cmd/incus/network_zone.go:631 cmd/incus/network_zone.go:688 cmd/incus/network_zone.go:758 cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:869 cmd/incus/network_zone.go:951 cmd/incus/network_zone.go:1027 cmd/incus/network_zone.go:1057 cmd/incus/network_zone.go:1175 cmd/incus/network_zone.go:1224 cmd/incus/network_zone.go:1239 cmd/incus/network_zone.go:1285 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:167 cmd/incus/profile.go:250 cmd/incus/profile.go:320 cmd/incus/profile.go:374 cmd/incus/profile.go:424 cmd/incus/profile.go:552 cmd/incus/profile.go:613 cmd/incus/profile.go:674 cmd/incus/profile.go:750 cmd/incus/profile.go:802 cmd/incus/profile.go:878 cmd/incus/profile.go:934 cmd/incus/project.go:29 cmd/incus/project.go:93 cmd/incus/project.go:158 cmd/incus/project.go:221 cmd/incus/project.go:349 cmd/incus/project.go:410 cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659 cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617 cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808 cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846 cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82 cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243 cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452 cmd/incus/storage_bucket.go:529 cmd/incus/storage_bucket.go:623 cmd/incus/storage_bucket.go:692 cmd/incus/storage_bucket.go:726 cmd/incus/storage_bucket.go:767 cmd/incus/storage_bucket.go:846 cmd/incus/storage_bucket.go:924 cmd/incus/storage_bucket.go:988 cmd/incus/storage_bucket.go:1123 cmd/incus/storage_volume.go:44 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:237 cmd/incus/storage_volume.go:328 cmd/incus/storage_volume.go:531 cmd/incus/storage_volume.go:610 cmd/incus/storage_volume.go:671 cmd/incus/storage_volume.go:753 cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:1043 cmd/incus/storage_volume.go:1158 cmd/incus/storage_volume.go:1305 cmd/incus/storage_volume.go:1389 cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:1677 cmd/incus/storage_volume.go:1745 cmd/incus/storage_volume.go:1889 cmd/incus/storage_volume.go:1971 cmd/incus/storage_volume.go:2014 cmd/incus/storage_volume.go:2063 cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2235 cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2349 cmd/incus/storage_volume.go:2420 cmd/incus/storage_volume.go:2484 cmd/incus/storage_volume.go:2568 cmd/incus/storage_volume.go:2722 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:53 cmd/incus/action.go:75 cmd/incus/action.go:98 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:160 cmd/incus/alias.go:215 cmd/incus/cluster.go:29 cmd/incus/cluster.go:122 cmd/incus/cluster.go:206 cmd/incus/cluster.go:255 cmd/incus/cluster.go:306 cmd/incus/cluster.go:367 cmd/incus/cluster.go:439 cmd/incus/cluster.go:471 cmd/incus/cluster.go:521 cmd/incus/cluster.go:604 cmd/incus/cluster.go:689 cmd/incus/cluster.go:802 cmd/incus/cluster.go:866 cmd/incus/cluster.go:968 cmd/incus/cluster.go:1047 cmd/incus/cluster.go:1154 cmd/incus/cluster.go:1175 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:157 cmd/incus/cluster_group.go:214 cmd/incus/cluster_group.go:266 cmd/incus/cluster_group.go:382 cmd/incus/cluster_group.go:456 cmd/incus/cluster_group.go:529 cmd/incus/cluster_group.go:577 cmd/incus/cluster_group.go:631 cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:106 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:380 cmd/incus/config.go:505 cmd/incus/config.go:719 cmd/incus/config.go:843 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:208 cmd/incus/config_device.go:285 cmd/incus/config_device.go:356 cmd/incus/config_device.go:450 cmd/incus/config_device.go:548 cmd/incus/config_device.go:555 cmd/incus/config_device.go:668 cmd/incus/config_device.go:741 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:179 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:109 cmd/incus/config_template.go:151 cmd/incus/config_template.go:239 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:90 cmd/incus/config_trust.go:170 cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:388 cmd/incus/config_trust.go:470 cmd/incus/config_trust.go:572 cmd/incus/config_trust.go:618 cmd/incus/config_trust.go:689 cmd/incus/console.go:36 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120 cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458 cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:220 cmd/incus/network.go:293 cmd/incus/network.go:372 cmd/incus/network.go:422 cmd/incus/network.go:507 cmd/incus/network.go:592 cmd/incus/network.go:720 cmd/incus/network.go:789 cmd/incus/network.go:912 cmd/incus/network.go:1005 cmd/incus/network.go:1076 cmd/incus/network.go:1128 cmd/incus/network.go:1216 cmd/incus/network.go:1280 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:164 cmd/incus/network_acl.go:217 cmd/incus/network_acl.go:265 cmd/incus/network_acl.go:326 cmd/incus/network_acl.go:411 cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:652 cmd/incus/network_acl.go:701 cmd/incus/network_acl.go:750 cmd/incus/network_acl.go:765 cmd/incus/network_acl.go:886 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:166 cmd/incus/network_forward.go:230 cmd/incus/network_forward.go:328 cmd/incus/network_forward.go:397 cmd/incus/network_forward.go:495 cmd/incus/network_forward.go:525 cmd/incus/network_forward.go:667 cmd/incus/network_forward.go:729 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:809 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:169 cmd/incus/network_load_balancer.go:233 cmd/incus/network_load_balancer.go:331 cmd/incus/network_load_balancer.go:399 cmd/incus/network_load_balancer.go:497 cmd/incus/network_load_balancer.go:527 cmd/incus/network_load_balancer.go:670 cmd/incus/network_load_balancer.go:731 cmd/incus/network_load_balancer.go:746 cmd/incus/network_load_balancer.go:810 cmd/incus/network_load_balancer.go:896 cmd/incus/network_load_balancer.go:911 cmd/incus/network_load_balancer.go:972 cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:80 cmd/incus/network_peer.go:157 cmd/incus/network_peer.go:214 cmd/incus/network_peer.go:330 cmd/incus/network_peer.go:398 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:642 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84 cmd/incus/network_zone.go:155 cmd/incus/network_zone.go:210 cmd/incus/network_zone.go:270 cmd/incus/network_zone.go:353 cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:464 cmd/incus/network_zone.go:583 cmd/incus/network_zone.go:631 cmd/incus/network_zone.go:688 cmd/incus/network_zone.go:758 cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:869 cmd/incus/network_zone.go:951 cmd/incus/network_zone.go:1027 cmd/incus/network_zone.go:1057 cmd/incus/network_zone.go:1175 cmd/incus/network_zone.go:1224 cmd/incus/network_zone.go:1239 cmd/incus/network_zone.go:1285 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:167 cmd/incus/profile.go:250 cmd/incus/profile.go:320 cmd/incus/profile.go:374 cmd/incus/profile.go:424 cmd/incus/profile.go:552 cmd/incus/profile.go:613 cmd/incus/profile.go:674 cmd/incus/profile.go:750 cmd/incus/profile.go:802 cmd/incus/profile.go:878 cmd/incus/profile.go:934 cmd/incus/project.go:29 cmd/incus/project.go:93 cmd/incus/project.go:158 cmd/incus/project.go:221 cmd/incus/project.go:349 cmd/incus/project.go:410 cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659 cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624 cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815 cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846 cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82 cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243 cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452 cmd/incus/storage_bucket.go:529 cmd/incus/storage_bucket.go:623 cmd/incus/storage_bucket.go:692 cmd/incus/storage_bucket.go:726 cmd/incus/storage_bucket.go:767 cmd/incus/storage_bucket.go:846 cmd/incus/storage_bucket.go:924 cmd/incus/storage_bucket.go:988 cmd/incus/storage_bucket.go:1123 cmd/incus/storage_volume.go:44 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:237 cmd/incus/storage_volume.go:328 cmd/incus/storage_volume.go:531 cmd/incus/storage_volume.go:610 cmd/incus/storage_volume.go:671 cmd/incus/storage_volume.go:753 cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:1043 cmd/incus/storage_volume.go:1158 cmd/incus/storage_volume.go:1305 cmd/incus/storage_volume.go:1389 cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:1677 cmd/incus/storage_volume.go:1745 cmd/incus/storage_volume.go:1889 cmd/incus/storage_volume.go:1971 cmd/incus/storage_volume.go:2014 cmd/incus/storage_volume.go:2063 cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2235 cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2349 cmd/incus/storage_volume.go:2420 cmd/incus/storage_volume.go:2484 cmd/incus/storage_volume.go:2568 cmd/incus/storage_volume.go:2722 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -2152,7 +2156,7 @@ msgstr  ""
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid   "Failed to add remote"
 msgstr  ""
 
@@ -2171,7 +2175,7 @@ msgstr  ""
 msgid   "Failed to close export file: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
@@ -2201,7 +2205,7 @@ msgstr  ""
 msgid   "Failed to connect to target cluster node %q: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
@@ -2211,7 +2215,7 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid   "Failed to create certificate: %w"
 msgstr  ""
@@ -2231,7 +2235,7 @@ msgstr  ""
 msgid   "Failed to fetch storage volume backup file: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
@@ -2341,7 +2345,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
@@ -2416,7 +2420,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867 cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241 cmd/incus/config_trust.go:390 cmd/incus/config_trust.go:472 cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133 cmd/incus/network.go:916 cmd/incus/network.go:1007 cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:691 cmd/incus/operation.go:109 cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804 cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587 cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768 cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256 cmd/incus/warning.go:94
+#: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867 cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241 cmd/incus/config_trust.go:390 cmd/incus/config_trust.go:472 cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133 cmd/incus/network.go:916 cmd/incus/network.go:1007 cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:691 cmd/incus/operation.go:109 cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804 cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587 cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768 cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256 cmd/incus/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2452,7 +2456,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2468,7 +2472,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2870,7 +2874,7 @@ msgstr  ""
 msgid   "Invalid URL %q: %w"
 msgstr  ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2971,7 +2975,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -3321,7 +3325,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3621,7 +3625,7 @@ msgid   "Manage storage volumes\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
@@ -3683,12 +3687,12 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -3877,7 +3881,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:183 cmd/incus/cluster.go:950 cmd/incus/cluster_group.go:437 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980 cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138 cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740 cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714 cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505 cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
+#: cmd/incus/cluster.go:183 cmd/incus/cluster.go:950 cmd/incus/cluster_group.go:437 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980 cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138 cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740 cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721 cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505 cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid   "NAME"
 msgstr  ""
 
@@ -3906,7 +3910,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456 cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471 cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674 cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456 cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471 cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681 cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid   "NO"
 msgstr  ""
 
@@ -3965,7 +3969,7 @@ msgstr  ""
 msgid   "Name of the new storage pool"
 msgstr  ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
@@ -4201,7 +4205,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -4272,11 +4276,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4323,7 +4327,7 @@ msgstr  ""
 msgid   "Please create those missing entries and then hit ENTER:"
 msgstr  ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
@@ -4331,7 +4335,7 @@ msgstr  ""
 msgid   "Please provide join token:"
 msgstr  ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
@@ -4470,7 +4474,7 @@ msgstr  ""
 msgid   "Project %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid   "Project to use for the remote"
 msgstr  ""
 
@@ -4569,7 +4573,11 @@ msgstr  ""
 msgid   "Provided certificate path doesn't exist: %s"
 msgstr  ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid   "Proxy timeout (exits when no connections)"
+msgstr  ""
+
+#: cmd/incus/remote.go:111
 msgid   "Public image server"
 msgstr  ""
 
@@ -4672,36 +4680,36 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828 cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835 cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid   "Remote trust token"
 msgstr  ""
 
@@ -4771,7 +4779,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4828,7 +4836,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -4930,6 +4938,14 @@ msgstr  ""
 msgid   "Rows affected: %d"
 msgstr  ""
 
+#: cmd/incus/remote_unix.go:36
+msgid   "Run a local API proxy"
+msgstr  ""
+
+#: cmd/incus/remote_unix.go:37
+msgid   "Run a local API proxy for the remote"
+msgstr  ""
+
 #: cmd/incus/network_allocations.go:58
 msgid   "Run again a specific project"
 msgstr  ""
@@ -4981,7 +4997,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid   "STATIC"
 msgstr  ""
 
@@ -5022,15 +5038,15 @@ msgstr  ""
 msgid   "Send a raw query to the server"
 msgstr  ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
@@ -5038,7 +5054,7 @@ msgstr  ""
 msgid   "Server isn't part of a cluster"
 msgstr  ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid   "Server protocol (incus or simplestreams)"
 msgstr  ""
 
@@ -5218,7 +5234,7 @@ msgid   "Set storage volume configuration keys\n"
         "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -5422,7 +5438,7 @@ msgstr  ""
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -5673,7 +5689,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -6061,7 +6077,7 @@ msgstr  ""
 msgid   "Transmit policy"
 msgstr  ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid   "Trust token for %s: "
 msgstr  ""
@@ -6101,7 +6117,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid   "URL"
 msgstr  ""
 
@@ -6131,7 +6147,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid   "Unavailable remote server"
 msgstr  ""
 
@@ -6535,7 +6551,7 @@ msgstr  ""
 msgid   "Would you like to use clustering?"
 msgstr  ""
 
-#: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458 cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473 cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676 cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458 cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473 cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683 cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid   "YES"
 msgstr  ""
 
@@ -7119,7 +7135,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
@@ -7127,7 +7143,7 @@ msgstr  ""
 msgid   "[[<remote>:]<name>]"
 msgstr  ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid   "current"
 msgstr  ""
 
@@ -7388,7 +7404,7 @@ msgstr  ""
 msgid   "info"
 msgstr  ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid   "n"
 msgstr  ""
 
@@ -7400,7 +7416,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -7437,7 +7453,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid   "y"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -682,17 +682,22 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
 msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+#, fuzzy
+msgid "<remote>: <path>"
+msgstr "Creazione del container in corso"
 
 #: cmd/incus/file.go:456
 #, fuzzy
@@ -738,11 +743,11 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
@@ -807,11 +812,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -936,7 +941,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1013,7 +1018,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1036,7 +1041,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -1201,7 +1206,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1290,7 +1295,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1302,7 +1307,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1326,7 +1331,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1598,12 +1603,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1632,7 +1637,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -2045,15 +2050,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2717,7 +2722,7 @@ msgstr "Accetta certificato"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2736,7 +2741,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2766,7 +2771,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2776,7 +2781,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
@@ -2796,7 +2801,7 @@ msgstr "Accetta certificato"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2909,7 +2914,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -3002,7 +3007,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -3042,7 +3047,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -3058,7 +3063,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3479,7 +3484,7 @@ msgstr "Il nome del container è: %s"
 msgid "Invalid URL %q: %w"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3583,7 +3588,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3964,7 +3969,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -4292,7 +4297,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4355,12 +4360,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4662,7 +4667,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4695,8 +4700,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4758,7 +4763,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4998,7 +5003,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -5071,11 +5076,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5123,7 +5128,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -5132,7 +5137,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5283,7 +5288,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5400,7 +5405,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5512,37 +5521,37 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5619,7 +5628,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5680,7 +5689,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5790,6 +5799,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5843,7 +5860,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5884,15 +5901,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5901,7 +5918,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -6115,7 +6132,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6334,7 +6351,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6593,7 +6610,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -7014,7 +7031,7 @@ msgstr "Creazione del container in corso"
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Password amministratore per %s: "
@@ -7058,7 +7075,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -7092,7 +7109,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
@@ -7530,8 +7547,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -8298,7 +8315,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
@@ -8308,7 +8325,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8618,7 +8635,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -8631,7 +8648,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8668,7 +8685,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -679,17 +679,22 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr "<remote>"
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
+
+#: cmd/incus/remote_unix.go:35
+#, fuzzy
+msgid "<remote>: <path>"
+msgstr "[<remote>:]<API path>"
 
 #: cmd/incus/file.go:456
 msgid "<source path>... [<remote>:]<instance>/<path>"
@@ -736,11 +741,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
@@ -804,11 +809,11 @@ msgstr "グループからメンバーを削除します"
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 #, fuzzy
 msgid ""
 "Add new remote servers\n"
@@ -947,7 +952,7 @@ msgstr ""
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
@@ -1027,7 +1032,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1050,7 +1055,7 @@ msgstr "自動更新: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
@@ -1217,7 +1222,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1311,7 +1316,7 @@ msgstr "カード: %s (%s)"
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1325,7 +1330,7 @@ msgid ""
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -1349,7 +1354,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1643,12 +1648,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1677,7 +1682,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -2082,15 +2087,15 @@ msgstr "警告を削除します"
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2777,7 +2782,7 @@ msgstr "sshfs の起動に失敗しました: %w"
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
@@ -2796,7 +2801,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
@@ -2826,7 +2831,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -2836,7 +2841,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
@@ -2856,7 +2861,7 @@ msgstr "新しいインスタンス名が取得できません"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
@@ -2969,7 +2974,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
@@ -3075,7 +3080,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -3115,7 +3120,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -3131,7 +3136,7 @@ msgstr "GPUs:"
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -3563,7 +3568,7 @@ msgstr "不正なスナップショット名"
 msgid "Invalid URL %q: %w"
 msgstr "不正なフォーマット %q"
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3671,7 +3676,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -4176,7 +4181,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -4523,7 +4528,7 @@ msgstr ""
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
@@ -4585,12 +4590,12 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -4899,7 +4904,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4932,8 +4937,8 @@ msgstr "NICs:"
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr "NO"
 
@@ -4997,7 +5002,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
@@ -5241,7 +5246,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -5314,11 +5319,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5365,7 +5370,7 @@ msgstr "インクリメンタルコピーを実行します"
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバアドレスを指定してください（空の場合は中止）:"
 
@@ -5374,7 +5379,7 @@ msgstr "別のサーバアドレスを指定してください（空の場合は
 msgid "Please provide join token:"
 msgstr "クライアント名を入力してください: "
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
@@ -5525,7 +5530,7 @@ msgstr "プロジェクト %s を削除しました"
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
@@ -5660,7 +5665,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "クライアント %s の証明書追加トークン: %s"
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
@@ -5771,37 +5780,37 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 #, fuzzy
 msgid "Remote trust token"
 msgstr "信頼済みクライアントを削除します"
@@ -5873,7 +5882,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5933,7 +5942,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -6047,6 +6056,14 @@ msgstr "ロール（admin または read-only）"
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -6100,7 +6117,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -6142,16 +6159,16 @@ msgstr "秘密鍵: %s"
 msgid "Send a raw query to the server"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 #, fuzzy
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
@@ -6161,7 +6178,7 @@ msgstr "認証後、サーバが我々を信用していません"
 msgid "Server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 #, fuzzy
 msgid "Server protocol (incus or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
@@ -6441,7 +6458,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -6657,7 +6674,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -6913,7 +6930,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -7367,7 +7384,7 @@ msgstr "インスタンスを転送中: %s"
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -7412,7 +7429,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr "URL"
 
@@ -7446,7 +7463,7 @@ msgstr "クラスタメンバへの接続に失敗しました"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
@@ -7886,8 +7903,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr "YES"
 
@@ -8543,7 +8560,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
@@ -8552,7 +8569,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<name>]"
 msgstr "[<remote>:] <name>"
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr "現在値"
 
@@ -9035,7 +9052,7 @@ msgstr ""
 msgid "info"
 msgstr "ストレージ情報"
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr "n"
 
@@ -9047,7 +9064,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -9087,7 +9104,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr "y"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -663,16 +663,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -717,11 +721,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -783,11 +787,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -910,7 +914,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -985,7 +989,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1008,7 +1012,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -1172,7 +1176,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1261,7 +1265,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1273,7 +1277,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1297,7 +1301,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1568,12 +1572,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1602,7 +1606,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1998,15 +2002,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2656,7 +2660,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2675,7 +2679,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2705,7 +2709,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2715,7 +2719,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2735,7 +2739,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2848,7 +2852,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2939,7 +2943,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2979,7 +2983,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2995,7 +2999,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3401,7 +3405,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3503,7 +3507,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3870,7 +3874,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -4178,7 +4182,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4240,12 +4244,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4531,7 +4535,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4564,8 +4568,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4627,7 +4631,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4867,7 +4871,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4940,11 +4944,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4991,7 +4995,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4999,7 +5003,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5148,7 +5152,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5265,7 +5269,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5374,37 +5382,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5475,7 +5483,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5533,7 +5541,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5637,6 +5645,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5689,7 +5705,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5730,15 +5746,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5747,7 +5763,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5956,7 +5972,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6162,7 +6178,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6417,7 +6433,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6835,7 +6851,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6878,7 +6894,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6911,7 +6927,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7332,8 +7348,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7960,7 +7976,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7968,7 +7984,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8278,7 +8294,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8290,7 +8306,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8327,7 +8343,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -697,16 +697,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -751,11 +755,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -817,11 +821,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -944,7 +948,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1019,7 +1023,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1042,7 +1046,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -1206,7 +1210,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1295,7 +1299,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1307,7 +1311,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1331,7 +1335,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1602,12 +1606,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1636,7 +1640,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -2032,15 +2036,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2690,7 +2694,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2709,7 +2713,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2739,7 +2743,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2749,7 +2753,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2769,7 +2773,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2973,7 +2977,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -3013,7 +3017,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -3029,7 +3033,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3435,7 +3439,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3537,7 +3541,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3904,7 +3908,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -4212,7 +4216,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4274,12 +4278,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4565,7 +4569,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4598,8 +4602,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4661,7 +4665,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4901,7 +4905,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4974,11 +4978,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5025,7 +5029,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -5033,7 +5037,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5182,7 +5186,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5299,7 +5303,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5408,37 +5416,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5509,7 +5517,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5567,7 +5575,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5671,6 +5679,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5723,7 +5739,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5764,15 +5780,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5781,7 +5797,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5990,7 +6006,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6196,7 +6212,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6451,7 +6467,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6869,7 +6885,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6912,7 +6928,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6945,7 +6961,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7366,8 +7382,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7994,7 +8010,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -8002,7 +8018,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8312,7 +8328,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8324,7 +8340,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8361,7 +8377,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -698,17 +698,22 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
 msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+#, fuzzy
+msgid "<remote>: <path>"
+msgstr "Criar perfis"
 
 #: cmd/incus/file.go:456
 #, fuzzy
@@ -754,11 +759,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
@@ -824,11 +829,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -957,7 +962,7 @@ msgstr ""
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1039,7 +1044,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1062,7 +1067,7 @@ msgstr "Atualização automática: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 #, fuzzy
 msgid "Available projects:"
 msgstr "Criar projetos"
@@ -1228,7 +1233,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1318,7 +1323,7 @@ msgstr "Em cache: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1330,7 +1335,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -1354,7 +1359,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1639,12 +1644,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1673,7 +1678,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -2099,15 +2104,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2779,7 +2784,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2798,7 +2803,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2828,7 +2833,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
@@ -2858,7 +2863,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2971,7 +2976,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -3063,7 +3068,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -3103,7 +3108,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -3119,7 +3124,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3548,7 +3553,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid URL %q: %w"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3651,7 +3656,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -4029,7 +4034,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -4361,7 +4366,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4425,12 +4430,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4732,7 +4737,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4765,8 +4770,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4828,7 +4833,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -5141,11 +5146,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5192,7 +5197,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -5201,7 +5206,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5472,7 +5477,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5584,37 +5593,37 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 #, fuzzy
 msgid "Remote trust token"
 msgstr "Adicionar novos clientes confiáveis"
@@ -5694,7 +5703,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5758,7 +5767,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5873,6 +5882,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5926,7 +5943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5967,15 +5984,15 @@ msgstr "Criado: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5984,7 +6001,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -6205,7 +6222,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6435,7 +6452,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6694,7 +6711,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -7117,7 +7134,7 @@ msgstr "Editar arquivos no container"
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Senha de administrador para %s: "
@@ -7161,7 +7178,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -7195,7 +7212,7 @@ msgstr "Nome de membro do cluster"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
@@ -7644,8 +7661,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -8342,7 +8359,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
@@ -8352,7 +8369,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<name>]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8662,7 +8679,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8674,7 +8691,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8711,7 +8728,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -697,17 +697,25 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
 msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+#, fuzzy
+msgid "<remote>: <path>"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/file.go:456
 #, fuzzy
@@ -757,11 +765,11 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
@@ -827,11 +835,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -957,7 +965,7 @@ msgstr ""
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1035,7 +1043,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1058,7 +1066,7 @@ msgstr "Авто-обновление: %s"
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 #, fuzzy
 msgid "Available projects:"
 msgstr "Доступные команды:"
@@ -1225,7 +1233,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1314,7 +1322,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1326,7 +1334,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1350,7 +1358,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1624,12 +1632,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1658,7 +1666,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -2081,15 +2089,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2761,7 +2769,7 @@ msgstr "Принять сертификат"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2780,7 +2788,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2810,7 +2818,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2820,7 +2828,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
@@ -2840,7 +2848,7 @@ msgstr "Принять сертификат"
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2953,7 +2961,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -3045,7 +3053,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -3085,7 +3093,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -3101,7 +3109,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3530,7 +3538,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid URL %q: %w"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3633,7 +3641,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -4017,7 +4025,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -4352,7 +4360,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4417,12 +4425,12 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4725,7 +4733,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4758,8 +4766,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4823,7 +4831,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -5067,7 +5075,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -5140,11 +5148,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5191,7 +5199,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -5200,7 +5208,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5349,7 +5357,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5466,7 +5474,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5579,37 +5591,37 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5686,7 +5698,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5747,7 +5759,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5859,6 +5871,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5912,7 +5932,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5953,15 +5973,15 @@ msgstr "Авто-обновление: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5970,7 +5990,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -6186,7 +6206,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6413,7 +6433,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6676,7 +6696,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -7095,7 +7115,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "Пароль администратора для %s: "
@@ -7139,7 +7159,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -7173,7 +7193,7 @@ msgstr "Копирование образа: %s"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7617,8 +7637,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -8797,7 +8817,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8813,7 +8833,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -9123,7 +9143,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -9135,7 +9155,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9172,7 +9192,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -447,16 +447,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -501,11 +505,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -567,11 +571,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -694,7 +698,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -769,7 +773,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -792,7 +796,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -956,7 +960,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1045,7 +1049,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1057,7 +1061,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1081,7 +1085,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1352,12 +1356,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1386,7 +1390,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1782,15 +1786,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2440,7 +2444,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2459,7 +2463,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2489,7 +2493,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2499,7 +2503,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2519,7 +2523,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2632,7 +2636,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2723,7 +2727,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2763,7 +2767,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2779,7 +2783,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3185,7 +3189,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3287,7 +3291,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3654,7 +3658,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3962,7 +3966,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4024,12 +4028,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4315,7 +4319,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4348,8 +4352,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4411,7 +4415,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4651,7 +4655,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4724,11 +4728,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4775,7 +4779,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4783,7 +4787,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4932,7 +4936,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5049,7 +5053,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5158,37 +5166,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5259,7 +5267,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5317,7 +5325,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5421,6 +5429,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5473,7 +5489,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5514,15 +5530,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5531,7 +5547,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5740,7 +5756,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5946,7 +5962,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6201,7 +6217,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6619,7 +6635,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6662,7 +6678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6695,7 +6711,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7116,8 +7132,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7744,7 +7760,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7752,7 +7768,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8062,7 +8078,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8074,7 +8090,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8111,7 +8127,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -447,16 +447,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -501,11 +505,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -567,11 +571,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -694,7 +698,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -769,7 +773,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -792,7 +796,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -956,7 +960,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1045,7 +1049,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1057,7 +1061,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1081,7 +1085,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1352,12 +1356,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1386,7 +1390,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1782,15 +1786,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2440,7 +2444,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2459,7 +2463,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2489,7 +2493,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2499,7 +2503,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2519,7 +2523,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2632,7 +2636,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2723,7 +2727,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2763,7 +2767,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2779,7 +2783,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3185,7 +3189,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3287,7 +3291,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3654,7 +3658,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3962,7 +3966,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4024,12 +4028,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4315,7 +4319,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4348,8 +4352,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4411,7 +4415,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4651,7 +4655,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4724,11 +4728,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4775,7 +4779,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4783,7 +4787,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4932,7 +4936,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5049,7 +5053,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5158,37 +5166,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5259,7 +5267,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5317,7 +5325,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5421,6 +5429,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5473,7 +5489,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5514,15 +5530,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5531,7 +5547,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5740,7 +5756,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5946,7 +5962,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6201,7 +6217,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6619,7 +6635,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6662,7 +6678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6695,7 +6711,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7116,8 +7132,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7744,7 +7760,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7752,7 +7768,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8062,7 +8078,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8074,7 +8090,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8111,7 +8127,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -443,16 +443,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -497,11 +501,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -563,11 +567,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -690,7 +694,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -765,7 +769,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -788,7 +792,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -952,7 +956,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1041,7 +1045,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1053,7 +1057,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1077,7 +1081,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1348,12 +1352,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1382,7 +1386,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1778,15 +1782,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2436,7 +2440,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2455,7 +2459,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2485,7 +2489,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2495,7 +2499,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2515,7 +2519,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2628,7 +2632,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2719,7 +2723,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2759,7 +2763,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2775,7 +2779,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3181,7 +3185,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3283,7 +3287,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3650,7 +3654,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3958,7 +3962,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4020,12 +4024,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4311,7 +4315,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4344,8 +4348,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4407,7 +4411,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4647,7 +4651,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4720,11 +4724,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4771,7 +4775,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4779,7 +4783,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4928,7 +4932,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5045,7 +5049,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5154,37 +5162,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5255,7 +5263,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5313,7 +5321,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5417,6 +5425,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5469,7 +5485,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5510,15 +5526,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5527,7 +5543,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5736,7 +5752,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5942,7 +5958,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6197,7 +6213,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6615,7 +6631,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6658,7 +6674,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6691,7 +6707,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7112,8 +7128,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7740,7 +7756,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7748,7 +7764,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8058,7 +8074,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8070,7 +8086,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8107,7 +8123,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -447,16 +447,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -501,11 +505,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -567,11 +571,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -694,7 +698,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -769,7 +773,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -792,7 +796,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -956,7 +960,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1045,7 +1049,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1057,7 +1061,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1081,7 +1085,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1352,12 +1356,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1386,7 +1390,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1782,15 +1786,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2440,7 +2444,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2459,7 +2463,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2489,7 +2493,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2499,7 +2503,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2519,7 +2523,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2632,7 +2636,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2723,7 +2727,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2763,7 +2767,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2779,7 +2783,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3185,7 +3189,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3287,7 +3291,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3654,7 +3658,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3962,7 +3966,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4024,12 +4028,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4315,7 +4319,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4348,8 +4352,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4411,7 +4415,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4651,7 +4655,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4724,11 +4728,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4775,7 +4779,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4783,7 +4787,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4932,7 +4936,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5049,7 +5053,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5158,37 +5166,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5259,7 +5267,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5317,7 +5325,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5421,6 +5429,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5473,7 +5489,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5514,15 +5530,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5531,7 +5547,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5740,7 +5756,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5946,7 +5962,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6201,7 +6217,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6619,7 +6635,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6662,7 +6678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6695,7 +6711,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7116,8 +7132,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7744,7 +7760,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7752,7 +7768,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8062,7 +8078,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8074,7 +8090,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8111,7 +8127,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -644,16 +644,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -698,11 +702,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -764,11 +768,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -891,7 +895,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -966,7 +970,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -989,7 +993,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -1153,7 +1157,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1242,7 +1246,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1254,7 +1258,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1278,7 +1282,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1549,12 +1553,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1583,7 +1587,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1979,15 +1983,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2637,7 +2641,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2656,7 +2660,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2686,7 +2690,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2696,7 +2700,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2716,7 +2720,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2829,7 +2833,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2920,7 +2924,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2960,7 +2964,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2976,7 +2980,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3382,7 +3386,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3484,7 +3488,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3851,7 +3855,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -4159,7 +4163,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4221,12 +4225,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4512,7 +4516,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4545,8 +4549,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4608,7 +4612,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4848,7 +4852,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4921,11 +4925,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4972,7 +4976,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4980,7 +4984,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -5129,7 +5133,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5246,7 +5250,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5355,37 +5363,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5456,7 +5464,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5514,7 +5522,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5618,6 +5626,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5670,7 +5686,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5711,15 +5727,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5728,7 +5744,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5937,7 +5953,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6143,7 +6159,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6398,7 +6414,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6816,7 +6832,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6859,7 +6875,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6892,7 +6908,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7313,8 +7329,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7941,7 +7957,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7949,7 +7965,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8259,7 +8275,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8271,7 +8287,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8308,7 +8324,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-12-06 16:49-0500\n"
+"POT-Creation-Date: 2023-12-10 17:31-0500\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -446,16 +446,20 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: cmd/incus/remote.go:805 cmd/incus/remote.go:861
+#: cmd/incus/remote.go:812 cmd/incus/remote.go:868
 msgid "<remote>"
 msgstr ""
 
-#: cmd/incus/remote.go:899
+#: cmd/incus/remote.go:906
 msgid "<remote> <URL>"
 msgstr ""
 
-#: cmd/incus/remote.go:734
+#: cmd/incus/remote.go:741
 msgid "<remote> <new-name>"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:35
+msgid "<remote>: <path>"
 msgstr ""
 
 #: cmd/incus/file.go:456
@@ -500,11 +504,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: cmd/incus/remote.go:717
+#: cmd/incus/remote.go:724
 msgid "AUTH TYPE"
 msgstr ""
 
-#: cmd/incus/remote.go:100
+#: cmd/incus/remote.go:107
 msgid "Accept certificate"
 msgstr ""
 
@@ -566,11 +570,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: cmd/incus/remote.go:89
+#: cmd/incus/remote.go:96
 msgid "Add new remote servers"
 msgstr ""
 
-#: cmd/incus/remote.go:90
+#: cmd/incus/remote.go:97
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -693,7 +697,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: cmd/incus/remote.go:180
+#: cmd/incus/remote.go:187
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -768,7 +772,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: cmd/incus/remote.go:544
+#: cmd/incus/remote.go:551
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr ""
 msgid "Automatic (non-interactive) mode"
 msgstr ""
 
-#: cmd/incus/remote.go:135
+#: cmd/incus/remote.go:142
 msgid "Available projects:"
 msgstr ""
 
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:840
+#: cmd/incus/remote.go:847
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: cmd/incus/remote.go:218
+#: cmd/incus/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1056,7 +1060,7 @@ msgid ""
 "Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
-#: cmd/incus/remote.go:446
+#: cmd/incus/remote.go:453
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1080,7 +1084,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: cmd/incus/remote.go:590
+#: cmd/incus/remote.go:597
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1355,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: cmd/incus/remote.go:482
+#: cmd/incus/remote.go:489
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:224 cmd/incus/remote.go:466
+#: cmd/incus/remote.go:231 cmd/incus/remote.go:473
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:477
+#: cmd/incus/remote.go:484
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1781,15 +1785,15 @@ msgstr ""
 #: cmd/incus/project.go:523 cmd/incus/project.go:580 cmd/incus/project.go:659
 #: cmd/incus/project.go:690 cmd/incus/project.go:743 cmd/incus/project.go:802
 #: cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27
-#: cmd/incus/remote.go:36 cmd/incus/remote.go:90 cmd/incus/remote.go:617
-#: cmd/incus/remote.go:653 cmd/incus/remote.go:737 cmd/incus/remote.go:808
-#: cmd/incus/remote.go:863 cmd/incus/remote.go:901 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71 cmd/incus/snapshot.go:170
-#: cmd/incus/snapshot.go:247 cmd/incus/snapshot.go:345
-#: cmd/incus/snapshot.go:394 cmd/incus/storage.go:32 cmd/incus/storage.go:95
-#: cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343
-#: cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664
-#: cmd/incus/storage.go:760 cmd/incus/storage.go:846
+#: cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624
+#: cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815
+#: cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37
+#: cmd/incus/rename.go:21 cmd/incus/snapshot.go:28 cmd/incus/snapshot.go:71
+#: cmd/incus/snapshot.go:170 cmd/incus/snapshot.go:247
+#: cmd/incus/snapshot.go:345 cmd/incus/snapshot.go:394 cmd/incus/storage.go:32
+#: cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219
+#: cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585
+#: cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846
 #: cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82
 #: cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243
 #: cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452
@@ -2439,7 +2443,7 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:190
+#: cmd/incus/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "Failed to close export file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:241
+#: cmd/incus/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Failed to connect to target cluster node %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:231
+#: cmd/incus/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2498,7 +2502,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:256
+#: cmd/incus/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
@@ -2518,7 +2522,7 @@ msgstr ""
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:263
+#: cmd/incus/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2631,7 +2635,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:236
+#: cmd/incus/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2722,7 +2726,7 @@ msgstr ""
 #: cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87
 #: cmd/incus/network_zone.go:691 cmd/incus/operation.go:109
 #: cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:804
-#: cmd/incus/remote.go:657 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
+#: cmd/incus/remote.go:664 cmd/incus/snapshot.go:250 cmd/incus/storage.go:587
 #: cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768
 #: cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256
 #: cmd/incus/warning.go:94
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: cmd/incus/remote.go:720
+#: cmd/incus/remote.go:727
 msgid "GLOBAL"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: cmd/incus/remote.go:158 cmd/incus/remote.go:392
+#: cmd/incus/remote.go:165 cmd/incus/remote.go:399
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3184,7 +3188,7 @@ msgstr ""
 msgid "Invalid URL %q: %w"
 msgstr ""
 
-#: cmd/incus/remote.go:344
+#: cmd/incus/remote.go:351
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3286,7 +3290,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/remote.go:333
+#: cmd/incus/remote.go:340
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3653,7 +3657,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: cmd/incus/remote.go:652 cmd/incus/remote.go:653
+#: cmd/incus/remote.go:659 cmd/incus/remote.go:660
 msgid "List the available remotes"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: cmd/incus/remote.go:35 cmd/incus/remote.go:36
+#: cmd/incus/remote.go:36 cmd/incus/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4023,12 +4027,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:287 cmd/incus/move.go:401
+#: cmd/incus/move.go:287 cmd/incus/move.go:400
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:312 cmd/incus/move.go:406
+#: cmd/incus/move.go:312 cmd/incus/move.go:405
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4314,7 +4318,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:552 cmd/incus/list.go:565 cmd/incus/network.go:980
 #: cmd/incus/network_acl.go:146 cmd/incus/network_peer.go:138
 #: cmd/incus/network_zone.go:137 cmd/incus/network_zone.go:740
-#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:714
+#: cmd/incus/profile.go:657 cmd/incus/project.go:498 cmd/incus/remote.go:721
 #: cmd/incus/storage.go:637 cmd/incus/storage_bucket.go:505
 #: cmd/incus/storage_bucket.go:825 cmd/incus/storage_volume.go:1493
 msgid "NAME"
@@ -4347,8 +4351,8 @@ msgstr ""
 
 #: cmd/incus/network.go:957 cmd/incus/operation.go:155 cmd/incus/project.go:456
 #: cmd/incus/project.go:461 cmd/incus/project.go:466 cmd/incus/project.go:471
-#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:674
-#: cmd/incus/remote.go:679 cmd/incus/remote.go:684
+#: cmd/incus/project.go:476 cmd/incus/project.go:481 cmd/incus/remote.go:681
+#: cmd/incus/remote.go:686 cmd/incus/remote.go:691
 msgid "NO"
 msgstr ""
 
@@ -4410,7 +4414,7 @@ msgstr ""
 msgid "Name of the new storage pool"
 msgstr ""
 
-#: cmd/incus/remote.go:140
+#: cmd/incus/remote.go:147
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4650,7 +4654,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: cmd/incus/remote.go:327
+#: cmd/incus/remote.go:334
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4723,11 +4727,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: cmd/incus/remote.go:716
+#: cmd/incus/remote.go:723
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:718
+#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -4774,7 +4778,7 @@ msgstr ""
 msgid "Please create those missing entries and then hit ENTER:"
 msgstr ""
 
-#: cmd/incus/remote.go:181
+#: cmd/incus/remote.go:188
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4782,7 +4786,7 @@ msgstr ""
 msgid "Please provide join token:"
 msgstr ""
 
-#: cmd/incus/remote.go:458
+#: cmd/incus/remote.go:465
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4931,7 +4935,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/remote.go:105
+#: cmd/incus/remote.go:112
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -5048,7 +5052,11 @@ msgstr ""
 msgid "Provided certificate path doesn't exist: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:104
+#: cmd/incus/remote_unix.go:42
+msgid "Proxy timeout (exits when no connections)"
+msgstr ""
+
+#: cmd/incus/remote.go:111
 msgid "Public image server"
 msgstr ""
 
@@ -5157,37 +5165,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: cmd/incus/remote.go:766
+#: cmd/incus/remote.go:773
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:769 cmd/incus/remote.go:757 cmd/incus/remote.go:828
-#: cmd/incus/remote.go:883 cmd/incus/remote.go:921
+#: cmd/incus/project.go:769 cmd/incus/remote.go:764 cmd/incus/remote.go:835
+#: cmd/incus/remote.go:890 cmd/incus/remote.go:928
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/remote.go:296
+#: cmd/incus/remote.go:303
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: cmd/incus/remote.go:836
+#: cmd/incus/remote.go:843
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: cmd/incus/remote.go:761 cmd/incus/remote.go:832 cmd/incus/remote.go:925
+#: cmd/incus/remote.go:768 cmd/incus/remote.go:839 cmd/incus/remote.go:932
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: cmd/incus/remote.go:290
+#: cmd/incus/remote.go:297
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: cmd/incus/remote.go:101
+#: cmd/incus/remote.go:108
 msgid "Remote trust token"
 msgstr ""
 
@@ -5258,7 +5266,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: cmd/incus/remote.go:807 cmd/incus/remote.go:808
+#: cmd/incus/remote.go:814 cmd/incus/remote.go:815
 msgid "Remove remotes"
 msgstr ""
 
@@ -5316,7 +5324,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: cmd/incus/remote.go:736 cmd/incus/remote.go:737
+#: cmd/incus/remote.go:743 cmd/incus/remote.go:744
 msgid "Rename remotes"
 msgstr ""
 
@@ -5420,6 +5428,14 @@ msgstr ""
 msgid "Rows affected: %d"
 msgstr ""
 
+#: cmd/incus/remote_unix.go:36
+msgid "Run a local API proxy"
+msgstr ""
+
+#: cmd/incus/remote_unix.go:37
+msgid "Run a local API proxy for the remote"
+msgstr ""
+
 #: cmd/incus/network_allocations.go:58
 msgid "Run again a specific project"
 msgstr ""
@@ -5472,7 +5488,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: cmd/incus/remote.go:719
+#: cmd/incus/remote.go:726
 msgid "STATIC"
 msgstr ""
 
@@ -5513,15 +5529,15 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/remote.go:103
+#: cmd/incus/remote.go:110
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: cmd/incus/remote.go:456
+#: cmd/incus/remote.go:463
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: cmd/incus/remote.go:586
+#: cmd/incus/remote.go:593
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5530,7 +5546,7 @@ msgstr ""
 msgid "Server isn't part of a cluster"
 msgstr ""
 
-#: cmd/incus/remote.go:102
+#: cmd/incus/remote.go:109
 msgid "Server protocol (incus or simplestreams)"
 msgstr ""
 
@@ -5739,7 +5755,7 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/remote.go:900 cmd/incus/remote.go:901
+#: cmd/incus/remote.go:907 cmd/incus/remote.go:908
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5945,7 +5961,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/remote.go:616 cmd/incus/remote.go:617
+#: cmd/incus/remote.go:623 cmd/incus/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
@@ -6200,7 +6216,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: cmd/incus/remote.go:862 cmd/incus/remote.go:863
+#: cmd/incus/remote.go:869 cmd/incus/remote.go:870
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6618,7 +6634,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: cmd/incus/remote.go:558
+#: cmd/incus/remote.go:565
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6661,7 +6677,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: cmd/incus/cluster.go:184 cmd/incus/remote.go:715
+#: cmd/incus/cluster.go:184 cmd/incus/remote.go:722
 msgid "URL"
 msgstr ""
 
@@ -6694,7 +6710,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: cmd/incus/remote.go:213 cmd/incus/remote.go:247
+#: cmd/incus/remote.go:220 cmd/incus/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -7115,8 +7131,8 @@ msgstr ""
 
 #: cmd/incus/network.go:959 cmd/incus/operation.go:157 cmd/incus/project.go:458
 #: cmd/incus/project.go:463 cmd/incus/project.go:468 cmd/incus/project.go:473
-#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:676
-#: cmd/incus/remote.go:681 cmd/incus/remote.go:686
+#: cmd/incus/project.go:478 cmd/incus/project.go:483 cmd/incus/remote.go:683
+#: cmd/incus/remote.go:688 cmd/incus/remote.go:693
 msgid "YES"
 msgstr ""
 
@@ -7743,7 +7759,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/remote.go:88
+#: cmd/incus/remote.go:95
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -7751,7 +7767,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: cmd/incus/project.go:488 cmd/incus/remote.go:705
+#: cmd/incus/project.go:488 cmd/incus/remote.go:712
 msgid "current"
 msgstr ""
 
@@ -8061,7 +8077,7 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: cmd/incus/remote.go:455
+#: cmd/incus/remote.go:462
 msgid "n"
 msgstr ""
 
@@ -8073,7 +8089,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: cmd/incus/remote.go:447
+#: cmd/incus/remote.go:454
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8110,7 +8126,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: cmd/incus/remote.go:457
+#: cmd/incus/remote.go:464
 msgid "y"
 msgstr ""
 

--- a/shared/cliconfig/keepalive.go
+++ b/shared/cliconfig/keepalive.go
@@ -1,0 +1,60 @@
+//go:build !windows
+
+package cliconfig
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/lxc/incus/client"
+	"github.com/lxc/incus/shared/subprocess"
+	"github.com/lxc/incus/shared/util"
+)
+
+func (c *Config) handleKeepAlive(remote Remote, name string, args *incus.ConnectionArgs) (incus.InstanceServer, error) {
+	// Create the socker directory if missing.
+	socketDir := filepath.Join(c.ConfigDir, "keepalive")
+	err := os.Mkdir(socketDir, 0700)
+	if err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	// Attempt to use the existing socket.
+	socketPath := filepath.Join(socketDir, fmt.Sprintf("%s.socket", name))
+	d, err := incus.ConnectIncusUnix(socketPath, args)
+	if err != nil {
+		// Delete any existing sockets.
+		_ = os.Remove(socketPath)
+
+		// Spawn the proxy.
+		proc, err := subprocess.NewProcess("incus", []string{"remote", "proxy", name, socketPath, fmt.Sprintf("--timeout=%d", remote.KeepAlive)}, "", "")
+		if err != nil {
+			return nil, err
+		}
+
+		err = proc.Start(context.Background())
+		if err != nil {
+			return nil, err
+		}
+
+		// Try up to 10 times over 5s.
+		for i := 0; i < 10; i++ {
+			if util.PathExists(socketPath) {
+				break
+			}
+
+			time.Sleep(500 * time.Millisecond)
+		}
+
+		// Connect to the proxy.
+		d, err = incus.ConnectIncusUnix(socketPath, args)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return d, nil
+}

--- a/shared/cliconfig/keepalive_windows.go
+++ b/shared/cliconfig/keepalive_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package cliconfig
+
+import (
+	"fmt"
+
+	"github.com/lxc/incus/client"
+)
+
+func (c *Config) handleKeepAlive(remote Remote, name string, args *incus.ConnectionArgs) (incus.InstanceServer, error) {
+	return nil, fmt.Errorf("Keepalive isn't supported on Windows")
+}

--- a/shared/cliconfig/remote.go
+++ b/shared/cliconfig/remote.go
@@ -20,13 +20,14 @@ import (
 
 // Remote holds details for communication with a remote daemon.
 type Remote struct {
-	Addr     string `yaml:"addr"`
-	AuthType string `yaml:"auth_type,omitempty"`
-	Project  string `yaml:"project,omitempty"`
-	Protocol string `yaml:"protocol,omitempty"`
-	Public   bool   `yaml:"public"`
-	Global   bool   `yaml:"-"`
-	Static   bool   `yaml:"-"`
+	Addr      string `yaml:"addr"`
+	AuthType  string `yaml:"auth_type,omitempty"`
+	KeepAlive int    `yaml:"keepalive,omitempty"`
+	Project   string `yaml:"project,omitempty"`
+	Protocol  string `yaml:"protocol,omitempty"`
+	Public    bool   `yaml:"public"`
+	Global    bool   `yaml:"-"`
+	Static    bool   `yaml:"-"`
 }
 
 // ParseRemote splits remote and object.


### PR DESCRIPTION
This adds a new `incus remote proxy` sub-command which operates a simple reverse proxy server over a unix socket. This then gets used when a `keepalive` property is set on a remote.

That property is a number of seconds during which to keep the proxy running.

Using the keepalive proxy has a few advantages:
 - Allows for more efficient backend connections (keep-alive)
 - Keeps OIDC initialized over multiple calls
 - Caches the calls to /1.0, effectively reducing API calls in half

In my tests, this leads to around 30% performance improvement on workloads that run a lot of individual CLI calls like Ansible.