### PR TITLE
Fix rare race condition in event handling

### DIFF
--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1264,6 +1264,8 @@ func (d *Daemon) init() error {
 		return err
 	}
 
+	d.events.SetLocalLocation(d.serverName)
+
 	// Mount the storage pools.
 	logger.Infof("Initializing storage pools")
 	err = storageStartup(d.State(), false)
@@ -1319,6 +1321,8 @@ func (d *Daemon) init() error {
 	if err != nil {
 		return err
 	}
+
+	d.events.SetLocalLocation(d.serverName)
 
 	// Get daemon configuration.
 	bgpAddress := d.localConfig.BGPAddress()

--- a/cmd/incusd/events.go
+++ b/cmd/incusd/events.go
@@ -100,22 +100,11 @@ func eventsSocket(s *state.State, r *http.Request, w http.ResponseWriter) error 
 
 	l := logger.AddContext(logger.Ctx{"remote": r.RemoteAddr})
 
-	// Upgrade the connection to websocket
-	conn, err := ws.Upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		l.Warn("Failed upgrading event connection", logger.Ctx{"err": err})
-		return nil
-	}
-
-	defer func() { _ = conn.Close() }() // Ensure listener below ends when this function ends.
-
-	s.Events.SetLocalLocation(s.ServerName)
-
 	var excludeLocations []string
 	// Get the current local serverName and store it for the events.
 	// We do that now to avoid issues with changes to the name and to limit
 	// the number of DB access to just one per connection.
-	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		if isClusterNotification(r) {
 			ctx := r.Context()
 
@@ -154,8 +143,17 @@ func eventsSocket(s *state.State, r *http.Request, w http.ResponseWriter) error 
 		}
 	}
 
-	listenerConnection := events.NewWebsocketListenerConnection(conn)
+	// Upgrade the connection to websocket as late as possible.
+	// This is because the client will assume it's getting events as soon as the upgrade is performed.
+	conn, err := ws.Upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		l.Warn("Failed upgrading event connection", logger.Ctx{"err": err})
+		return nil
+	}
 
+	defer func() { _ = conn.Close() }() // Ensure listener below ends when this function ends.
+
+	listenerConnection := events.NewWebsocketListenerConnection(conn)
 	listener, err := s.Events.AddListener(projectName, allProjects, projectPermissionFunc, listenerConnection, types, excludeSources, recvFunc, excludeLocations)
 	if err != nil {
 		l.Warn("Failed to add event listener", logger.Ctx{"err": err})


### PR DESCRIPTION
So to describe what's going on here. We've recently seen a number of failures, primarily hitting the clustering image refresh tests.

Digging into those failures, it looked like the image propagation was just left hanging indefinitely, eventually hitting a 120s timeout in the test and failing due to images apparently having refreshed correctly across project but the old image was left around.

The high level of image refreshes is:

 - Incus is told to refresh the images (by the test or through a timer during normal operation)
 - It fetches the new image and figures out what projects need updating
 - It detects that the image is present on multiple servers in the cluster
 - It sends out copies of the image to those other servers
 - Once all servers got the new image, the old image is deleted

Based on above, we're stuck in between those last two steps, causing the failure.

Now what's happening when Incus sends out copies of the image is:
 - It gets a new Incus API client for the target server
 - It calls CreateImage with the local image files
 - It gets an operation UUID back from the target server
 - It then sets up a websocket listener for incoming events
 - Immediately after getting the listener in place, it refreshes the operation status in case it finished between the initial API call and the listener being in place
 - If the operation is still ongoing, it waits for an event on the websocket

In our case, we're stuck on the last one, we never get the event.

The reason for this is that the client assumes that it's ready to receive events as soon as the connection has been upgraded to a websocket by the server. That's at that point that it refreshes the operation to (supposedly) avoid any race conditions.

The problem is that the server was actually upgrading the connection to websocket quite early on, before a bunch of DB operations and other checks. If the operation completed at any point between the websocket upgrade and the listener actually being added to our event handler, the client would never get an event and would wait forever.

The fix is pretty simple, upgrade to websocket right before adding the connection to the event handler. Especially making sure that there's no DB calls or similar slow/locked operations between the two.

While I was at it, I also noticed that for some very odd reason, every event connection was updating a global field on the event handler, a field storing the name of the server (mirroring the ServerName field on the state struct). I removed that logic (which was acquiring a lock every time...) and moved it to the various places where the server name is actually modified. That should speed things up a tiny bit too.