### PR TITLE
incusd: Refresh the state on cluster put/join

### DIFF
--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -370,6 +370,9 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 		d.serverClustered = true
 		d.globalConfigMu.Unlock()
 
+		// Refresh the state.
+		s = d.State()
+
 		// Start clustering tasks
 		d.startClusterTasks()
 
@@ -785,6 +788,9 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		if err != nil {
 			return err
 		}
+
+		// Refresh the state.
+		s = d.State()
 
 		// Start up networks so any post-join changes can be applied now that we have a Node ID.
 		logger.Debug("Starting networks after cluster join")


### PR DESCRIPTION
Without that, the updated global config (or server name) doesn't make it into the state which is passed on through other functions.