### PR TITLE
fix: use openfga go sdk v0.3.1-go1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ifneq "$(INCUS_OFFLINE)" ""
 endif
 	$(GO) get -t -v -d -u ./...
 	$(GO) get github.com/mdlayher/socket@v0.4.1
-	$(GO) get github.com/openfga/go-sdk@v0.2.2
+	$(GO) get github.com/openfga/go-sdk@v0.3.1-go1.20
 	$(GO) mod tidy --go=1.20
 	$(GO) get toolchain@none
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.65
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/openfga/go-sdk v0.2.2
+	github.com/openfga/go-sdk v0.3.1-go1.20
 	github.com/osrg/gobgp/v3 v3.21.0
 	github.com/pkg/sftp v1.13.6
 	github.com/pkg/xattr v0.4.9

--- a/go.sum
+++ b/go.sum
@@ -344,6 +344,7 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/openfga/go-sdk v0.2.2 h1:zzQPdcX/CNLXwycqYNx5LvP78kzVs6R8p5GXw/0II3s=
 github.com/openfga/go-sdk v0.2.2/go.mod h1:ZB13O8GilPc0ITWssOszgxmz6CnIe8PQLZqbqAnx2IY=
+github.com/openfga/go-sdk v0.3.1-go1.20/go.mod h1:W4SNYMSxptGOtA9aGYxsYUmSC7LaZYP7y9qbT36ouCc=
 github.com/osrg/gobgp/v3 v3.21.0 h1:OCjDIz2duA36tLoQElm8S2ZfxClPqcM9B4SfIlfYQTI=
 github.com/osrg/gobgp/v3 v3.21.0/go.mod h1:4fbscYpsCk14EO16nTWAdJyErO4MbAZ2zLJmsmeXu/k=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/internal/server/auth/driver_openfga.go
