### PR TITLE
incus/network: add dynamic command line completions

### DIFF
--- a/cmd/incus/completion.go
+++ b/cmd/incus/completion.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDirective) {
+	results := []string{}
+
+	resources, _ := g.ParseServers(toComplete)
+
+	if len(resources) > 0 {
+		resource := resources[0]
+
+		instances, _ := resource.server.GetInstanceNames("container")
+		vms, _ := resource.server.GetInstanceNames("virtual-machine")
+		instances = append(instances, vms...)
+
+		for _, instance := range instances {
+			var name string
+
+			if resource.remote == g.conf.DefaultRemote {
+				name = instance
+			} else {
+				name = fmt.Sprintf("%s:%s", resource.remote, instance)
+			}
+
+			results = append(results, name)
+		}
+	}
+
+	if !strings.Contains(toComplete, ":") {
+		remotes, _ := g.cmpRemotes()
+		results = append(results, remotes...)
+	}
+
+	return results, cobra.ShellCompDirectiveNoFileComp
+}
+
+func (g *cmdGlobal) cmpNetworks(toComplete string) ([]string, cobra.ShellCompDirective) {
+	results := []string{}
+
+	resources, _ := g.ParseServers(toComplete)
+
+	if len(resources) > 0 {
+		resource := resources[0]
+
+		networks, err := resource.server.GetNetworks()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		for _, network := range networks {
+			var name string
+
+			if resource.remote == g.conf.DefaultRemote {
+				name = network.Name
+			} else {
+				name = fmt.Sprintf("%s:%s", resource.remote, network.Name)
+			}
+
+			results = append(results, name)
+		}
+	}
+
+	if !strings.Contains(toComplete, ":") {
+		remotes, _ := g.cmpRemotes()
+		results = append(results, remotes...)
+	}
+
+	return results, cobra.ShellCompDirectiveNoFileComp
+}
+
+func (g *cmdGlobal) cmpNetworkConfigs(networkName string) ([]string, cobra.ShellCompDirective) {
+	// Parse remote
+	resources, err := g.ParseServers(networkName)
+	if err != nil || len(resources) == 0 {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	resource := resources[0]
+	client := resource.server
+
+	network, _, err := client.GetNetwork(networkName)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var results []string
+	for k := range network.Config {
+		results = append(results, k)
+	}
+
+	return results, cobra.ShellCompDirectiveError
+}
+
+func (g *cmdGlobal) cmpNetworkInstances(networkName string) ([]string, cobra.ShellCompDirective) {
+	// Parse remote
+	resources, err := g.ParseServers(networkName)
+	if err != nil || len(resources) == 0 {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	resource := resources[0]
+	client := resource.server
+
+	network, _, err := client.GetNetwork(networkName)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var results []string
+	for _, i := range network.UsedBy {
+		r := regexp.MustCompile(`/1.0/instances/(.*)`)
+		match := r.FindStringSubmatch(i)
+
+		if len(match) == 2 {
+			results = append(results, match[1])
+		}
+	}
+
+	return results, cobra.ShellCompDirectiveError
+}
+
+func (g *cmdGlobal) cmpNetworkProfiles(networkName string) ([]string, cobra.ShellCompDirective) {
+	// Parse remote
+	resources, err := g.ParseServers(networkName)
+	if err != nil || len(resources) == 0 {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	resource := resources[0]
+	client := resource.server
+
+	network, _, err := client.GetNetwork(networkName)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var results []string
+	for _, i := range network.UsedBy {
+		r := regexp.MustCompile(`/1.0/profiles/(.*)`)
+		match := r.FindStringSubmatch(i)
+
+		if len(match) == 2 {
+			results = append(results, match[1])
+		}
+	}
+
+	return results, cobra.ShellCompDirectiveError
+}
+
+func (g *cmdGlobal) cmpProfiles(toComplete string) ([]string, cobra.ShellCompDirective) {
+	results := []string{}
+
+	resources, _ := g.ParseServers(toComplete)
+
+	if len(resources) > 0 {
+		resource := resources[0]
+
+		profiles, _ := resource.server.GetProfileNames()
+
+		for _, profile := range profiles {
+			var name string
+
+			if resource.remote == g.conf.DefaultRemote {
+				name = profile
+			} else {
+				name = fmt.Sprintf("%s:%s", resource.remote, profile)
+			}
+
+			results = append(results, name)
+		}
+	}
+
+	if !strings.Contains(toComplete, ":") {
+		remotes, _ := g.cmpRemotes()
+		results = append(results, remotes...)
+	}
+
+	return results, cobra.ShellCompDirectiveNoFileComp
+}
+
+func (g *cmdGlobal) cmpRemotes() ([]string, cobra.ShellCompDirective) {
+	results := []string{}
+
+	for remoteName, rc := range g.conf.Remotes {
+		if rc.Protocol != "incus" && rc.Protocol != "" {
+			continue
+		}
+
+		results = append(results, fmt.Sprintf("%s:", remoteName))
+	}
+
+	return results, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/incus/config.go
+++ b/cmd/incus/config.go
@@ -723,6 +723,14 @@ func (c *cmdConfigShow) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.config.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpInstances(toComplete)
+	}
+
 	return cmd
 }
 

--- a/cmd/incus/network.go
+++ b/cmd/incus/network.go
@@ -137,6 +137,18 @@ func (c *cmdNetworkAttach) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpNetworks(toComplete)
+		}
+
+		if len(args) == 1 {
+			return c.global.cmpInstances(args[0])
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 
@@ -222,6 +234,18 @@ func (c *cmdNetworkAttachProfile) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpNetworks(toComplete)
+		}
+
+		if len(args) == 1 {
+			return c.global.cmpProfiles(args[0])
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 
@@ -302,6 +326,14 @@ incus network create bar network=baz --type ovn
 
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpRemotes()
+	}
+
 	return cmd
 }
 
