### PR TITLE
incusd/instance/qemu: Start using seabios as CSM firmware

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -132,6 +132,7 @@ var ovmfSecurebootFirmwares = []ovmfFirmware{
 }
 
 var ovmfCSMFirmwares = []ovmfFirmware{
+	{code: "seabios.bin", vars: "seabios.bin"},
 	{code: "OVMF_CODE.4MB.CSM.fd", vars: "OVMF_VARS.4MB.CSM.fd"},
 	{code: "OVMF_CODE.2MB.CSM.fd", vars: "OVMF_VARS.2MB.CSM.fd"},
 	{code: "OVMF_CODE.CSM.fd", vars: "OVMF_VARS.CSM.fd"},


### PR DESCRIPTION
This adds support for directly using seabios as the CSM firmware rather than using EDK2's chain boot feature. It also makes this behavior be the preferred one for new CSM-enabled VMs.

The reason for this change is the removal of CSM support from recent EDK2.