### PR TITLE
Add support for all-projects to incus image list and API

### DIFF
--- a/client/incus_images.go
+++ b/client/incus_images.go
@@ -34,6 +34,26 @@ func (r *ProtocolIncus) GetImages() ([]api.Image, error) {
 	return images, nil
 }
 
+// GetImagesAllProjects returns a list of images across all projects as Image structs.
+func (r *ProtocolIncus) GetImagesAllProjects() ([]api.Image, error) {
+	images := []api.Image{}
+
+	v := url.Values{}
+	v.Set("recursion", "1")
+	v.Set("all-projects", "true")
+
+	if !r.HasExtension("images_all_projects") {
+		return nil, fmt.Errorf("The server is missing the required \"images_all_projects\" API extension")
+	}
+
+	_, err := r.queryStruct("GET", fmt.Sprintf("/images?%s", v.Encode()), nil, "", &images)
+	if err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
 func (r *ProtocolIncus) GetImagesWithFilter(filters []string) ([]api.Image, error) {
 	if !r.HasExtension("api_filtering") {

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -48,6 +48,7 @@ type ImageServer interface {
 
 	// Image handling functions
 	GetImages() (images []api.Image, err error)
+	GetImagesAllProjects() (images []api.Image, err error)
 	GetImageFingerprints() (fingerprints []string, err error)
 	GetImagesWithFilter(filters []string) (images []api.Image, err error)
 

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -24,6 +24,11 @@ func (r *ProtocolSimpleStreams) GetImages() ([]api.Image, error) {
 	return r.ssClient.ListImages()
 }
 
+// GetImagesAllProjects returns a list of available images as Image structs.
+func (r *ProtocolSimpleStreams) GetImagesAllProjects() ([]api.Image, error) {
+	return r.GetImages()
+}
+
 // GetImageFingerprints returns a list of available image fingerprints.
 func (r *ProtocolSimpleStreams) GetImageFingerprints() ([]string, error) {
 	// Get all the images from simplestreams

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1901,6 +1901,10 @@ client authentication.
 
 Adds ability to copy image to a project different from the source.
 
+## `images_all_projects`
+
+This adds support for listing images across all projects through the `all-projects` parameter on the `GET /1.0/images`API.
+
 ## `cluster_migration_inconsistent_copy`
 
 Adds `allow_inconsistent` field to `POST /1.0/instances/<name>`. Set to `true` to allow inconsistent copying between cluster

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -689,6 +689,11 @@ definitions:
                     type: string
                 type: array
                 x-go-name: Profiles
+            project:
+                description: Project name
+                example: project1
+                type: string
+                x-go-name: Project
             properties:
                 additionalProperties:
                     type: string
@@ -7304,6 +7309,10 @@ paths:
                   in: query
                   name: filter
                   type: string
+                - description: Retrieve images from all projects
+                  in: query
+                  name: all-projects
+                  type: boolean
             produces:
                 - application/json
             responses:
@@ -8055,6 +8064,10 @@ paths:
                   in: query
                   name: filter
                   type: string
+                - description: Retrieve images from all projects
+                  in: query
+                  name: all-projects
+                  type: boolean
             produces:
                 - application/json
             responses:
@@ -8143,6 +8156,10 @@ paths:
                   in: query
                   name: filter
                   type: string
+                - description: Retrieve images from all projects
+                  in: query
+                  name: all-projects
+                  type: boolean
             produces:
                 - application/json
             responses:
@@ -8191,6 +8208,11 @@ paths:
                   in: query
                   name: filter
                   type: string
+                - description: Retrieve images from all projects
+                  example: default
+                  in: query
+                  name: all-projects
+                  type: boolean
             produces:
                 - application/json
             responses:

--- a/internal/server/db/images.go
+++ b/internal/server/db/images.go
@@ -400,6 +400,7 @@ func (c *ClusterTx) GetImageByFingerprintPrefix(ctx context.Context, fingerprint
 	image.Cached = object.Cached
 	image.Public = object.Public
 	image.AutoUpdate = object.AutoUpdate
+	image.Project = object.Project
 
 	err = c.imageFill(
 		ctx, object.ID, &image,

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -317,6 +317,7 @@ var APIExtensions = []string{
 	"projects_restricted_intercept",
 	"metrics_authentication",
 	"images_target_project",
+	"images_all_projects",
 	"cluster_migration_inconsistent_copy",
 	"cluster_ovn_chassis",
 	"container_syscall_intercept_sched_setscheduler",

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-30 15:38-0500\n"
+"POT-Creation-Date: 2024-02-10 17:56-0500\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -164,7 +164,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/image.go:381
+#: cmd/incus/image.go:405
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -584,7 +584,7 @@ msgstr "%s ist kein Verzeichnis"
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1091
+#: cmd/incus/image.go:1163
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
@@ -643,7 +643,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/create.go:126 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image.go:651
+#: cmd/incus/image.go:683
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -757,15 +757,15 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1055 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1126 cmd/incus/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1056
+#: cmd/incus/image.go:1127
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/cluster.go:186 cmd/incus/image.go:1061 cmd/incus/list.go:554
+#: cmd/incus/cluster.go:186 cmd/incus/image.go:1121 cmd/incus/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -951,7 +951,7 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "Alias name missing"
 msgstr "Aliasname fehlt"
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1044
 #, fuzzy, c-format
 msgid "Alias: %s"
 msgstr "Aliasse:\n"
@@ -961,7 +961,7 @@ msgstr "Aliasse:\n"
 msgid "Aliases already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/image.go:976
+#: cmd/incus/image.go:1028
 #, fuzzy
 msgid "Aliases:"
 msgstr "Aliasse:\n"
@@ -984,7 +984,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/image.go:947 cmd/incus/info.go:476
+#: cmd/incus/image.go:999 cmd/incus/info.go:476
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:357 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1067,11 +1067,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:177
+#: cmd/incus/image.go:189
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:986
+#: cmd/incus/image.go:1038
 #, c-format
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:138 cmd/incus/create.go:221 cmd/incus/move.go:358
+#: cmd/incus/copy.go:138 cmd/incus/create.go:229 cmd/incus/move.go:358
 #: cmd/incus/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1133,7 +1133,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:758
+#: cmd/incus/image.go:802
 #, fuzzy, c-format
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
@@ -1215,7 +1215,7 @@ msgstr "ERSTELLT AM"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: cmd/incus/image.go:985
+#: cmd/incus/image.go:1037
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1243,7 +1243,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:210
+#: cmd/incus/image.go:222
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1306,7 +1306,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:326
+#: cmd/incus/create.go:334
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1046 cmd/incus/list.go:132
+#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1100 cmd/incus/list.go:132
 #: cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239
 #: cmd/incus/warning.go:93
 msgid "Columns"
@@ -1533,7 +1533,7 @@ msgstr ""
 #: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339
 #: cmd/incus/config.go:268 cmd/incus/config.go:343
 #: cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352
-#: cmd/incus/image.go:459 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
+#: cmd/incus/image.go:483 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
 #: cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637
 #: cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550
 #: cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518
@@ -1648,7 +1648,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:266
+#: cmd/incus/image.go:278
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1850,13 +1850,13 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:954 cmd/incus/info.go:487
+#: cmd/incus/image.go:1006 cmd/incus/info.go:487
 #: cmd/incus/storage_volume.go:1273
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:174
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
@@ -1866,7 +1866,7 @@ msgstr "Erstelle %s"
 msgid "Creating %s: %%s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/create.go:164
+#: cmd/incus/create.go:172
 #, fuzzy
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1881,7 +1881,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438
-#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1060
+#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1122
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088
 #: cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139
@@ -1943,7 +1943,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:314 cmd/incus/image.go:315
+#: cmd/incus/image.go:326 cmd/incus/image.go:327
 msgid "Delete images"
 msgstr ""
 
@@ -2071,10 +2071,10 @@ msgstr ""
 #: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131
 #: cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428
 #: cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
-#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
-#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
-#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382
+#: cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930
+#: cmd/incus/image.go:1074 cmd/incus/image.go:1424 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704
 #: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
@@ -2256,13 +2256,13 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/create.go:417
+#: cmd/incus/create.go:425
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "Falsche Anzahl an Objekten im Abbild, Container oder Sicherungspunkt gelesen."
 
-#: cmd/incus/image.go:668
+#: cmd/incus/image.go:712
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2301,6 +2301,11 @@ msgstr " Prozessorauslastung:"
 #, fuzzy
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
+
+#: cmd/incus/image.go:1102
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "Herunterfahren des Containers erzwingen."
 
 #: cmd/incus/list.go:135
 #, fuzzy
@@ -2386,7 +2391,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/image.go:365 cmd/incus/image.go:366
+#: cmd/incus/image.go:381 cmd/incus/image.go:382
 msgid "Edit image properties"
 msgstr ""
 
@@ -2470,7 +2475,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1072 cmd/incus/list.go:614
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1144 cmd/incus/list.go:614
 #: cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2653,20 +2658,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:960
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:962
+#: cmd/incus/image.go:1014
 msgid "Expires: never"
 msgstr ""
 
-#: cmd/incus/image.go:492
+#: cmd/incus/image.go:516
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:493
+#: cmd/incus/image.go:517
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2698,7 +2703,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/image.go:560
+#: cmd/incus/image.go:592
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2711,8 +2716,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1057
-#: cmd/incus/image.go:1058 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1124
+#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
 
@@ -2800,17 +2805,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/create.go:180
+#: cmd/incus/create.go:188
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/create.go:305
+#: cmd/incus/create.go:313
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:231
+#: cmd/incus/create.go:239
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3059,7 +3064,7 @@ msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
-#: cmd/incus/image.go:945
+#: cmd/incus/image.go:997
 #, fuzzy, c-format
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
@@ -3124,7 +3129,7 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867
 #: cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241
 #: cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587
-#: cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
+#: cmd/incus/image.go:1101 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
 #: cmd/incus/network.go:1011 cmd/incus/network.go:1110
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93
@@ -3196,7 +3201,7 @@ msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/image.go:1478 cmd/incus/image.go:1479
+#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
 msgid "Get image properties"
 msgstr ""
 
@@ -3465,11 +3470,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/image.go:1401
+#: cmd/incus/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:283
+#: cmd/incus/image.go:295
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3477,25 +3482,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:636
+#: cmd/incus/image.go:668
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:338 cmd/incus/image.go:1363
+#: cmd/incus/image.go:354 cmd/incus/image.go:1451
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:406 cmd/incus/image.go:1555
+#: cmd/incus/image.go:430 cmd/incus/image.go:1672
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: cmd/incus/image.go:856
+#: cmd/incus/image.go:900
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: cmd/incus/image.go:1399
+#: cmd/incus/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3517,14 +3522,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:653
+#: cmd/incus/image.go:685
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:652
+#: cmd/incus/image.go:684
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3589,7 +3594,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:428
+#: cmd/incus/create.go:436
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3800,21 +3805,21 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/image.go:966
+#: cmd/incus/image.go:1018
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:968
+#: cmd/incus/image.go:1020
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:160
+#: cmd/incus/create.go:168
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/create.go:158
+#: cmd/incus/create.go:166
 #, fuzzy
 msgid "Launching the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3919,11 +3924,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: cmd/incus/image.go:1020
+#: cmd/incus/image.go:1073
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1074
 msgid ""
 "List images\n"
 "\n"
@@ -3944,6 +3949,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4314,7 +4320,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:658
+#: cmd/incus/image.go:154 cmd/incus/image.go:690
 msgid "Make image public"
 msgstr "Veröffentliche Abbild"
 
@@ -4887,7 +4893,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:670
+#: cmd/incus/image.go:714
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -5144,7 +5150,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:659
+#: cmd/incus/image.go:157 cmd/incus/image.go:691
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -5250,7 +5256,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:747
+#: cmd/incus/image.go:791
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -5314,8 +5320,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512
-#: cmd/incus/warning.go:213
+#: cmd/incus/image.go:1123 cmd/incus/list.go:559
+#: cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5327,7 +5333,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
+#: cmd/incus/image.go:1128 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5422,7 +5428,7 @@ msgstr ""
 #: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340
 #: cmd/incus/config.go:269 cmd/incus/config.go:344
 #: cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205
-#: cmd/incus/config_trust.go:353 cmd/incus/image.go:460
+#: cmd/incus/config_trust.go:353 cmd/incus/image.go:484
 #: cmd/incus/network.go:759 cmd/incus/network_acl.go:620
 #: cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638
 #: cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551
@@ -5514,12 +5520,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/image.go:998
+#: cmd/incus/image.go:1050
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1048
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
@@ -5543,16 +5549,16 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:971
+#: cmd/incus/image.go:1023
 #, fuzzy
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: cmd/incus/image.go:1514
+#: cmd/incus/image.go:1623
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1043
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -5665,7 +5671,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:949
+#: cmd/incus/image.go:1001
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
@@ -5704,7 +5710,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:498 cmd/incus/image.go:889 cmd/incus/image.go:1423
+#: cmd/incus/image.go:522 cmd/incus/image.go:933 cmd/incus/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5766,7 +5772,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:1339 cmd/incus/image.go:1340
+#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
 msgid "Refresh images"
 msgstr ""
 
@@ -5775,7 +5781,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/image.go:1368
+#: cmd/incus/image.go:1456
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -6049,7 +6055,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Retrieve the instance's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/create.go:371
+#: cmd/incus/create.go:379
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6098,7 +6104,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1062
+#: cmd/incus/image.go:1129
 msgid "SIZE"
 msgstr ""
 
@@ -6203,7 +6209,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:990
+#: cmd/incus/image.go:1042
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr ""
@@ -6244,7 +6250,7 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1530 cmd/incus/image.go:1531
+#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
 msgid "Set image properties"
 msgstr ""
 
@@ -6562,7 +6568,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
 
-#: cmd/incus/image.go:1419 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6707,7 +6713,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show useful information about a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/image.go:885 cmd/incus/image.go:886
+#: cmd/incus/image.go:929 cmd/incus/image.go:930
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6723,7 +6729,7 @@ msgstr ""
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:946
+#: cmd/incus/image.go:998
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Größe: %.2vMB\n"
@@ -6762,7 +6768,7 @@ msgid ""
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:989
+#: cmd/incus/image.go:1041
 msgid "Source:"
 msgstr ""
 
@@ -6771,7 +6777,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/launch.go:83
+#: cmd/incus/launch.go:99
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6955,7 +6961,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1064
+#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084
 #: cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26
 #: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492
@@ -7088,7 +7094,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:449
+#: cmd/incus/create.go:457
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7293,16 +7299,16 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
-#: cmd/incus/image.go:950
+#: cmd/incus/image.go:1002
 #, fuzzy
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: cmd/incus/create.go:451
+#: cmd/incus/create.go:459
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:450
+#: cmd/incus/create.go:458
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7362,7 +7368,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:769
+#: cmd/incus/image.go:813
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -7381,7 +7387,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: cmd/incus/action.go:316 cmd/incus/launch.go:115
+#: cmd/incus/action.go:316 cmd/incus/launch.go:131
 #, c-format
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
@@ -7401,7 +7407,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/image.go:948 cmd/incus/info.go:273 cmd/incus/info.go:473
+#: cmd/incus/image.go:1000 cmd/incus/info.go:273 cmd/incus/info.go:473
 #: cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
 #, c-format
 msgid "Type: %s"
@@ -7416,7 +7422,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1063
+#: cmd/incus/image.go:1131
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -7469,7 +7475,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1080 cmd/incus/list.go:629
+#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1152 cmd/incus/list.go:629
 #: cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7510,7 +7516,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/image.go:1586 cmd/incus/image.go:1587
+#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
 msgid "Unset image properties"
 msgstr ""
 
@@ -7680,7 +7686,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/image.go:957
+#: cmd/incus/image.go:1009
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -8011,7 +8017,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image.go:1018 cmd/incus/list.go:46
+#: cmd/incus/image.go:1071 cmd/incus/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -8181,7 +8187,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image.go:364 cmd/incus/image.go:884 cmd/incus/image.go:1418
+#: cmd/incus/image.go:380 cmd/incus/image.go:928 cmd/incus/image.go:1506
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -8190,7 +8196,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image.go:1477 cmd/incus/image.go:1585
+#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -8199,7 +8205,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image.go:1529
+#: cmd/incus/image.go:1638
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -8231,7 +8237,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image.go:491
+#: cmd/incus/image.go:515
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -8239,7 +8245,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image.go:312 cmd/incus/image.go:1338
+#: cmd/incus/image.go:324 cmd/incus/image.go:1422
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -9178,7 +9184,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:935
+#: cmd/incus/image.go:987
 msgid "disabled"
 msgstr ""
 
@@ -9186,7 +9192,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:937
+#: cmd/incus/image.go:989
 msgid "enabled"
 msgstr ""
 
@@ -9295,7 +9301,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:368
+#: cmd/incus/image.go:384
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9500,8 +9506,8 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:497 cmd/incus/image.go:925 cmd/incus/image.go:930
-#: cmd/incus/image.go:1120
+#: cmd/incus/config_trust.go:497 cmd/incus/image.go:977 cmd/incus/image.go:982
+#: cmd/incus/image.go:1192
 msgid "no"
 msgstr ""
 
@@ -9547,8 +9553,8 @@ msgid "y"
 msgstr ""
 
 #: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494
-#: cmd/incus/delete.go:47 cmd/incus/image.go:927 cmd/incus/image.go:932
-#: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
+#: cmd/incus/delete.go:47 cmd/incus/image.go:979 cmd/incus/image.go:984
+#: cmd/incus/image.go:1189 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-30 15:38-0500\n"
+"POT-Creation-Date: 2024-02-10 17:56-0500\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -167,7 +167,7 @@ msgstr ""
 "###\n"
 "### Note que el nombre se muestra pero no puede ser cambiado"
 
-#: cmd/incus/image.go:381
+#: cmd/incus/image.go:405
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -573,7 +573,7 @@ msgstr "%s no es un directorio"
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1091
+#: cmd/incus/image.go:1163
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
@@ -631,7 +631,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/create.go:126 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:651
+#: cmd/incus/image.go:683
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -733,15 +733,15 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1055 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1126 cmd/incus/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1056
+#: cmd/incus/image.go:1127
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/cluster.go:186 cmd/incus/image.go:1061 cmd/incus/list.go:554
+#: cmd/incus/cluster.go:186 cmd/incus/image.go:1121 cmd/incus/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -921,7 +921,7 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1044
 #, fuzzy, c-format
 msgid "Alias: %s"
 msgstr "Aliases:"
@@ -931,7 +931,7 @@ msgstr "Aliases:"
 msgid "Aliases already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: cmd/incus/image.go:976
+#: cmd/incus/image.go:1028
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: cmd/incus/image.go:947 cmd/incus/info.go:476
+#: cmd/incus/image.go:999 cmd/incus/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -975,7 +975,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:357 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1030,11 +1030,11 @@ msgstr "Tipo de autenticación %s no está soportada por el servidor"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:177
+#: cmd/incus/image.go:189
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:986
+#: cmd/incus/image.go:1038
 #, c-format
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:138 cmd/incus/create.go:221 cmd/incus/move.go:358
+#: cmd/incus/copy.go:138 cmd/incus/create.go:229 cmd/incus/move.go:358
 #: cmd/incus/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1094,7 +1094,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:758
+#: cmd/incus/image.go:802
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
@@ -1176,7 +1176,7 @@ msgstr "CREADO EN"
 msgid "CUDA Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/image.go:985
+#: cmd/incus/image.go:1037
 #, c-format
 msgid "Cached: %s"
 msgstr "Cacheado: %s"
@@ -1198,7 +1198,7 @@ msgstr ""
 "No se puede anular la configuración o los perfiles en el cambio de nombre "
 "local"
 
-#: cmd/incus/image.go:210
+#: cmd/incus/image.go:222
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
@@ -1262,7 +1262,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:326
+#: cmd/incus/create.go:334
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1434,7 +1434,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1046 cmd/incus/list.go:132
+#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1100 cmd/incus/list.go:132
 #: cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239
 #: cmd/incus/warning.go:93
 msgid "Columns"
@@ -1485,7 +1485,7 @@ msgstr ""
 #: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339
 #: cmd/incus/config.go:268 cmd/incus/config.go:343
 #: cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352
-#: cmd/incus/image.go:459 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
+#: cmd/incus/image.go:483 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
 #: cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637
 #: cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550
 #: cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518
@@ -1597,7 +1597,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/image.go:266
+#: cmd/incus/image.go:278
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
@@ -1787,13 +1787,13 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:954 cmd/incus/info.go:487
+#: cmd/incus/image.go:1006 cmd/incus/info.go:487
 #: cmd/incus/storage_volume.go:1273
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:174
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
@@ -1803,7 +1803,7 @@ msgstr "Creando %s"
 msgid "Creating %s: %%s"
 msgstr "Creando %s"
 
-#: cmd/incus/create.go:164
+#: cmd/incus/create.go:172
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
@@ -1818,7 +1818,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438
-#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1060
+#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1122
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088
 #: cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr "Eliminar alias de imagen"
 
-#: cmd/incus/image.go:314 cmd/incus/image.go:315
+#: cmd/incus/image.go:326 cmd/incus/image.go:327
 msgid "Delete images"
 msgstr "Eliminar imágenes"
 
@@ -2003,10 +2003,10 @@ msgstr ""
 #: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131
 #: cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428
 #: cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
-#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
-#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
-#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382
+#: cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930
+#: cmd/incus/image.go:1074 cmd/incus/image.go:1424 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704
 #: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
@@ -2182,11 +2182,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/create.go:417
+#: cmd/incus/create.go:425
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: cmd/incus/image.go:668
+#: cmd/incus/image.go:712
 msgid "Directory import is not available on this platform"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
@@ -2222,6 +2222,11 @@ msgstr "Disco:"
 #: cmd/incus/info.go:423
 msgid "Disks:"
 msgstr "Discos:"
+
+#: cmd/incus/image.go:1102
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/list.go:135
 #, fuzzy
@@ -2305,7 +2310,7 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:365 cmd/incus/image.go:366
+#: cmd/incus/image.go:381 cmd/incus/image.go:382
 msgid "Edit image properties"
 msgstr ""
 
@@ -2383,7 +2388,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1072 cmd/incus/list.go:614
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1144 cmd/incus/list.go:614
 #: cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2558,20 +2563,20 @@ msgstr ""
 msgid "Expires at"
 msgstr "Expira: %s"
 
-#: cmd/incus/image.go:960
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Expires: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/image.go:962
+#: cmd/incus/image.go:1014
 msgid "Expires: never"
 msgstr "Expira: nunca"
 
-#: cmd/incus/image.go:492
+#: cmd/incus/image.go:516
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:493
+#: cmd/incus/image.go:517
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2601,7 +2606,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:560
+#: cmd/incus/image.go:592
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
@@ -2614,8 +2619,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1057
-#: cmd/incus/image.go:1058 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1124
+#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
@@ -2703,17 +2708,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/create.go:180
+#: cmd/incus/create.go:188
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/create.go:305
+#: cmd/incus/create.go:313
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:231
+#: cmd/incus/create.go:239
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Acepta certificado"
@@ -2959,7 +2964,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
-#: cmd/incus/image.go:945
+#: cmd/incus/image.go:997
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
@@ -3024,7 +3029,7 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867
 #: cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241
 #: cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587
-#: cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
+#: cmd/incus/image.go:1101 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
 #: cmd/incus/network.go:1011 cmd/incus/network.go:1110
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93
@@ -3095,7 +3100,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/image.go:1478 cmd/incus/image.go:1479
+#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
 msgid "Get image properties"
 msgstr ""
 
@@ -3357,11 +3362,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image.go:1401
+#: cmd/incus/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:283
+#: cmd/incus/image.go:295
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3369,25 +3374,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:636
+#: cmd/incus/image.go:668
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:338 cmd/incus/image.go:1363
+#: cmd/incus/image.go:354 cmd/incus/image.go:1451
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:406 cmd/incus/image.go:1555
+#: cmd/incus/image.go:430 cmd/incus/image.go:1672
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:856
+#: cmd/incus/image.go:900
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1399
+#: cmd/incus/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3407,14 +3412,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/image.go:653
+#: cmd/incus/image.go:685
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:652
+#: cmd/incus/image.go:684
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3481,7 +3486,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: cmd/incus/create.go:428
+#: cmd/incus/create.go:436
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3685,21 +3690,21 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Creado: %s"
 
-#: cmd/incus/image.go:966
+#: cmd/incus/image.go:1018
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:968
+#: cmd/incus/image.go:1020
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:160
+#: cmd/incus/create.go:168
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creando %s"
 
-#: cmd/incus/create.go:158
+#: cmd/incus/create.go:166
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creando el contenedor"
@@ -3804,11 +3809,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: cmd/incus/image.go:1020
+#: cmd/incus/image.go:1073
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1074
 msgid ""
 "List images\n"
 "\n"
@@ -3829,6 +3834,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4175,7 +4181,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:658
+#: cmd/incus/image.go:154 cmd/incus/image.go:690
 msgid "Make image public"
 msgstr ""
 
@@ -4721,7 +4727,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:670
+#: cmd/incus/image.go:714
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4972,7 +4978,7 @@ msgstr "Perfil %s eliminado"
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:659
+#: cmd/incus/image.go:157 cmd/incus/image.go:691
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -5075,7 +5081,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:747
+#: cmd/incus/image.go:791
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -5139,8 +5145,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512
-#: cmd/incus/warning.go:213
+#: cmd/incus/image.go:1123 cmd/incus/list.go:559
+#: cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5152,7 +5158,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
+#: cmd/incus/image.go:1128 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5245,7 +5251,7 @@ msgstr ""
 #: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340
 #: cmd/incus/config.go:269 cmd/incus/config.go:344
 #: cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205
-#: cmd/incus/config_trust.go:353 cmd/incus/image.go:460
+#: cmd/incus/config_trust.go:353 cmd/incus/image.go:484
 #: cmd/incus/network.go:759 cmd/incus/network_acl.go:620
 #: cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638
 #: cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551
@@ -5337,11 +5343,11 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:998
+#: cmd/incus/image.go:1050
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1048
 #, fuzzy
 msgid "Profiles: "
 msgstr "Perfil %s creado"
@@ -5365,15 +5371,15 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:971
+#: cmd/incus/image.go:1023
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1514
+#: cmd/incus/image.go:1623
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1043
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Auto actualización: %s"
@@ -5486,7 +5492,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:949
+#: cmd/incus/image.go:1001
 #, c-format
 msgid "Public: %s"
 msgstr "Público: %s"
@@ -5522,7 +5528,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:498 cmd/incus/image.go:889 cmd/incus/image.go:1423
+#: cmd/incus/image.go:522 cmd/incus/image.go:933 cmd/incus/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5583,7 +5589,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1339 cmd/incus/image.go:1340
+#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
 msgid "Refresh images"
 msgstr ""
 
@@ -5592,7 +5598,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:1368
+#: cmd/incus/image.go:1456
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5855,7 +5861,7 @@ msgstr "Aliases:"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:371
+#: cmd/incus/create.go:379
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5904,7 +5910,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1062
+#: cmd/incus/image.go:1129
 msgid "SIZE"
 msgstr ""
 
@@ -6007,7 +6013,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:990
+#: cmd/incus/image.go:1042
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "Dispositivo: %s"
@@ -6043,7 +6049,7 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1530 cmd/incus/image.go:1531
+#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
 msgid "Set image properties"
 msgstr ""
 
@@ -6349,7 +6355,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1419 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6485,7 +6491,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/image.go:885 cmd/incus/image.go:886
+#: cmd/incus/image.go:929 cmd/incus/image.go:930
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6501,7 +6507,7 @@ msgstr ""
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:946
+#: cmd/incus/image.go:998
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Auto actualización: %s"
@@ -6539,7 +6545,7 @@ msgid ""
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:989
+#: cmd/incus/image.go:1041
 msgid "Source:"
 msgstr ""
 
@@ -6547,7 +6553,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/launch.go:83
+#: cmd/incus/launch.go:99
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6725,7 +6731,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1064
+#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084
 #: cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26
 #: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492
@@ -6855,7 +6861,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:449
+#: cmd/incus/create.go:457
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7056,15 +7062,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:950
+#: cmd/incus/image.go:1002
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:451
+#: cmd/incus/create.go:459
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:450
+#: cmd/incus/create.go:458
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7124,7 +7130,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:769
+#: cmd/incus/image.go:813
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -7143,7 +7149,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Contraseña admin para %s: "
 
-#: cmd/incus/action.go:316 cmd/incus/launch.go:115
+#: cmd/incus/action.go:316 cmd/incus/launch.go:131
 #, c-format
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
@@ -7164,7 +7170,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/image.go:948 cmd/incus/info.go:273 cmd/incus/info.go:473
+#: cmd/incus/image.go:1000 cmd/incus/info.go:273 cmd/incus/info.go:473
 #: cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -7179,7 +7185,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1063
+#: cmd/incus/image.go:1131
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -7231,7 +7237,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1080 cmd/incus/list.go:629
+#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1152 cmd/incus/list.go:629
 #: cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7270,7 +7276,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1586 cmd/incus/image.go:1587
+#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
 msgid "Unset image properties"
 msgstr ""
 
@@ -7434,7 +7440,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/image.go:957
+#: cmd/incus/image.go:1009
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7728,7 +7734,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:1018 cmd/incus/list.go:46
+#: cmd/incus/image.go:1071 cmd/incus/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7832,17 +7838,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:364 cmd/incus/image.go:884 cmd/incus/image.go:1418
+#: cmd/incus/image.go:380 cmd/incus/image.go:928 cmd/incus/image.go:1506
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:1477 cmd/incus/image.go:1585
+#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:1529
+#: cmd/incus/image.go:1638
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7862,12 +7868,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:491
+#: cmd/incus/image.go:515
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image.go:312 cmd/incus/image.go:1338
+#: cmd/incus/image.go:324 cmd/incus/image.go:1422
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8451,7 +8457,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:935
+#: cmd/incus/image.go:987
 msgid "disabled"
 msgstr ""
 
@@ -8459,7 +8465,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:937
+#: cmd/incus/image.go:989
 msgid "enabled"
 msgstr ""
 
@@ -8568,7 +8574,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:368
+#: cmd/incus/image.go:384
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8769,8 +8775,8 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:497 cmd/incus/image.go:925 cmd/incus/image.go:930
-#: cmd/incus/image.go:1120
+#: cmd/incus/config_trust.go:497 cmd/incus/image.go:977 cmd/incus/image.go:982
+#: cmd/incus/image.go:1192
 msgid "no"
 msgstr ""
 
@@ -8816,8 +8822,8 @@ msgid "y"
 msgstr ""
 
 #: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494
-#: cmd/incus/delete.go:47 cmd/incus/image.go:927 cmd/incus/image.go:932
-#: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
+#: cmd/incus/delete.go:47 cmd/incus/image.go:979 cmd/incus/image.go:984
+#: cmd/incus/image.go:1189 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-30 15:38-0500\n"
+"POT-Creation-Date: 2024-02-10 17:56-0500\n"
 "PO-Revision-Date: 2024-02-08 13:27+0000\n"
 "Last-Translator: Corabel Bertolini <Corabel.Bertolini@freemailonline.us>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -159,7 +159,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: cmd/incus/image.go:381
+#: cmd/incus/image.go:405
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -583,7 +583,7 @@ msgstr "%q n'est pas une adresse IP"
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr "%s %q pool %q du projet %q (incluant %d copie instantanée)"
 
-#: cmd/incus/image.go:1091
+#: cmd/incus/image.go:1163
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
@@ -641,7 +641,7 @@ msgstr "--console ne peut être utilisé avec --all"
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
-#: cmd/incus/create.go:126 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
@@ -710,7 +710,7 @@ msgstr "<serveur_distant>: <chemin>"
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<chemin_source>... [<serveur_distant>:]<instance>/<chemin>"
 
-#: cmd/incus/image.go:651
+#: cmd/incus/image.go:683
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -738,15 +738,15 @@ msgstr "Vous devez fournir le nom d'un membre appartenant à un cluster"
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1055 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1126 cmd/incus/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1056
+#: cmd/incus/image.go:1127
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: cmd/incus/cluster.go:186 cmd/incus/image.go:1061 cmd/incus/list.go:554
+#: cmd/incus/cluster.go:186 cmd/incus/image.go:1121 cmd/incus/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -842,9 +842,8 @@ msgstr ""
 "\n"
 "L'identification HTTP Basic (RFC 26176) peut être utilisée si ellle est "
 "combinée avec le protocole « simplestreams » :\n"
-"...incus remote add ressource_distante_identifiant "
-"https://UTILISATEUR:MOTDEPASSE@exemple.com/complement/de/chemin --protocol="
-"simplestreams\n"
+"...incus remote add ressource_distante_identifiant https://UTILISATEUR:"
+"MOTDEPASSE@exemple.com/complement/de/chemin --protocol=simplestreams\n"
 
 #: cmd/incus/config_trust.go:89
 msgid "Add new trusted client"
@@ -947,7 +946,7 @@ msgstr "L'alias %s n'existe pas"
 msgid "Alias name missing"
 msgstr "Nom d'alias manquant"
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1044
 #, c-format
 msgid "Alias: %s"
 msgstr "Alias : %s"
@@ -957,7 +956,7 @@ msgstr "Alias : %s"
 msgid "Aliases already exists: %s"
 msgstr "L'alias %s existe déjà"
 
-#: cmd/incus/image.go:976
+#: cmd/incus/image.go:1028
 msgid "Aliases:"
 msgstr "Alias :"
 
@@ -979,7 +978,7 @@ msgstr "Toutes les adresses serveurs sont indisponibles"
 msgid "Alternative certificate name"
 msgstr "Nom alternatif du certificat"
 
-#: cmd/incus/image.go:947 cmd/incus/info.go:476
+#: cmd/incus/image.go:999 cmd/incus/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -1003,7 +1002,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "Aucun n'a pu être trouvé, la socket SPICE peut être trouvé à:"
 
-#: cmd/incus/create.go:357 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr "Machine virtuelle a été demandé mais l'image est de type conteneur"
 
@@ -1065,12 +1064,12 @@ msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 msgid "Auto negotiation: %v"
 msgstr "Auto-négociation: %v"
 
-#: cmd/incus/image.go:177
+#: cmd/incus/image.go:189
 msgid "Auto update is only available in pull mode"
 msgstr ""
 "La mise à jour automatique est uniquement disponible en mode hissage (pull)"
 
-#: cmd/incus/image.go:986
+#: cmd/incus/image.go:1038
 #, c-format
 msgid "Auto update: %s"
 msgstr "Mise à jour auto : %s"
@@ -1120,7 +1119,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
 
-#: cmd/incus/copy.go:138 cmd/incus/create.go:221 cmd/incus/move.go:358
+#: cmd/incus/copy.go:138 cmd/incus/create.go:229 cmd/incus/move.go:358
 #: cmd/incus/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1132,7 +1131,7 @@ msgstr "Mauvaise association clef=valeur: %q"
 msgid "Bad key=value pair: %s"
 msgstr "Mauvaise paire clé=valeur: %s"
 
-#: cmd/incus/image.go:758
+#: cmd/incus/image.go:802
 #, c-format
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété: %s"
@@ -1213,7 +1212,7 @@ msgstr "CRÉÉ À"
 msgid "CUDA Version: %v"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/image.go:985
+#: cmd/incus/image.go:1037
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr "Mem. cache : %s"
@@ -1235,7 +1234,7 @@ msgstr ""
 "Impossible de surcharger la configuration ou les profiles lors du renommage "
 "local"
 
-#: cmd/incus/image.go:210
+#: cmd/incus/image.go:222
 msgid "Can't provide a name for the target image"
 msgstr "Impossible de fournir un nom à l'image cible"
 
@@ -1302,7 +1301,7 @@ msgstr "Impossible d'utiliser --minimal et --preseed ensemble"
 msgid "Can't use an image with --empty"
 msgstr "Impossible d'utiliser une image avec --empty"
 
-#: cmd/incus/create.go:326
+#: cmd/incus/create.go:334
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1483,7 +1482,7 @@ msgstr "Membre de la grappe de serveur"
 msgid "Clustering enabled"
 msgstr "Activation de la grappe"
 
-#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1046 cmd/incus/list.go:132
+#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1100 cmd/incus/list.go:132
 #: cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239
 #: cmd/incus/warning.go:93
 msgid "Columns"
@@ -1542,7 +1541,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339
 #: cmd/incus/config.go:268 cmd/incus/config.go:343
 #: cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352
-#: cmd/incus/image.go:459 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
+#: cmd/incus/image.go:483 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
 #: cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637
 #: cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550
 #: cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518
@@ -1676,7 +1675,7 @@ msgstr "Copie dans un projet différent de la source"
 msgid "Copy virtual machine images"
 msgstr "Copie d'image de machines virtuelle : %s"
 
-#: cmd/incus/image.go:266
+#: cmd/incus/image.go:278
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
@@ -1897,13 +1896,13 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/image.go:954 cmd/incus/info.go:487
+#: cmd/incus/image.go:1006 cmd/incus/info.go:487
 #: cmd/incus/storage_volume.go:1273
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:174
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
@@ -1913,7 +1912,7 @@ msgstr "Création de %s"
 msgid "Creating %s: %%s"
 msgstr "Création de %s"
 
-#: cmd/incus/create.go:164
+#: cmd/incus/create.go:172
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Création du conteneur"
@@ -1928,7 +1927,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "ADRESSE CIBLE PAR DÉFAUT"
 
 #: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438
-#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1060
+#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1122
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088
 #: cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139
@@ -1993,7 +1992,7 @@ msgstr "Création du conteneur"
 msgid "Delete image aliases"
 msgstr "Supprimer les alias d'image"
 
-#: cmd/incus/image.go:314 cmd/incus/image.go:315
+#: cmd/incus/image.go:326 cmd/incus/image.go:327
 #, fuzzy
 msgid "Delete images"
 msgstr "Récupération de l'image : %s"
@@ -2124,10 +2123,10 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131
 #: cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428
 #: cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
-#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
-#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
-#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382
+#: cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930
+#: cmd/incus/image.go:1074 cmd/incus/image.go:1424 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704
 #: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
@@ -2309,12 +2308,12 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/create.go:417
+#: cmd/incus/create.go:425
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 
-#: cmd/incus/image.go:668
+#: cmd/incus/image.go:712
 msgid "Directory import is not available on this platform"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
@@ -2354,6 +2353,11 @@ msgstr "  Disque utilisé :"
 #, fuzzy
 msgid "Disks:"
 msgstr "  Disque utilisé :"
+
+#: cmd/incus/image.go:1102
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "Forcer le conteneur à s'arrêter"
 
 #: cmd/incus/list.go:135
 #, fuzzy
@@ -2443,7 +2447,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/image.go:365 cmd/incus/image.go:366
+#: cmd/incus/image.go:381 cmd/incus/image.go:382
 msgid "Edit image properties"
 msgstr "Modifier les propriétés de l'image"
 
@@ -2528,7 +2532,7 @@ msgstr "Modifier les configurations de volume de stockage au format YAML"
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1072 cmd/incus/list.go:614
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1144 cmd/incus/list.go:614
 #: cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2769,21 +2773,21 @@ msgstr "Attendait une struct, a obtenu un %v"
 msgid "Expires at"
 msgstr "Expire : %s"
 
-#: cmd/incus/image.go:960
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Expires: %s"
 msgstr "Expire : %s"
 
-#: cmd/incus/image.go:962
+#: cmd/incus/image.go:1014
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
-#: cmd/incus/image.go:492
+#: cmd/incus/image.go:516
 #, fuzzy
 msgid "Export and download images"
 msgstr "Import de l'image : %s"
 
-#: cmd/incus/image.go:493
+#: cmd/incus/image.go:517
 #, fuzzy
 msgid ""
 "Export and download images\n"
@@ -2820,7 +2824,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
 
-#: cmd/incus/image.go:560
+#: cmd/incus/image.go:592
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
@@ -2834,8 +2838,8 @@ msgstr "DOMAINE D'ÉCHEC"
 msgid "FILENAME"
 msgstr "NOM"
 
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1057
-#: cmd/incus/image.go:1058 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1124
+#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
@@ -2923,17 +2927,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: cmd/incus/create.go:180
+#: cmd/incus/create.go:188
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: cmd/incus/create.go:305
+#: cmd/incus/create.go:313
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:231
+#: cmd/incus/create.go:239
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -3181,7 +3185,7 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:945
+#: cmd/incus/image.go:997
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
@@ -3248,7 +3252,7 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867
 #: cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241
 #: cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587
-#: cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
+#: cmd/incus/image.go:1101 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
 #: cmd/incus/network.go:1011 cmd/incus/network.go:1110
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93
@@ -3319,7 +3323,7 @@ msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/image.go:1478 cmd/incus/image.go:1479
+#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
 msgid "Get image properties"
 msgstr ""
 
@@ -3595,11 +3599,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/image.go:1401
+#: cmd/incus/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:283
+#: cmd/incus/image.go:295
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
@@ -3607,26 +3611,26 @@ msgstr "Image copiée avec succès !"
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:636
+#: cmd/incus/image.go:668
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/image.go:338 cmd/incus/image.go:1363
+#: cmd/incus/image.go:354 cmd/incus/image.go:1451
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:406 cmd/incus/image.go:1555
+#: cmd/incus/image.go:430 cmd/incus/image.go:1672
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: cmd/incus/image.go:856
+#: cmd/incus/image.go:900
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: cmd/incus/image.go:1399
+#: cmd/incus/image.go:1487
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3649,14 +3653,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/image.go:653
+#: cmd/incus/image.go:685
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:652
+#: cmd/incus/image.go:684
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Import de l'image : %s"
@@ -3725,7 +3729,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: cmd/incus/create.go:428
+#: cmd/incus/create.go:436
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3932,21 +3936,21 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: cmd/incus/image.go:966
+#: cmd/incus/image.go:1018
 #, c-format
 msgid "Last used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: cmd/incus/image.go:968
+#: cmd/incus/image.go:1020
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: cmd/incus/create.go:160
+#: cmd/incus/create.go:168
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Création de %s"
 
-#: cmd/incus/create.go:158
+#: cmd/incus/create.go:166
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Création du conteneur"
@@ -4051,11 +4055,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: cmd/incus/image.go:1020
+#: cmd/incus/image.go:1073
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1074
 msgid ""
 "List images\n"
 "\n"
@@ -4076,6 +4080,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4488,7 +4493,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:658
+#: cmd/incus/image.go:154 cmd/incus/image.go:690
 msgid "Make image public"
 msgstr "Rendre l'image publique"
 
@@ -5065,7 +5070,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:670
+#: cmd/incus/image.go:714
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -5323,7 +5328,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "New alias to define at target"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:659
+#: cmd/incus/image.go:157 cmd/incus/image.go:691
 #, fuzzy
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
@@ -5435,7 +5440,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
-#: cmd/incus/image.go:747
+#: cmd/incus/image.go:791
 #, fuzzy
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
@@ -5504,8 +5509,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512
-#: cmd/incus/warning.go:213
+#: cmd/incus/image.go:1123 cmd/incus/list.go:559
+#: cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5517,7 +5522,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
+#: cmd/incus/image.go:1128 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5613,7 +5618,7 @@ msgstr ""
 #: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340
 #: cmd/incus/config.go:269 cmd/incus/config.go:344
 #: cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205
-#: cmd/incus/config_trust.go:353 cmd/incus/image.go:460
+#: cmd/incus/config_trust.go:353 cmd/incus/image.go:484
 #: cmd/incus/network.go:759 cmd/incus/network_acl.go:620
 #: cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638
 #: cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551
@@ -5706,12 +5711,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: cmd/incus/image.go:998
+#: cmd/incus/image.go:1050
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profils : %s"
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1048
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profils : %s"
@@ -5735,15 +5740,15 @@ msgstr "Profil %s ajouté à %s"
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:971
+#: cmd/incus/image.go:1023
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: cmd/incus/image.go:1514
+#: cmd/incus/image.go:1623
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1043
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Cible invalide %s"
@@ -5856,7 +5861,7 @@ msgstr ""
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
-#: cmd/incus/image.go:949
+#: cmd/incus/image.go:1001
 #, c-format
 msgid "Public: %s"
 msgstr "Public : %s"
@@ -5895,7 +5900,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:498 cmd/incus/image.go:889 cmd/incus/image.go:1423
+#: cmd/incus/image.go:522 cmd/incus/image.go:933 cmd/incus/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5959,7 +5964,7 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/image.go:1339 cmd/incus/image.go:1340
+#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
@@ -5969,7 +5974,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/image.go:1368
+#: cmd/incus/image.go:1456
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -6261,7 +6266,7 @@ msgstr "Création du conteneur"
 msgid "Retrieve the instance's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/create.go:371
+#: cmd/incus/create.go:379
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -6310,7 +6315,7 @@ msgstr "Rendre l'image publique"
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1062
+#: cmd/incus/image.go:1129
 msgid "SIZE"
 msgstr "TAILLE"
 
@@ -6419,7 +6424,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:990
+#: cmd/incus/image.go:1042
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "Serveur distant : %s"
@@ -6456,7 +6461,7 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1530 cmd/incus/image.go:1531
+#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
 msgid "Set image properties"
 msgstr ""
 
@@ -6776,7 +6781,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/image.go:1419 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6927,7 +6932,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show useful information about a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/image.go:885 cmd/incus/image.go:886
+#: cmd/incus/image.go:929 cmd/incus/image.go:930
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6943,7 +6948,7 @@ msgstr ""
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:946
+#: cmd/incus/image.go:998
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Taille : %.2f Mo"
@@ -6982,7 +6987,7 @@ msgid ""
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:989
+#: cmd/incus/image.go:1041
 msgid "Source:"
 msgstr "Source :"
 
@@ -6991,7 +6996,7 @@ msgstr "Source :"
 msgid "Start instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/launch.go:83
+#: cmd/incus/launch.go:99
 #, c-format
 msgid "Starting %s"
 msgstr "Démarrage de %s"
@@ -7178,7 +7183,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1064
+#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084
 #: cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26
 #: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492
@@ -7313,7 +7318,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: cmd/incus/create.go:449
+#: cmd/incus/create.go:457
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
@@ -7518,16 +7523,16 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
-#: cmd/incus/image.go:950
+#: cmd/incus/image.go:1002
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: cmd/incus/create.go:451
+#: cmd/incus/create.go:459
 #, fuzzy
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: cmd/incus/create.go:450
+#: cmd/incus/create.go:458
 #, fuzzy
 msgid "To create a new network, use: incus network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
@@ -7590,7 +7595,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:769
+#: cmd/incus/image.go:813
 #, c-format
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
@@ -7609,7 +7614,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: cmd/incus/action.go:316 cmd/incus/launch.go:115
+#: cmd/incus/action.go:316 cmd/incus/launch.go:131
 #, fuzzy, c-format
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
@@ -7630,7 +7635,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/image.go:948 cmd/incus/info.go:273 cmd/incus/info.go:473
+#: cmd/incus/image.go:1000 cmd/incus/info.go:273 cmd/incus/info.go:473
 #: cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -7645,7 +7650,7 @@ msgstr "Type : éphémère"
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1063
+#: cmd/incus/image.go:1131
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
@@ -7698,7 +7703,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1080 cmd/incus/list.go:629
+#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1152 cmd/incus/list.go:629
 #: cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7739,7 +7744,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/image.go:1586 cmd/incus/image.go:1587
+#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
 msgid "Unset image properties"
 msgstr ""
 
@@ -7912,7 +7917,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/image.go:957
+#: cmd/incus/image.go:1009
 #, c-format
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
@@ -8225,7 +8230,7 @@ msgstr "[<serveur distant>:] <certificat>"
 msgid "[<remote>:] <name>"
 msgstr "[<serveur distant>:] <nom>"
 
-#: cmd/incus/image.go:1018 cmd/incus/list.go:46
+#: cmd/incus/image.go:1071 cmd/incus/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<serveur distant>:] [<filtre>...]"
 
@@ -8385,7 +8390,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:364 cmd/incus/image.go:884 cmd/incus/image.go:1418
+#: cmd/incus/image.go:380 cmd/incus/image.go:928 cmd/incus/image.go:1506
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -8397,7 +8402,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/image.go:1477 cmd/incus/image.go:1585
+#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -8409,7 +8414,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/image.go:1529
+#: cmd/incus/image.go:1638
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -8441,7 +8446,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:491
+#: cmd/incus/image.go:515
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -8449,7 +8454,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:312 cmd/incus/image.go:1338
+#: cmd/incus/image.go:324 cmd/incus/image.go:1422
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -9476,7 +9481,7 @@ msgstr "Swap (courant)"
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:935
+#: cmd/incus/image.go:987
 msgid "disabled"
 msgstr "désactivé"
 
@@ -9484,7 +9489,7 @@ msgstr "désactivé"
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:937
+#: cmd/incus/image.go:989
 msgid "enabled"
 msgstr "activé"
 
@@ -9593,7 +9598,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:368
+#: cmd/incus/image.go:384
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9817,8 +9822,8 @@ msgstr "non"
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:497 cmd/incus/image.go:925 cmd/incus/image.go:930
-#: cmd/incus/image.go:1120
+#: cmd/incus/config_trust.go:497 cmd/incus/image.go:977 cmd/incus/image.go:982
+#: cmd/incus/image.go:1192
 msgid "no"
 msgstr "non"
 
@@ -9865,8 +9870,8 @@ msgid "y"
 msgstr "o"
 
 #: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494
-#: cmd/incus/delete.go:47 cmd/incus/image.go:927 cmd/incus/image.go:932
-#: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
+#: cmd/incus/delete.go:47 cmd/incus/image.go:979 cmd/incus/image.go:984
+#: cmd/incus/image.go:1189 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr "oui"
 

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-01-30 15:38-0500\n"
+        "POT-Creation-Date: 2024-02-10 17:56-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -89,7 +89,7 @@ msgid   "### This is a YAML representation of the configuration.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/image.go:381
+#: cmd/incus/image.go:405
 msgid   "### This is a YAML representation of the image properties.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -316,7 +316,7 @@ msgstr  ""
 msgid   "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr  ""
 
-#: cmd/incus/image.go:1091
+#: cmd/incus/image.go:1163
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -372,7 +372,7 @@ msgstr  ""
 msgid   "--console only works with a single instance"
 msgstr  ""
 
-#: cmd/incus/create.go:126 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
@@ -440,7 +440,7 @@ msgstr  ""
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: cmd/incus/image.go:651
+#: cmd/incus/image.go:683
 msgid   "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr  ""
 
@@ -465,15 +465,15 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1055 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1126 cmd/incus/image_alias.go:234
 msgid   "ALIAS"
 msgstr  ""
 
-#: cmd/incus/image.go:1056
+#: cmd/incus/image.go:1127
 msgid   "ALIASES"
 msgstr  ""
 
-#: cmd/incus/cluster.go:186 cmd/incus/image.go:1061 cmd/incus/list.go:554
+#: cmd/incus/cluster.go:186 cmd/incus/image.go:1121 cmd/incus/list.go:554
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -639,7 +639,7 @@ msgstr  ""
 msgid   "Alias name missing"
 msgstr  ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1044
 #, c-format
 msgid   "Alias: %s"
 msgstr  ""
@@ -649,7 +649,7 @@ msgstr  ""
 msgid   "Aliases already exists: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:976
+#: cmd/incus/image.go:1028
 msgid   "Aliases:"
 msgstr  ""
 
@@ -669,7 +669,7 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: cmd/incus/image.go:947 cmd/incus/info.go:476
+#: cmd/incus/image.go:999 cmd/incus/info.go:476
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -692,7 +692,7 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: cmd/incus/create.go:357 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
@@ -745,11 +745,11 @@ msgstr  ""
 msgid   "Auto negotiation: %v"
 msgstr  ""
 
-#: cmd/incus/image.go:177
+#: cmd/incus/image.go:189
 msgid   "Auto update is only available in pull mode"
 msgstr  ""
 
-#: cmd/incus/image.go:986
+#: cmd/incus/image.go:1038
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
@@ -794,7 +794,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:138 cmd/incus/create.go:221 cmd/incus/move.go:358 cmd/incus/project.go:129
+#: cmd/incus/copy.go:138 cmd/incus/create.go:229 cmd/incus/move.go:358 cmd/incus/project.go:129
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -804,7 +804,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:758
+#: cmd/incus/image.go:802
 #, c-format
 msgid   "Bad property: %s"
 msgstr  ""
@@ -885,7 +885,7 @@ msgstr  ""
 msgid   "CUDA Version: %v"
 msgstr  ""
 
-#: cmd/incus/image.go:985
+#: cmd/incus/image.go:1037
 #, c-format
 msgid   "Cached: %s"
 msgstr  ""
@@ -903,7 +903,7 @@ msgstr  ""
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
-#: cmd/incus/image.go:210
+#: cmd/incus/image.go:222
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
@@ -965,7 +965,7 @@ msgstr  ""
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: cmd/incus/create.go:326
+#: cmd/incus/create.go:334
 #, c-format
 msgid   "Cannot override config for device %q: Device not found in profile devices"
 msgstr  ""
@@ -1098,7 +1098,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1046 cmd/incus/list.go:132 cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239 cmd/incus/warning.go:93
+#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1100 cmd/incus/list.go:132 cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239 cmd/incus/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1139,7 +1139,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339 cmd/incus/config.go:268 cmd/incus/config.go:343 cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352 cmd/incus/image.go:459 cmd/incus/network.go:758 cmd/incus/network_acl.go:619 cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637 cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518 cmd/incus/project.go:315 cmd/incus/storage.go:309 cmd/incus/storage_bucket.go:342 cmd/incus/storage_bucket.go:1091 cmd/incus/storage_volume.go:976 cmd/incus/storage_volume.go:1008
+#: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339 cmd/incus/config.go:268 cmd/incus/config.go:343 cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352 cmd/incus/image.go:483 cmd/incus/network.go:758 cmd/incus/network_acl.go:619 cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637 cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550 cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518 cmd/incus/project.go:315 cmd/incus/storage.go:309 cmd/incus/storage_bucket.go:342 cmd/incus/storage_bucket.go:1091 cmd/incus/storage_volume.go:976 cmd/incus/storage_volume.go:1008
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1237,7 +1237,7 @@ msgstr  ""
 msgid   "Copy virtual machine images"
 msgstr  ""
 
-#: cmd/incus/image.go:266
+#: cmd/incus/image.go:278
 #, c-format
 msgid   "Copying the image: %s"
 msgstr  ""
@@ -1417,12 +1417,12 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:954 cmd/incus/info.go:487 cmd/incus/storage_volume.go:1273
+#: cmd/incus/image.go:1006 cmd/incus/info.go:487 cmd/incus/storage_volume.go:1273
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:174
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
@@ -1432,7 +1432,7 @@ msgstr  ""
 msgid   "Creating %s: %%s"
 msgstr  ""
 
-#: cmd/incus/create.go:164
+#: cmd/incus/create.go:172
 msgid   "Creating the instance"
 msgstr  ""
 
@@ -1445,7 +1445,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438 cmd/incus/config_trust.go:436 cmd/incus/image.go:1060 cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088 cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144 cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139 cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:741 cmd/incus/operation.go:173 cmd/incus/profile.go:658 cmd/incus/project.go:504 cmd/incus/storage.go:645 cmd/incus/storage_bucket.go:506 cmd/incus/storage_bucket.go:826 cmd/incus/storage_volume.go:1494
+#: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438 cmd/incus/config_trust.go:436 cmd/incus/image.go:1122 cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088 cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144 cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139 cmd/incus/network_zone.go:138 cmd/incus/network_zone.go:741 cmd/incus/operation.go:173 cmd/incus/profile.go:658 cmd/incus/project.go:504 cmd/incus/storage.go:645 cmd/incus/storage_bucket.go:506 cmd/incus/storage_bucket.go:826 cmd/incus/storage_volume.go:1494
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1499,7 +1499,7 @@ msgstr  ""
 msgid   "Delete image aliases"
 msgstr  ""
 
-#: cmd/incus/image.go:314 cmd/incus/image.go:315
+#: cmd/incus/image.go:326 cmd/incus/image.go:327
 msgid   "Delete images"
 msgstr  ""
 
@@ -1575,7 +1575,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:53 cmd/incus/action.go:75 cmd/incus/action.go:97 cmd/incus/action.go:120 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:29 cmd/incus/cluster.go:122 cmd/incus/cluster.go:206 cmd/incus/cluster.go:255 cmd/incus/cluster.go:306 cmd/incus/cluster.go:367 cmd/incus/cluster.go:439 cmd/incus/cluster.go:471 cmd/incus/cluster.go:521 cmd/incus/cluster.go:604 cmd/incus/cluster.go:689 cmd/incus/cluster.go:802 cmd/incus/cluster.go:866 cmd/incus/cluster.go:968 cmd/incus/cluster.go:1047 cmd/incus/cluster.go:1154 cmd/incus/cluster.go:1175 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:157 cmd/incus/cluster_group.go:214 cmd/incus/cluster_group.go:266 cmd/incus/cluster_group.go:382 cmd/incus/cluster_group.go:456 cmd/incus/cluster_group.go:529 cmd/incus/cluster_group.go:577 cmd/incus/cluster_group.go:631 cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:106 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:380 cmd/incus/config.go:505 cmd/incus/config.go:719 cmd/incus/config.go:851 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:208 cmd/incus/config_device.go:285 cmd/incus/config_device.go:356 cmd/incus/config_device.go:450 cmd/incus/config_device.go:548 cmd/incus/config_device.go:555 cmd/incus/config_device.go:668 cmd/incus/config_device.go:741 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:179 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:109 cmd/incus/config_template.go:151 cmd/incus/config_template.go:239 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:90 cmd/incus/config_trust.go:170 cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:401 cmd/incus/config_trust.go:585 cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733 cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131 cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428 cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873 cmd/incus/network.go:1007 cmd/incus/network.go:1108 cmd/incus/network.go:1187 cmd/incus/network.go:1247 cmd/incus/network.go:1343 cmd/incus/network.go:1415 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:164 cmd/incus/network_acl.go:217 cmd/incus/network_acl.go:265 cmd/incus/network_acl.go:326 cmd/incus/network_acl.go:411 cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:652 cmd/incus/network_acl.go:701 cmd/incus/network_acl.go:750 cmd/incus/network_acl.go:765 cmd/incus/network_acl.go:886 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:166 cmd/incus/network_forward.go:230 cmd/incus/network_forward.go:328 cmd/incus/network_forward.go:397 cmd/incus/network_forward.go:495 cmd/incus/network_forward.go:525 cmd/incus/network_forward.go:667 cmd/incus/network_forward.go:729 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:809 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:169 cmd/incus/network_load_balancer.go:233 cmd/incus/network_load_balancer.go:331 cmd/incus/network_load_balancer.go:399 cmd/incus/network_load_balancer.go:497 cmd/incus/network_load_balancer.go:527 cmd/incus/network_load_balancer.go:670 cmd/incus/network_load_balancer.go:731 cmd/incus/network_load_balancer.go:746 cmd/incus/network_load_balancer.go:810 cmd/incus/network_load_balancer.go:896 cmd/incus/network_load_balancer.go:911 cmd/incus/network_load_balancer.go:972 cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:80 cmd/incus/network_peer.go:157 cmd/incus/network_peer.go:214 cmd/incus/network_peer.go:330 cmd/incus/network_peer.go:398 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:642 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84 cmd/incus/network_zone.go:155 cmd/incus/network_zone.go:210 cmd/incus/network_zone.go:270 cmd/incus/network_zone.go:353 cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:464 cmd/incus/network_zone.go:583 cmd/incus/network_zone.go:631 cmd/incus/network_zone.go:688 cmd/incus/network_zone.go:758 cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:869 cmd/incus/network_zone.go:951 cmd/incus/network_zone.go:1027 cmd/incus/network_zone.go:1057 cmd/incus/network_zone.go:1175 cmd/incus/network_zone.go:1224 cmd/incus/network_zone.go:1239 cmd/incus/network_zone.go:1285 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:167 cmd/incus/profile.go:250 cmd/incus/profile.go:320 cmd/incus/profile.go:374 cmd/incus/profile.go:424 cmd/incus/profile.go:552 cmd/incus/profile.go:613 cmd/incus/profile.go:674 cmd/incus/profile.go:750 cmd/incus/profile.go:802 cmd/incus/profile.go:878 cmd/incus/profile.go:934 cmd/incus/project.go:29 cmd/incus/project.go:93 cmd/incus/project.go:158 cmd/incus/project.go:221 cmd/incus/project.go:349 cmd/incus/project.go:410 cmd/incus/project.go:522 cmd/incus/project.go:579 cmd/incus/project.go:658 cmd/incus/project.go:689 cmd/incus/project.go:742 cmd/incus/project.go:801 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624 cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815 cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:29 cmd/incus/snapshot.go:76 cmd/incus/snapshot.go:175 cmd/incus/snapshot.go:252 cmd/incus/snapshot.go:343 cmd/incus/snapshot.go:392 cmd/incus/snapshot.go:462 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846 cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82 cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243 cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452 cmd/incus/storage_bucket.go:529 cmd/incus/storage_bucket.go:623 cmd/incus/storage_bucket.go:692 cmd/incus/storage_bucket.go:726 cmd/incus/storage_bucket.go:767 cmd/incus/storage_bucket.go:846 cmd/incus/storage_bucket.go:924 cmd/incus/storage_bucket.go:988 cmd/incus/storage_bucket.go:1123 cmd/incus/storage_volume.go:44 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:237 cmd/incus/storage_volume.go:328 cmd/incus/storage_volume.go:531 cmd/incus/storage_volume.go:610 cmd/incus/storage_volume.go:671 cmd/incus/storage_volume.go:753 cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:1043 cmd/incus/storage_volume.go:1158 cmd/incus/storage_volume.go:1305 cmd/incus/storage_volume.go:1389 cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:1677 cmd/incus/storage_volume.go:1745 cmd/incus/storage_volume.go:1889 cmd/incus/storage_volume.go:1971 cmd/incus/storage_volume.go:2014 cmd/incus/storage_volume.go:2063 cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2235 cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2349 cmd/incus/storage_volume.go:2420 cmd/incus/storage_volume.go:2484 cmd/incus/storage_volume.go:2568 cmd/incus/storage_volume.go:2722 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:53 cmd/incus/action.go:75 cmd/incus/action.go:97 cmd/incus/action.go:120 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:29 cmd/incus/cluster.go:122 cmd/incus/cluster.go:206 cmd/incus/cluster.go:255 cmd/incus/cluster.go:306 cmd/incus/cluster.go:367 cmd/incus/cluster.go:439 cmd/incus/cluster.go:471 cmd/incus/cluster.go:521 cmd/incus/cluster.go:604 cmd/incus/cluster.go:689 cmd/incus/cluster.go:802 cmd/incus/cluster.go:866 cmd/incus/cluster.go:968 cmd/incus/cluster.go:1047 cmd/incus/cluster.go:1154 cmd/incus/cluster.go:1175 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:157 cmd/incus/cluster_group.go:214 cmd/incus/cluster_group.go:266 cmd/incus/cluster_group.go:382 cmd/incus/cluster_group.go:456 cmd/incus/cluster_group.go:529 cmd/incus/cluster_group.go:577 cmd/incus/cluster_group.go:631 cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:106 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:380 cmd/incus/config.go:505 cmd/incus/config.go:719 cmd/incus/config.go:851 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:208 cmd/incus/config_device.go:285 cmd/incus/config_device.go:356 cmd/incus/config_device.go:450 cmd/incus/config_device.go:548 cmd/incus/config_device.go:555 cmd/incus/config_device.go:668 cmd/incus/config_device.go:741 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:179 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:109 cmd/incus/config_template.go:151 cmd/incus/config_template.go:239 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:90 cmd/incus/config_trust.go:170 cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:401 cmd/incus/config_trust.go:585 cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733 cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131 cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428 cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1074 cmd/incus/image.go:1424 cmd/incus/image.go:1508 cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873 cmd/incus/network.go:1007 cmd/incus/network.go:1108 cmd/incus/network.go:1187 cmd/incus/network.go:1247 cmd/incus/network.go:1343 cmd/incus/network.go:1415 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:164 cmd/incus/network_acl.go:217 cmd/incus/network_acl.go:265 cmd/incus/network_acl.go:326 cmd/incus/network_acl.go:411 cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:652 cmd/incus/network_acl.go:701 cmd/incus/network_acl.go:750 cmd/incus/network_acl.go:765 cmd/incus/network_acl.go:886 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:166 cmd/incus/network_forward.go:230 cmd/incus/network_forward.go:328 cmd/incus/network_forward.go:397 cmd/incus/network_forward.go:495 cmd/incus/network_forward.go:525 cmd/incus/network_forward.go:667 cmd/incus/network_forward.go:729 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:809 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:169 cmd/incus/network_load_balancer.go:233 cmd/incus/network_load_balancer.go:331 cmd/incus/network_load_balancer.go:399 cmd/incus/network_load_balancer.go:497 cmd/incus/network_load_balancer.go:527 cmd/incus/network_load_balancer.go:670 cmd/incus/network_load_balancer.go:731 cmd/incus/network_load_balancer.go:746 cmd/incus/network_load_balancer.go:810 cmd/incus/network_load_balancer.go:896 cmd/incus/network_load_balancer.go:911 cmd/incus/network_load_balancer.go:972 cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:80 cmd/incus/network_peer.go:157 cmd/incus/network_peer.go:214 cmd/incus/network_peer.go:330 cmd/incus/network_peer.go:398 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:642 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84 cmd/incus/network_zone.go:155 cmd/incus/network_zone.go:210 cmd/incus/network_zone.go:270 cmd/incus/network_zone.go:353 cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:464 cmd/incus/network_zone.go:583 cmd/incus/network_zone.go:631 cmd/incus/network_zone.go:688 cmd/incus/network_zone.go:758 cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:869 cmd/incus/network_zone.go:951 cmd/incus/network_zone.go:1027 cmd/incus/network_zone.go:1057 cmd/incus/network_zone.go:1175 cmd/incus/network_zone.go:1224 cmd/incus/network_zone.go:1239 cmd/incus/network_zone.go:1285 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:167 cmd/incus/profile.go:250 cmd/incus/profile.go:320 cmd/incus/profile.go:374 cmd/incus/profile.go:424 cmd/incus/profile.go:552 cmd/incus/profile.go:613 cmd/incus/profile.go:674 cmd/incus/profile.go:750 cmd/incus/profile.go:802 cmd/incus/profile.go:878 cmd/incus/profile.go:934 cmd/incus/project.go:29 cmd/incus/project.go:93 cmd/incus/project.go:158 cmd/incus/project.go:221 cmd/incus/project.go:349 cmd/incus/project.go:410 cmd/incus/project.go:522 cmd/incus/project.go:579 cmd/incus/project.go:658 cmd/incus/project.go:689 cmd/incus/project.go:742 cmd/incus/project.go:801 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624 cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815 cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:29 cmd/incus/snapshot.go:76 cmd/incus/snapshot.go:175 cmd/incus/snapshot.go:252 cmd/incus/snapshot.go:343 cmd/incus/snapshot.go:392 cmd/incus/snapshot.go:462 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846 cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82 cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243 cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452 cmd/incus/storage_bucket.go:529 cmd/incus/storage_bucket.go:623 cmd/incus/storage_bucket.go:692 cmd/incus/storage_bucket.go:726 cmd/incus/storage_bucket.go:767 cmd/incus/storage_bucket.go:846 cmd/incus/storage_bucket.go:924 cmd/incus/storage_bucket.go:988 cmd/incus/storage_bucket.go:1123 cmd/incus/storage_volume.go:44 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:237 cmd/incus/storage_volume.go:328 cmd/incus/storage_volume.go:531 cmd/incus/storage_volume.go:610 cmd/incus/storage_volume.go:671 cmd/incus/storage_volume.go:753 cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:1043 cmd/incus/storage_volume.go:1158 cmd/incus/storage_volume.go:1305 cmd/incus/storage_volume.go:1389 cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:1677 cmd/incus/storage_volume.go:1745 cmd/incus/storage_volume.go:1889 cmd/incus/storage_volume.go:1971 cmd/incus/storage_volume.go:2014 cmd/incus/storage_volume.go:2063 cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2235 cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2349 cmd/incus/storage_volume.go:2420 cmd/incus/storage_volume.go:2484 cmd/incus/storage_volume.go:2568 cmd/incus/storage_volume.go:2722 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1645,11 +1645,11 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:417
+#: cmd/incus/create.go:425
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
-#: cmd/incus/image.go:668
+#: cmd/incus/image.go:712
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
@@ -1684,6 +1684,10 @@ msgstr  ""
 
 #: cmd/incus/info.go:423
 msgid   "Disks:"
+msgstr  ""
+
+#: cmd/incus/image.go:1102
+msgid   "Display images from all projects"
 msgstr  ""
 
 #: cmd/incus/list.go:135
@@ -1764,7 +1768,7 @@ msgstr  ""
 msgid   "Edit files in instances"
 msgstr  ""
 
-#: cmd/incus/image.go:365 cmd/incus/image.go:366
+#: cmd/incus/image.go:381 cmd/incus/image.go:382
 msgid   "Edit image properties"
 msgstr  ""
 
@@ -1836,7 +1840,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1072 cmd/incus/list.go:614 cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1144 cmd/incus/list.go:614 cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1986,20 +1990,20 @@ msgstr  ""
 msgid   "Expires at"
 msgstr  ""
 
-#: cmd/incus/image.go:960
+#: cmd/incus/image.go:1012
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:962
+#: cmd/incus/image.go:1014
 msgid   "Expires: never"
 msgstr  ""
 
-#: cmd/incus/image.go:492
+#: cmd/incus/image.go:516
 msgid   "Export and download images"
 msgstr  ""
 
-#: cmd/incus/image.go:493
+#: cmd/incus/image.go:517
 msgid   "Export and download images\n"
         "\n"
         "The output target is optional and defaults to the working directory."
@@ -2026,7 +2030,7 @@ msgstr  ""
 msgid   "Exporting the backup: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:560
+#: cmd/incus/image.go:592
 #, c-format
 msgid   "Exporting the image: %s"
 msgstr  ""
@@ -2039,7 +2043,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1057 cmd/incus/image.go:1058 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1124 cmd/incus/image.go:1125 cmd/incus/image_alias.go:235
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -2127,17 +2131,17 @@ msgstr  ""
 msgid   "Failed import request: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:180
+#: cmd/incus/create.go:188
 #, c-format
 msgid   "Failed loading network %q: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:305
+#: cmd/incus/create.go:313
 #, c-format
 msgid   "Failed loading profile %q for device override: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:231
+#: cmd/incus/create.go:239
 #, c-format
 msgid   "Failed loading storage pool %q: %w"
 msgstr  ""
@@ -2379,7 +2383,7 @@ msgstr  ""
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
-#: cmd/incus/image.go:945
+#: cmd/incus/image.go:997
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
@@ -2435,7 +2439,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867 cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241 cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587 cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133 cmd/incus/network.go:1011 cmd/incus/network.go:1110 cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:691 cmd/incus/operation.go:109 cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:803 cmd/incus/remote.go:664 cmd/incus/snapshot.go:255 cmd/incus/storage.go:587 cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768 cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256 cmd/incus/warning.go:94
+#: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867 cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241 cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587 cmd/incus/image.go:1101 cmd/incus/image_alias.go:157 cmd/incus/list.go:133 cmd/incus/network.go:1011 cmd/incus/network.go:1110 cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:83 cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:691 cmd/incus/operation.go:109 cmd/incus/profile.go:617 cmd/incus/project.go:412 cmd/incus/project.go:803 cmd/incus/remote.go:664 cmd/incus/snapshot.go:255 cmd/incus/storage.go:587 cmd/incus/storage_bucket.go:453 cmd/incus/storage_bucket.go:768 cmd/incus/storage_volume.go:1405 cmd/incus/storage_volume.go:2256 cmd/incus/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2495,7 +2499,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: cmd/incus/image.go:1478 cmd/incus/image.go:1479
+#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2738,11 +2742,11 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: cmd/incus/image.go:1401
+#: cmd/incus/image.go:1489
 msgid   "Image already up to date."
 msgstr  ""
 
-#: cmd/incus/image.go:283
+#: cmd/incus/image.go:295
 msgid   "Image copied successfully!"
 msgstr  ""
 
@@ -2750,25 +2754,25 @@ msgstr  ""
 msgid   "Image expiration date (format: rfc3339)"
 msgstr  ""
 
-#: cmd/incus/image.go:636
+#: cmd/incus/image.go:668
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: cmd/incus/image.go:338 cmd/incus/image.go:1363
+#: cmd/incus/image.go:354 cmd/incus/image.go:1451
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: cmd/incus/image.go:406 cmd/incus/image.go:1555
+#: cmd/incus/image.go:430 cmd/incus/image.go:1672
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:856
+#: cmd/incus/image.go:900
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:1399
+#: cmd/incus/image.go:1487
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2788,13 +2792,13 @@ msgstr  ""
 msgid   "Import custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/image.go:653
+#: cmd/incus/image.go:685
 msgid   "Import image into the image store\n"
         "\n"
         "Directory import is only available on Linux and must be performed as root."
 msgstr  ""
 
-#: cmd/incus/image.go:652
+#: cmd/incus/image.go:684
 msgid   "Import images into the image store"
 msgstr  ""
 
@@ -2857,7 +2861,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: cmd/incus/create.go:428
+#: cmd/incus/create.go:436
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -3052,21 +3056,21 @@ msgstr  ""
 msgid   "Last Used: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:966
+#: cmd/incus/image.go:1018
 #, c-format
 msgid   "Last used: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:968
+#: cmd/incus/image.go:1020
 msgid   "Last used: never"
 msgstr  ""
 
-#: cmd/incus/create.go:160
+#: cmd/incus/create.go:168
 #, c-format
 msgid   "Launching %s"
 msgstr  ""
 
-#: cmd/incus/create.go:158
+#: cmd/incus/create.go:166
 msgid   "Launching the instance"
 msgstr  ""
 
@@ -3162,11 +3166,11 @@ msgid   "List image aliases\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr  ""
 
-#: cmd/incus/image.go:1020
+#: cmd/incus/image.go:1073
 msgid   "List images"
 msgstr  ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1074
 msgid   "List images\n"
         "\n"
         "Filters may be of the <key>=<value> form for property based filtering,\n"
@@ -3186,6 +3190,7 @@ msgid   "List images\n"
         "    F - Fingerprint (long)\n"
         "    p - Whether image is public\n"
         "    d - Description\n"
+        "    e - Project\n"
         "    a - Architecture\n"
         "    s - Size\n"
         "    u - Upload date\n"
@@ -3512,7 +3517,7 @@ msgstr  ""
 msgid   "MTU: %d"
 msgstr  ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:658
+#: cmd/incus/image.go:154 cmd/incus/image.go:690
 msgid   "Make image public"
 msgstr  ""
 
@@ -3928,7 +3933,7 @@ msgstr  ""
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
-#: cmd/incus/image.go:670
+#: cmd/incus/image.go:714
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
@@ -4163,7 +4168,7 @@ msgstr  ""
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:659
+#: cmd/incus/image.go:157 cmd/incus/image.go:691
 msgid   "New aliases to add to the image"
 msgstr  ""
 
@@ -4264,7 +4269,7 @@ msgstr  ""
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
-#: cmd/incus/image.go:747
+#: cmd/incus/image.go:791
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
@@ -4327,7 +4332,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
+#: cmd/incus/image.go:1123 cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4339,7 +4344,7 @@ msgstr  ""
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
+#: cmd/incus/image.go:1128 cmd/incus/remote.go:725
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4428,7 +4433,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340 cmd/incus/config.go:269 cmd/incus/config.go:344 cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205 cmd/incus/config_trust.go:353 cmd/incus/image.go:460 cmd/incus/network.go:759 cmd/incus/network_acl.go:620 cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638 cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551 cmd/incus/network_zone.go:1143 cmd/incus/profile.go:519 cmd/incus/project.go:316 cmd/incus/storage.go:310 cmd/incus/storage_bucket.go:343 cmd/incus/storage_bucket.go:1092 cmd/incus/storage_volume.go:977 cmd/incus/storage_volume.go:1009
+#: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340 cmd/incus/config.go:269 cmd/incus/config.go:344 cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205 cmd/incus/config_trust.go:353 cmd/incus/image.go:484 cmd/incus/network.go:759 cmd/incus/network_acl.go:620 cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638 cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551 cmd/incus/network_zone.go:1143 cmd/incus/profile.go:519 cmd/incus/project.go:316 cmd/incus/storage.go:310 cmd/incus/storage_bucket.go:343 cmd/incus/storage_bucket.go:1092 cmd/incus/storage_volume.go:977 cmd/incus/storage_volume.go:1009
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4510,11 +4515,11 @@ msgstr  ""
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: cmd/incus/image.go:998
+#: cmd/incus/image.go:1050
 msgid   "Profiles:"
 msgstr  ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1048
 msgid   "Profiles: "
 msgstr  ""
 
@@ -4537,15 +4542,15 @@ msgstr  ""
 msgid   "Project to use for the remote"
 msgstr  ""
 
-#: cmd/incus/image.go:971
+#: cmd/incus/image.go:1023
 msgid   "Properties:"
 msgstr  ""
 
-#: cmd/incus/image.go:1514
+#: cmd/incus/image.go:1623
 msgid   "Property not found"
 msgstr  ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1043
 #, c-format
 msgid   "Protocol: %s"
 msgstr  ""
@@ -4640,7 +4645,7 @@ msgstr  ""
 msgid   "Public image server"
 msgstr  ""
 
-#: cmd/incus/image.go:949
+#: cmd/incus/image.go:1001
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
@@ -4676,7 +4681,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: cmd/incus/image.go:498 cmd/incus/image.go:889 cmd/incus/image.go:1423
+#: cmd/incus/image.go:522 cmd/incus/image.go:933 cmd/incus/image.go:1511
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4729,7 +4734,7 @@ msgstr  ""
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: cmd/incus/image.go:1339 cmd/incus/image.go:1340
+#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
 msgid   "Refresh images"
 msgstr  ""
 
@@ -4738,7 +4743,7 @@ msgstr  ""
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: cmd/incus/image.go:1368
+#: cmd/incus/image.go:1456
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4983,7 +4988,7 @@ msgstr  ""
 msgid   "Retrieve the instance's console log"
 msgstr  ""
 
-#: cmd/incus/create.go:371
+#: cmd/incus/create.go:379
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -5029,7 +5034,7 @@ msgstr  ""
 msgid   "SEVERITY"
 msgstr  ""
 
-#: cmd/incus/image.go:1062
+#: cmd/incus/image.go:1129
 msgid   "SIZE"
 msgstr  ""
 
@@ -5130,7 +5135,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: cmd/incus/image.go:990
+#: cmd/incus/image.go:1042
 #, c-format
 msgid   "Server: %s"
 msgstr  ""
@@ -5161,7 +5166,7 @@ msgid   "Set device configuration keys\n"
         "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/image.go:1530 cmd/incus/image.go:1531
+#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
 msgid   "Set image properties"
 msgstr  ""
 
@@ -5429,7 +5434,7 @@ msgstr  ""
 msgid   "Show full device configuration"
 msgstr  ""
 
-#: cmd/incus/image.go:1419 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
 msgid   "Show image properties"
 msgstr  ""
 
@@ -5553,7 +5558,7 @@ msgstr  ""
 msgid   "Show useful information about a cluster member"
 msgstr  ""
 
-#: cmd/incus/image.go:885 cmd/incus/image.go:886
+#: cmd/incus/image.go:929 cmd/incus/image.go:930
 msgid   "Show useful information about images"
 msgstr  ""
 
@@ -5569,7 +5574,7 @@ msgstr  ""
 msgid   "Size in GiB of the new loop device"
 msgstr  ""
 
-#: cmd/incus/image.go:946
+#: cmd/incus/image.go:998
 #, c-format
 msgid   "Size: %.2fMiB"
 msgstr  ""
@@ -5605,7 +5610,7 @@ msgstr  ""
 msgid   "Source of the storage pool (block device, volume group, dataset, path, ... as applicable):"
 msgstr  ""
 
-#: cmd/incus/image.go:989
+#: cmd/incus/image.go:1041
 msgid   "Source:"
 msgstr  ""
 
@@ -5613,7 +5618,7 @@ msgstr  ""
 msgid   "Start instances"
 msgstr  ""
 
-#: cmd/incus/launch.go:83
+#: cmd/incus/launch.go:99
 #, c-format
 msgid   "Starting %s"
 msgstr  ""
@@ -5788,7 +5793,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1064 cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084 cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26 cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492 cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1130 cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084 cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26 cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492 cmd/incus/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -5899,7 +5904,7 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: cmd/incus/create.go:449
+#: cmd/incus/create.go:457
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -6090,15 +6095,15 @@ msgstr  ""
 msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
-#: cmd/incus/image.go:950
+#: cmd/incus/image.go:1002
 msgid   "Timestamps:"
 msgstr  ""
 
-#: cmd/incus/create.go:451
+#: cmd/incus/create.go:459
 msgid   "To attach a network to an instance, use: incus network attach"
 msgstr  ""
 
-#: cmd/incus/create.go:450
+#: cmd/incus/create.go:458
 msgid   "To create a new network, use: incus network create"
 msgstr  ""
 
@@ -6154,7 +6159,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
-#: cmd/incus/image.go:769
+#: cmd/incus/image.go:813
 #, c-format
 msgid   "Transferring image: %s"
 msgstr  ""
@@ -6173,7 +6178,7 @@ msgstr  ""
 msgid   "Trust token for %s: "
 msgstr  ""
 
-#: cmd/incus/action.go:316 cmd/incus/launch.go:115
+#: cmd/incus/action.go:316 cmd/incus/launch.go:131
 #, c-format
 msgid   "Try `incus info --show-log %s` for more info"
 msgstr  ""
@@ -6190,7 +6195,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: cmd/incus/image.go:948 cmd/incus/info.go:273 cmd/incus/info.go:473 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
+#: cmd/incus/image.go:1000 cmd/incus/info.go:273 cmd/incus/info.go:473 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -6204,7 +6209,7 @@ msgstr  ""
 msgid   "UNLIMITED"
 msgstr  ""
 
-#: cmd/incus/image.go:1063
+#: cmd/incus/image.go:1131
 msgid   "UPLOAD DATE"
 msgstr  ""
 
@@ -6252,7 +6257,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1080 cmd/incus/list.go:629 cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
+#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1152 cmd/incus/list.go:629 cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -6289,7 +6294,7 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: cmd/incus/image.go:1586 cmd/incus/image.go:1587
+#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
 msgid   "Unset image properties"
 msgstr  ""
 
@@ -6434,7 +6439,7 @@ msgstr  ""
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
-#: cmd/incus/image.go:957
+#: cmd/incus/image.go:1009
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
@@ -6698,7 +6703,7 @@ msgstr  ""
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
-#: cmd/incus/image.go:1018 cmd/incus/list.go:46
+#: cmd/incus/image.go:1071 cmd/incus/list.go:46
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
@@ -6778,15 +6783,15 @@ msgstr  ""
 msgid   "[<remote>:]<group> <new-name>"
 msgstr  ""
 
-#: cmd/incus/image.go:364 cmd/incus/image.go:884 cmd/incus/image.go:1418
+#: cmd/incus/image.go:380 cmd/incus/image.go:928 cmd/incus/image.go:1506
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: cmd/incus/image.go:1477 cmd/incus/image.go:1585
+#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: cmd/incus/image.go:1529
+#: cmd/incus/image.go:1638
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
@@ -6802,11 +6807,11 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
-#: cmd/incus/image.go:491
+#: cmd/incus/image.go:515
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: cmd/incus/image.go:312 cmd/incus/image.go:1338
+#: cmd/incus/image.go:324 cmd/incus/image.go:1422
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
@@ -7250,7 +7255,7 @@ msgstr  ""
 msgid   "description"
 msgstr  ""
 
-#: cmd/incus/image.go:935
+#: cmd/incus/image.go:987
 msgid   "disabled"
 msgstr  ""
 
@@ -7258,7 +7263,7 @@ msgstr  ""
 msgid   "driver"
 msgstr  ""
 
-#: cmd/incus/image.go:937
+#: cmd/incus/image.go:989
 msgid   "enabled"
 msgstr  ""
 
@@ -7350,7 +7355,7 @@ msgid   "incus file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
 
-#: cmd/incus/image.go:368
+#: cmd/incus/image.go:384
 msgid   "incus image edit <image>\n"
         "    Launch a text editor to edit the properties\n"
         "\n"
@@ -7518,7 +7523,7 @@ msgstr  ""
 msgid   "name"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:497 cmd/incus/image.go:925 cmd/incus/image.go:930 cmd/incus/image.go:1120
+#: cmd/incus/config_trust.go:497 cmd/incus/image.go:977 cmd/incus/image.go:982 cmd/incus/image.go:1192
 msgid   "no"
 msgstr  ""
 
@@ -7563,7 +7568,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494 cmd/incus/delete.go:47 cmd/incus/image.go:927 cmd/incus/image.go:932 cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
+#: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494 cmd/incus/delete.go:47 cmd/incus/image.go:979 cmd/incus/image.go:984 cmd/incus/image.go:1189 cmd/incus/snapshot.go:220
 msgid   "yes"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-30 15:38-0500\n"
+"POT-Creation-Date: 2024-02-10 17:56-0500\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -173,7 +173,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/image.go:381
+#: cmd/incus/image.go:405
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -574,7 +574,7 @@ msgstr "%s non è una directory"
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1091
+#: cmd/incus/image.go:1163
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
@@ -631,7 +631,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/create.go:126 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr "Creazione del container in corso"
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:651
+#: cmd/incus/image.go:683
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -730,15 +730,15 @@ msgstr "Il nome del container è: %s"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1055 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1126 cmd/incus/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1056
+#: cmd/incus/image.go:1127
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: cmd/incus/cluster.go:186 cmd/incus/image.go:1061 cmd/incus/list.go:554
+#: cmd/incus/cluster.go:186 cmd/incus/image.go:1121 cmd/incus/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -918,7 +918,7 @@ msgstr "il remote %s non esiste"
 msgid "Alias name missing"
 msgstr "Nome dell'alias mancante"
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1044
 #, fuzzy, c-format
 msgid "Alias: %s"
 msgstr "Alias:"
@@ -928,7 +928,7 @@ msgstr "Alias:"
 msgid "Aliases already exists: %s"
 msgstr "il remote %s esiste già"
 
-#: cmd/incus/image.go:976
+#: cmd/incus/image.go:1028
 msgid "Aliases:"
 msgstr "Alias:"
 
@@ -949,7 +949,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: cmd/incus/image.go:947 cmd/incus/info.go:476
+#: cmd/incus/image.go:999 cmd/incus/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -972,7 +972,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:357 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:177
+#: cmd/incus/image.go:189
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:986
+#: cmd/incus/image.go:1038
 #, c-format
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1079,7 +1079,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:138 cmd/incus/create.go:221 cmd/incus/move.go:358
+#: cmd/incus/copy.go:138 cmd/incus/create.go:229 cmd/incus/move.go:358
 #: cmd/incus/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1091,7 +1091,7 @@ msgstr "Proprietà errata: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:758
+#: cmd/incus/image.go:802
 #, c-format
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
@@ -1173,7 +1173,7 @@ msgstr "CREATO IL"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: cmd/incus/image.go:985
+#: cmd/incus/image.go:1037
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:210
+#: cmd/incus/image.go:222
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:326
+#: cmd/incus/create.go:334
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1427,7 +1427,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1046 cmd/incus/list.go:132
+#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1100 cmd/incus/list.go:132
 #: cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239
 #: cmd/incus/warning.go:93
 msgid "Columns"
@@ -1475,7 +1475,7 @@ msgstr ""
 #: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339
 #: cmd/incus/config.go:268 cmd/incus/config.go:343
 #: cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352
-#: cmd/incus/image.go:459 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
+#: cmd/incus/image.go:483 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
 #: cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637
 #: cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550
 #: cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518
@@ -1586,7 +1586,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:266
+#: cmd/incus/image.go:278
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1778,13 +1778,13 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:954 cmd/incus/info.go:487
+#: cmd/incus/image.go:1006 cmd/incus/info.go:487
 #: cmd/incus/storage_volume.go:1273
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:174
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
@@ -1794,7 +1794,7 @@ msgstr "Creazione di %s in corso"
 msgid "Creating %s: %%s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/create.go:164
+#: cmd/incus/create.go:172
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
@@ -1809,7 +1809,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438
-#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1060
+#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1122
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088
 #: cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139
@@ -1871,7 +1871,7 @@ msgstr "Creazione del container in corso"
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:314 cmd/incus/image.go:315
+#: cmd/incus/image.go:326 cmd/incus/image.go:327
 msgid "Delete images"
 msgstr ""
 
@@ -1994,10 +1994,10 @@ msgstr ""
 #: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131
 #: cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428
 #: cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
-#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
-#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
-#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382
+#: cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930
+#: cmd/incus/image.go:1074 cmd/incus/image.go:1424 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704
 #: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
@@ -2173,11 +2173,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:417
+#: cmd/incus/create.go:425
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: cmd/incus/image.go:668
+#: cmd/incus/image.go:712
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
@@ -2215,6 +2215,11 @@ msgstr "Utilizzo disco:"
 #, fuzzy
 msgid "Disks:"
 msgstr "Utilizzo disco:"
+
+#: cmd/incus/image.go:1102
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "Creazione del container in corso"
 
 #: cmd/incus/list.go:135
 #, fuzzy
@@ -2299,7 +2304,7 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:365 cmd/incus/image.go:366
+#: cmd/incus/image.go:381 cmd/incus/image.go:382
 msgid "Edit image properties"
 msgstr ""
 
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1072 cmd/incus/list.go:614
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1144 cmd/incus/list.go:614
 #: cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2550,20 +2555,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:960
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:962
+#: cmd/incus/image.go:1014
 msgid "Expires: never"
 msgstr ""
 
-#: cmd/incus/image.go:492
+#: cmd/incus/image.go:516
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:493
+#: cmd/incus/image.go:517
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2593,7 +2598,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:560
+#: cmd/incus/image.go:592
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2606,8 +2611,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1057
-#: cmd/incus/image.go:1058 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1124
+#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2695,17 +2700,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/create.go:180
+#: cmd/incus/create.go:188
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/create.go:305
+#: cmd/incus/create.go:313
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:231
+#: cmd/incus/create.go:239
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Accetta certificato"
@@ -2952,7 +2957,7 @@ msgstr "Creazione del container in corso"
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: cmd/incus/image.go:945
+#: cmd/incus/image.go:997
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -3017,7 +3022,7 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867
 #: cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241
 #: cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587
-#: cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
+#: cmd/incus/image.go:1101 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
 #: cmd/incus/network.go:1011 cmd/incus/network.go:1110
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93
@@ -3088,7 +3093,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/image.go:1478 cmd/incus/image.go:1479
+#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
 msgid "Get image properties"
 msgstr ""
 
@@ -3346,11 +3351,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1401
+#: cmd/incus/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:283
+#: cmd/incus/image.go:295
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3358,25 +3363,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:636
+#: cmd/incus/image.go:668
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:338 cmd/incus/image.go:1363
+#: cmd/incus/image.go:354 cmd/incus/image.go:1451
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:406 cmd/incus/image.go:1555
+#: cmd/incus/image.go:430 cmd/incus/image.go:1672
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:856
+#: cmd/incus/image.go:900
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1399
+#: cmd/incus/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3396,14 +3401,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/image.go:653
+#: cmd/incus/image.go:685
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:652
+#: cmd/incus/image.go:684
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3468,7 +3473,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:428
+#: cmd/incus/create.go:436
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -3673,21 +3678,21 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/image.go:966
+#: cmd/incus/image.go:1018
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:968
+#: cmd/incus/image.go:1020
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:160
+#: cmd/incus/create.go:168
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/create.go:158
+#: cmd/incus/create.go:166
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creazione del container in corso"
@@ -3792,11 +3797,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: cmd/incus/image.go:1020
+#: cmd/incus/image.go:1073
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1074
 msgid ""
 "List images\n"
 "\n"
@@ -3817,6 +3822,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4165,7 +4171,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:658
+#: cmd/incus/image.go:154 cmd/incus/image.go:690
 msgid "Make image public"
 msgstr ""
 
@@ -4714,7 +4720,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:670
+#: cmd/incus/image.go:714
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4965,7 +4971,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:659
+#: cmd/incus/image.go:157 cmd/incus/image.go:691
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -5068,7 +5074,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:747
+#: cmd/incus/image.go:791
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -5132,8 +5138,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512
-#: cmd/incus/warning.go:213
+#: cmd/incus/image.go:1123 cmd/incus/list.go:559
+#: cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5145,7 +5151,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
+#: cmd/incus/image.go:1128 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5239,7 +5245,7 @@ msgstr ""
 #: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340
 #: cmd/incus/config.go:269 cmd/incus/config.go:344
 #: cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205
-#: cmd/incus/config_trust.go:353 cmd/incus/image.go:460
+#: cmd/incus/config_trust.go:353 cmd/incus/image.go:484
 #: cmd/incus/network.go:759 cmd/incus/network_acl.go:620
 #: cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638
 #: cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551
@@ -5330,11 +5336,11 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:998
+#: cmd/incus/image.go:1050
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1048
 msgid "Profiles: "
 msgstr ""
 
@@ -5357,15 +5363,15 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:971
+#: cmd/incus/image.go:1023
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1514
+#: cmd/incus/image.go:1623
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1043
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -5478,7 +5484,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:949
+#: cmd/incus/image.go:1001
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5515,7 +5521,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:498 cmd/incus/image.go:889 cmd/incus/image.go:1423
+#: cmd/incus/image.go:522 cmd/incus/image.go:933 cmd/incus/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5576,7 +5582,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1339 cmd/incus/image.go:1340
+#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
 msgid "Refresh images"
 msgstr ""
 
@@ -5585,7 +5591,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1368
+#: cmd/incus/image.go:1456
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5849,7 +5855,7 @@ msgstr "Creazione del container in corso"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:371
+#: cmd/incus/create.go:379
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5898,7 +5904,7 @@ msgstr "Creazione del container in corso"
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1062
+#: cmd/incus/image.go:1129
 msgid "SIZE"
 msgstr ""
 
@@ -6001,7 +6007,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:990
+#: cmd/incus/image.go:1042
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6037,7 +6043,7 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1530 cmd/incus/image.go:1531
+#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
 msgid "Set image properties"
 msgstr ""
 
@@ -6339,7 +6345,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1419 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6475,7 +6481,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/image.go:885 cmd/incus/image.go:886
+#: cmd/incus/image.go:929 cmd/incus/image.go:930
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6491,7 +6497,7 @@ msgstr ""
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:946
+#: cmd/incus/image.go:998
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Aggiornamento automatico: %s"
@@ -6529,7 +6535,7 @@ msgid ""
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:989
+#: cmd/incus/image.go:1041
 msgid "Source:"
 msgstr ""
 
@@ -6538,7 +6544,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/launch.go:83
+#: cmd/incus/launch.go:99
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6716,7 +6722,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1064
+#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084
 #: cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26
 #: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492
@@ -6845,7 +6851,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:449
+#: cmd/incus/create.go:457
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7047,15 +7053,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:950
+#: cmd/incus/image.go:1002
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:451
+#: cmd/incus/create.go:459
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:450
+#: cmd/incus/create.go:458
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7115,7 +7121,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:769
+#: cmd/incus/image.go:813
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -7134,7 +7140,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/action.go:316 cmd/incus/launch.go:115
+#: cmd/incus/action.go:316 cmd/incus/launch.go:131
 #, c-format
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
@@ -7154,7 +7160,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/image.go:948 cmd/incus/info.go:273 cmd/incus/info.go:473
+#: cmd/incus/image.go:1000 cmd/incus/info.go:273 cmd/incus/info.go:473
 #: cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
 #, c-format
 msgid "Type: %s"
@@ -7169,7 +7175,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1063
+#: cmd/incus/image.go:1131
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -7222,7 +7228,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1080 cmd/incus/list.go:629
+#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1152 cmd/incus/list.go:629
 #: cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7262,7 +7268,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1586 cmd/incus/image.go:1587
+#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
 msgid "Unset image properties"
 msgstr ""
 
@@ -7420,7 +7426,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/image.go:957
+#: cmd/incus/image.go:1009
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7718,7 +7724,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1018 cmd/incus/list.go:46
+#: cmd/incus/image.go:1071 cmd/incus/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7822,17 +7828,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:364 cmd/incus/image.go:884 cmd/incus/image.go:1418
+#: cmd/incus/image.go:380 cmd/incus/image.go:928 cmd/incus/image.go:1506
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1477 cmd/incus/image.go:1585
+#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:1529
+#: cmd/incus/image.go:1638
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
@@ -7852,12 +7858,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:491
+#: cmd/incus/image.go:515
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image.go:312 cmd/incus/image.go:1338
+#: cmd/incus/image.go:324 cmd/incus/image.go:1422
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
@@ -8441,7 +8447,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:935
+#: cmd/incus/image.go:987
 msgid "disabled"
 msgstr ""
 
@@ -8449,7 +8455,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:937
+#: cmd/incus/image.go:989
 msgid "enabled"
 msgstr ""
 
@@ -8558,7 +8564,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:368
+#: cmd/incus/image.go:384
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8760,8 +8766,8 @@ msgstr "no"
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:497 cmd/incus/image.go:925 cmd/incus/image.go:930
-#: cmd/incus/image.go:1120
+#: cmd/incus/config_trust.go:497 cmd/incus/image.go:977 cmd/incus/image.go:982
+#: cmd/incus/image.go:1192
 msgid "no"
 msgstr "no"
 
@@ -8807,8 +8813,8 @@ msgid "y"
 msgstr ""
 
 #: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494
-#: cmd/incus/delete.go:47 cmd/incus/image.go:927 cmd/incus/image.go:932
-#: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
+#: cmd/incus/delete.go:47 cmd/incus/image.go:979 cmd/incus/image.go:984
+#: cmd/incus/image.go:1189 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-30 15:38-0500\n"
+"POT-Creation-Date: 2024-02-10 17:56-0500\n"
 "PO-Revision-Date: 2024-02-02 10:01+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -152,7 +152,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: cmd/incus/image.go:381
+#: cmd/incus/image.go:405
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -567,7 +567,7 @@ msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 "%s %q（プール %q 上, プロジェクト %q 内, スナップショット %d 個を含む）"
 
-#: cmd/incus/image.go:1091
+#: cmd/incus/image.go:1163
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s（他%d個）"
@@ -623,7 +623,7 @@ msgstr "--console と --all は同時に指定できません"
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
-#: cmd/incus/create.go:126 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
@@ -692,7 +692,7 @@ msgstr "<remote>: <path>"
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
-#: cmd/incus/image.go:651
+#: cmd/incus/image.go:683
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -719,15 +719,15 @@ msgstr "クラスターメンバー名が必要です"
 msgid "ADDRESS"
 msgstr "ADDRESS"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1055 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1126 cmd/incus/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1056
+#: cmd/incus/image.go:1127
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/cluster.go:186 cmd/incus/image.go:1061 cmd/incus/list.go:554
+#: cmd/incus/cluster.go:186 cmd/incus/image.go:1121 cmd/incus/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -918,7 +918,7 @@ msgstr "エイリアス %s は存在しません"
 msgid "Alias name missing"
 msgstr "エイリアスを指定してください"
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1044
 #, c-format
 msgid "Alias: %s"
 msgstr "エイリアス: %s"
@@ -928,7 +928,7 @@ msgstr "エイリアス: %s"
 msgid "Aliases already exists: %s"
 msgstr "エイリアスは既に存在します: %s"
 
-#: cmd/incus/image.go:976
+#: cmd/incus/image.go:1028
 msgid "Aliases:"
 msgstr "エイリアス:"
 
@@ -948,7 +948,7 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: cmd/incus/image.go:947 cmd/incus/info.go:476
+#: cmd/incus/image.go:999 cmd/incus/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -972,7 +972,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: cmd/incus/create.go:357 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
@@ -1030,11 +1030,11 @@ msgstr "認証タイプ '%s' はサーバではサポートされていません
 msgid "Auto negotiation: %v"
 msgstr "オートネゴシエーション: %v"
 
-#: cmd/incus/image.go:177
+#: cmd/incus/image.go:189
 msgid "Auto update is only available in pull mode"
 msgstr "自動更新は pull モードのときのみ有効です"
 
-#: cmd/incus/image.go:986
+#: cmd/incus/image.go:1038
 #, c-format
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
@@ -1084,7 +1084,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: cmd/incus/copy.go:138 cmd/incus/create.go:221 cmd/incus/move.go:358
+#: cmd/incus/copy.go:138 cmd/incus/create.go:229 cmd/incus/move.go:358
 #: cmd/incus/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1096,7 +1096,7 @@ msgstr "不適切な キー=値 のペア: %q"
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: cmd/incus/image.go:758
+#: cmd/incus/image.go:802
 #, c-format
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
@@ -1177,7 +1177,7 @@ msgstr "CREATED AT"
 msgid "CUDA Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/image.go:985
+#: cmd/incus/image.go:1037
 #, c-format
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
@@ -1196,7 +1196,7 @@ msgstr "アドレス %q をバインドできません: %w"
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
-#: cmd/incus/image.go:210
+#: cmd/incus/image.go:222
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
@@ -1260,7 +1260,7 @@ msgstr "--minimal と --preseed を同時に使えません"
 msgid "Can't use an image with --empty"
 msgstr "イメージに --empty は使えません"
 
-#: cmd/incus/create.go:326
+#: cmd/incus/create.go:334
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1439,7 +1439,7 @@ msgstr "クラスターメンバ名"
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1046 cmd/incus/list.go:132
+#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1100 cmd/incus/list.go:132
 #: cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239
 #: cmd/incus/warning.go:93
 msgid "Columns"
@@ -1492,7 +1492,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339
 #: cmd/incus/config.go:268 cmd/incus/config.go:343
 #: cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352
-#: cmd/incus/image.go:459 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
+#: cmd/incus/image.go:483 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
 #: cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637
 #: cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550
 #: cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518
@@ -1619,7 +1619,7 @@ msgstr "コピー／移動元とは異なるプロジェクトにコピーしま
 msgid "Copy virtual machine images"
 msgstr "仮想マシンイメージをコピーします"
 
-#: cmd/incus/image.go:266
+#: cmd/incus/image.go:278
 #, c-format
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
@@ -1806,13 +1806,13 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: cmd/incus/image.go:954 cmd/incus/info.go:487
+#: cmd/incus/image.go:1006 cmd/incus/info.go:487
 #: cmd/incus/storage_volume.go:1273
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:174
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
@@ -1822,7 +1822,7 @@ msgstr "%s を作成中"
 msgid "Creating %s: %%s"
 msgstr "%s を作成中"
 
-#: cmd/incus/create.go:164
+#: cmd/incus/create.go:172
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
@@ -1836,7 +1836,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438
-#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1060
+#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1122
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088
 #: cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139
@@ -1898,7 +1898,7 @@ msgstr "インスタンス内のファイルを削除します"
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
-#: cmd/incus/image.go:314 cmd/incus/image.go:315
+#: cmd/incus/image.go:326 cmd/incus/image.go:327
 msgid "Delete images"
 msgstr "イメージを削除します"
 
@@ -2015,10 +2015,10 @@ msgstr "警告を削除します"
 #: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131
 #: cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428
 #: cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
-#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
-#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
-#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382
+#: cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930
+#: cmd/incus/image.go:1074 cmd/incus/image.go:1424 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704
 #: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
@@ -2196,13 +2196,13 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/create.go:417
+#: cmd/incus/create.go:425
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
 "でした"
 
-#: cmd/incus/image.go:668
+#: cmd/incus/image.go:712
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
@@ -2238,6 +2238,11 @@ msgstr "ディスク:"
 #: cmd/incus/info.go:423
 msgid "Disks:"
 msgstr "ディスク:"
+
+#: cmd/incus/image.go:1102
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "すべてのプロジェクトのインスタンスを表示します"
 
 #: cmd/incus/list.go:135
 msgid "Display instances from all projects"
@@ -2321,7 +2326,7 @@ msgstr "クラスターメンバーの設定をYAMLファイルで編集しま�
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
-#: cmd/incus/image.go:365 cmd/incus/image.go:366
+#: cmd/incus/image.go:381 cmd/incus/image.go:382
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
@@ -2394,7 +2399,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1072 cmd/incus/list.go:614
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1144 cmd/incus/list.go:614
 #: cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2602,9 +2607,8 @@ msgstr ""
 "\n"
 "  incus exec <instance> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
-"デフォルトのモードは non-interactive です。"
-"もし標準入出力が両方ともターミナルの場合は interactive モードが選択されます "
-"(標準エラー出力は無視されます)。"
+"デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
+"の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
 #: cmd/incus/utils_properties.go:95
 #, c-format
@@ -2617,20 +2621,20 @@ msgstr "構造体を期待しましたが、%v が返されました"
 msgid "Expires at"
 msgstr "失効日時"
 
-#: cmd/incus/image.go:960
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Expires: %s"
 msgstr "失効日時: %s"
 
-#: cmd/incus/image.go:962
+#: cmd/incus/image.go:1014
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
-#: cmd/incus/image.go:492
+#: cmd/incus/image.go:516
 msgid "Export and download images"
 msgstr "イメージをエクスポートしてダウンロードします"
 
-#: cmd/incus/image.go:493
+#: cmd/incus/image.go:517
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2662,7 +2666,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
 
-#: cmd/incus/image.go:560
+#: cmd/incus/image.go:592
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
@@ -2675,8 +2679,8 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1057
-#: cmd/incus/image.go:1058 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1124
+#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
@@ -2764,17 +2768,17 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed import request: %w"
 msgstr "%q の作成に失敗しました: %w"
 
-#: cmd/incus/create.go:180
+#: cmd/incus/create.go:188
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "%q の作成に失敗しました: %w"
 
-#: cmd/incus/create.go:305
+#: cmd/incus/create.go:313
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: cmd/incus/create.go:231
+#: cmd/incus/create.go:239
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -3020,7 +3024,7 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
-#: cmd/incus/image.go:945
+#: cmd/incus/image.go:997
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -3099,7 +3103,7 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867
 #: cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241
 #: cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587
-#: cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
+#: cmd/incus/image.go:1101 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
 #: cmd/incus/network.go:1011 cmd/incus/network.go:1110
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93
@@ -3170,7 +3174,7 @@ msgstr "クライアント証明書を生成します。1分ぐらいかかり�
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: cmd/incus/image.go:1478 cmd/incus/image.go:1479
+#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -3432,11 +3436,11 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: cmd/incus/image.go:1401
+#: cmd/incus/image.go:1489
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
-#: cmd/incus/image.go:283
+#: cmd/incus/image.go:295
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
@@ -3444,25 +3448,25 @@ msgstr "イメージのコピーが成功しました!"
 msgid "Image expiration date (format: rfc3339)"
 msgstr "イメージの失効日（フォーマット: rfc3339）"
 
-#: cmd/incus/image.go:636
+#: cmd/incus/image.go:668
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: cmd/incus/image.go:338 cmd/incus/image.go:1363
+#: cmd/incus/image.go:354 cmd/incus/image.go:1451
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: cmd/incus/image.go:406 cmd/incus/image.go:1555
+#: cmd/incus/image.go:430 cmd/incus/image.go:1672
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
 
-#: cmd/incus/image.go:856
+#: cmd/incus/image.go:900
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: cmd/incus/image.go:1399
+#: cmd/incus/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3485,7 +3489,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/image.go:653
+#: cmd/incus/image.go:685
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3496,7 +3500,7 @@ msgstr ""
 "ディレクトリのインポートは Linux 上でのみ可能で、root で実行する必要がありま"
 "す。"
 
-#: cmd/incus/image.go:652
+#: cmd/incus/image.go:684
 msgid "Import images into the image store"
 msgstr "イメージをイメージストアにインポートします"
 
@@ -3562,7 +3566,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: cmd/incus/create.go:428
+#: cmd/incus/create.go:436
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -3770,21 +3774,21 @@ msgstr "LOCATION"
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
 
-#: cmd/incus/image.go:966
+#: cmd/incus/image.go:1018
 #, c-format
 msgid "Last used: %s"
 msgstr "最終使用: %s"
 
-#: cmd/incus/image.go:968
+#: cmd/incus/image.go:1020
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: cmd/incus/create.go:160
+#: cmd/incus/create.go:168
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "%s を作成中"
 
-#: cmd/incus/create.go:158
+#: cmd/incus/create.go:166
 #, fuzzy
 msgid "Launching the instance"
 msgstr "インスタンスを作成中"
@@ -3886,11 +3890,12 @@ msgstr ""
 "指定するフィルタはイメージのハッシュ値の一部でもイメージのエイリアスの一部で"
 "も構いません。\n"
 
-#: cmd/incus/image.go:1020
+#: cmd/incus/image.go:1073
 msgid "List images"
 msgstr "イメージを一覧表示します"
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1074
+#, fuzzy
 msgid ""
 "List images\n"
 "\n"
@@ -3911,6 +3916,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4421,7 +4427,7 @@ msgstr "MTU"
 msgid "MTU: %d"
 msgstr "MTU: %d"
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:658
+#: cmd/incus/image.go:154 cmd/incus/image.go:690
 msgid "Make image public"
 msgstr "イメージを public にする"
 
@@ -4980,7 +4986,7 @@ msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
 
-#: cmd/incus/image.go:670
+#: cmd/incus/image.go:714
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
@@ -5236,7 +5242,7 @@ msgstr "ネットワークゾーンレコード %s を削除しました"
 msgid "New alias to define at target"
 msgstr "新しいエイリアスを定義する"
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:659
+#: cmd/incus/image.go:157 cmd/incus/image.go:691
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
@@ -5344,7 +5350,7 @@ msgstr "\"カスタム\" のボリュームのみがスナップショットを�
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
-#: cmd/incus/image.go:747
+#: cmd/incus/image.go:791
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
@@ -5410,8 +5416,8 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512
-#: cmd/incus/warning.go:213
+#: cmd/incus/image.go:1123 cmd/incus/list.go:559
+#: cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -5424,7 +5430,7 @@ msgstr "PROJECT"
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
+#: cmd/incus/image.go:1128 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5517,7 +5523,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340
 #: cmd/incus/config.go:269 cmd/incus/config.go:344
 #: cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205
-#: cmd/incus/config_trust.go:353 cmd/incus/image.go:460
+#: cmd/incus/config_trust.go:353 cmd/incus/image.go:484
 #: cmd/incus/network.go:759 cmd/incus/network_acl.go:620
 #: cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638
 #: cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551
@@ -5608,11 +5614,11 @@ msgstr "移動先のインスタンスに適用するプロファイル"
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: cmd/incus/image.go:998
+#: cmd/incus/image.go:1050
 msgid "Profiles:"
 msgstr "プロファイル:"
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1048
 msgid "Profiles: "
 msgstr "プロファイル: "
 
@@ -5635,15 +5641,15 @@ msgstr "プロジェクト名 %s を %s に変更しました"
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
-#: cmd/incus/image.go:971
+#: cmd/incus/image.go:1023
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: cmd/incus/image.go:1514
+#: cmd/incus/image.go:1623
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1043
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -5786,7 +5792,7 @@ msgstr "プロキシータイムアウト (接続がない場合終了)"
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
-#: cmd/incus/image.go:949
+#: cmd/incus/image.go:1001
 #, c-format
 msgid "Public: %s"
 msgstr "パブリック: %s"
@@ -5822,7 +5828,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: cmd/incus/image.go:498 cmd/incus/image.go:889 cmd/incus/image.go:1423
+#: cmd/incus/image.go:522 cmd/incus/image.go:933 cmd/incus/image.go:1511
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5891,7 +5897,7 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: cmd/incus/image.go:1339 cmd/incus/image.go:1340
+#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
@@ -5900,7 +5906,7 @@ msgstr "イメージを更新します"
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: cmd/incus/image.go:1368
+#: cmd/incus/image.go:1456
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -6164,7 +6170,7 @@ msgstr "インスタンスを再起動します"
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: cmd/incus/create.go:371
+#: cmd/incus/create.go:379
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -6211,7 +6217,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
-#: cmd/incus/image.go:1062
+#: cmd/incus/image.go:1129
 msgid "SIZE"
 msgstr "SIZE"
 
@@ -6318,7 +6324,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: cmd/incus/image.go:990
+#: cmd/incus/image.go:1042
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "デバイス: %s"
@@ -6363,7 +6369,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: cmd/incus/image.go:1530 cmd/incus/image.go:1531
+#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
@@ -6729,7 +6735,7 @@ msgstr "すべてのプロジェクトのイベントを表示します"
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
-#: cmd/incus/image.go:1419 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
@@ -6856,7 +6862,7 @@ msgstr "信頼済みクライアントの設定を表示します"
 msgid "Show useful information about a cluster member"
 msgstr "クラスターメンバーについての情報を表示します"
 
-#: cmd/incus/image.go:885 cmd/incus/image.go:886
+#: cmd/incus/image.go:929 cmd/incus/image.go:930
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
@@ -6872,7 +6878,7 @@ msgstr "警告を表示します"
 msgid "Size in GiB of the new loop device"
 msgstr "新しい loop デバイスのサイズ (GiB)"
 
-#: cmd/incus/image.go:946
+#: cmd/incus/image.go:998
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "サイズ: %.2fMB"
@@ -6912,7 +6918,7 @@ msgstr ""
 "ストレージプールのソース (適用できるブロックデバイス、ボリュームグループ、"
 "データセット、パス...)"
 
-#: cmd/incus/image.go:989
+#: cmd/incus/image.go:1041
 msgid "Source:"
 msgstr "取得元:"
 
@@ -6920,7 +6926,7 @@ msgstr "取得元:"
 msgid "Start instances"
 msgstr "インスタンスを起動します"
 
-#: cmd/incus/launch.go:83
+#: cmd/incus/launch.go:99
 #, c-format
 msgid "Starting %s"
 msgstr "%s を起動中"
@@ -7097,7 +7103,7 @@ msgstr "TARGET"
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1064
+#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084
 #: cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26
 #: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492
@@ -7257,7 +7263,7 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: cmd/incus/create.go:449
+#: cmd/incus/create.go:457
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
@@ -7485,18 +7491,18 @@ msgstr "スレッド:"
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスがクリーンにシャットダウンするまで待つ時間"
 
-#: cmd/incus/image.go:950
+#: cmd/incus/image.go:1002
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: cmd/incus/create.go:451
+#: cmd/incus/create.go:459
 #, fuzzy
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: cmd/incus/create.go:450
+#: cmd/incus/create.go:458
 #, fuzzy
 msgid "To create a new network, use: incus network create"
 msgstr ""
@@ -7564,7 +7570,7 @@ msgstr "転送モード。pull, push, relay のいずれか"
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
-#: cmd/incus/image.go:769
+#: cmd/incus/image.go:813
 #, c-format
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
@@ -7583,7 +7589,7 @@ msgstr "通信ポリシー"
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: cmd/incus/action.go:316 cmd/incus/launch.go:115
+#: cmd/incus/action.go:316 cmd/incus/launch.go:131
 #, fuzzy, c-format
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
@@ -7604,7 +7610,7 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: cmd/incus/image.go:948 cmd/incus/info.go:273 cmd/incus/info.go:473
+#: cmd/incus/image.go:1000 cmd/incus/info.go:273 cmd/incus/info.go:473
 #: cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
 #, c-format
 msgid "Type: %s"
@@ -7619,7 +7625,7 @@ msgstr "タイプ: %s (ephemeral)"
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
-#: cmd/incus/image.go:1063
+#: cmd/incus/image.go:1131
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
@@ -7671,7 +7677,7 @@ msgstr "未知の証明書タイプ %q"
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1080 cmd/incus/list.go:629
+#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1152 cmd/incus/list.go:629
 #: cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7709,7 +7715,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: cmd/incus/image.go:1586 cmd/incus/image.go:1587
+#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
@@ -7867,7 +7873,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
 
-#: cmd/incus/image.go:957
+#: cmd/incus/image.go:1009
 #, c-format
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
@@ -8106,7 +8112,8 @@ msgstr "既存のブリッジかホストのインターフェースを使用し
 msgid ""
 "Would you like to use an existing empty block device (e.g. a disk or "
 "partition)?"
-msgstr "既存の空のブロックデバイス（ディスクやパーティションなど）を使用しますか?"
+msgstr ""
+"既存の空のブロックデバイス（ディスクやパーティションなど）を使用しますか?"
 
 #: cmd/incus/admin_init_interactive.go:106
 msgid "Would you like to use clustering?"
@@ -8181,7 +8188,7 @@ msgstr "[<remote>:] [<cert>]"
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
-#: cmd/incus/image.go:1018 cmd/incus/list.go:46
+#: cmd/incus/image.go:1071 cmd/incus/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -8265,15 +8272,15 @@ msgstr "[<remote>:]<group>"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: cmd/incus/image.go:364 cmd/incus/image.go:884 cmd/incus/image.go:1418
+#: cmd/incus/image.go:380 cmd/incus/image.go:928 cmd/incus/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: cmd/incus/image.go:1477 cmd/incus/image.go:1585
+#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: cmd/incus/image.go:1529
+#: cmd/incus/image.go:1638
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
@@ -8290,11 +8297,11 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
-#: cmd/incus/image.go:491
+#: cmd/incus/image.go:515
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: cmd/incus/image.go:312 cmd/incus/image.go:1338
+#: cmd/incus/image.go:324 cmd/incus/image.go:1422
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
@@ -8797,7 +8804,7 @@ msgstr "現在値"
 msgid "description"
 msgstr "説明"
 
-#: cmd/incus/image.go:935
+#: cmd/incus/image.go:987
 msgid "disabled"
 msgstr "無効"
 
@@ -8805,7 +8812,7 @@ msgstr "無効"
 msgid "driver"
 msgstr "ドライバ"
 
-#: cmd/incus/image.go:937
+#: cmd/incus/image.go:989
 msgid "enabled"
 msgstr "有効"
 
@@ -8944,8 +8951,8 @@ msgstr ""
 "incus file create foo/bar\n"
 "\t   インスタンス foo 内に /bar ファイルを作成します。\n"
 "incus file create --type=symlink foo/bar baz\n"
-"\t   インスタンス foo 内に、ターゲットが baz であるシンボリックリンク /bar "
-"を作成します。"
+"\t   インスタンス foo 内に、ターゲットが baz であるシンボリックリンク /bar を"
+"作成します。"
 
 #: cmd/incus/file.go:1154
 #, fuzzy
@@ -8978,7 +8985,7 @@ msgstr ""
 "   /etc/hosts ファイルを、インスタンス \"foo\" 内 (の /etc/hosts) にコピーし"
 "ます。"
 
-#: cmd/incus/image.go:368
+#: cmd/incus/image.go:384
 #, fuzzy
 msgid ""
 "incus image edit <image>\n"
@@ -9125,8 +9132,8 @@ msgstr ""
 "    foo という名前の新しいネットワークを作成します\n"
 "\n"
 "incus network create bar network=baz --type ovn\n"
-"    上流ネットワークに baz を使用する、bar という名前の新しい OVN "
-"ネットワークを作成します"
+"    上流ネットワークに baz を使用する、bar という名前の新しい OVN ネットワー"
+"クを作成します"
 
 #: cmd/incus/operation.go:196
 #, fuzzy
@@ -9299,8 +9306,8 @@ msgstr "n"
 msgid "name"
 msgstr "名前"
 
-#: cmd/incus/config_trust.go:497 cmd/incus/image.go:925 cmd/incus/image.go:930
-#: cmd/incus/image.go:1120
+#: cmd/incus/config_trust.go:497 cmd/incus/image.go:977 cmd/incus/image.go:982
+#: cmd/incus/image.go:1192
 msgid "no"
 msgstr "no"
 
@@ -9349,8 +9356,8 @@ msgid "y"
 msgstr "y"
 
 #: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494
-#: cmd/incus/delete.go:47 cmd/incus/image.go:927 cmd/incus/image.go:932
-#: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
+#: cmd/incus/delete.go:47 cmd/incus/image.go:979 cmd/incus/image.go:984
+#: cmd/incus/image.go:1189 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr "yes"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-30 15:38-0500\n"
+"POT-Creation-Date: 2024-02-10 17:56-0500\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -155,7 +155,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: cmd/incus/image.go:381
+#: cmd/incus/image.go:405
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -584,7 +584,7 @@ msgstr "%q is geen IP adres"
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr "%s %q van pool %q in project %q (bevat %d snapshots)"
 
-#: cmd/incus/image.go:1091
+#: cmd/incus/image.go:1163
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
@@ -642,7 +642,7 @@ msgstr "--console kan niet gebruikt worden samen met --all"
 msgid "--console only works with a single instance"
 msgstr "--console werkt alleen als het een enkele instantie (instance) betreft"
 
-#: cmd/incus/create.go:126 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 "--empty kan niet gebruikt worden in combinatie met een virtuele disk (image) "
@@ -714,7 +714,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/image.go:651
+#: cmd/incus/image.go:683
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -740,15 +740,15 @@ msgstr "Een clusterlid (cluster member) naam (name) moet worden meegegeven"
 msgid "ADDRESS"
 msgstr "ADRES"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1055 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1126 cmd/incus/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1056
+#: cmd/incus/image.go:1127
 msgid "ALIASES"
 msgstr "ALIASSEN"
 
-#: cmd/incus/cluster.go:186 cmd/incus/image.go:1061 cmd/incus/list.go:554
+#: cmd/incus/cluster.go:186 cmd/incus/image.go:1121 cmd/incus/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -936,7 +936,7 @@ msgstr "Alias %s bestaat niet"
 msgid "Alias name missing"
 msgstr "Alias naam (name) mist"
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1044
 #, c-format
 msgid "Alias: %s"
 msgstr "Alias: %s"
@@ -946,7 +946,7 @@ msgstr "Alias: %s"
 msgid "Aliases already exists: %s"
 msgstr "Aliassen bestaan al: %s"
 
-#: cmd/incus/image.go:976
+#: cmd/incus/image.go:1028
 msgid "Aliases:"
 msgstr "Aliassen:"
 
@@ -968,7 +968,7 @@ msgstr "Alle server adressen zijn onbeschikbaar"
 msgid "Alternative certificate name"
 msgstr "Alternatieve certificaat naam"
 
-#: cmd/incus/image.go:947 cmd/incus/info.go:476
+#: cmd/incus/image.go:999 cmd/incus/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architectuur: %s"
@@ -993,7 +993,7 @@ msgstr ""
 "Beide konden niet worden gevonden, de directe SPICE plug (raw SPICE socket) "
 "kan hier gevonden worden:"
 
-#: cmd/incus/create.go:357 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 "Gevraagd naar een virtueel machine (VM), maar het bestand (image) is van het "
@@ -1051,11 +1051,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:177
+#: cmd/incus/image.go:189
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:986
+#: cmd/incus/image.go:1038
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1103,7 +1103,7 @@ msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
 
-#: cmd/incus/copy.go:138 cmd/incus/create.go:221 cmd/incus/move.go:358
+#: cmd/incus/copy.go:138 cmd/incus/create.go:229 cmd/incus/move.go:358
 #: cmd/incus/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1115,7 +1115,7 @@ msgstr "Ongeldig sleutel=waarde paar: %q"
 msgid "Bad key=value pair: %s"
 msgstr "Ongeldig sleutel=waarde paar: %s"
 
-#: cmd/incus/image.go:758
+#: cmd/incus/image.go:802
 #, c-format
 msgid "Bad property: %s"
 msgstr "Ongeldig eigenschap: %s"
@@ -1196,7 +1196,7 @@ msgstr "GECREËERD OM"
 msgid "CUDA Version: %v"
 msgstr "CUDA Versie: %v"
 
-#: cmd/incus/image.go:985
+#: cmd/incus/image.go:1037
 #, c-format
 msgid "Cached: %s"
 msgstr "Cached: %s"
@@ -1217,7 +1217,7 @@ msgstr ""
 "Niet mogelijk om geforceerd (override) de configuratie of de profielen in "
 "een lokaal (local) herbenaming (rename) uit te voeren"
 
-#: cmd/incus/image.go:210
+#: cmd/incus/image.go:222
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1280,7 +1280,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:326
+#: cmd/incus/create.go:334
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1451,7 +1451,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1046 cmd/incus/list.go:132
+#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1100 cmd/incus/list.go:132
 #: cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239
 #: cmd/incus/warning.go:93
 msgid "Columns"
@@ -1499,7 +1499,7 @@ msgstr ""
 #: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339
 #: cmd/incus/config.go:268 cmd/incus/config.go:343
 #: cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352
-#: cmd/incus/image.go:459 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
+#: cmd/incus/image.go:483 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
 #: cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637
 #: cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550
 #: cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518
@@ -1610,7 +1610,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:266
+#: cmd/incus/image.go:278
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1792,13 +1792,13 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:954 cmd/incus/info.go:487
+#: cmd/incus/image.go:1006 cmd/incus/info.go:487
 #: cmd/incus/storage_volume.go:1273
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:174
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1808,7 +1808,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:164
+#: cmd/incus/create.go:172
 msgid "Creating the instance"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438
-#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1060
+#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1122
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088
 #: cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:314 cmd/incus/image.go:315
+#: cmd/incus/image.go:326 cmd/incus/image.go:327
 msgid "Delete images"
 msgstr ""
 
@@ -2000,10 +2000,10 @@ msgstr ""
 #: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131
 #: cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428
 #: cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
-#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
-#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
-#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382
+#: cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930
+#: cmd/incus/image.go:1074 cmd/incus/image.go:1424 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704
 #: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
@@ -2177,11 +2177,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:417
+#: cmd/incus/create.go:425
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: cmd/incus/image.go:668
+#: cmd/incus/image.go:712
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2216,6 +2216,10 @@ msgstr ""
 
 #: cmd/incus/info.go:423
 msgid "Disks:"
+msgstr ""
+
+#: cmd/incus/image.go:1102
+msgid "Display images from all projects"
 msgstr ""
 
 #: cmd/incus/list.go:135
@@ -2298,7 +2302,7 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:365 cmd/incus/image.go:366
+#: cmd/incus/image.go:381 cmd/incus/image.go:382
 msgid "Edit image properties"
 msgstr ""
 
@@ -2371,7 +2375,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1072 cmd/incus/list.go:614
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1144 cmd/incus/list.go:614
 #: cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2544,20 +2548,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:960
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:962
+#: cmd/incus/image.go:1014
 msgid "Expires: never"
 msgstr ""
 
-#: cmd/incus/image.go:492
+#: cmd/incus/image.go:516
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:493
+#: cmd/incus/image.go:517
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2585,7 +2589,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: cmd/incus/image.go:560
+#: cmd/incus/image.go:592
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2598,8 +2602,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1057
-#: cmd/incus/image.go:1058 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1124
+#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2687,17 +2691,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:180
+#: cmd/incus/create.go:188
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:305
+#: cmd/incus/create.go:313
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:231
+#: cmd/incus/create.go:239
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
@@ -2943,7 +2947,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:945
+#: cmd/incus/image.go:997
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -3007,7 +3011,7 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867
 #: cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241
 #: cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587
-#: cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
+#: cmd/incus/image.go:1101 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
 #: cmd/incus/network.go:1011 cmd/incus/network.go:1110
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93
@@ -3078,7 +3082,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/image.go:1478 cmd/incus/image.go:1479
+#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
 msgid "Get image properties"
 msgstr ""
 
@@ -3324,11 +3328,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image.go:1401
+#: cmd/incus/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:283
+#: cmd/incus/image.go:295
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3336,25 +3340,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:636
+#: cmd/incus/image.go:668
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:338 cmd/incus/image.go:1363
+#: cmd/incus/image.go:354 cmd/incus/image.go:1451
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:406 cmd/incus/image.go:1555
+#: cmd/incus/image.go:430 cmd/incus/image.go:1672
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:856
+#: cmd/incus/image.go:900
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1399
+#: cmd/incus/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3374,14 +3378,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/image.go:653
+#: cmd/incus/image.go:685
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:652
+#: cmd/incus/image.go:684
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3444,7 +3448,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:428
+#: cmd/incus/create.go:436
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3645,21 +3649,21 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:966
+#: cmd/incus/image.go:1018
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:968
+#: cmd/incus/image.go:1020
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:160
+#: cmd/incus/create.go:168
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:158
+#: cmd/incus/create.go:166
 msgid "Launching the instance"
 msgstr ""
 
@@ -3756,11 +3760,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: cmd/incus/image.go:1020
+#: cmd/incus/image.go:1073
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1074
 msgid ""
 "List images\n"
 "\n"
@@ -3781,6 +3785,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4120,7 +4125,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:658
+#: cmd/incus/image.go:154 cmd/incus/image.go:690
 msgid "Make image public"
 msgstr ""
 
@@ -4635,7 +4640,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:670
+#: cmd/incus/image.go:714
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4886,7 +4891,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:659
+#: cmd/incus/image.go:157 cmd/incus/image.go:691
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4989,7 +4994,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:747
+#: cmd/incus/image.go:791
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -5053,8 +5058,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512
-#: cmd/incus/warning.go:213
+#: cmd/incus/image.go:1123 cmd/incus/list.go:559
+#: cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5066,7 +5071,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
+#: cmd/incus/image.go:1128 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5158,7 +5163,7 @@ msgstr ""
 #: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340
 #: cmd/incus/config.go:269 cmd/incus/config.go:344
 #: cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205
-#: cmd/incus/config_trust.go:353 cmd/incus/image.go:460
+#: cmd/incus/config_trust.go:353 cmd/incus/image.go:484
 #: cmd/incus/network.go:759 cmd/incus/network_acl.go:620
 #: cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638
 #: cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551
@@ -5247,11 +5252,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:998
+#: cmd/incus/image.go:1050
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1048
 msgid "Profiles: "
 msgstr ""
 
@@ -5274,15 +5279,15 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:971
+#: cmd/incus/image.go:1023
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1514
+#: cmd/incus/image.go:1623
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1043
 #, c-format
 msgid "Protocol: %s"
 msgstr ""
@@ -5395,7 +5400,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:949
+#: cmd/incus/image.go:1001
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5431,7 +5436,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:498 cmd/incus/image.go:889 cmd/incus/image.go:1423
+#: cmd/incus/image.go:522 cmd/incus/image.go:933 cmd/incus/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5490,7 +5495,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1339 cmd/incus/image.go:1340
+#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
 msgid "Refresh images"
 msgstr ""
 
@@ -5499,7 +5504,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1368
+#: cmd/incus/image.go:1456
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5749,7 +5754,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:371
+#: cmd/incus/create.go:379
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5795,7 +5800,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1062
+#: cmd/incus/image.go:1129
 msgid "SIZE"
 msgstr ""
 
@@ -5898,7 +5903,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:990
+#: cmd/incus/image.go:1042
 #, c-format
 msgid "Server: %s"
 msgstr ""
@@ -5933,7 +5938,7 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1530 cmd/incus/image.go:1531
+#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
 msgid "Set image properties"
 msgstr ""
 
@@ -6226,7 +6231,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1419 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6352,7 +6357,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: cmd/incus/image.go:885 cmd/incus/image.go:886
+#: cmd/incus/image.go:929 cmd/incus/image.go:930
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6368,7 +6373,7 @@ msgstr ""
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:946
+#: cmd/incus/image.go:998
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -6406,7 +6411,7 @@ msgid ""
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:989
+#: cmd/incus/image.go:1041
 msgid "Source:"
 msgstr ""
 
@@ -6414,7 +6419,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/launch.go:83
+#: cmd/incus/launch.go:99
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6590,7 +6595,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1064
+#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084
 #: cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26
 #: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492
@@ -6718,7 +6723,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:449
+#: cmd/incus/create.go:457
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6918,15 +6923,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:950
+#: cmd/incus/image.go:1002
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:451
+#: cmd/incus/create.go:459
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:450
+#: cmd/incus/create.go:458
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -6986,7 +6991,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:769
+#: cmd/incus/image.go:813
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -7005,7 +7010,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:316 cmd/incus/launch.go:115
+#: cmd/incus/action.go:316 cmd/incus/launch.go:131
 #, c-format
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
@@ -7024,7 +7029,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/image.go:948 cmd/incus/info.go:273 cmd/incus/info.go:473
+#: cmd/incus/image.go:1000 cmd/incus/info.go:273 cmd/incus/info.go:473
 #: cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
 #, c-format
 msgid "Type: %s"
@@ -7039,7 +7044,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1063
+#: cmd/incus/image.go:1131
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -7090,7 +7095,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1080 cmd/incus/list.go:629
+#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1152 cmd/incus/list.go:629
 #: cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7128,7 +7133,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1586 cmd/incus/image.go:1587
+#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
 msgid "Unset image properties"
 msgstr ""
 
@@ -7275,7 +7280,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/image.go:957
+#: cmd/incus/image.go:1009
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7560,7 +7565,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1018 cmd/incus/list.go:46
+#: cmd/incus/image.go:1071 cmd/incus/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7644,15 +7649,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: cmd/incus/image.go:364 cmd/incus/image.go:884 cmd/incus/image.go:1418
+#: cmd/incus/image.go:380 cmd/incus/image.go:928 cmd/incus/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1477 cmd/incus/image.go:1585
+#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: cmd/incus/image.go:1529
+#: cmd/incus/image.go:1638
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -7668,11 +7673,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: cmd/incus/image.go:491
+#: cmd/incus/image.go:515
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: cmd/incus/image.go:312 cmd/incus/image.go:1338
+#: cmd/incus/image.go:324 cmd/incus/image.go:1422
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -8149,7 +8154,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:935
+#: cmd/incus/image.go:987
 msgid "disabled"
 msgstr ""
 
@@ -8157,7 +8162,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:937
+#: cmd/incus/image.go:989
 msgid "enabled"
 msgstr ""
 
@@ -8266,7 +8271,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:368
+#: cmd/incus/image.go:384
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8467,8 +8472,8 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:497 cmd/incus/image.go:925 cmd/incus/image.go:930
-#: cmd/incus/image.go:1120
+#: cmd/incus/config_trust.go:497 cmd/incus/image.go:977 cmd/incus/image.go:982
+#: cmd/incus/image.go:1192
 msgid "no"
 msgstr ""
 
@@ -8514,8 +8519,8 @@ msgid "y"
 msgstr ""
 
 #: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494
-#: cmd/incus/delete.go:47 cmd/incus/image.go:927 cmd/incus/image.go:932
-#: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
+#: cmd/incus/delete.go:47 cmd/incus/image.go:979 cmd/incus/image.go:984
+#: cmd/incus/image.go:1189 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-30 15:38-0500\n"
+"POT-Creation-Date: 2024-02-10 17:56-0500\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -156,7 +156,7 @@ msgstr ""
 "###\n"
 "### Observe que o nome é exibido mas não pode ser modificado"
 
-#: cmd/incus/image.go:381
+#: cmd/incus/image.go:405
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -567,7 +567,7 @@ msgstr "%s não é um diretório"
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1091
+#: cmd/incus/image.go:1163
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
@@ -626,7 +626,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/create.go:126 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
@@ -705,7 +705,7 @@ msgstr "Criar perfis"
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/image.go:651
+#: cmd/incus/image.go:683
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -732,15 +732,15 @@ msgstr "Nome de membro do cluster"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1055 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1126 cmd/incus/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: cmd/incus/image.go:1056
+#: cmd/incus/image.go:1127
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: cmd/incus/cluster.go:186 cmd/incus/image.go:1061 cmd/incus/list.go:554
+#: cmd/incus/cluster.go:186 cmd/incus/image.go:1121 cmd/incus/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -924,7 +924,7 @@ msgstr "Alias %s não existe"
 msgid "Alias name missing"
 msgstr "Nome do alias ausente"
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1044
 #, fuzzy, c-format
 msgid "Alias: %s"
 msgstr "Aliases:"
@@ -934,7 +934,7 @@ msgstr "Aliases:"
 msgid "Aliases already exists: %s"
 msgstr "Alias %s já existe"
 
-#: cmd/incus/image.go:976
+#: cmd/incus/image.go:1028
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -956,7 +956,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/image.go:947 cmd/incus/info.go:476
+#: cmd/incus/image.go:999 cmd/incus/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
@@ -979,7 +979,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:357 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1039,11 +1039,11 @@ msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:177
+#: cmd/incus/image.go:189
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:986
+#: cmd/incus/image.go:1038
 #, c-format
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
@@ -1092,7 +1092,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: cmd/incus/copy.go:138 cmd/incus/create.go:221 cmd/incus/move.go:358
+#: cmd/incus/copy.go:138 cmd/incus/create.go:229 cmd/incus/move.go:358
 #: cmd/incus/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1104,7 +1104,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: cmd/incus/image.go:758
+#: cmd/incus/image.go:802
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
@@ -1185,7 +1185,7 @@ msgstr "CRIADO EM"
 msgid "CUDA Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/image.go:985
+#: cmd/incus/image.go:1037
 #, c-format
 msgid "Cached: %s"
 msgstr "Em cache: %s"
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:210
+#: cmd/incus/image.go:222
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:326
+#: cmd/incus/create.go:334
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1441,7 +1441,7 @@ msgstr "Nome de membro do cluster"
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1046 cmd/incus/list.go:132
+#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1100 cmd/incus/list.go:132
 #: cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239
 #: cmd/incus/warning.go:93
 msgid "Columns"
@@ -1500,7 +1500,7 @@ msgstr ""
 #: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339
 #: cmd/incus/config.go:268 cmd/incus/config.go:343
 #: cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352
-#: cmd/incus/image.go:459 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
+#: cmd/incus/image.go:483 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
 #: cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637
 #: cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550
 #: cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/image.go:266
+#: cmd/incus/image.go:278
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
@@ -1811,13 +1811,13 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:954 cmd/incus/info.go:487
+#: cmd/incus/image.go:1006 cmd/incus/info.go:487
 #: cmd/incus/storage_volume.go:1273
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:174
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
@@ -1827,7 +1827,7 @@ msgstr "Criando %s"
 msgid "Creating %s: %%s"
 msgstr "Criando %s"
 
-#: cmd/incus/create.go:164
+#: cmd/incus/create.go:172
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Criando %s"
@@ -1842,7 +1842,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438
-#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1060
+#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1122
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088
 #: cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139
@@ -1906,7 +1906,7 @@ msgstr "Editar arquivos no container"
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/image.go:314 cmd/incus/image.go:315
+#: cmd/incus/image.go:326 cmd/incus/image.go:327
 msgid "Delete images"
 msgstr ""
 
@@ -2034,10 +2034,10 @@ msgstr ""
 #: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131
 #: cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428
 #: cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
-#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
-#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
-#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382
+#: cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930
+#: cmd/incus/image.go:1074 cmd/incus/image.go:1424 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704
 #: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/create.go:417
+#: cmd/incus/create.go:425
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: cmd/incus/image.go:668
+#: cmd/incus/image.go:712
 msgid "Directory import is not available on this platform"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
@@ -2257,6 +2257,11 @@ msgstr "Uso de disco:"
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso de disco:"
+
+#: cmd/incus/image.go:1102
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "Criar projetos"
 
 #: cmd/incus/list.go:135
 msgid "Display instances from all projects"
@@ -2341,7 +2346,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/image.go:365 cmd/incus/image.go:366
+#: cmd/incus/image.go:381 cmd/incus/image.go:382
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
@@ -2426,7 +2431,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1072 cmd/incus/list.go:614
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1144 cmd/incus/list.go:614
 #: cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2600,20 +2605,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:960
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:962
+#: cmd/incus/image.go:1014
 msgid "Expires: never"
 msgstr ""
 
-#: cmd/incus/image.go:492
+#: cmd/incus/image.go:516
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:493
+#: cmd/incus/image.go:517
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2641,7 +2646,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: cmd/incus/image.go:560
+#: cmd/incus/image.go:592
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2654,8 +2659,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1057
-#: cmd/incus/image.go:1058 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1124
+#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2743,17 +2748,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/create.go:180
+#: cmd/incus/create.go:188
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/create.go:305
+#: cmd/incus/create.go:313
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:231
+#: cmd/incus/create.go:239
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Aceitar certificado"
@@ -2999,7 +3004,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:945
+#: cmd/incus/image.go:997
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -3064,7 +3069,7 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867
 #: cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241
 #: cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587
-#: cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
+#: cmd/incus/image.go:1101 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
 #: cmd/incus/network.go:1011 cmd/incus/network.go:1110
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93
@@ -3135,7 +3140,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/image.go:1478 cmd/incus/image.go:1479
+#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -3401,11 +3406,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: cmd/incus/image.go:1401
+#: cmd/incus/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:283
+#: cmd/incus/image.go:295
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3413,25 +3418,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:636
+#: cmd/incus/image.go:668
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: cmd/incus/image.go:338 cmd/incus/image.go:1363
+#: cmd/incus/image.go:354 cmd/incus/image.go:1451
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: cmd/incus/image.go:406 cmd/incus/image.go:1555
+#: cmd/incus/image.go:430 cmd/incus/image.go:1672
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
 
-#: cmd/incus/image.go:856
+#: cmd/incus/image.go:900
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1399
+#: cmd/incus/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3452,14 +3457,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/image.go:653
+#: cmd/incus/image.go:685
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:652
+#: cmd/incus/image.go:684
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3523,7 +3528,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:428
+#: cmd/incus/create.go:436
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3727,21 +3732,21 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/image.go:966
+#: cmd/incus/image.go:1018
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:968
+#: cmd/incus/image.go:1020
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:160
+#: cmd/incus/create.go:168
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Criando %s"
 
-#: cmd/incus/create.go:158
+#: cmd/incus/create.go:166
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Criando %s"
@@ -3844,11 +3849,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: cmd/incus/image.go:1020
+#: cmd/incus/image.go:1073
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1074
 msgid ""
 "List images\n"
 "\n"
@@ -3869,6 +3874,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4215,7 +4221,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:658
+#: cmd/incus/image.go:154 cmd/incus/image.go:690
 msgid "Make image public"
 msgstr ""
 
@@ -4770,7 +4776,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:670
+#: cmd/incus/image.go:714
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -5021,7 +5027,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:659
+#: cmd/incus/image.go:157 cmd/incus/image.go:691
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -5124,7 +5130,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:747
+#: cmd/incus/image.go:791
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -5188,8 +5194,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512
-#: cmd/incus/warning.go:213
+#: cmd/incus/image.go:1123 cmd/incus/list.go:559
+#: cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5201,7 +5207,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
+#: cmd/incus/image.go:1128 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5294,7 +5300,7 @@ msgstr ""
 #: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340
 #: cmd/incus/config.go:269 cmd/incus/config.go:344
 #: cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205
-#: cmd/incus/config_trust.go:353 cmd/incus/image.go:460
+#: cmd/incus/config_trust.go:353 cmd/incus/image.go:484
 #: cmd/incus/network.go:759 cmd/incus/network_acl.go:620
 #: cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638
 #: cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551
@@ -5386,12 +5392,12 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:998
+#: cmd/incus/image.go:1050
 #, fuzzy
 msgid "Profiles:"
 msgstr "Copiar perfis"
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1048
 #, fuzzy
 msgid "Profiles: "
 msgstr "Copiar perfis"
@@ -5415,15 +5421,15 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:971
+#: cmd/incus/image.go:1023
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1514
+#: cmd/incus/image.go:1623
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1043
 #, c-format
 msgid "Protocol: %s"
 msgstr ""
@@ -5536,7 +5542,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:949
+#: cmd/incus/image.go:1001
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5573,7 +5579,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:498 cmd/incus/image.go:889 cmd/incus/image.go:1423
+#: cmd/incus/image.go:522 cmd/incus/image.go:933 cmd/incus/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5634,7 +5640,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1339 cmd/incus/image.go:1340
+#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
 msgid "Refresh images"
 msgstr ""
 
@@ -5643,7 +5649,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/image.go:1368
+#: cmd/incus/image.go:1456
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5918,7 +5924,7 @@ msgstr "Editar arquivos no container"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:371
+#: cmd/incus/create.go:379
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5967,7 +5973,7 @@ msgstr "Criar projetos"
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1062
+#: cmd/incus/image.go:1129
 msgid "SIZE"
 msgstr ""
 
@@ -6070,7 +6076,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:990
+#: cmd/incus/image.go:1042
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "Em cache: %s"
@@ -6107,7 +6113,7 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1530 cmd/incus/image.go:1531
+#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
@@ -6420,7 +6426,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
 
-#: cmd/incus/image.go:1419 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6563,7 +6569,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show useful information about a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/image.go:885 cmd/incus/image.go:886
+#: cmd/incus/image.go:929 cmd/incus/image.go:930
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6579,7 +6585,7 @@ msgstr ""
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:946
+#: cmd/incus/image.go:998
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -6617,7 +6623,7 @@ msgid ""
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:989
+#: cmd/incus/image.go:1041
 msgid "Source:"
 msgstr ""
 
@@ -6625,7 +6631,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/launch.go:83
+#: cmd/incus/launch.go:99
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6803,7 +6809,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1064
+#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084
 #: cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26
 #: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492
@@ -6935,7 +6941,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:449
+#: cmd/incus/create.go:457
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7136,15 +7142,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:950
+#: cmd/incus/image.go:1002
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:451
+#: cmd/incus/create.go:459
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:450
+#: cmd/incus/create.go:458
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7204,7 +7210,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:769
+#: cmd/incus/image.go:813
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -7223,7 +7229,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Senha de administrador para %s: "
 
-#: cmd/incus/action.go:316 cmd/incus/launch.go:115
+#: cmd/incus/action.go:316 cmd/incus/launch.go:131
 #, c-format
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
@@ -7243,7 +7249,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/image.go:948 cmd/incus/info.go:273 cmd/incus/info.go:473
+#: cmd/incus/image.go:1000 cmd/incus/info.go:273 cmd/incus/info.go:473
 #: cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
 #, c-format
 msgid "Type: %s"
@@ -7258,7 +7264,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1063
+#: cmd/incus/image.go:1131
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -7311,7 +7317,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1080 cmd/incus/list.go:629
+#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1152 cmd/incus/list.go:629
 #: cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7352,7 +7358,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/image.go:1586 cmd/incus/image.go:1587
+#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
@@ -7520,7 +7526,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/image.go:957
+#: cmd/incus/image.go:1009
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7812,7 +7818,7 @@ msgstr "Criar perfis"
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1018 cmd/incus/list.go:46
+#: cmd/incus/image.go:1071 cmd/incus/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7909,16 +7915,16 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/image.go:364 cmd/incus/image.go:884 cmd/incus/image.go:1418
+#: cmd/incus/image.go:380 cmd/incus/image.go:928 cmd/incus/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1477 cmd/incus/image.go:1585
+#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/image.go:1529
+#: cmd/incus/image.go:1638
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
@@ -7936,11 +7942,11 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: cmd/incus/image.go:491
+#: cmd/incus/image.go:515
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: cmd/incus/image.go:312 cmd/incus/image.go:1338
+#: cmd/incus/image.go:324 cmd/incus/image.go:1422
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -8471,7 +8477,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:935
+#: cmd/incus/image.go:987
 msgid "disabled"
 msgstr ""
 
@@ -8479,7 +8485,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:937
+#: cmd/incus/image.go:989
 msgid "enabled"
 msgstr ""
 
@@ -8588,7 +8594,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:368
+#: cmd/incus/image.go:384
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8789,8 +8795,8 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:497 cmd/incus/image.go:925 cmd/incus/image.go:930
-#: cmd/incus/image.go:1120
+#: cmd/incus/config_trust.go:497 cmd/incus/image.go:977 cmd/incus/image.go:982
+#: cmd/incus/image.go:1192
 msgid "no"
 msgstr ""
 
@@ -8836,8 +8842,8 @@ msgid "y"
 msgstr ""
 
 #: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494
-#: cmd/incus/delete.go:47 cmd/incus/image.go:927 cmd/incus/image.go:932
-#: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
+#: cmd/incus/delete.go:47 cmd/incus/image.go:979 cmd/incus/image.go:984
+#: cmd/incus/image.go:1189 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr "sim"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-30 15:38-0500\n"
+"POT-Creation-Date: 2024-02-10 17:56-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/image.go:381
+#: cmd/incus/image.go:405
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -591,7 +591,7 @@ msgstr ""
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1091
+#: cmd/incus/image.go:1163
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -647,7 +647,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:126 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:651
+#: cmd/incus/image.go:683
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -752,16 +752,16 @@ msgstr "Копирование образа: %s"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1055 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1126 cmd/incus/image_alias.go:234
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: cmd/incus/image.go:1056
+#: cmd/incus/image.go:1127
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: cmd/incus/cluster.go:186 cmd/incus/image.go:1061 cmd/incus/list.go:554
+#: cmd/incus/cluster.go:186 cmd/incus/image.go:1121 cmd/incus/list.go:554
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1044
 #, fuzzy, c-format
 msgid "Alias: %s"
 msgstr "Псевдонимы:"
@@ -952,7 +952,7 @@ msgstr "Псевдонимы:"
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: cmd/incus/image.go:976
+#: cmd/incus/image.go:1028
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: cmd/incus/image.go:947 cmd/incus/info.go:476
+#: cmd/incus/image.go:999 cmd/incus/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -997,7 +997,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:357 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1053,11 +1053,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:177
+#: cmd/incus/image.go:189
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:986
+#: cmd/incus/image.go:1038
 #, c-format
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
@@ -1106,7 +1106,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:138 cmd/incus/create.go:221 cmd/incus/move.go:358
+#: cmd/incus/copy.go:138 cmd/incus/create.go:229 cmd/incus/move.go:358
 #: cmd/incus/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1118,7 +1118,7 @@ msgstr "Имя контейнера: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:758
+#: cmd/incus/image.go:802
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr "СОЗДАН"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: cmd/incus/image.go:985
+#: cmd/incus/image.go:1037
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:210
+#: cmd/incus/image.go:222
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:326
+#: cmd/incus/create.go:334
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1455,7 +1455,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1046 cmd/incus/list.go:132
+#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1100 cmd/incus/list.go:132
 #: cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239
 #: cmd/incus/warning.go:93
 msgid "Columns"
@@ -1503,7 +1503,7 @@ msgstr ""
 #: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339
 #: cmd/incus/config.go:268 cmd/incus/config.go:343
 #: cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352
-#: cmd/incus/image.go:459 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
+#: cmd/incus/image.go:483 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
 #: cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637
 #: cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550
 #: cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518
@@ -1616,7 +1616,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:266
+#: cmd/incus/image.go:278
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
@@ -1814,13 +1814,13 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image.go:954 cmd/incus/info.go:487
+#: cmd/incus/image.go:1006 cmd/incus/info.go:487
 #: cmd/incus/storage_volume.go:1273
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:174
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:164
+#: cmd/incus/create.go:172
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1845,7 +1845,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438
-#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1060
+#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1122
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088
 #: cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139
@@ -1907,7 +1907,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:314 cmd/incus/image.go:315
+#: cmd/incus/image.go:326 cmd/incus/image.go:327
 msgid "Delete images"
 msgstr ""
 
@@ -2034,10 +2034,10 @@ msgstr ""
 #: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131
 #: cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428
 #: cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
-#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
-#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
-#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382
+#: cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930
+#: cmd/incus/image.go:1074 cmd/incus/image.go:1424 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704
 #: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
@@ -2213,11 +2213,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:417
+#: cmd/incus/create.go:425
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: cmd/incus/image.go:668
+#: cmd/incus/image.go:712
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2256,6 +2256,11 @@ msgstr " Использование диска:"
 #, fuzzy
 msgid "Disks:"
 msgstr " Использование диска:"
+
+#: cmd/incus/image.go:1102
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "Копирование образа: %s"
 
 #: cmd/incus/list.go:135
 #, fuzzy
@@ -2338,7 +2343,7 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:365 cmd/incus/image.go:366
+#: cmd/incus/image.go:381 cmd/incus/image.go:382
 msgid "Edit image properties"
 msgstr ""
 
@@ -2418,7 +2423,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1072 cmd/incus/list.go:614
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1144 cmd/incus/list.go:614
 #: cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2595,21 +2600,21 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:960
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:962
+#: cmd/incus/image.go:1014
 msgid "Expires: never"
 msgstr ""
 
-#: cmd/incus/image.go:492
+#: cmd/incus/image.go:516
 #, fuzzy
 msgid "Export and download images"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:493
+#: cmd/incus/image.go:517
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2641,7 +2646,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:560
+#: cmd/incus/image.go:592
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
@@ -2654,8 +2659,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1057
-#: cmd/incus/image.go:1058 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1124
+#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2743,17 +2748,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/create.go:180
+#: cmd/incus/create.go:188
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/create.go:305
+#: cmd/incus/create.go:313
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:231
+#: cmd/incus/create.go:239
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Принять сертификат"
@@ -2999,7 +3004,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:945
+#: cmd/incus/image.go:997
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -3064,7 +3069,7 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867
 #: cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241
 #: cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587
-#: cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
+#: cmd/incus/image.go:1101 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
 #: cmd/incus/network.go:1011 cmd/incus/network.go:1110
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93
@@ -3135,7 +3140,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/image.go:1478 cmd/incus/image.go:1479
+#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
 msgid "Get image properties"
 msgstr ""
 
@@ -3398,11 +3403,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image.go:1401
+#: cmd/incus/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:283
+#: cmd/incus/image.go:295
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3410,25 +3415,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:636
+#: cmd/incus/image.go:668
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:338 cmd/incus/image.go:1363
+#: cmd/incus/image.go:354 cmd/incus/image.go:1451
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:406 cmd/incus/image.go:1555
+#: cmd/incus/image.go:430 cmd/incus/image.go:1672
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:856
+#: cmd/incus/image.go:900
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1399
+#: cmd/incus/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3449,14 +3454,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:653
+#: cmd/incus/image.go:685
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:652
+#: cmd/incus/image.go:684
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Копирование образа: %s"
@@ -3523,7 +3528,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: cmd/incus/create.go:428
+#: cmd/incus/create.go:436
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -3727,21 +3732,21 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/image.go:966
+#: cmd/incus/image.go:1018
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:968
+#: cmd/incus/image.go:1020
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:160
+#: cmd/incus/create.go:168
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:158
+#: cmd/incus/create.go:166
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3846,11 +3851,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: cmd/incus/image.go:1020
+#: cmd/incus/image.go:1073
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1074
 msgid ""
 "List images\n"
 "\n"
@@ -3871,6 +3876,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4222,7 +4228,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:658
+#: cmd/incus/image.go:154 cmd/incus/image.go:690
 msgid "Make image public"
 msgstr ""
 
@@ -4781,7 +4787,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:670
+#: cmd/incus/image.go:714
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -5037,7 +5043,7 @@ msgstr " Использование сети:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:659
+#: cmd/incus/image.go:157 cmd/incus/image.go:691
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -5141,7 +5147,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:747
+#: cmd/incus/image.go:791
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -5205,8 +5211,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512
-#: cmd/incus/warning.go:213
+#: cmd/incus/image.go:1123 cmd/incus/list.go:559
+#: cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5218,7 +5224,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
+#: cmd/incus/image.go:1128 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5311,7 +5317,7 @@ msgstr ""
 #: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340
 #: cmd/incus/config.go:269 cmd/incus/config.go:344
 #: cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205
-#: cmd/incus/config_trust.go:353 cmd/incus/image.go:460
+#: cmd/incus/config_trust.go:353 cmd/incus/image.go:484
 #: cmd/incus/network.go:759 cmd/incus/network_acl.go:620
 #: cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638
 #: cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551
@@ -5400,11 +5406,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:998
+#: cmd/incus/image.go:1050
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1048
 msgid "Profiles: "
 msgstr ""
 
@@ -5427,15 +5433,15 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:971
+#: cmd/incus/image.go:1023
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1514
+#: cmd/incus/image.go:1623
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1043
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Авто-обновление: %s"
@@ -5548,7 +5554,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:949
+#: cmd/incus/image.go:1001
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5584,7 +5590,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:498 cmd/incus/image.go:889 cmd/incus/image.go:1423
+#: cmd/incus/image.go:522 cmd/incus/image.go:933 cmd/incus/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5646,7 +5652,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:1339 cmd/incus/image.go:1340
+#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
@@ -5656,7 +5662,7 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image.go:1368
+#: cmd/incus/image.go:1456
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5922,7 +5928,7 @@ msgstr "Псевдонимы:"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:371
+#: cmd/incus/create.go:379
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5971,7 +5977,7 @@ msgstr "Доступные команды:"
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1062
+#: cmd/incus/image.go:1129
 msgid "SIZE"
 msgstr ""
 
@@ -6074,7 +6080,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:990
+#: cmd/incus/image.go:1042
 #, fuzzy, c-format
 msgid "Server: %s"
 msgstr "Авто-обновление: %s"
@@ -6110,7 +6116,7 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1530 cmd/incus/image.go:1531
+#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
 msgid "Set image properties"
 msgstr ""
 
@@ -6419,7 +6425,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1419 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6559,7 +6565,7 @@ msgstr "Копирование образа: %s"
 msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/image.go:885 cmd/incus/image.go:886
+#: cmd/incus/image.go:929 cmd/incus/image.go:930
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6575,7 +6581,7 @@ msgstr ""
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:946
+#: cmd/incus/image.go:998
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Авто-обновление: %s"
@@ -6614,7 +6620,7 @@ msgid ""
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:989
+#: cmd/incus/image.go:1041
 msgid "Source:"
 msgstr ""
 
@@ -6622,7 +6628,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/launch.go:83
+#: cmd/incus/launch.go:99
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6803,7 +6809,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1064
+#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084
 #: cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26
 #: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492
@@ -6931,7 +6937,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:449
+#: cmd/incus/create.go:457
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7132,15 +7138,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:950
+#: cmd/incus/image.go:1002
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:451
+#: cmd/incus/create.go:459
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:450
+#: cmd/incus/create.go:458
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7200,7 +7206,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:769
+#: cmd/incus/image.go:813
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -7219,7 +7225,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/action.go:316 cmd/incus/launch.go:115
+#: cmd/incus/action.go:316 cmd/incus/launch.go:131
 #, c-format
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
@@ -7239,7 +7245,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/image.go:948 cmd/incus/info.go:273 cmd/incus/info.go:473
+#: cmd/incus/image.go:1000 cmd/incus/info.go:273 cmd/incus/info.go:473
 #: cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
 #, c-format
 msgid "Type: %s"
@@ -7254,7 +7260,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1063
+#: cmd/incus/image.go:1131
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -7306,7 +7312,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1080 cmd/incus/list.go:629
+#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1152 cmd/incus/list.go:629
 #: cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7345,7 +7351,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1586 cmd/incus/image.go:1587
+#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
 msgid "Unset image properties"
 msgstr ""
 
@@ -7511,7 +7517,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/image.go:957
+#: cmd/incus/image.go:1009
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7827,7 +7833,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:1018 cmd/incus/list.go:46
+#: cmd/incus/image.go:1071 cmd/incus/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7991,7 +7997,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:364 cmd/incus/image.go:884 cmd/incus/image.go:1418
+#: cmd/incus/image.go:380 cmd/incus/image.go:928 cmd/incus/image.go:1506
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7999,7 +8005,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:1477 cmd/incus/image.go:1585
+#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -8007,7 +8013,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:1529
+#: cmd/incus/image.go:1638
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -8039,7 +8045,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:491
+#: cmd/incus/image.go:515
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -8047,7 +8053,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image.go:312 cmd/incus/image.go:1338
+#: cmd/incus/image.go:324 cmd/incus/image.go:1422
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -8956,7 +8962,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:935
+#: cmd/incus/image.go:987
 msgid "disabled"
 msgstr ""
 
@@ -8964,7 +8970,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:937
+#: cmd/incus/image.go:989
 msgid "enabled"
 msgstr ""
 
@@ -9073,7 +9079,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:368
+#: cmd/incus/image.go:384
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9274,8 +9280,8 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:497 cmd/incus/image.go:925 cmd/incus/image.go:930
-#: cmd/incus/image.go:1120
+#: cmd/incus/config_trust.go:497 cmd/incus/image.go:977 cmd/incus/image.go:982
+#: cmd/incus/image.go:1192
 msgid "no"
 msgstr ""
 
@@ -9321,8 +9327,8 @@ msgid "y"
 msgstr ""
 
 #: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494
-#: cmd/incus/delete.go:47 cmd/incus/image.go:927 cmd/incus/image.go:932
-#: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
+#: cmd/incus/delete.go:47 cmd/incus/image.go:979 cmd/incus/image.go:984
+#: cmd/incus/image.go:1189 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr "да"
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-30 15:38-0500\n"
+"POT-Creation-Date: 2024-02-10 17:56-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -173,7 +173,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: cmd/incus/image.go:381
+#: cmd/incus/image.go:405
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -539,7 +539,7 @@ msgstr "%s 不是一个目录"
 msgid "%s %q on pool %q in project %q (includes %d snapshots)"
 msgstr ""
 
-#: cmd/incus/image.go:1091
+#: cmd/incus/image.go:1163
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -595,7 +595,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:126 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -664,7 +664,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/image.go:651
+#: cmd/incus/image.go:683
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -690,15 +690,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1055 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1126 cmd/incus/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: cmd/incus/image.go:1056
+#: cmd/incus/image.go:1127
 msgid "ALIASES"
 msgstr ""
 
-#: cmd/incus/cluster.go:186 cmd/incus/image.go:1061 cmd/incus/list.go:554
+#: cmd/incus/cluster.go:186 cmd/incus/image.go:1121 cmd/incus/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -873,7 +873,7 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
-#: cmd/incus/image.go:992
+#: cmd/incus/image.go:1044
 #, c-format
 msgid "Alias: %s"
 msgstr ""
@@ -883,7 +883,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: cmd/incus/image.go:976
+#: cmd/incus/image.go:1028
 msgid "Aliases:"
 msgstr ""
 
@@ -903,7 +903,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:947 cmd/incus/info.go:476
+#: cmd/incus/image.go:999 cmd/incus/info.go:476
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -926,7 +926,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:357 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -980,11 +980,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: cmd/incus/image.go:177
+#: cmd/incus/image.go:189
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: cmd/incus/image.go:986
+#: cmd/incus/image.go:1038
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1032,7 +1032,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:138 cmd/incus/create.go:221 cmd/incus/move.go:358
+#: cmd/incus/copy.go:138 cmd/incus/create.go:229 cmd/incus/move.go:358
 #: cmd/incus/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1044,7 +1044,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: cmd/incus/image.go:758
+#: cmd/incus/image.go:802
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: cmd/incus/image.go:985
+#: cmd/incus/image.go:1037
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1144,7 +1144,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: cmd/incus/image.go:210
+#: cmd/incus/image.go:222
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1207,7 +1207,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:326
+#: cmd/incus/create.go:334
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1378,7 +1378,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1046 cmd/incus/list.go:132
+#: cmd/incus/config_trust.go:422 cmd/incus/image.go:1100 cmd/incus/list.go:132
 #: cmd/incus/storage_volume.go:1387 cmd/incus/storage_volume.go:2239
 #: cmd/incus/warning.go:93
 msgid "Columns"
@@ -1426,7 +1426,7 @@ msgstr ""
 #: cmd/incus/cluster.go:770 cmd/incus/cluster_group.go:339
 #: cmd/incus/config.go:268 cmd/incus/config.go:343
 #: cmd/incus/config_metadata.go:146 cmd/incus/config_trust.go:352
-#: cmd/incus/image.go:459 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
+#: cmd/incus/image.go:483 cmd/incus/network.go:758 cmd/incus/network_acl.go:619
 #: cmd/incus/network_forward.go:634 cmd/incus/network_load_balancer.go:637
 #: cmd/incus/network_peer.go:609 cmd/incus/network_zone.go:550
 #: cmd/incus/network_zone.go:1142 cmd/incus/profile.go:518
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: cmd/incus/image.go:266
+#: cmd/incus/image.go:278
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1719,13 +1719,13 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:954 cmd/incus/info.go:487
+#: cmd/incus/image.go:1006 cmd/incus/info.go:487
 #: cmd/incus/storage_volume.go:1273
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:174
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:164
+#: cmd/incus/create.go:172
 msgid "Creating the instance"
 msgstr ""
 
@@ -1749,7 +1749,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:188 cmd/incus/cluster_group.go:438
-#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1060
+#: cmd/incus/config_trust.go:436 cmd/incus/image.go:1122
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:557 cmd/incus/network.go:1088
 #: cmd/incus/network_acl.go:147 cmd/incus/network_forward.go:144
 #: cmd/incus/network_load_balancer.go:148 cmd/incus/network_peer.go:139
@@ -1810,7 +1810,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: cmd/incus/image.go:314 cmd/incus/image.go:315
+#: cmd/incus/image.go:326 cmd/incus/image.go:327
 msgid "Delete images"
 msgstr ""
 
@@ -1927,10 +1927,10 @@ msgstr ""
 #: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:131
 #: cmd/incus/file.go:309 cmd/incus/file.go:358 cmd/incus/file.go:428
 #: cmd/incus/file.go:647 cmd/incus/file.go:1152 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
-#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
-#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
-#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382
+#: cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930
+#: cmd/incus/image.go:1074 cmd/incus/image.go:1424 cmd/incus/image.go:1508
+#: cmd/incus/image.go:1575 cmd/incus/image.go:1640 cmd/incus/image.go:1704
 #: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
@@ -2104,11 +2104,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:417
+#: cmd/incus/create.go:425
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: cmd/incus/image.go:668
+#: cmd/incus/image.go:712
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2143,6 +2143,10 @@ msgstr ""
 
 #: cmd/incus/info.go:423
 msgid "Disks:"
+msgstr ""
+
+#: cmd/incus/image.go:1102
+msgid "Display images from all projects"
 msgstr ""
 
 #: cmd/incus/list.go:135
@@ -2225,7 +2229,7 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: cmd/incus/image.go:365 cmd/incus/image.go:366
+#: cmd/incus/image.go:381 cmd/incus/image.go:382
 msgid "Edit image properties"
 msgstr ""
 
@@ -2298,7 +2302,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1072 cmd/incus/list.go:614
+#: cmd/incus/config_trust.go:448 cmd/incus/image.go:1144 cmd/incus/list.go:614
 #: cmd/incus/storage_volume.go:1522 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2471,20 +2475,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: cmd/incus/image.go:960
+#: cmd/incus/image.go:1012
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: cmd/incus/image.go:962
+#: cmd/incus/image.go:1014
 msgid "Expires: never"
 msgstr ""
 
-#: cmd/incus/image.go:492
+#: cmd/incus/image.go:516
 msgid "Export and download images"
 msgstr ""
 
-#: cmd/incus/image.go:493
+#: cmd/incus/image.go:517
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2512,7 +2516,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: cmd/incus/image.go:560
+#: cmd/incus/image.go:592
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2525,8 +2529,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1057
-#: cmd/incus/image.go:1058 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1124
+#: cmd/incus/image.go:1125 cmd/incus/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2614,17 +2618,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:180
+#: cmd/incus/create.go:188
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:305
+#: cmd/incus/create.go:313
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:231
+#: cmd/incus/create.go:239
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
@@ -2870,7 +2874,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: cmd/incus/image.go:945
+#: cmd/incus/image.go:997
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2934,7 +2938,7 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:124 cmd/incus/cluster.go:867
 #: cmd/incus/cluster_group.go:384 cmd/incus/config_template.go:241
 #: cmd/incus/config_trust.go:423 cmd/incus/config_trust.go:587
-#: cmd/incus/image.go:1047 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
+#: cmd/incus/image.go:1101 cmd/incus/image_alias.go:157 cmd/incus/list.go:133
 #: cmd/incus/network.go:1011 cmd/incus/network.go:1110
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93
@@ -3005,7 +3009,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: cmd/incus/image.go:1478 cmd/incus/image.go:1479
+#: cmd/incus/image.go:1574 cmd/incus/image.go:1575
 msgid "Get image properties"
 msgstr ""
 
@@ -3251,11 +3255,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: cmd/incus/image.go:1401
+#: cmd/incus/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
-#: cmd/incus/image.go:283
+#: cmd/incus/image.go:295
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3263,25 +3267,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: cmd/incus/image.go:636
+#: cmd/incus/image.go:668
 msgid "Image exported successfully!"
 msgstr ""
 
-#: cmd/incus/image.go:338 cmd/incus/image.go:1363
+#: cmd/incus/image.go:354 cmd/incus/image.go:1451
 msgid "Image identifier missing"
 msgstr ""
 
-#: cmd/incus/image.go:406 cmd/incus/image.go:1555
+#: cmd/incus/image.go:430 cmd/incus/image.go:1672
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: cmd/incus/image.go:856
+#: cmd/incus/image.go:900
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1399
+#: cmd/incus/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3301,14 +3305,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/image.go:653
+#: cmd/incus/image.go:685
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: cmd/incus/image.go:652
+#: cmd/incus/image.go:684
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3371,7 +3375,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:428
+#: cmd/incus/create.go:436
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3572,21 +3576,21 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:966
+#: cmd/incus/image.go:1018
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: cmd/incus/image.go:968
+#: cmd/incus/image.go:1020
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:160
+#: cmd/incus/create.go:168
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:158
+#: cmd/incus/create.go:166
 msgid "Launching the instance"
 msgstr ""
 
@@ -3683,11 +3687,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: cmd/incus/image.go:1020
+#: cmd/incus/image.go:1073
 msgid "List images"
 msgstr ""
 
-#: cmd/incus/image.go:1021
+#: cmd/incus/image.go:1074
 msgid ""
 "List images\n"
 "\n"
@@ -3708,6 +3712,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4047,7 +4052,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: cmd/incus/image.go:154 cmd/incus/image.go:658
+#: cmd/incus/image.go:154 cmd/incus/image.go:690
 msgid "Make image public"
 msgstr ""
 
@@ -4562,7 +4567,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/image.go:670
+#: cmd/incus/image.go:714
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4813,7 +4818,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: cmd/incus/image.go:157 cmd/incus/image.go:659
+#: cmd/incus/image.go:157 cmd/incus/image.go:691
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4916,7 +4921,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: cmd/incus/image.go:747
+#: cmd/incus/image.go:791
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4980,8 +4985,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/list.go:559 cmd/incus/storage_volume.go:1512
-#: cmd/incus/warning.go:213
+#: cmd/incus/image.go:1123 cmd/incus/list.go:559
+#: cmd/incus/storage_volume.go:1512 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4993,7 +4998,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: cmd/incus/image.go:1059 cmd/incus/remote.go:725
+#: cmd/incus/image.go:1128 cmd/incus/remote.go:725
 msgid "PUBLIC"
 msgstr ""
 
@@ -5085,7 +5090,7 @@ msgstr ""
 #: cmd/incus/cluster.go:771 cmd/incus/cluster_group.go:340
 #: cmd/incus/config.go:269 cmd/incus/config.go:344
 #: cmd/incus/config_metadata.go:147 cmd/incus/config_template.go:205
-#: cmd/incus/config_trust.go:353 cmd/incus/image.go:460
+#: cmd/incus/config_trust.go:353 cmd/incus/image.go:484
 #: cmd/incus/network.go:759 cmd/incus/network_acl.go:620
 #: cmd/incus/network_forward.go:635 cmd/incus/network_load_balancer.go:638
 #: cmd/incus/network_peer.go:610 cmd/incus/network_zone.go:551
@@ -5174,11 +5179,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: cmd/incus/image.go:998
+#: cmd/incus/image.go:1050
 msgid "Profiles:"
 msgstr ""
 
-#: cmd/incus/image.go:996
+#: cmd/incus/image.go:1048
 msgid "Profiles: "
 msgstr ""
 
@@ -5201,15 +5206,15 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: cmd/incus/image.go:971
+#: cmd/incus/image.go:1023
 msgid "Properties:"
 msgstr ""
 
-#: cmd/incus/image.go:1514
+#: cmd/incus/image.go:1623
 msgid "Property not found"
 msgstr ""
 
-#: cmd/incus/image.go:991
+#: cmd/incus/image.go:1043
 #, c-format
 msgid "Protocol: %s"
 msgstr ""
@@ -5322,7 +5327,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: cmd/incus/image.go:949
+#: cmd/incus/image.go:1001
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5358,7 +5363,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: cmd/incus/image.go:498 cmd/incus/image.go:889 cmd/incus/image.go:1423
+#: cmd/incus/image.go:522 cmd/incus/image.go:933 cmd/incus/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5417,7 +5422,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: cmd/incus/image.go:1339 cmd/incus/image.go:1340
+#: cmd/incus/image.go:1423 cmd/incus/image.go:1424
 msgid "Refresh images"
 msgstr ""
 
@@ -5426,7 +5431,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: cmd/incus/image.go:1368
+#: cmd/incus/image.go:1456
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5676,7 +5681,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:371
+#: cmd/incus/create.go:379
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5722,7 +5727,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: cmd/incus/image.go:1062
+#: cmd/incus/image.go:1129
 msgid "SIZE"
 msgstr ""
 
@@ -5825,7 +5830,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: cmd/incus/image.go:990
+#: cmd/incus/image.go:1042
 #, c-format
 msgid "Server: %s"
 msgstr ""
@@ -5860,7 +5865,7 @@ msgid ""
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: cmd/incus/image.go:1530 cmd/incus/image.go:1531
+#: cmd/incus/image.go:1639 cmd/incus/image.go:1640
 msgid "Set image properties"
 msgstr ""
 
@@ -6153,7 +6158,7 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: cmd/incus/image.go:1419 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1507 cmd/incus/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6279,7 +6284,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: cmd/incus/image.go:885 cmd/incus/image.go:886
+#: cmd/incus/image.go:929 cmd/incus/image.go:930
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6295,7 +6300,7 @@ msgstr ""
 msgid "Size in GiB of the new loop device"
 msgstr ""
 
-#: cmd/incus/image.go:946
+#: cmd/incus/image.go:998
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -6333,7 +6338,7 @@ msgid ""
 "as applicable):"
 msgstr ""
 
-#: cmd/incus/image.go:989
+#: cmd/incus/image.go:1041
 msgid "Source:"
 msgstr ""
 
@@ -6341,7 +6346,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/launch.go:83
+#: cmd/incus/launch.go:99
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6517,7 +6522,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1064
+#: cmd/incus/config_trust.go:433 cmd/incus/image.go:1130
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:571 cmd/incus/network.go:1084
 #: cmd/incus/network.go:1166 cmd/incus/network_allocations.go:26
 #: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1492
@@ -6645,7 +6650,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:449
+#: cmd/incus/create.go:457
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6845,15 +6850,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: cmd/incus/image.go:950
+#: cmd/incus/image.go:1002
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:451
+#: cmd/incus/create.go:459
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:450
+#: cmd/incus/create.go:458
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -6913,7 +6918,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: cmd/incus/image.go:769
+#: cmd/incus/image.go:813
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6932,7 +6937,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:316 cmd/incus/launch.go:115
+#: cmd/incus/action.go:316 cmd/incus/launch.go:131
 #, c-format
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
@@ -6951,7 +6956,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/image.go:948 cmd/incus/info.go:273 cmd/incus/info.go:473
+#: cmd/incus/image.go:1000 cmd/incus/info.go:273 cmd/incus/info.go:473
 #: cmd/incus/network.go:929 cmd/incus/storage_volume.go:1253
 #, c-format
 msgid "Type: %s"
@@ -6966,7 +6971,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: cmd/incus/image.go:1063
+#: cmd/incus/image.go:1131
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -7017,7 +7022,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1080 cmd/incus/list.go:629
+#: cmd/incus/config_trust.go:456 cmd/incus/image.go:1152 cmd/incus/list.go:629
 #: cmd/incus/storage_volume.go:1530 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7055,7 +7060,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: cmd/incus/image.go:1586 cmd/incus/image.go:1587
+#: cmd/incus/image.go:1703 cmd/incus/image.go:1704
 msgid "Unset image properties"
 msgstr ""
 
@@ -7202,7 +7207,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/image.go:957
+#: cmd/incus/image.go:1009
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7487,7 +7492,7 @@ msgstr ""
 msgid "[<remote>:] <name>"
 msgstr ""
 
-#: cmd/incus/image.go:1018 cmd/incus/list.go:46
+#: cmd/incus/image.go:1071 cmd/incus/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7571,15 +7576,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: cmd/incus/image.go:364 cmd/incus/image.go:884 cmd/incus/image.go:1418
+#: cmd/incus/image.go:380 cmd/incus/image.go:928 cmd/incus/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: cmd/incus/image.go:1477 cmd/incus/image.go:1585
+#: cmd/incus/image.go:1573 cmd/incus/image.go:1702
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: cmd/incus/image.go:1529
+#: cmd/incus/image.go:1638
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -7595,11 +7600,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: cmd/incus/image.go:491
+#: cmd/incus/image.go:515
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: cmd/incus/image.go:312 cmd/incus/image.go:1338
+#: cmd/incus/image.go:324 cmd/incus/image.go:1422
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -8076,7 +8081,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: cmd/incus/image.go:935
+#: cmd/incus/image.go:987
 msgid "disabled"
 msgstr ""
 
@@ -8084,7 +8089,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: cmd/incus/image.go:937
+#: cmd/incus/image.go:989
 msgid "enabled"
 msgstr ""
 
@@ -8193,7 +8198,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: cmd/incus/image.go:368
+#: cmd/incus/image.go:384
 msgid ""
 "incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8394,8 +8399,8 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:497 cmd/incus/image.go:925 cmd/incus/image.go:930
-#: cmd/incus/image.go:1120
+#: cmd/incus/config_trust.go:497 cmd/incus/image.go:977 cmd/incus/image.go:982
+#: cmd/incus/image.go:1192
 msgid "no"
 msgstr ""
 
@@ -8441,8 +8446,8 @@ msgid "y"
 msgstr ""
 
 #: cmd/incus/cluster.go:551 cmd/incus/config_trust.go:494
-#: cmd/incus/delete.go:47 cmd/incus/image.go:927 cmd/incus/image.go:932
-#: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
+#: cmd/incus/delete.go:47 cmd/incus/image.go:979 cmd/incus/image.go:984
+#: cmd/incus/image.go:1189 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr ""
 

--- a/shared/api/image.go
+++ b/shared/api/image.go
@@ -179,6 +179,12 @@ type Image struct {
 	// When the image was added to this server
 	// Example: 2021-03-24T14:18:15.115036787-04:00
 	UploadedAt time.Time `json:"uploaded_at" yaml:"uploaded_at"`
+
+	// Project name
+	// Example: project1
+	//
+	// API extension: images_all_projects
+	Project string `json:"project" yaml:"project"`
 }
 
 // Writable converts a full Image struct into a ImagePut struct (filters read-only fields).


### PR DESCRIPTION
```
incus image list --all-projects
+------------------------+-------+--------------+--------+--------------------------------------+--------------+-----------+-----------+-----------------------------+
|        PROJECT         | ALIAS | FINGERPRINT  | PUBLIC |             DESCRIPTION              | ARCHITECTURE |   TYPE    |   SIZE    |         UPLOAD DATE         |
+------------------------+-------+--------------+--------+--------------------------------------+--------------+-----------+-----------+-----------------------------+
| default                |       | 4183ea2d1572 | no     | Ubuntu jammy amd64 (20240202_07:42)  | x86_64       | CONTAINER | 119.16MiB | Feb 2, 2024 at 3:40pm (UTC) |
+------------------------+-------+--------------+--------+--------------------------------------+--------------+-----------+-----------+-----------------------------+
| isolated-image-project |       | 826ea49a23d5 | no     | Ubuntu focal amd64 (20240202_07:42)  | x86_64       | CONTAINER | 116.56MiB | Feb 2, 2024 at 2:47pm (UTC) |
+------------------------+-------+--------------+--------+--------------------------------------+--------------+-----------+-----------+-----------------------------+
| isolated-image-project |       | b19f914bc653 | no     | Ubuntu mantic amd64 (20240202_07:42) | x86_64       | CONTAINER | 121.15MiB | Feb 2, 2024 at 2:46pm (UTC) |
+------------------------+-------+--------------+--------+--------------------------------------+--------------+-----------+-----------+-----------------------------+
| isolated-image-project |       | eb3294bde5ef | no     | Ubuntu bionic amd64 (20240202_07:42) | x86_64       | CONTAINER | 108.19MiB | Feb 2, 2024 at 3:40pm (UTC) |
+------------------------+-------+--------------+--------+--------------------------------------+--------------+-----------+-----------+-----------------------------+
```

```
curl --unix-socket /var/lib/incus/unix.socket incus/1.0/images?all-projects=true | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   423  100   423    0     0  72159      0 --:--:-- --:--:-- --:--:-- 84600
{
  "type": "sync",
  "status": "Success",
  "status_code": 200,
  "operation": "",
  "error_code": 0,
  "error": "",
  "metadata": [
    "/1.0/images/e5e192274efc8503436c81582d3f2bd0cea32cfcb6474c73e3bd807535bc4dcf",
    "/1.0/images/b176f45e4193026c02df29de34fb113491c123a8c0edde778f5048a6a1a108c3",
    "/1.0/images/b99e5a672bccbee9bbe7d88595e348efc0f5d68083666e7cc80d7c5aeb6cdc6c",
    "/1.0/images/f0dda6b9661893d499ffc73943a98b8cac29ba7cd8e19e88993631f1b085187b"
  ]
}
```

---
### What was changed?
Following guidance from [issue 390](https://github.com/lxc/incus/issues/390) with a couple of additional changes to support project column in output.

- [x]  api: images_all_projects :  
- new API extension to both internal/version/api.go and doc/api-extensions.md

- [x]  incusd/images: Add support for all_projects: 
- Add support for all-projects to cmd/incusd/images.go for the imagesGet function. 
- Include adding the all-projects to the swagger comments on imagesGet.
- Also, add Project field to Image struct and update value in GetImageByFingerprintPrefix in shared/api/image.go and internal/server/db/images.go respectively

- [x] doc/rest-api: Refresh swagger YAML
- Re-generate the swagger YAML data

- [x] client: Add GetImagesAllProjects
- Add a new GetImagesAllProjects function to client/incus_images.go and add that function to the ImageServer interface in client/interfaces.go
- Implement it in client/simplestreams_images.go as an alias for the standard GetImages.

- [x] incus/image: Add --all-projects flag to list
- Add the new argument to cmd/incus/image.go, when passed, call GetImagesAllProjects instead of GetImages.
- Also, add shorthad char e(for Project) and print project name when passed

- [x]  i18n: Update translation templates
- Re-generate the translation template for the new CLI string.

---
### Tests:
gofmt -d passed(for api.go)
make completed fine
