### PR TITLE
Fix incorrect type in JSON metadata

### DIFF
--- a/internal/server/config/generate/incus_doc.go
+++ b/internal/server/config/generate/incus_doc.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -35,37 +34,6 @@ type IterableAny interface {
 // doc is the structure of the JSON file that contains the generated configuration metadata.
 type doc struct {
 	Configs map[string]any `json:"configs"`
-}
-
-// detectType detects the type of a string and returns the corresponding value.
-func detectType(s string) any {
-	i, err := strconv.Atoi(s)
-	if err == nil {
-		return i
-	}
-
-	b, err := strconv.ParseBool(s)
-	if err == nil {
-		return b
-	}
-
-	f, err := strconv.ParseFloat(s, 64)
-	if err == nil {
-		return f
-	}
-
-	t, err := time.Parse(time.RFC3339, s)
-	if err == nil {
-		return t
-	}
-
-	// special characters handling
-	if s == "-" {
-		return ""
-	}
-
-	// If all conversions fail, it's a string
-	return s
 }
 
 // sortConfigKeys alphabetically sorts the entries by key (config option key) within each config group in an entity.
@@ -210,7 +178,7 @@ func parse(path string, outputJSONPath string, excludedPaths []string) (*doc, er
 						continue
 					}
 
-					configKeyEntry[metadataMap["key"]].(map[string]any)[dataKVMatch[1]] = detectType(dataKVMatch[2])
+					configKeyEntry[metadataMap["key"]].(map[string]any)[dataKVMatch[1]] = dataKVMatch[2]
 				}
 
 				_, ok = groupKeyEntry[metadataMap["group"]]

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -34,7 +34,7 @@
 					},
 					{
 						"boot.autostart.delay": {
-							"defaultdesc": 0,
+							"defaultdesc": "0",
 							"liveupdate": "no",
 							"longdesc": "The number of seconds to wait after the instance started before starting the next one.",
 							"shortdesc": "Delay after starting the instance",
@@ -43,7 +43,7 @@
 					},
 					{
 						"boot.autostart.priority": {
-							"defaultdesc": 0,
+							"defaultdesc": "0",
 							"liveupdate": "no",
 							"longdesc": "The instance with the highest value is started first.",
 							"shortdesc": "What order to start the instances in",
@@ -52,7 +52,7 @@
 					},
 					{
 						"boot.host_shutdown_timeout": {
-							"defaultdesc": 30,
+							"defaultdesc": "30",
 							"liveupdate": "yes",
 							"longdesc": "Number of seconds to wait for the instance to shut down before it is force-stopped.",
 							"shortdesc": "How long to wait for the instance to shut down",
@@ -61,7 +61,7 @@
 					},
 					{
 						"boot.stop.priority": {
-							"defaultdesc": 0,
+							"defaultdesc": "0",
 							"liveupdate": "no",
 							"longdesc": "The instance with the highest value is shut down first.",
 							"shortdesc": "What order to shut down the instances in",


### PR DESCRIPTION
This was causing WebUI crashes as the assumption was that all description fields would always be strings.