### PR TITLE
incusd/cluster: Ensure the cluster member config is always sorted

### DIFF
--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -209,6 +210,26 @@ func clusterGet(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	// Sort the member config.
+	sort.Slice(memberConfig, func(i, j int) bool {
+		left := memberConfig[i]
+		right := memberConfig[j]
+
+		if left.Entity != right.Entity {
+			return left.Entity < right.Entity
+		}
+
+		if left.Name != right.Name {
+			return left.Name < right.Name
+		}
+
+		if left.Key != right.Key {
+			return left.Key < right.Key
+		}
+
+		return left.Description < right.Description
+	})
 
 	cluster := api.Cluster{
 		ServerName:   serverName,


### PR DESCRIPTION
The database functions return maps which are inherently unsorted, this then would turn the MemberConfig slice under a similarly unsorted slice..

That's a problem because our own CLI and some 3rd party tools will ask the user to answer each of the MemberConfig questions during join.

The user may assume that when joining multiple systems, the questions will be in the same order on all systems, when they're not, they may incorrectly answer some of the questions.