### PR TITLE
Docs windows install update

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -305,6 +305,7 @@ vSwitch
 VXLAN
 WebSocket
 WebSockets
+Winget
 XFS
 XHR
 YAML

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -169,13 +169,23 @@ To install the feature branch of Incus, run:
 
 ```{group-tab} Windows
 
-The Incus client on Windows is provided as a [Chocolatey](https://community.chocolatey.org/packages/incus) package.
-To install it:
+The Incus client on Windows is provided as a [Chocolatey](https://community.chocolatey.org/packages/incus) and [Winget](https://github.com/microsoft/winget-cli) package.
+To install it using Chocolatey or Winget, follow the instructions below:
+
+**Chocolatey**
 
 1. Install Chocolatey by following the [installation instructions](https://docs.chocolatey.org/en-us/choco/setup).
 1. Install the Incus client:
 
         choco install incus
+
+**Winget**
+
+1. Install Winget by following the [installation instructions](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget)
+1. Install the Incus client:
+
+        winget install LinuxContainers.Incus
+
 ```
 
 ````


### PR DESCRIPTION
Incus has now a [winget package](https://github.com/microsoft/winget-pkgs/pull/131752) available and the Windows installation docs have been updated with the instructions to install Incus with winget.

ps: I tried using stacked tabs, but the result was not good, so that's why the instructions are stacked.

ps2: while running the `make doc` from Ubuntu on WSL (what else?), I came across a package missing: `python3.10-venv`. Nothing critical, more a FYI.

Signed-off-by: Nuno do Carmo [nuno.carmo@suse.com](mailto:nuno.carmo@suse.com)