### PR TITLE
lxd-to-incus: touch completion file after migration

### DIFF
--- a/cmd/lxd-to-incus/main.go
+++ b/cmd/lxd-to-incus/main.go
@@ -765,6 +765,12 @@ Instead this tool will be providing specific commands for each of the servers.
 		}
 	}
 
+	completeFile, err := os.Create(filepath.Join(targetPaths.Daemon, ".migrated-from-lxd"))
+	defer completeFile.Close()
+	if err != nil {
+		_, _ = logFile.WriteString(fmt.Sprintf("ERROR: %v\n", err))
+	}
+
 	// Confirm uninstall.
 	if !c.flagYes {
 		ok, err := c.global.asker.AskBool("Uninstall the LXD package? [default=no]: ", "no")


### PR DESCRIPTION
Creating this touch file allows us to add a ConditionPathExists to the lxd service to make sure it won't start on a host that was migrated. NixOS users will have to reconfigure their host after migration to remove LXD, so there will likely be a non-zero period where both services are installed and enabled.