@@ -374,6 +406,14 @@ func (c *cmdNetworkDelete) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpNetworks(toComplete)
+	}
+
 	return cmd
 }
 
@@ -423,6 +463,18 @@ func (c *cmdNetworkDetach) Command() *cobra.Command {
 		`Detach network interfaces from instances`))
 
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpNetworks(toComplete)
+		}
+
+		if len(args) == 1 {
+			return c.global.cmpNetworkInstances(args[0])
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }
@@ -509,6 +561,18 @@ func (c *cmdNetworkDetachProfile) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpNetworks(toComplete)
+		}
+
+		if len(args) == 1 {
+			return c.global.cmpNetworkProfiles(args[0])
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 
@@ -593,6 +657,14 @@ func (c *cmdNetworkEdit) Command() *cobra.Command {
 		`Edit network configurations as YAML`))
 
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpNetworks(toComplete)
+	}
 
 	return cmd
 }
@@ -724,6 +796,18 @@ func (c *cmdNetworkGet) Command() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a network property"))
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpNetworks(toComplete)
+		}
+
+		if len(args) == 1 {
+			return c.global.cmpNetworkConfigs(args[0])
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 
@@ -791,6 +875,14 @@ func (c *cmdNetworkInfo) Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpNetworks(toComplete)
+	}
 
 	return cmd
 }
@@ -915,6 +1007,14 @@ func (c *cmdNetworkList) Command() *cobra.Command {
 	cmd.RunE = c.Run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpRemotes()
+	}
+
 	return cmd
 }
 
@@ -1008,6 +1108,14 @@ func (c *cmdNetworkListLeases) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpNetworks(toComplete)
+	}
+
 	return cmd
 }
 
@@ -1078,6 +1186,14 @@ func (c *cmdNetworkRename) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpNetworks(toComplete)
+	}
+
 	return cmd
 }
 
@@ -1134,6 +1250,14 @@ For backward compatibility, a single configuration key may still be set with:
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a network property"))
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpNetworks(toComplete)
+	}
 
 	return cmd
 }
@@ -1219,6 +1343,14 @@ func (c *cmdNetworkShow) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpNetworks(toComplete)
+	}
+
 	return cmd
 }
 
@@ -1283,6 +1415,18 @@ func (c *cmdNetworkUnset) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a network property"))
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpNetworks(toComplete)
+		}
+
+		if len(args) == 1 {
+			return c.global.cmpNetworkConfigs(args[0])
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }


### PR DESCRIPTION
The shell handles the filtering for you, but we could try and filter by remote name for example in class someone hits tab again.

~I'll probably finish building out network to see if I can just reuse this function or the bulk of it, but this is a start.~ Done.

Example

``` fish
─❯ incus network show <TAB>
bond0    fast1           incus1:fast0  incus1:oob0      oob0
bridge0  incus1:bond0    incus1:fast1  incus1:vlan2010  vlan2010
fast0    incus1:bridge0  incus1:lo     lo

```

One can also explore these directly

```
─❯ go run ./cmd/incus __complete network show ""
incus1:lo
incus1:oob0
incus1:bond0
incus1:bridge0
incus1:vlan2010
incus1:fast0
incus1:fast1
lo
oob0
bond0
bridge0
vlan2010
fast0
fast1
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```