+++ b/internal/server/auth/driver_openfga.go
@@ -384,7 +384,7 @@ func (f *fga) AddProject(ctx context.Context, _ int64, projectName string) error
 
 func (f *fga) DeleteProject(ctx context.Context, _ int64, projectName string) error {
 	// Only empty projects can be deleted, so we don't need to worry about any tuples with this project as a parent.
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			// Remove the default profile
 			User:     ObjectProject(projectName).String(),
@@ -416,7 +416,7 @@ func (f *fga) RenameProject(ctx context.Context, _ int64, oldName string, newNam
 	}
 
 	// Only empty projects can be renamed, so we don't need to worry about any tuples with this project as a parent.
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			// Remove the default profile
 			User:     ObjectProject(oldName).String(),
@@ -448,7 +448,7 @@ func (f *fga) AddCertificate(ctx context.Context, fingerprint string) error {
 
 // DeleteCertificate is a no-op.
 func (f *fga) DeleteCertificate(ctx context.Context, fingerprint string) error {
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectServer().String(),
 			Relation: relationServer,
@@ -474,7 +474,7 @@ func (f *fga) AddStoragePool(ctx context.Context, storagePoolName string) error 
 
 // DeleteStoragePool is a no-op.
 func (f *fga) DeleteStoragePool(ctx context.Context, storagePoolName string) error {
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectServer().String(),
 			Relation: relationServer,
@@ -500,7 +500,7 @@ func (f *fga) AddImage(ctx context.Context, projectName string, fingerprint stri
 
 // DeleteImage is a no-op.
 func (f *fga) DeleteImage(ctx context.Context, projectName string, fingerprint string) error {
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -526,7 +526,7 @@ func (f *fga) AddImageAlias(ctx context.Context, projectName string, imageAliasN
 
 // DeleteImageAlias is a no-op.
 func (f *fga) DeleteImageAlias(ctx context.Context, projectName string, imageAliasName string) error {
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -547,7 +547,7 @@ func (f *fga) RenameImageAlias(ctx context.Context, projectName string, oldAlias
 		},
 	}
 
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -573,7 +573,7 @@ func (f *fga) AddInstance(ctx context.Context, projectName string, instanceName 
 
 // DeleteInstance is a no-op.
 func (f *fga) DeleteInstance(ctx context.Context, projectName string, instanceName string) error {
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -594,7 +594,7 @@ func (f *fga) RenameInstance(ctx context.Context, projectName string, oldInstanc
 		},
 	}
 
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -620,7 +620,7 @@ func (f *fga) AddNetwork(ctx context.Context, projectName string, networkName st
 
 // DeleteNetwork is a no-op.
 func (f *fga) DeleteNetwork(ctx context.Context, projectName string, networkName string) error {
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -641,7 +641,7 @@ func (f *fga) RenameNetwork(ctx context.Context, projectName string, oldNetworkN
 		},
 	}
 
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -667,7 +667,7 @@ func (f *fga) AddNetworkZone(ctx context.Context, projectName string, networkZon
 
 // DeleteNetworkZone is a no-op.
 func (f *fga) DeleteNetworkZone(ctx context.Context, projectName string, networkZoneName string) error {
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -693,7 +693,7 @@ func (f *fga) AddNetworkACL(ctx context.Context, projectName string, networkACLN
 
 // DeleteNetworkACL is a no-op.
 func (f *fga) DeleteNetworkACL(ctx context.Context, projectName string, networkACLName string) error {
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -714,7 +714,7 @@ func (f *fga) RenameNetworkACL(ctx context.Context, projectName string, oldNetwo
 		},
 	}
 
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -740,7 +740,7 @@ func (f *fga) AddProfile(ctx context.Context, projectName string, profileName st
 
 // DeleteProfile is a no-op.
 func (f *fga) DeleteProfile(ctx context.Context, projectName string, profileName string) error {
-	deletes := []client.ClientTupleKey{
+	deletes := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -761,7 +761,7 @@ func (f *fga) RenameProfile(ctx context.Context, projectName string, oldProfileN
 		},
 	}
 
-	deletes := []client.ClientTupleKey{
+	deletes := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -787,7 +787,7 @@ func (f *fga) AddStoragePoolVolume(ctx context.Context, projectName string, stor
 
 // DeleteStoragePoolVolume is a no-op.
 func (f *fga) DeleteStoragePoolVolume(ctx context.Context, projectName string, storagePoolName string, storageVolumeType string, storageVolumeName string, storageVolumeLocation string) error {
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -808,7 +808,7 @@ func (f *fga) RenameStoragePoolVolume(ctx context.Context, projectName string, s
 		},
 	}
 
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -834,7 +834,7 @@ func (f *fga) AddStorageBucket(ctx context.Context, projectName string, storageP
 
 // DeleteStorageBucket is a no-op.
 func (f *fga) DeleteStorageBucket(ctx context.Context, projectName string, storagePoolName string, storageBucketName string, storageBucketLocation string) error {
-	deletions := []client.ClientTupleKey{
+	deletions := []client.ClientTupleKeyWithoutCondition{
 		{
 			User:     ObjectProject(projectName).String(),
 			Relation: relationProject,
@@ -845,7 +845,7 @@ func (f *fga) DeleteStorageBucket(ctx context.Context, projectName string, stora
 	return f.updateTuples(ctx, nil, deletions)
 }
 
-func (f *fga) updateTuples(ctx context.Context, writes []client.ClientTupleKey, deletions []client.ClientTupleKey) error {
+func (f *fga) updateTuples(ctx context.Context, writes []client.ClientTupleKey, deletions []client.ClientTupleKeyWithoutCondition) error {
 	// If offline, skip updating as a full sync will happen after connection.
 	if !f.online {
 		return nil
@@ -870,15 +870,15 @@ func (f *fga) updateTuples(ctx context.Context, writes []client.ClientTupleKey, 
 	body := client.ClientWriteRequest{}
 
 	if writes != nil {
-		body.Writes = &writes
+		body.Writes = writes
 	} else {
-		body.Writes = &[]client.ClientTupleKey{}
+		body.Writes = []client.ClientTupleKey{}
 	}
 
 	if deletions != nil {
-		body.Deletes = &deletions
+		body.Deletes = deletions
 	} else {
-		body.Deletes = &[]client.ClientTupleKey{}
+		body.Deletes = []client.ClientTupleKeyWithoutCondition{}
 	}
 
 	clientWriteResponse, err := f.client.Write(ctx).Options(opts).Body(body).Execute()
@@ -938,7 +938,7 @@ func (f *fga) projectObjects(ctx context.Context, projectName string) ([]string,
 
 func (f *fga) syncResources(ctx context.Context, resources Resources) error {
 	var writes []client.ClientTupleKey
-	var deletions []client.ClientTupleKey
+	var deletions []client.ClientTupleKeyWithoutCondition
 
 	// Check if the type-bound public access is set.
 	resp, err := f.client.Check(ctx).Options(client.ClientCheckOptions{AuthorizationModelId: openfga.PtrString(f.authModelID)}).Body(client.ClientCheckRequest{
@@ -990,7 +990,7 @@ func (f *fga) syncResources(ctx context.Context, resources Resources) error {
 					user = ObjectProject(remoteObject.Project()).String()
 				}
 
-				deletions = append(deletions, client.ClientTupleKey{
+				deletions = append(deletions, client.ClientTupleKeyWithoutCondition{
 					User:     user,
 					Relation: relation,
 					Object:   remoteObject.String(),


### PR DESCRIPTION
This PR bumps the OpenFGA Go SDK to `v0.3.1-go1.20`

relates to: https://github.com/lxc/incus/issues/315