### PR TITLE
Instance migration related fixes

### DIFF
--- a/cmd/incus/move.go
+++ b/cmd/incus/move.go
@@ -173,7 +173,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 
 	// Support for server-side move. Currently, such migration can only move an instance to different project
 	// or storage pool. If specific profile, device or config is provided, the instance should be copied (move using copy).
-	if sourceRemote == destRemote && c.flagStorage != "" || c.flagTargetProject != "" {
+	if sourceRemote == destRemote && (c.flagStorage != "" || c.flagTargetProject != "") {
 		source, err := conf.GetInstanceServer(sourceRemote)
 		if err != nil {
 			return err

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -338,6 +338,8 @@ func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.In
 			logger.Error("Failed to add instance to authorizer", logger.Ctx{"instanceName": d.Name(), "projectName": d.project.Name, "error": err})
 		}
 
+		revert.Add(func() { d.state.Authorizer.DeleteInstance(d.state.ShutdownCtx, d.project.Name, d.Name()) })
+
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceCreated.Event(d, map[string]any{
 			"type":         api.InstanceTypeContainer,
 			"storage-pool": d.storagePool.Name(),

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -344,6 +344,8 @@ func qemuCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.I
 			logger.Error("Failed to add instance to authorizer", logger.Ctx{"name": d.Name(), "project": d.project.Name, "error": err})
 		}
 
+		revert.Add(func() { d.state.Authorizer.DeleteInstance(d.state.ShutdownCtx, d.project.Name, d.Name()) })
+
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceCreated.Event(d, map[string]any{
 			"type":         api.InstanceTypeVM,
 			"storage-pool": d.storagePool.Name(),


### PR DESCRIPTION
Those are a couple of issues I ran into during a live demo in a recent live stream.

The first is yet another OpenFGA revert issue, apparently I had missed those code paths in my recent fixes. The second is a trivial logic bug in the client which was making the client always take the same-server code path when dealing with a project target, even with the source and target servers were different.