### PR TITLE
Add `incus file create` subcommand

### DIFF
--- a/cmd/incus/file.go
+++ b/cmd/incus/file.go
@@ -612,8 +612,9 @@ func (c *cmdFilePush) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			_, dUID, dGID := internalIO.GetOwnerMode(finfo)
 			if c.file.flagUID == -1 || c.file.flagGID == -1 {
+				_, dUID, dGID := internalIO.GetOwnerMode(finfo)
+
 				if c.file.flagUID == -1 {
 					uid = dUID
 				}

--- a/cmd/incus/file.go
+++ b/cmd/incus/file.go
@@ -30,8 +30,12 @@ import (
 	"github.com/lxc/incus/shared/util"
 )
 
-// DirMode represents the file mode for creating dirs on `incus file pull/push`.
-const DirMode = 0755
+const (
+	// DirMode represents the file mode for creating dirs on `incus file pull/push`.
+	DirMode = 0755
+	// FileMode represents the file mode for creating files on `incus file create`.
+	FileMode = 0644
+)
 
 type cmdFile struct {
 	global *cmdGlobal
@@ -80,9 +84,17 @@ func (c *cmdFile) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Manage files in instances`))
 
+	// Create
+	fileCreateCmd := cmdFileCreate{global: c.global, file: c}
+	cmd.AddCommand(fileCreateCmd.Command())
+
 	// Delete
 	fileDeleteCmd := cmdFileDelete{global: c.global, file: c}
 	cmd.AddCommand(fileDeleteCmd.Command())
+
+	// Mount
+	fileMountCmd := cmdFileMount{global: c.global, file: c}
+	cmd.AddCommand(fileMountCmd.Command())
 
 	// Pull
 	filePullCmd := cmdFilePull{global: c.global, file: c}
@@ -96,14 +108,192 @@ func (c *cmdFile) Command() *cobra.Command {
 	fileEditCmd := cmdFileEdit{global: c.global, file: c, filePull: &filePullCmd, filePush: &filePushCmd}
 	cmd.AddCommand(fileEditCmd.Command())
 
-	// Mount
-	fileMountCmd := cmdFileMount{global: c.global, file: c}
-	cmd.AddCommand(fileMountCmd.Command())
-
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
 	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
 	return cmd
+}
+
+// Create.
+type cmdFileCreate struct {
+	global *cmdGlobal
+	file   *cmdFile
+
+	flagContent string
+	flagForce   bool
+	flagType    string
+}
+
+// Command returns the cobra command for `file create`.
+func (c *cmdFileCreate) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("create", i18n.G("[<remote>:]<instance>/<path> [<symlink target path>]"))
+	cmd.Short = i18n.G("Create files and directories in instances")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Create files and directories in instances`))
+	cmd.Example = cli.FormatSection("", i18n.G(
+		`incus file create foo/bar
+	   To create a file /bar in the foo instance.
+incus file create --type=symlink foo/bar baz
+	   To create a symlink /bar in instance foo whose target is baz.`))
+
+	cmd.Flags().BoolVarP(&c.file.flagMkdir, "create-dirs", "p", false, i18n.G("Create any directories necessary")+"``")
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Force creating files or directories")+"``")
+	cmd.Flags().IntVar(&c.file.flagGID, "gid", -1, i18n.G("Set the file's gid on create")+"``")
+	cmd.Flags().IntVar(&c.file.flagUID, "uid", -1, i18n.G("Set the file's uid on create")+"``")
+	cmd.Flags().StringVar(&c.file.flagMode, "mode", "", i18n.G("Set the file's perms on create")+"``")
+	cmd.Flags().StringVar(&c.flagType, "type", "file", i18n.G("The type to create (file, symlink, or directory)")+"``")
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+// Run runs the `file create` command.
+func (c *cmdFileCreate) Run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
+	if exit {
+		return err
+	}
+
+	if !util.ValueInSlice(c.flagType, []string{"file", "symlink", "directory"}) {
+		return fmt.Errorf(i18n.G("Invalid type %q"), c.flagType)
+	}
+
+	if len(args) == 2 && c.flagType != "symlink" {
+		return fmt.Errorf(i18n.G(`Symlink target path can only be used for type "symlink"`))
+	}
+
+	if strings.HasSuffix(args[0], "/") {
+		c.flagType = "directory"
+	}
+
+	pathSpec := strings.SplitN(args[0], "/", 2)
+
+	if len(pathSpec) != 2 {
+		return fmt.Errorf(i18n.G("Invalid target %s"), args[0])
+	}
+
+	// Parse remote.
+	resources, err := c.global.ParseServers(pathSpec[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	// re-add leading / that got stripped by the SplitN
+	targetPath := path.Clean("/" + pathSpec[1])
+
+	// normalization may reveal that path is still a dir, e.g. /.
+	if strings.HasSuffix(targetPath, "/") {
+		c.flagType = "directory"
+	}
+
+	var symlinkTargetPath string
+
+	// Determine the target if specified.
+	if len(args) == 2 {
+		symlinkTargetPath = filepath.Clean(args[1])
+	}
+
+	// Determine the target uid
+	uid := 0
+	if c.file.flagUID > 0 {
+		uid = c.file.flagUID
+	}
+
+	// Determine the target gid
+	gid := 0
+	if c.file.flagGID > 0 {
+		gid = c.file.flagGID
+	}
+
+	var mode os.FileMode
+
+	// Determine the target mode
+	if c.flagType == "directory" {
+		mode = os.FileMode(DirMode)
+	} else if c.flagType == "file" {
+		mode = os.FileMode(FileMode)
+	}
+
+	if c.file.flagMode != "" {
+		if len(c.file.flagMode) == 3 {
+			c.file.flagMode = "0" + c.file.flagMode
+		}
+
+		m, err := strconv.ParseInt(c.file.flagMode, 0, 0)
+		if err != nil {
+			return err
+		}
+
+		mode = os.FileMode(m)
+	}
+
+	// Create needed paths if requested
+	if c.file.flagMkdir {
+		err = c.file.recursiveMkdir(resource.server, resource.name, path.Dir(targetPath), nil, int64(uid), int64(gid))
+		if err != nil {
+			return err
+		}
+	}
+
+	var content io.ReadSeeker
+	var readCloser io.ReadCloser
+	var contentLength int64
+
+	if c.flagType == "symlink" {
+		content = strings.NewReader(symlinkTargetPath)
+		readCloser = io.NopCloser(content)
+		contentLength = int64(len(symlinkTargetPath))
+	} else if c.flagType == "file" {
+		// Just creating an empty file.
+		content = strings.NewReader("")
+		readCloser = io.NopCloser(content)
+		contentLength = 0
+	}
+
+	fileArgs := incus.InstanceFileArgs{
+		Type:    c.flagType,
+		UID:     int64(uid),
+		GID:     int64(gid),
+		Mode:    int(mode.Perm()),
+		Content: content,
+	}
+
+	if c.flagForce {
+		fileArgs.WriteMode = "overwrite"
+	}
+
+	progress := cli.ProgressRenderer{
+		Format: fmt.Sprintf(i18n.G("Creating %s: %%s"), targetPath),
+		Quiet:  c.global.flagQuiet,
+	}
+
+	if readCloser != nil {
+		fileArgs.Content = internalIO.NewReadSeeker(&ioprogress.ProgressReader{
+			ReadCloser: readCloser,
+			Tracker: &ioprogress.ProgressTracker{
+				Length: contentLength,
+				Handler: func(percent int64, speed int64) {
+					progress.UpdateProgress(ioprogress.ProgressData{
+						Text: fmt.Sprintf("%d%% (%s/s)", percent, units.GetByteSizeString(speed, 2)),
+					})
+				},
+			},
+		}, fileArgs.Content)
+	}
+
+	err = resource.server.CreateInstanceFile(resource.name, targetPath, fileArgs)
+	if err != nil {
+		progress.Done("")
+		return err
+	}
+
+	progress.Done("")
+
+	return nil
 }
 
 // Delete.

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-19 22:59-0500\n"
+"POT-Creation-Date: 2024-01-21 22:35-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -599,12 +599,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:911
+#: cmd/incus/file.go:1102
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: cmd/incus/file.go:801
+#: cmd/incus/file.go:992
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -721,7 +721,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:456
+#: cmd/incus/file.go:646
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1248,7 +1248,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:331
+#: cmd/incus/file.go:521
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:533
+#: cmd/incus/file.go:723
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1742,9 +1742,14 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:245 cmd/incus/file.go:465
+#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
 msgid "Create any directories necessary"
 msgstr ""
+
+#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: cmd/incus/export.go:80
 #, fuzzy, c-format
@@ -1854,6 +1859,11 @@ msgstr "Erstellt: %s"
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
+#: cmd/incus/file.go:270
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Erstelle %s"
+
 #: cmd/incus/create.go:164
 #, fuzzy
 msgid "Creating the instance"
@@ -1922,7 +1932,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/file.go:119 cmd/incus/file.go:120
+#: cmd/incus/file.go:309 cmd/incus/file.go:310
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2056,22 +2066,22 @@ msgstr ""
 #: cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733
 #: cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40
 #: cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120
-#: cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458
-#: cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493
-#: cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021
-#: cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479
-#: cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24
-#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
-#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
-#: cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24
-#: cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32
-#: cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317
-#: cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559
-#: cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873
-#: cmd/incus/network.go:1004 cmd/incus/network.go:1105
+#: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:132
+#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
+#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
+#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
+#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
+#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
+#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
+#: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232
+#: cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462
+#: cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792
+#: cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105
 #: cmd/incus/network.go:1184 cmd/incus/network.go:1244
 #: cmd/incus/network.go:1340 cmd/incus/network.go:1412
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
@@ -2258,7 +2268,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:970
+#: cmd/incus/file.go:1161
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2354,7 +2364,7 @@ msgstr "ABLAUFDATUM"
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: cmd/incus/file.go:71
+#: cmd/incus/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2369,7 +2379,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/file.go:168 cmd/incus/file.go:169
+#: cmd/incus/file.go:358 cmd/incus/file.go:359
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2708,12 +2718,12 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1213
+#: cmd/incus/file.go:1404
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1236
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2728,12 +2738,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1263
+#: cmd/incus/file.go:1454
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1048
+#: cmd/incus/file.go:1239
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2763,7 +2773,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/file.go:1169
+#: cmd/incus/file.go:1360
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2803,7 +2813,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1174
+#: cmd/incus/file.go:1365
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2818,12 +2828,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1074
+#: cmd/incus/file.go:1265
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1201
+#: cmd/incus/file.go:1392
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2917,7 +2927,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1186
+#: cmd/incus/file.go:1377
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3015,7 +3025,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to update cluster member state: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:796
+#: cmd/incus/file.go:987
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3054,6 +3064,10 @@ msgstr "Fingerabdruck: %s\n"
 
 #: cmd/incus/cluster.go:1156
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: cmd/incus/file.go:141
+msgid "Force creating files or directories"
 msgstr ""
 
 #: cmd/incus/cluster.go:1183
@@ -3350,22 +3364,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1286
+#: cmd/incus/file.go:1477
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1275
+#: cmd/incus/file.go:1466
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1098
+#: cmd/incus/file.go:1289
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1108
+#: cmd/incus/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3559,12 +3573,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1100
+#: cmd/incus/file.go:1291
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/file.go:1277
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3578,7 +3592,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1020
+#: cmd/incus/file.go:1211
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3671,7 +3685,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/file.go:1015
+#: cmd/incus/file.go:1206
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -3707,7 +3721,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:334
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -3724,14 +3738,19 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/file.go:304
+#: cmd/incus/file.go:494
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/file.go:486
+#: cmd/incus/file.go:174 cmd/incus/file.go:676
 #, c-format
 msgid "Invalid target %s"
+msgstr "Ungültiges Ziel %s"
+
+#: cmd/incus/file.go:160
+#, fuzzy, c-format
+msgid "Invalid type %q"
 msgstr "Ungültiges Ziel %s"
 
 #: cmd/incus/info.go:230
@@ -4201,12 +4220,12 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/file.go:1192
+#: cmd/incus/file.go:1383
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1385
 msgid "Login without username and password"
 msgstr ""
 
@@ -4326,7 +4345,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:79 cmd/incus/file.go:80
+#: cmd/incus/file.go:83 cmd/incus/file.go:84
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4764,7 +4783,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/file.go:581
+#: cmd/incus/file.go:771
 msgid "Missing target directory"
 msgstr ""
 
@@ -4804,12 +4823,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:279
+#: cmd/incus/file.go:469
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: cmd/incus/file.go:961 cmd/incus/file.go:962
+#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5323,7 +5342,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1353
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Administrator Passwort für %s: "
@@ -5390,7 +5409,7 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/file.go:1078
+#: cmd/incus/file.go:1269
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5655,22 +5674,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/file.go:238 cmd/incus/file.go:239
+#: cmd/incus/file.go:428 cmd/incus/file.go:429
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:407 cmd/incus/file.go:743
+#: cmd/incus/file.go:597 cmd/incus/file.go:934
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:457 cmd/incus/file.go:458
+#: cmd/incus/file.go:647 cmd/incus/file.go:648
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:677 cmd/incus/file.go:843
+#: cmd/incus/file.go:868 cmd/incus/file.go:1034
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5732,7 +5751,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:246 cmd/incus/file.go:464
+#: cmd/incus/file.go:436 cmd/incus/file.go:654
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6089,17 +6108,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1189
+#: cmd/incus/file.go:1380
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1397
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1207
+#: cmd/incus/file.go:1398
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -6192,7 +6211,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/file.go:971
+#: cmd/incus/file.go:1162
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6399,15 +6418,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:467
+#: cmd/incus/file.go:142
+#, fuzzy
+msgid "Set the file's gid on create"
+msgstr "Setzt die gid der Datei beim Übertragen"
+
+#: cmd/incus/file.go:657
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:144
+#, fuzzy
+msgid "Set the file's perms on create"
+msgstr "Setzt die Dateiberechtigungen beim Übertragen"
+
+#: cmd/incus/file.go:658
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: cmd/incus/file.go:466
+#: cmd/incus/file.go:143
+#, fuzzy
+msgid "Set the file's uid on create"
+msgstr "Setzt die uid der Datei beim Übertragen"
+
+#: cmd/incus/file.go:656
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -6475,7 +6509,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:969
+#: cmd/incus/file.go:1160
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6903,6 +6937,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: cmd/incus/file.go:164
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: cmd/incus/alias.go:141
 msgid "TARGET"
 msgstr ""
@@ -6924,12 +6962,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1008
+#: cmd/incus/file.go:1199
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/file.go:1002
+#: cmd/incus/file.go:1193
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7209,6 +7247,10 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
 
+#: cmd/incus/file.go:145
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
+
 #: cmd/incus/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
@@ -7274,7 +7316,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:370
+#: cmd/incus/file.go:560
 msgid "Too many links"
 msgstr ""
 
@@ -7401,7 +7443,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:194
+#: cmd/incus/file.go:384
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7416,7 +7458,7 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/file.go:1229
+#: cmd/incus/file.go:1420
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -7432,7 +7474,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/file.go:783
+#: cmd/incus/file.go:974
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -7675,7 +7717,7 @@ msgstr "Profil %s erstellt\n"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:68
+#: cmd/incus/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8357,7 +8399,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:357
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -8366,7 +8408,16 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:130
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+"Löscht einen Container oder Container Sicherungspunkt.\n"
+"\n"
+"Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
+"Daten (Konfiguration, Sicherungspunkte, ...).\n"
+
+#: cmd/incus/file.go:307
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -8374,7 +8425,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/file.go:237
+#: cmd/incus/file.go:427
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -8384,7 +8435,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:960
+#: cmd/incus/file.go:1151
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -9211,20 +9262,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:964
+#: cmd/incus/file.go:134
+msgid ""
+"incus file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"incus file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: cmd/incus/file.go:1155
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:241
+#: cmd/incus/file.go:431
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:650
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9452,16 +9511,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1118
+#: cmd/incus/file.go:1309
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1077
+#: cmd/incus/file.go:1268
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1030
+#: cmd/incus/file.go:1221
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -9486,6 +9545,10 @@ msgstr ""
 #: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "The content of the created file"
+#~ msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #, fuzzy
 #~ msgid "The --mode flag can't be used with --storage"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-19 22:59-0500\n"
+"POT-Creation-Date: 2024-01-21 22:35-0500\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -588,12 +588,12 @@ msgstr "%s (%d más)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:911
+#: cmd/incus/file.go:1102
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/file.go:801
+#: cmd/incus/file.go:992
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -701,7 +701,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:456
+#: cmd/incus/file.go:646
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -1202,7 +1202,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: cmd/incus/file.go:331
+#: cmd/incus/file.go:521
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1233,7 +1233,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:533
+#: cmd/incus/file.go:723
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1689,9 +1689,14 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:245 cmd/incus/file.go:465
+#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
 msgid "Create any directories necessary"
 msgstr ""
+
+#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Creando el contenedor"
 
 #: cmd/incus/export.go:80
 #, fuzzy, c-format
@@ -1790,6 +1795,11 @@ msgstr "Creado: %s"
 msgid "Creating %s"
 msgstr "Creando %s"
 
+#: cmd/incus/file.go:270
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Creando %s"
+
 #: cmd/incus/create.go:164
 #, fuzzy
 msgid "Creating the instance"
@@ -1858,7 +1868,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/file.go:119 cmd/incus/file.go:120
+#: cmd/incus/file.go:309 cmd/incus/file.go:310
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1987,22 +1997,22 @@ msgstr ""
 #: cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733
 #: cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40
 #: cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120
-#: cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458
-#: cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493
-#: cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021
-#: cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479
-#: cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24
-#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
-#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
-#: cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24
-#: cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32
-#: cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317
-#: cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559
-#: cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873
-#: cmd/incus/network.go:1004 cmd/incus/network.go:1105
+#: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:132
+#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
+#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
+#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
+#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
+#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
+#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
+#: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232
+#: cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462
+#: cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792
+#: cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105
 #: cmd/incus/network.go:1184 cmd/incus/network.go:1244
 #: cmd/incus/network.go:1340 cmd/incus/network.go:1412
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
@@ -2181,7 +2191,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:970
+#: cmd/incus/file.go:1161
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2274,7 +2284,7 @@ msgstr "FECHA DE EXPIRACIÓN"
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: cmd/incus/file.go:71
+#: cmd/incus/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2288,7 +2298,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:168 cmd/incus/file.go:169
+#: cmd/incus/file.go:358 cmd/incus/file.go:359
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2610,12 +2620,12 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1213
+#: cmd/incus/file.go:1404
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1236
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2630,12 +2640,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1263
+#: cmd/incus/file.go:1454
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1048
+#: cmd/incus/file.go:1239
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2665,7 +2675,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1169
+#: cmd/incus/file.go:1360
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2705,7 +2715,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1174
+#: cmd/incus/file.go:1365
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2720,12 +2730,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1074
+#: cmd/incus/file.go:1265
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1201
+#: cmd/incus/file.go:1392
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2819,7 +2829,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1186
+#: cmd/incus/file.go:1377
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2917,7 +2927,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to update cluster member state: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:796
+#: cmd/incus/file.go:987
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2953,6 +2963,10 @@ msgstr "Huella dactilar: %s"
 
 #: cmd/incus/cluster.go:1156
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: cmd/incus/file.go:141
+msgid "Force creating files or directories"
 msgstr ""
 
 #: cmd/incus/cluster.go:1183
@@ -3242,22 +3256,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1286
+#: cmd/incus/file.go:1477
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/file.go:1275
+#: cmd/incus/file.go:1466
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/file.go:1098
+#: cmd/incus/file.go:1289
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: cmd/incus/file.go:1108
+#: cmd/incus/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -3450,11 +3464,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1100
+#: cmd/incus/file.go:1291
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1277
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3469,7 +3483,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1020
+#: cmd/incus/file.go:1211
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3560,7 +3574,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1015
+#: cmd/incus/file.go:1206
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3595,7 +3609,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:334
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3612,15 +3626,20 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:304
+#: cmd/incus/file.go:494
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:486
+#: cmd/incus/file.go:174 cmd/incus/file.go:676
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: cmd/incus/file.go:160
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/info.go:230
 #, fuzzy, c-format
@@ -4067,12 +4086,12 @@ msgstr ""
 msgid "Log:"
 msgstr "Registro:"
 
-#: cmd/incus/file.go:1192
+#: cmd/incus/file.go:1383
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1385
 msgid "Login without username and password"
 msgstr ""
 
@@ -4182,7 +4201,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:79 cmd/incus/file.go:80
+#: cmd/incus/file.go:83 cmd/incus/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4601,7 +4620,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:581
+#: cmd/incus/file.go:771
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -4641,11 +4660,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:279
+#: cmd/incus/file.go:469
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:961 cmd/incus/file.go:962
+#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -5147,7 +5166,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1353
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Contraseña admin para %s:"
@@ -5212,7 +5231,7 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/file.go:1078
+#: cmd/incus/file.go:1269
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5474,20 +5493,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:238 cmd/incus/file.go:239
+#: cmd/incus/file.go:428 cmd/incus/file.go:429
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:407 cmd/incus/file.go:743
+#: cmd/incus/file.go:597 cmd/incus/file.go:934
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:457 cmd/incus/file.go:458
+#: cmd/incus/file.go:647 cmd/incus/file.go:648
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:677 cmd/incus/file.go:843
+#: cmd/incus/file.go:868 cmd/incus/file.go:1034
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5549,7 +5568,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:246 cmd/incus/file.go:464
+#: cmd/incus/file.go:436 cmd/incus/file.go:654
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5894,17 +5913,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1189
+#: cmd/incus/file.go:1380
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1397
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1207
+#: cmd/incus/file.go:1398
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5991,7 +6010,7 @@ msgstr "Dispositivo: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/file.go:971
+#: cmd/incus/file.go:1162
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6192,15 +6211,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:467
+#: cmd/incus/file.go:142
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: cmd/incus/file.go:657
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:144
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: cmd/incus/file.go:658
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:466
+#: cmd/incus/file.go:143
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: cmd/incus/file.go:656
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6266,7 +6297,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:969
+#: cmd/incus/file.go:1160
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6675,6 +6706,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: cmd/incus/file.go:164
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: cmd/incus/alias.go:141
 msgid "TARGET"
 msgstr ""
@@ -6696,11 +6731,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1008
+#: cmd/incus/file.go:1199
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1002
+#: cmd/incus/file.go:1193
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6975,6 +7010,10 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
+#: cmd/incus/file.go:145
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
+
 #: cmd/incus/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
@@ -7038,7 +7077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:370
+#: cmd/incus/file.go:560
 msgid "Too many links"
 msgstr ""
 
@@ -7166,7 +7205,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:194
+#: cmd/incus/file.go:384
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7180,7 +7219,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1229
+#: cmd/incus/file.go:1420
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7196,7 +7235,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:783
+#: cmd/incus/file.go:974
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7430,7 +7469,7 @@ msgstr "Perfil %s creado"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:68
+#: cmd/incus/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7920,23 +7959,28 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:357
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:130
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: cmd/incus/file.go:307
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:237
+#: cmd/incus/file.go:427
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:960
+#: cmd/incus/file.go:1151
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8490,20 +8534,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:964
+#: cmd/incus/file.go:134
+msgid ""
+"incus file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"incus file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: cmd/incus/file.go:1155
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:241
+#: cmd/incus/file.go:431
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:650
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8727,16 +8779,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1118
+#: cmd/incus/file.go:1309
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1077
+#: cmd/incus/file.go:1268
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1030
+#: cmd/incus/file.go:1221
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-19 22:59-0500\n"
+"POT-Creation-Date: 2024-01-21 22:35-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -604,12 +604,12 @@ msgstr "%s (%d disponible)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (principal=%q, source=%q)"
 
-#: cmd/incus/file.go:911
+#: cmd/incus/file.go:1102
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: cmd/incus/file.go:801
+#: cmd/incus/file.go:992
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -717,7 +717,7 @@ msgstr "<serveur distant> <nouveau nom> "
 msgid "<remote>: <path>"
 msgstr "<serveur distant>: <chemin>"
 
-#: cmd/incus/file.go:456
+#: cmd/incus/file.go:646
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<chemin source>... [<serveur distant>:]<instance>/<chemin>"
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Impossible de fournir un nom à l'image cible"
 
-#: cmd/incus/file.go:331
+#: cmd/incus/file.go:521
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1291,7 +1291,7 @@ msgstr "Impossible de spécifier un autre serveur distant pour un renommage"
 msgid "Can't specify column L when not clustered"
 msgstr "Impossible de spécifier la colonne L en dehors d'une grappe"
 
-#: cmd/incus/file.go:533
+#: cmd/incus/file.go:723
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1775,8 +1775,13 @@ msgstr "Création du conteneur"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:245 cmd/incus/file.go:465
+#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
 msgid "Create any directories necessary"
+msgstr "Créer tous répertoires nécessaires"
+
+#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#, fuzzy
+msgid "Create files and directories in instances"
 msgstr "Créer tous répertoires nécessaires"
 
 #: cmd/incus/export.go:80
@@ -1903,6 +1908,11 @@ msgstr "Créé : %s"
 msgid "Creating %s"
 msgstr "Création de %s"
 
+#: cmd/incus/file.go:270
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Création de %s"
+
 #: cmd/incus/create.go:164
 #, fuzzy
 msgid "Creating the instance"
@@ -1973,7 +1983,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/file.go:119 cmd/incus/file.go:120
+#: cmd/incus/file.go:309 cmd/incus/file.go:310
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
@@ -2110,22 +2120,22 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733
 #: cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40
 #: cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120
-#: cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458
-#: cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493
-#: cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021
-#: cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479
-#: cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24
-#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
-#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
-#: cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24
-#: cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32
-#: cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317
-#: cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559
-#: cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873
-#: cmd/incus/network.go:1004 cmd/incus/network.go:1105
+#: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:132
+#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
+#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
+#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
+#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
+#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
+#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
+#: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232
+#: cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462
+#: cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792
+#: cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105
 #: cmd/incus/network.go:1184 cmd/incus/network.go:1244
 #: cmd/incus/network.go:1340 cmd/incus/network.go:1412
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
@@ -2306,7 +2316,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:970
+#: cmd/incus/file.go:1161
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2403,7 +2413,7 @@ msgstr "DATE D'EXPIRATION"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: cmd/incus/file.go:71
+#: cmd/incus/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2418,7 +2428,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/file.go:168 cmd/incus/file.go:169
+#: cmd/incus/file.go:358 cmd/incus/file.go:359
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2769,12 +2779,12 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1213
+#: cmd/incus/file.go:1404
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1236
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2789,12 +2799,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/file.go:1263
+#: cmd/incus/file.go:1454
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1048
+#: cmd/incus/file.go:1239
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2824,7 +2834,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/file.go:1169
+#: cmd/incus/file.go:1360
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2864,7 +2874,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: cmd/incus/file.go:1174
+#: cmd/incus/file.go:1365
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2879,12 +2889,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: cmd/incus/file.go:1074
+#: cmd/incus/file.go:1265
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: cmd/incus/file.go:1201
+#: cmd/incus/file.go:1392
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2979,7 +2989,7 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to join cluster: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/file.go:1186
+#: cmd/incus/file.go:1377
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -3077,7 +3087,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to update cluster member state: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/file.go:796
+#: cmd/incus/file.go:987
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3114,6 +3124,10 @@ msgstr "Empreinte : %s"
 
 #: cmd/incus/cluster.go:1156
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: cmd/incus/file.go:141
+msgid "Force creating files or directories"
 msgstr ""
 
 #: cmd/incus/cluster.go:1183
@@ -3414,22 +3428,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1286
+#: cmd/incus/file.go:1477
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/file.go:1275
+#: cmd/incus/file.go:1466
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/file.go:1098
+#: cmd/incus/file.go:1289
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/file.go:1108
+#: cmd/incus/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3632,12 +3646,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1100
+#: cmd/incus/file.go:1291
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/file.go:1277
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3652,7 +3666,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1020
+#: cmd/incus/file.go:1211
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3744,7 +3758,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1015
+#: cmd/incus/file.go:1206
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -3780,7 +3794,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:334
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -3797,14 +3811,19 @@ msgstr "Cible invalide %s"
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:304
+#: cmd/incus/file.go:494
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: cmd/incus/file.go:486
+#: cmd/incus/file.go:174 cmd/incus/file.go:676
 #, c-format
 msgid "Invalid target %s"
+msgstr "Cible invalide %s"
+
+#: cmd/incus/file.go:160
+#, fuzzy, c-format
+msgid "Invalid type %q"
 msgstr "Cible invalide %s"
 
 #: cmd/incus/info.go:230
@@ -4317,12 +4336,12 @@ msgstr ""
 msgid "Log:"
 msgstr "Journal : "
 
-#: cmd/incus/file.go:1192
+#: cmd/incus/file.go:1383
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1385
 msgid "Login without username and password"
 msgstr ""
 
@@ -4436,7 +4455,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:79 cmd/incus/file.go:80
+#: cmd/incus/file.go:83 cmd/incus/file.go:84
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
@@ -4877,7 +4896,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: cmd/incus/file.go:581
+#: cmd/incus/file.go:771
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -4920,12 +4939,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: cmd/incus/file.go:279
+#: cmd/incus/file.go:469
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: cmd/incus/file.go:961 cmd/incus/file.go:962
+#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -5452,7 +5471,7 @@ msgstr "Options :"
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1353
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Mot de passe administrateur pour %s : "
@@ -5519,7 +5538,7 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/file.go:1078
+#: cmd/incus/file.go:1269
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5784,22 +5803,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/file.go:238 cmd/incus/file.go:239
+#: cmd/incus/file.go:428 cmd/incus/file.go:429
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:407 cmd/incus/file.go:743
+#: cmd/incus/file.go:597 cmd/incus/file.go:934
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:457 cmd/incus/file.go:458
+#: cmd/incus/file.go:647 cmd/incus/file.go:648
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:677 cmd/incus/file.go:843
+#: cmd/incus/file.go:868 cmd/incus/file.go:1034
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5862,7 +5881,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:246 cmd/incus/file.go:464
+#: cmd/incus/file.go:436 cmd/incus/file.go:654
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -6239,17 +6258,17 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1189
+#: cmd/incus/file.go:1380
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1397
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1207
+#: cmd/incus/file.go:1398
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -6342,7 +6361,7 @@ msgstr "Serveur distant : %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/file.go:971
+#: cmd/incus/file.go:1162
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6551,15 +6570,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:467
+#: cmd/incus/file.go:142
+#, fuzzy
+msgid "Set the file's gid on create"
+msgstr "Définir le gid du fichier lors de l'envoi"
+
+#: cmd/incus/file.go:657
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:144
+#, fuzzy
+msgid "Set the file's perms on create"
+msgstr "Définir les permissions du fichier lors de l'envoi"
+
+#: cmd/incus/file.go:658
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:466
+#: cmd/incus/file.go:143
+#, fuzzy
+msgid "Set the file's uid on create"
+msgstr "Définir l'uid du fichier lors de l'envoi"
+
+#: cmd/incus/file.go:656
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -6627,7 +6661,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:969
+#: cmd/incus/file.go:1160
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7064,6 +7098,10 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
+#: cmd/incus/file.go:164
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: cmd/incus/alias.go:141
 msgid "TARGET"
 msgstr ""
@@ -7086,11 +7124,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: cmd/incus/file.go:1008
+#: cmd/incus/file.go:1199
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1002
+#: cmd/incus/file.go:1193
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7372,6 +7410,10 @@ msgstr "Le périphérique indiqué n'existe pas"
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
+#: cmd/incus/file.go:145
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
+
 #: cmd/incus/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
@@ -7440,7 +7482,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:370
+#: cmd/incus/file.go:560
 msgid "Too many links"
 msgstr ""
 
@@ -7568,7 +7610,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/file.go:194
+#: cmd/incus/file.go:384
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7583,7 +7625,7 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1229
+#: cmd/incus/file.go:1420
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7599,7 +7641,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:783
+#: cmd/incus/file.go:974
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7846,7 +7888,7 @@ msgstr "L'utilisateur a annulé l'opération de suppression."
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: cmd/incus/file.go:68
+#: cmd/incus/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8533,7 +8575,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:357
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -8545,7 +8587,19 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:130
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+"Supprimer des conteneurs ou des instantanés.\n"
+"\n"
+"lxc delete [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
+"<snapshot>]...]\n"
+"\n"
+"Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
+"(configuration, instantanés, …)."
+
+#: cmd/incus/file.go:307
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -8553,7 +8607,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:237
+#: cmd/incus/file.go:427
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -8566,7 +8620,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:960
+#: cmd/incus/file.go:1151
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -9445,20 +9499,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:964
+#: cmd/incus/file.go:134
+msgid ""
+"incus file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"incus file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: cmd/incus/file.go:1155
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:241
+#: cmd/incus/file.go:431
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:650
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9706,16 +9768,16 @@ msgstr "s'il vous plaît utilisez  `incus profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: cmd/incus/file.go:1118
+#: cmd/incus/file.go:1309
 msgid "sshfs has stopped"
 msgstr "sshfs s'est arrêté"
 
-#: cmd/incus/file.go:1077
+#: cmd/incus/file.go:1268
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs monté %q sur %q"
 
-#: cmd/incus/file.go:1030
+#: cmd/incus/file.go:1221
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr "sshfs non trouvé. Essayez SSH SFTP mode via le fanion --listen"
 
@@ -9740,6 +9802,10 @@ msgstr "o"
 #: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr "oui"
+
+#, fuzzy
+#~ msgid "The content of the created file"
+#~ msgstr "L'arrêt du conteneur a échoué !"
 
 #, fuzzy
 #~ msgid "Failed to get the new instance name"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-01-19 22:59-0500\n"
+        "POT-Creation-Date: 2024-01-21 22:35-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -331,12 +331,12 @@ msgstr  ""
 msgid   "%s (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/file.go:911
+#: cmd/incus/file.go:1102
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: cmd/incus/file.go:801
+#: cmd/incus/file.go:992
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -436,7 +436,7 @@ msgstr  ""
 msgid   "<remote>: <path>"
 msgstr  ""
 
-#: cmd/incus/file.go:456
+#: cmd/incus/file.go:646
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -907,7 +907,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: cmd/incus/file.go:331
+#: cmd/incus/file.go:521
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -936,7 +936,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: cmd/incus/file.go:533
+#: cmd/incus/file.go:723
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -1327,8 +1327,12 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: cmd/incus/file.go:245 cmd/incus/file.go:465
+#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
 msgid   "Create any directories necessary"
+msgstr  ""
+
+#: cmd/incus/file.go:131 cmd/incus/file.go:132
+msgid   "Create files and directories in instances"
 msgstr  ""
 
 #: cmd/incus/export.go:80
@@ -1421,6 +1425,11 @@ msgstr  ""
 msgid   "Creating %s"
 msgstr  ""
 
+#: cmd/incus/file.go:270
+#, c-format
+msgid   "Creating %s: %%s"
+msgstr  ""
+
 #: cmd/incus/create.go:164
 msgid   "Creating the instance"
 msgstr  ""
@@ -1480,7 +1489,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: cmd/incus/file.go:119 cmd/incus/file.go:120
+#: cmd/incus/file.go:309 cmd/incus/file.go:310
 msgid   "Delete files in instances"
 msgstr  ""
 
@@ -1564,7 +1573,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:53 cmd/incus/action.go:75 cmd/incus/action.go:97 cmd/incus/action.go:120 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:160 cmd/incus/alias.go:215 cmd/incus/cluster.go:29 cmd/incus/cluster.go:122 cmd/incus/cluster.go:206 cmd/incus/cluster.go:255 cmd/incus/cluster.go:306 cmd/incus/cluster.go:367 cmd/incus/cluster.go:439 cmd/incus/cluster.go:471 cmd/incus/cluster.go:521 cmd/incus/cluster.go:604 cmd/incus/cluster.go:689 cmd/incus/cluster.go:802 cmd/incus/cluster.go:866 cmd/incus/cluster.go:968 cmd/incus/cluster.go:1047 cmd/incus/cluster.go:1154 cmd/incus/cluster.go:1175 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:157 cmd/incus/cluster_group.go:214 cmd/incus/cluster_group.go:266 cmd/incus/cluster_group.go:382 cmd/incus/cluster_group.go:456 cmd/incus/cluster_group.go:529 cmd/incus/cluster_group.go:577 cmd/incus/cluster_group.go:631 cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:106 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:380 cmd/incus/config.go:505 cmd/incus/config.go:719 cmd/incus/config.go:851 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:208 cmd/incus/config_device.go:285 cmd/incus/config_device.go:356 cmd/incus/config_device.go:450 cmd/incus/config_device.go:548 cmd/incus/config_device.go:555 cmd/incus/config_device.go:668 cmd/incus/config_device.go:741 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:179 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:109 cmd/incus/config_template.go:151 cmd/incus/config_template.go:239 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:90 cmd/incus/config_trust.go:170 cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:401 cmd/incus/config_trust.go:585 cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733 cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120 cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458 cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105 cmd/incus/network.go:1184 cmd/incus/network.go:1244 cmd/incus/network.go:1340 cmd/incus/network.go:1412 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:164 cmd/incus/network_acl.go:217 cmd/incus/network_acl.go:265 cmd/incus/network_acl.go:326 cmd/incus/network_acl.go:411 cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:652 cmd/incus/network_acl.go:701 cmd/incus/network_acl.go:750 cmd/incus/network_acl.go:765 cmd/incus/network_acl.go:886 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:166 cmd/incus/network_forward.go:230 cmd/incus/network_forward.go:328 cmd/incus/network_forward.go:397 cmd/incus/network_forward.go:495 cmd/incus/network_forward.go:525 cmd/incus/network_forward.go:667 cmd/incus/network_forward.go:729 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:809 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:169 cmd/incus/network_load_balancer.go:233 cmd/incus/network_load_balancer.go:331 cmd/incus/network_load_balancer.go:399 cmd/incus/network_load_balancer.go:497 cmd/incus/network_load_balancer.go:527 cmd/incus/network_load_balancer.go:670 cmd/incus/network_load_balancer.go:731 cmd/incus/network_load_balancer.go:746 cmd/incus/network_load_balancer.go:810 cmd/incus/network_load_balancer.go:896 cmd/incus/network_load_balancer.go:911 cmd/incus/network_load_balancer.go:972 cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:80 cmd/incus/network_peer.go:157 cmd/incus/network_peer.go:214 cmd/incus/network_peer.go:330 cmd/incus/network_peer.go:398 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:642 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84 cmd/incus/network_zone.go:155 cmd/incus/network_zone.go:210 cmd/incus/network_zone.go:270 cmd/incus/network_zone.go:353 cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:464 cmd/incus/network_zone.go:583 cmd/incus/network_zone.go:631 cmd/incus/network_zone.go:688 cmd/incus/network_zone.go:758 cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:869 cmd/incus/network_zone.go:951 cmd/incus/network_zone.go:1027 cmd/incus/network_zone.go:1057 cmd/incus/network_zone.go:1175 cmd/incus/network_zone.go:1224 cmd/incus/network_zone.go:1239 cmd/incus/network_zone.go:1285 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:167 cmd/incus/profile.go:250 cmd/incus/profile.go:320 cmd/incus/profile.go:374 cmd/incus/profile.go:424 cmd/incus/profile.go:552 cmd/incus/profile.go:613 cmd/incus/profile.go:674 cmd/incus/profile.go:750 cmd/incus/profile.go:802 cmd/incus/profile.go:878 cmd/incus/profile.go:934 cmd/incus/project.go:29 cmd/incus/project.go:93 cmd/incus/project.go:158 cmd/incus/project.go:221 cmd/incus/project.go:349 cmd/incus/project.go:410 cmd/incus/project.go:522 cmd/incus/project.go:579 cmd/incus/project.go:658 cmd/incus/project.go:689 cmd/incus/project.go:742 cmd/incus/project.go:801 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624 cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815 cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:29 cmd/incus/snapshot.go:76 cmd/incus/snapshot.go:175 cmd/incus/snapshot.go:252 cmd/incus/snapshot.go:343 cmd/incus/snapshot.go:392 cmd/incus/snapshot.go:462 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846 cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82 cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243 cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452 cmd/incus/storage_bucket.go:529 cmd/incus/storage_bucket.go:623 cmd/incus/storage_bucket.go:692 cmd/incus/storage_bucket.go:726 cmd/incus/storage_bucket.go:767 cmd/incus/storage_bucket.go:846 cmd/incus/storage_bucket.go:924 cmd/incus/storage_bucket.go:988 cmd/incus/storage_bucket.go:1123 cmd/incus/storage_volume.go:44 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:237 cmd/incus/storage_volume.go:328 cmd/incus/storage_volume.go:531 cmd/incus/storage_volume.go:610 cmd/incus/storage_volume.go:671 cmd/incus/storage_volume.go:753 cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:1043 cmd/incus/storage_volume.go:1158 cmd/incus/storage_volume.go:1305 cmd/incus/storage_volume.go:1389 cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:1677 cmd/incus/storage_volume.go:1745 cmd/incus/storage_volume.go:1889 cmd/incus/storage_volume.go:1971 cmd/incus/storage_volume.go:2014 cmd/incus/storage_volume.go:2063 cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2235 cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2349 cmd/incus/storage_volume.go:2420 cmd/incus/storage_volume.go:2484 cmd/incus/storage_volume.go:2568 cmd/incus/storage_volume.go:2722 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:53 cmd/incus/action.go:75 cmd/incus/action.go:97 cmd/incus/action.go:120 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:160 cmd/incus/alias.go:215 cmd/incus/cluster.go:29 cmd/incus/cluster.go:122 cmd/incus/cluster.go:206 cmd/incus/cluster.go:255 cmd/incus/cluster.go:306 cmd/incus/cluster.go:367 cmd/incus/cluster.go:439 cmd/incus/cluster.go:471 cmd/incus/cluster.go:521 cmd/incus/cluster.go:604 cmd/incus/cluster.go:689 cmd/incus/cluster.go:802 cmd/incus/cluster.go:866 cmd/incus/cluster.go:968 cmd/incus/cluster.go:1047 cmd/incus/cluster.go:1154 cmd/incus/cluster.go:1175 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:157 cmd/incus/cluster_group.go:214 cmd/incus/cluster_group.go:266 cmd/incus/cluster_group.go:382 cmd/incus/cluster_group.go:456 cmd/incus/cluster_group.go:529 cmd/incus/cluster_group.go:577 cmd/incus/cluster_group.go:631 cmd/incus/cluster_role.go:23 cmd/incus/cluster_role.go:50 cmd/incus/cluster_role.go:106 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:380 cmd/incus/config.go:505 cmd/incus/config.go:719 cmd/incus/config.go:851 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:208 cmd/incus/config_device.go:285 cmd/incus/config_device.go:356 cmd/incus/config_device.go:450 cmd/incus/config_device.go:548 cmd/incus/config_device.go:555 cmd/incus/config_device.go:668 cmd/incus/config_device.go:741 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:179 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:109 cmd/incus/config_template.go:151 cmd/incus/config_template.go:239 cmd/incus/config_template.go:299 cmd/incus/config_trust.go:35 cmd/incus/config_trust.go:90 cmd/incus/config_trust.go:170 cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:401 cmd/incus/config_trust.go:585 cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733 cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105 cmd/incus/network.go:1184 cmd/incus/network.go:1244 cmd/incus/network.go:1340 cmd/incus/network.go:1412 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:164 cmd/incus/network_acl.go:217 cmd/incus/network_acl.go:265 cmd/incus/network_acl.go:326 cmd/incus/network_acl.go:411 cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:521 cmd/incus/network_acl.go:652 cmd/incus/network_acl.go:701 cmd/incus/network_acl.go:750 cmd/incus/network_acl.go:765 cmd/incus/network_acl.go:886 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:166 cmd/incus/network_forward.go:230 cmd/incus/network_forward.go:328 cmd/incus/network_forward.go:397 cmd/incus/network_forward.go:495 cmd/incus/network_forward.go:525 cmd/incus/network_forward.go:667 cmd/incus/network_forward.go:729 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:809 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:169 cmd/incus/network_load_balancer.go:233 cmd/incus/network_load_balancer.go:331 cmd/incus/network_load_balancer.go:399 cmd/incus/network_load_balancer.go:497 cmd/incus/network_load_balancer.go:527 cmd/incus/network_load_balancer.go:670 cmd/incus/network_load_balancer.go:731 cmd/incus/network_load_balancer.go:746 cmd/incus/network_load_balancer.go:810 cmd/incus/network_load_balancer.go:896 cmd/incus/network_load_balancer.go:911 cmd/incus/network_load_balancer.go:972 cmd/incus/network_peer.go:27 cmd/incus/network_peer.go:80 cmd/incus/network_peer.go:157 cmd/incus/network_peer.go:214 cmd/incus/network_peer.go:330 cmd/incus/network_peer.go:398 cmd/incus/network_peer.go:487 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:642 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84 cmd/incus/network_zone.go:155 cmd/incus/network_zone.go:210 cmd/incus/network_zone.go:270 cmd/incus/network_zone.go:353 cmd/incus/network_zone.go:433 cmd/incus/network_zone.go:464 cmd/incus/network_zone.go:583 cmd/incus/network_zone.go:631 cmd/incus/network_zone.go:688 cmd/incus/network_zone.go:758 cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:869 cmd/incus/network_zone.go:951 cmd/incus/network_zone.go:1027 cmd/incus/network_zone.go:1057 cmd/incus/network_zone.go:1175 cmd/incus/network_zone.go:1224 cmd/incus/network_zone.go:1239 cmd/incus/network_zone.go:1285 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:167 cmd/incus/profile.go:250 cmd/incus/profile.go:320 cmd/incus/profile.go:374 cmd/incus/profile.go:424 cmd/incus/profile.go:552 cmd/incus/profile.go:613 cmd/incus/profile.go:674 cmd/incus/profile.go:750 cmd/incus/profile.go:802 cmd/incus/profile.go:878 cmd/incus/profile.go:934 cmd/incus/project.go:29 cmd/incus/project.go:93 cmd/incus/project.go:158 cmd/incus/project.go:221 cmd/incus/project.go:349 cmd/incus/project.go:410 cmd/incus/project.go:522 cmd/incus/project.go:579 cmd/incus/project.go:658 cmd/incus/project.go:689 cmd/incus/project.go:742 cmd/incus/project.go:801 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:37 cmd/incus/remote.go:97 cmd/incus/remote.go:624 cmd/incus/remote.go:660 cmd/incus/remote.go:744 cmd/incus/remote.go:815 cmd/incus/remote.go:870 cmd/incus/remote.go:908 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:29 cmd/incus/snapshot.go:76 cmd/incus/snapshot.go:175 cmd/incus/snapshot.go:252 cmd/incus/snapshot.go:343 cmd/incus/snapshot.go:392 cmd/incus/snapshot.go:462 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:169 cmd/incus/storage.go:219 cmd/incus/storage.go:343 cmd/incus/storage.go:413 cmd/incus/storage.go:585 cmd/incus/storage.go:664 cmd/incus/storage.go:760 cmd/incus/storage.go:846 cmd/incus/storage_bucket.go:28 cmd/incus/storage_bucket.go:82 cmd/incus/storage_bucket.go:182 cmd/incus/storage_bucket.go:243 cmd/incus/storage_bucket.go:376 cmd/incus/storage_bucket.go:452 cmd/incus/storage_bucket.go:529 cmd/incus/storage_bucket.go:623 cmd/incus/storage_bucket.go:692 cmd/incus/storage_bucket.go:726 cmd/incus/storage_bucket.go:767 cmd/incus/storage_bucket.go:846 cmd/incus/storage_bucket.go:924 cmd/incus/storage_bucket.go:988 cmd/incus/storage_bucket.go:1123 cmd/incus/storage_volume.go:44 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:237 cmd/incus/storage_volume.go:328 cmd/incus/storage_volume.go:531 cmd/incus/storage_volume.go:610 cmd/incus/storage_volume.go:671 cmd/incus/storage_volume.go:753 cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:1043 cmd/incus/storage_volume.go:1158 cmd/incus/storage_volume.go:1305 cmd/incus/storage_volume.go:1389 cmd/incus/storage_volume.go:1596 cmd/incus/storage_volume.go:1677 cmd/incus/storage_volume.go:1745 cmd/incus/storage_volume.go:1889 cmd/incus/storage_volume.go:1971 cmd/incus/storage_volume.go:2014 cmd/incus/storage_volume.go:2063 cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2235 cmd/incus/storage_volume.go:2241 cmd/incus/storage_volume.go:2349 cmd/incus/storage_volume.go:2420 cmd/incus/storage_volume.go:2484 cmd/incus/storage_volume.go:2568 cmd/incus/storage_volume.go:2722 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1646,7 +1655,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: cmd/incus/file.go:970
+#: cmd/incus/file.go:1161
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1737,7 +1746,7 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: cmd/incus/file.go:71
+#: cmd/incus/file.go:75
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
@@ -1749,7 +1758,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/file.go:168 cmd/incus/file.go:169
+#: cmd/incus/file.go:358 cmd/incus/file.go:359
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -2036,12 +2045,12 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: cmd/incus/file.go:1213
+#: cmd/incus/file.go:1404
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1236
+#: cmd/incus/file.go:1427
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -2056,12 +2065,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1263
+#: cmd/incus/file.go:1454
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1048
+#: cmd/incus/file.go:1239
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2091,7 +2100,7 @@ msgstr  ""
 msgid   "Failed deleting source volume after copy: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1169
+#: cmd/incus/file.go:1360
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2131,7 +2140,7 @@ msgstr  ""
 msgid   "Failed loading storage pool %q: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1174
+#: cmd/incus/file.go:1365
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2146,12 +2155,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1074
+#: cmd/incus/file.go:1265
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1201
+#: cmd/incus/file.go:1392
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2245,7 +2254,7 @@ msgstr  ""
 msgid   "Failed to join cluster: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1186
+#: cmd/incus/file.go:1377
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -2340,7 +2349,7 @@ msgstr  ""
 msgid   "Failed to update cluster member state: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:796
+#: cmd/incus/file.go:987
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2375,6 +2384,10 @@ msgstr  ""
 
 #: cmd/incus/cluster.go:1156
 msgid   "Force a particular evacuation action"
+msgstr  ""
+
+#: cmd/incus/file.go:141
+msgid   "Force creating files or directories"
 msgstr  ""
 
 #: cmd/incus/cluster.go:1183
@@ -2629,22 +2642,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: cmd/incus/file.go:1286
+#: cmd/incus/file.go:1477
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1275
+#: cmd/incus/file.go:1466
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1098
+#: cmd/incus/file.go:1289
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1108
+#: cmd/incus/file.go:1299
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2829,11 +2842,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: cmd/incus/file.go:1100
+#: cmd/incus/file.go:1291
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: cmd/incus/file.go:1277
+#: cmd/incus/file.go:1468
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2847,7 +2860,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:1020
+#: cmd/incus/file.go:1211
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2936,7 +2949,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:1015
+#: cmd/incus/file.go:1206
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2970,7 +2983,7 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:334
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -2984,14 +2997,19 @@ msgstr  ""
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: cmd/incus/file.go:304
+#: cmd/incus/file.go:494
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: cmd/incus/file.go:486
+#: cmd/incus/file.go:174 cmd/incus/file.go:676
 #, c-format
 msgid   "Invalid target %s"
+msgstr  ""
+
+#: cmd/incus/file.go:160
+#, c-format
+msgid   "Invalid type %q"
 msgstr  ""
 
 #: cmd/incus/info.go:230
@@ -3407,12 +3425,12 @@ msgstr  ""
 msgid   "Log:"
 msgstr  ""
 
-#: cmd/incus/file.go:1192
+#: cmd/incus/file.go:1383
 #, c-format
 msgid   "Login with username %q and password %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1385
 msgid   "Login without username and password"
 msgstr  ""
 
@@ -3520,7 +3538,7 @@ msgstr  ""
 msgid   "Manage devices"
 msgstr  ""
 
-#: cmd/incus/file.go:79 cmd/incus/file.go:80
+#: cmd/incus/file.go:83 cmd/incus/file.go:84
 msgid   "Manage files in instances"
 msgstr  ""
 
@@ -3820,7 +3838,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: cmd/incus/file.go:581
+#: cmd/incus/file.go:771
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -3856,11 +3874,11 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: cmd/incus/file.go:279
+#: cmd/incus/file.go:469
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: cmd/incus/file.go:961 cmd/incus/file.go:962
+#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -4336,7 +4354,7 @@ msgstr  ""
 msgid   "Password for %s: "
 msgstr  ""
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1353
 #, c-format
 msgid   "Password rejected for %q"
 msgstr  ""
@@ -4400,7 +4418,7 @@ msgstr  ""
 msgid   "Pre-seed mode, expects YAML config from stdin"
 msgstr  ""
 
-#: cmd/incus/file.go:1078
+#: cmd/incus/file.go:1269
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
@@ -4630,20 +4648,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:238 cmd/incus/file.go:239
+#: cmd/incus/file.go:428 cmd/incus/file.go:429
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: cmd/incus/file.go:407 cmd/incus/file.go:743
+#: cmd/incus/file.go:597 cmd/incus/file.go:934
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: cmd/incus/file.go:457 cmd/incus/file.go:458
+#: cmd/incus/file.go:647 cmd/incus/file.go:648
 msgid   "Push files into instances"
 msgstr  ""
 
-#: cmd/incus/file.go:677 cmd/incus/file.go:843
+#: cmd/incus/file.go:868 cmd/incus/file.go:1034
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4697,7 +4715,7 @@ msgid   "Recover missing instances and volumes from existing and unknown storage
         "  pools but are not in the database. It will then offer to recreate these database records."
 msgstr  ""
 
-#: cmd/incus/file.go:246 cmd/incus/file.go:464
+#: cmd/incus/file.go:436 cmd/incus/file.go:654
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -5021,17 +5039,17 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: cmd/incus/file.go:1189
+#: cmd/incus/file.go:1380
 #, c-format
 msgid   "SSH SFTP listening on %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1397
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1207
+#: cmd/incus/file.go:1398
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -5115,7 +5133,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: cmd/incus/file.go:971
+#: cmd/incus/file.go:1162
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -5281,15 +5299,27 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: cmd/incus/file.go:467
+#: cmd/incus/file.go:142
+msgid   "Set the file's gid on create"
+msgstr  ""
+
+#: cmd/incus/file.go:657
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:144
+msgid   "Set the file's perms on create"
+msgstr  ""
+
+#: cmd/incus/file.go:658
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: cmd/incus/file.go:466
+#: cmd/incus/file.go:143
+msgid   "Set the file's uid on create"
+msgstr  ""
+
+#: cmd/incus/file.go:656
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -5349,7 +5379,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/file.go:969
+#: cmd/incus/file.go:1160
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -5740,6 +5770,10 @@ msgstr  ""
 msgid   "Switch the default remote"
 msgstr  ""
 
+#: cmd/incus/file.go:164
+msgid   "Symlink target path can only be used for type \"symlink\""
+msgstr  ""
+
 #: cmd/incus/alias.go:141
 msgid   "TARGET"
 msgstr  ""
@@ -5756,11 +5790,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: cmd/incus/file.go:1008
+#: cmd/incus/file.go:1199
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: cmd/incus/file.go:1002
+#: cmd/incus/file.go:1193
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -6015,6 +6049,10 @@ msgstr  ""
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
+#: cmd/incus/file.go:145
+msgid   "The type to create (file, symlink, or directory)"
+msgstr  ""
+
 #: cmd/incus/publish.go:83
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
@@ -6071,7 +6109,7 @@ msgstr  ""
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: cmd/incus/file.go:370
+#: cmd/incus/file.go:560
 msgid   "Too many links"
 msgstr  ""
 
@@ -6189,7 +6227,7 @@ msgstr  ""
 msgid   "Unable to connect to any of the cluster members specified in join token"
 msgstr  ""
 
-#: cmd/incus/file.go:194
+#: cmd/incus/file.go:384
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -6203,7 +6241,7 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1229
+#: cmd/incus/file.go:1420
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
@@ -6218,7 +6256,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: cmd/incus/file.go:783
+#: cmd/incus/file.go:974
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -6429,7 +6467,7 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: cmd/incus/file.go:68
+#: cmd/incus/file.go:72
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
@@ -6838,19 +6876,23 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:357
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:130
+msgid   "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr  ""
+
+#: cmd/incus/file.go:307
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: cmd/incus/file.go:237
+#: cmd/incus/file.go:427
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: cmd/incus/file.go:960
+#: cmd/incus/file.go:1151
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -7280,17 +7322,24 @@ msgid   "incus export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: cmd/incus/file.go:964
+#: cmd/incus/file.go:134
+msgid   "incus file create foo/bar\n"
+        "	   To create a file /bar in the foo instance.\n"
+        "incus file create --type=symlink foo/bar baz\n"
+        "	   To create a symlink /bar in instance foo whose target is baz."
+msgstr  ""
+
+#: cmd/incus/file.go:1155
 msgid   "incus file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: cmd/incus/file.go:241
+#: cmd/incus/file.go:431
 msgid   "incus file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:650
 msgid   "incus file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -7479,16 +7528,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: cmd/incus/file.go:1118
+#: cmd/incus/file.go:1309
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: cmd/incus/file.go:1077
+#: cmd/incus/file.go:1268
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1030
+#: cmd/incus/file.go:1221
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-19 22:59-0500\n"
+"POT-Creation-Date: 2024-01-21 22:35-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -590,12 +590,12 @@ msgstr "%s (altri %d)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:911
+#: cmd/incus/file.go:1102
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: cmd/incus/file.go:801
+#: cmd/incus/file.go:992
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -699,7 +699,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:456
+#: cmd/incus/file.go:646
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -1197,7 +1197,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:331
+#: cmd/incus/file.go:521
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1227,7 +1227,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:533
+#: cmd/incus/file.go:723
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1679,9 +1679,14 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:245 cmd/incus/file.go:465
+#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
 msgid "Create any directories necessary"
 msgstr ""
+
+#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Creazione del container in corso"
 
 #: cmd/incus/export.go:80
 #, fuzzy, c-format
@@ -1782,6 +1787,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
+#: cmd/incus/file.go:270
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Creazione di %s in corso"
+
 #: cmd/incus/create.go:164
 #, fuzzy
 msgid "Creating the instance"
@@ -1850,7 +1860,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/file.go:119 cmd/incus/file.go:120
+#: cmd/incus/file.go:309 cmd/incus/file.go:310
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
@@ -1979,22 +1989,22 @@ msgstr ""
 #: cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733
 #: cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40
 #: cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120
-#: cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458
-#: cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493
-#: cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021
-#: cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479
-#: cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24
-#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
-#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
-#: cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24
-#: cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32
-#: cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317
-#: cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559
-#: cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873
-#: cmd/incus/network.go:1004 cmd/incus/network.go:1105
+#: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:132
+#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
+#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
+#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
+#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
+#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
+#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
+#: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232
+#: cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462
+#: cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792
+#: cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105
 #: cmd/incus/network.go:1184 cmd/incus/network.go:1244
 #: cmd/incus/network.go:1340 cmd/incus/network.go:1412
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
@@ -2173,7 +2183,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:970
+#: cmd/incus/file.go:1161
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2268,7 +2278,7 @@ msgstr "DATA DI SCADENZA"
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: cmd/incus/file.go:71
+#: cmd/incus/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2282,7 +2292,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:168 cmd/incus/file.go:169
+#: cmd/incus/file.go:358 cmd/incus/file.go:359
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -2603,12 +2613,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1213
+#: cmd/incus/file.go:1404
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1236
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2623,12 +2633,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1263
+#: cmd/incus/file.go:1454
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1048
+#: cmd/incus/file.go:1239
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2658,7 +2668,7 @@ msgstr "Accetta certificato"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1169
+#: cmd/incus/file.go:1360
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2698,7 +2708,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1174
+#: cmd/incus/file.go:1365
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2713,12 +2723,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1074
+#: cmd/incus/file.go:1265
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1201
+#: cmd/incus/file.go:1392
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2812,7 +2822,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1186
+#: cmd/incus/file.go:1377
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2910,7 +2920,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to update cluster member state: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:796
+#: cmd/incus/file.go:987
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2947,6 +2957,10 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1156
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: cmd/incus/file.go:141
+msgid "Force creating files or directories"
 msgstr ""
 
 #: cmd/incus/cluster.go:1183
@@ -3233,22 +3247,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1286
+#: cmd/incus/file.go:1477
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1275
+#: cmd/incus/file.go:1466
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1098
+#: cmd/incus/file.go:1289
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1108
+#: cmd/incus/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -3439,11 +3453,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1100
+#: cmd/incus/file.go:1291
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1277
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3457,7 +3471,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1020
+#: cmd/incus/file.go:1211
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3548,7 +3562,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1015
+#: cmd/incus/file.go:1206
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3584,7 +3598,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:334
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3601,15 +3615,20 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:304
+#: cmd/incus/file.go:494
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:486
+#: cmd/incus/file.go:174 cmd/incus/file.go:676
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: cmd/incus/file.go:160
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Proprietà errata: %s"
 
 #: cmd/incus/info.go:230
 #, c-format
@@ -4057,12 +4076,12 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/file.go:1192
+#: cmd/incus/file.go:1383
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1385
 msgid "Login without username and password"
 msgstr ""
 
@@ -4174,7 +4193,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:79 cmd/incus/file.go:80
+#: cmd/incus/file.go:83 cmd/incus/file.go:84
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
@@ -4595,7 +4614,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:581
+#: cmd/incus/file.go:771
 msgid "Missing target directory"
 msgstr ""
 
@@ -4635,11 +4654,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:279
+#: cmd/incus/file.go:469
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:961 cmd/incus/file.go:962
+#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -5141,7 +5160,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1353
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Password amministratore per %s: "
@@ -5207,7 +5226,7 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/file.go:1078
+#: cmd/incus/file.go:1269
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5467,21 +5486,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:238 cmd/incus/file.go:239
+#: cmd/incus/file.go:428 cmd/incus/file.go:429
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:407 cmd/incus/file.go:743
+#: cmd/incus/file.go:597 cmd/incus/file.go:934
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:457 cmd/incus/file.go:458
+#: cmd/incus/file.go:647 cmd/incus/file.go:648
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:677 cmd/incus/file.go:843
+#: cmd/incus/file.go:868 cmd/incus/file.go:1034
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5543,7 +5562,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:246 cmd/incus/file.go:464
+#: cmd/incus/file.go:436 cmd/incus/file.go:654
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5889,17 +5908,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1189
+#: cmd/incus/file.go:1380
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1397
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1207
+#: cmd/incus/file.go:1398
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5986,7 +6005,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:971
+#: cmd/incus/file.go:1162
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6185,15 +6204,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:467
+#: cmd/incus/file.go:142
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: cmd/incus/file.go:657
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:144
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: cmd/incus/file.go:658
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:466
+#: cmd/incus/file.go:143
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: cmd/incus/file.go:656
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6257,7 +6288,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:969
+#: cmd/incus/file.go:1160
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6667,6 +6698,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: cmd/incus/file.go:164
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: cmd/incus/alias.go:141
 msgid "TARGET"
 msgstr ""
@@ -6689,11 +6724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: cmd/incus/file.go:1008
+#: cmd/incus/file.go:1199
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1002
+#: cmd/incus/file.go:1193
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6967,6 +7002,10 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
+#: cmd/incus/file.go:145
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
+
 #: cmd/incus/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
@@ -7030,7 +7069,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:370
+#: cmd/incus/file.go:560
 msgid "Too many links"
 msgstr ""
 
@@ -7157,7 +7196,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:194
+#: cmd/incus/file.go:384
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7172,7 +7211,7 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1229
+#: cmd/incus/file.go:1420
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7188,7 +7227,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:783
+#: cmd/incus/file.go:974
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7418,7 +7457,7 @@ msgstr "Il nome del container è: %s"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:68
+#: cmd/incus/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7911,23 +7950,28 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:357
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:130
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "Creazione del container in corso"
+
+#: cmd/incus/file.go:307
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:237
+#: cmd/incus/file.go:427
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:960
+#: cmd/incus/file.go:1151
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -8481,20 +8525,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:964
+#: cmd/incus/file.go:134
+msgid ""
+"incus file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"incus file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: cmd/incus/file.go:1155
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:241
+#: cmd/incus/file.go:431
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:650
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8719,16 +8771,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1118
+#: cmd/incus/file.go:1309
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1077
+#: cmd/incus/file.go:1268
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1030
+#: cmd/incus/file.go:1221
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-19 22:59-0500\n"
+"POT-Creation-Date: 2024-01-21 22:35-0500\n"
 "PO-Revision-Date: 2024-01-19 10:00+0000\n"
 "Last-Translator: Hiroaki Nakamura <hnakamur@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -582,12 +582,12 @@ msgstr "%s (%s) (%d個使用可能)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s（バックエンド=%q, ソース=%q）"
 
-#: cmd/incus/file.go:911
+#: cmd/incus/file.go:1102
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: cmd/incus/file.go:801
+#: cmd/incus/file.go:992
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -688,7 +688,7 @@ msgstr "<remote> <new-name>"
 msgid "<remote>: <path>"
 msgstr "<remote>: <path>"
 
-#: cmd/incus/file.go:456
+#: cmd/incus/file.go:646
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -1200,7 +1200,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: cmd/incus/file.go:331
+#: cmd/incus/file.go:521
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1231,7 +1231,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスターでない場合はカラムとして L は指定できません"
 
-#: cmd/incus/file.go:533
+#: cmd/incus/file.go:723
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1707,8 +1707,13 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: cmd/incus/file.go:245 cmd/incus/file.go:465
+#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
 msgid "Create any directories necessary"
+msgstr "必要なディレクトリをすべて作成します"
+
+#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#, fuzzy
+msgid "Create files and directories in instances"
 msgstr "必要なディレクトリをすべて作成します"
 
 #: cmd/incus/export.go:80
@@ -1808,6 +1813,11 @@ msgstr "作成日時: %s"
 msgid "Creating %s"
 msgstr "%s を作成中"
 
+#: cmd/incus/file.go:270
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "%s を作成中"
+
 #: cmd/incus/create.go:164
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
@@ -1876,7 +1886,7 @@ msgstr "クラスターグループを削除します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: cmd/incus/file.go:119 cmd/incus/file.go:120
+#: cmd/incus/file.go:309 cmd/incus/file.go:310
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
@@ -1998,22 +2008,22 @@ msgstr "警告を削除します"
 #: cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733
 #: cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40
 #: cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120
-#: cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458
-#: cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493
-#: cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021
-#: cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479
-#: cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24
-#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
-#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
-#: cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24
-#: cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32
-#: cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317
-#: cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559
-#: cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873
-#: cmd/incus/network.go:1004 cmd/incus/network.go:1105
+#: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:132
+#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
+#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
+#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
+#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
+#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
+#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
+#: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232
+#: cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462
+#: cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792
+#: cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105
 #: cmd/incus/network.go:1184 cmd/incus/network.go:1244
 #: cmd/incus/network.go:1340 cmd/incus/network.go:1412
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
@@ -2196,7 +2206,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: cmd/incus/file.go:970
+#: cmd/incus/file.go:1161
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2287,7 +2297,7 @@ msgstr "EXPIRES AT"
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: cmd/incus/file.go:71
+#: cmd/incus/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2303,7 +2313,7 @@ msgstr "クラスターグループを編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: cmd/incus/file.go:168 cmd/incus/file.go:169
+#: cmd/incus/file.go:358 cmd/incus/file.go:359
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -2670,12 +2680,12 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: cmd/incus/file.go:1213
+#: cmd/incus/file.go:1404
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: cmd/incus/file.go:1236
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2690,12 +2700,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: cmd/incus/file.go:1263
+#: cmd/incus/file.go:1454
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: cmd/incus/file.go:1048
+#: cmd/incus/file.go:1239
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2725,7 +2735,7 @@ msgstr "新しいインスタンス名が取得できません"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: cmd/incus/file.go:1169
+#: cmd/incus/file.go:1360
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2765,7 +2775,7 @@ msgstr "デバイス上書きのためのプロファイル %q のロードに�
 msgid "Failed loading storage pool %q: %w"
 msgstr "%q の作成に失敗しました: %w"
 
-#: cmd/incus/file.go:1174
+#: cmd/incus/file.go:1365
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -2780,12 +2790,12 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: cmd/incus/file.go:1074
+#: cmd/incus/file.go:1265
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: cmd/incus/file.go:1201
+#: cmd/incus/file.go:1392
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -2879,7 +2889,7 @@ msgstr "プロジェクトが見つけられませんでした: %w"
 msgid "Failed to join cluster: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: cmd/incus/file.go:1186
+#: cmd/incus/file.go:1377
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -2977,7 +2987,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to update cluster member state: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: cmd/incus/file.go:796
+#: cmd/incus/file.go:987
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -3014,6 +3024,10 @@ msgstr "証明書のフィンガープリント: %s"
 #: cmd/incus/cluster.go:1156
 msgid "Force a particular evacuation action"
 msgstr "特定の待避アクションを強制します"
+
+#: cmd/incus/file.go:141
+msgid "Force creating files or directories"
+msgstr ""
 
 #: cmd/incus/cluster.go:1183
 msgid "Force evacuation without user confirmation"
@@ -3312,22 +3326,22 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: cmd/incus/file.go:1286
+#: cmd/incus/file.go:1477
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: cmd/incus/file.go:1275
+#: cmd/incus/file.go:1466
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: cmd/incus/file.go:1098
+#: cmd/incus/file.go:1289
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: cmd/incus/file.go:1108
+#: cmd/incus/file.go:1299
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -3531,11 +3545,11 @@ msgstr "入力するデータ"
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: cmd/incus/file.go:1100
+#: cmd/incus/file.go:1291
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: cmd/incus/file.go:1277
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3549,7 +3563,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: cmd/incus/file.go:1020
+#: cmd/incus/file.go:1211
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3642,7 +3656,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: cmd/incus/file.go:1015
+#: cmd/incus/file.go:1206
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -3680,7 +3694,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:334
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -3696,14 +3710,19 @@ msgstr "不正なプロトコル: %s"
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: cmd/incus/file.go:304
+#: cmd/incus/file.go:494
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: cmd/incus/file.go:486
+#: cmd/incus/file.go:174 cmd/incus/file.go:676
 #, c-format
 msgid "Invalid target %s"
+msgstr "不正な送り先 %s"
+
+#: cmd/incus/file.go:160
+#, fuzzy, c-format
+msgid "Invalid type %q"
 msgstr "不正な送り先 %s"
 
 #: cmd/incus/info.go:230
@@ -4313,12 +4332,12 @@ msgstr "ログレベルのフィルタリングは pretty フォーマットで�
 msgid "Log:"
 msgstr "ログ:"
 
-#: cmd/incus/file.go:1192
+#: cmd/incus/file.go:1383
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr "ユーザー名 %q とパスワード %q でログイン"
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1385
 msgid "Login without username and password"
 msgstr "ユーザー名、パスワードを使用せずにログイン"
 
@@ -4426,7 +4445,7 @@ msgstr "コマンドのエイリアスを管理します"
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: cmd/incus/file.go:79 cmd/incus/file.go:80
+#: cmd/incus/file.go:83 cmd/incus/file.go:84
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
@@ -4840,7 +4859,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: cmd/incus/file.go:581
+#: cmd/incus/file.go:771
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -4883,13 +4902,13 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: cmd/incus/file.go:279
+#: cmd/incus/file.go:469
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: cmd/incus/file.go:961 cmd/incus/file.go:962
+#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -5418,7 +5437,7 @@ msgstr "パーティション:"
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1353
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "%s のパスワード: "
@@ -5483,7 +5502,7 @@ msgstr "ポート:"
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr "Pre-seed モード。標準入力から YAML で設定を入力します"
 
-#: cmd/incus/file.go:1078
+#: cmd/incus/file.go:1269
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
@@ -5773,20 +5792,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: cmd/incus/file.go:238 cmd/incus/file.go:239
+#: cmd/incus/file.go:428 cmd/incus/file.go:429
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: cmd/incus/file.go:407 cmd/incus/file.go:743
+#: cmd/incus/file.go:597 cmd/incus/file.go:934
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: cmd/incus/file.go:457 cmd/incus/file.go:458
+#: cmd/incus/file.go:647 cmd/incus/file.go:648
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: cmd/incus/file.go:677 cmd/incus/file.go:843
+#: cmd/incus/file.go:868 cmd/incus/file.go:1034
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -5856,7 +5875,7 @@ msgstr ""
 "リュームを特定します。\n"
 "  そして、データベースレコードの再作成を提案します。"
 
-#: cmd/incus/file.go:246 cmd/incus/file.go:464
+#: cmd/incus/file.go:436 cmd/incus/file.go:654
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -6200,17 +6219,17 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: cmd/incus/file.go:1189
+#: cmd/incus/file.go:1380
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr "SSH SFTP は %v でリッスンしています"
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1397
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: cmd/incus/file.go:1207
+#: cmd/incus/file.go:1398
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -6300,7 +6319,7 @@ msgstr "デバイス: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: cmd/incus/file.go:971
+#: cmd/incus/file.go:1162
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -6565,15 +6584,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: cmd/incus/file.go:467
+#: cmd/incus/file.go:142
+#, fuzzy
+msgid "Set the file's gid on create"
+msgstr "プッシュ時にファイルのgidを設定します"
+
+#: cmd/incus/file.go:657
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:144
+#, fuzzy
+msgid "Set the file's perms on create"
+msgstr "プッシュ時にファイルのパーミションを設定します"
+
+#: cmd/incus/file.go:658
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: cmd/incus/file.go:466
+#: cmd/incus/file.go:143
+#, fuzzy
+msgid "Set the file's uid on create"
+msgstr "プッシュ時にファイルのuidを設定します"
+
+#: cmd/incus/file.go:656
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -6642,7 +6676,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr "インスタンスプロパティとして設定します"
 
-#: cmd/incus/file.go:969
+#: cmd/incus/file.go:1160
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -7043,6 +7077,10 @@ msgstr "現在のプロジェクトを切り替えます"
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
+#: cmd/incus/file.go:164
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: cmd/incus/alias.go:141
 msgid "TARGET"
 msgstr "TARGET"
@@ -7064,11 +7102,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: cmd/incus/file.go:1008
+#: cmd/incus/file.go:1199
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: cmd/incus/file.go:1002
+#: cmd/incus/file.go:1193
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -7379,6 +7417,10 @@ msgstr "指定したデバイスが存在しません"
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
+#: cmd/incus/file.go:145
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
+
 #: cmd/incus/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
@@ -7466,7 +7508,7 @@ msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスターに属していなければ"
 "なりません"
 
-#: cmd/incus/file.go:370
+#: cmd/incus/file.go:560
 msgid "Too many links"
 msgstr ""
 
@@ -7594,7 +7636,7 @@ msgstr "UUID: %v"
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "クラスタメンバへの接続に失敗しました"
 
-#: cmd/incus/file.go:194
+#: cmd/incus/file.go:384
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -7608,7 +7650,7 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: cmd/incus/file.go:1229
+#: cmd/incus/file.go:1420
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
@@ -7624,7 +7666,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: cmd/incus/file.go:783
+#: cmd/incus/file.go:974
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -7853,7 +7895,7 @@ msgstr "ユーザが削除操作を中断しました"
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: cmd/incus/file.go:68
+#: cmd/incus/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8306,21 +8348,26 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:357
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:130
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
+
+#: cmd/incus/file.go:307
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: cmd/incus/file.go:237
+#: cmd/incus/file.go:427
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: cmd/incus/file.go:960
+#: cmd/incus/file.go:1151
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -8854,7 +8901,15 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: cmd/incus/file.go:964
+#: cmd/incus/file.go:134
+msgid ""
+"incus file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"incus file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: cmd/incus/file.go:1155
 #, fuzzy
 msgid ""
 "incus file mount foo/root fooroot\n"
@@ -8864,7 +8919,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: cmd/incus/file.go:241
+#: cmd/incus/file.go:431
 #, fuzzy
 msgid ""
 "incus file pull foo/etc/hosts .\n"
@@ -8875,7 +8930,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:650
 #, fuzzy
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
@@ -9218,16 +9273,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: cmd/incus/file.go:1118
+#: cmd/incus/file.go:1309
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: cmd/incus/file.go:1077
+#: cmd/incus/file.go:1268
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: cmd/incus/file.go:1030
+#: cmd/incus/file.go:1221
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"
@@ -9254,6 +9309,10 @@ msgstr "y"
 #: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr "yes"
+
+#, fuzzy
+#~ msgid "The content of the created file"
+#~ msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
 #~ msgid "The --mode flag can't be used with --storage"
 #~ msgstr "--mode と --storage は同時に指定できません"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-19 22:59-0500\n"
+"POT-Creation-Date: 2024-01-21 22:35-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -573,12 +573,12 @@ msgstr "%s (en nog %d)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:911
+#: cmd/incus/file.go:1102
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:801
+#: cmd/incus/file.go:992
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -679,7 +679,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:456
+#: cmd/incus/file.go:646
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:331
+#: cmd/incus/file.go:521
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1197,7 +1197,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:533
+#: cmd/incus/file.go:723
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1645,8 +1645,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:245 cmd/incus/file.go:465
+#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
 msgid "Create any directories necessary"
+msgstr ""
+
+#: cmd/incus/file.go:131 cmd/incus/file.go:132
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: cmd/incus/export.go:80
@@ -1742,6 +1746,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: cmd/incus/file.go:270
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: cmd/incus/create.go:164
 msgid "Creating the instance"
 msgstr ""
@@ -1809,7 +1818,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/file.go:119 cmd/incus/file.go:120
+#: cmd/incus/file.go:309 cmd/incus/file.go:310
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1931,22 +1940,22 @@ msgstr ""
 #: cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733
 #: cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40
 #: cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120
-#: cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458
-#: cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493
-#: cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021
-#: cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479
-#: cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24
-#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
-#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
-#: cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24
-#: cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32
-#: cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317
-#: cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559
-#: cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873
-#: cmd/incus/network.go:1004 cmd/incus/network.go:1105
+#: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:132
+#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
+#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
+#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
+#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
+#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
+#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
+#: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232
+#: cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462
+#: cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792
+#: cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105
 #: cmd/incus/network.go:1184 cmd/incus/network.go:1244
 #: cmd/incus/network.go:1340 cmd/incus/network.go:1412
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
@@ -2123,7 +2132,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:970
+#: cmd/incus/file.go:1161
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2214,7 +2223,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/file.go:71
+#: cmd/incus/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2228,7 +2237,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:168 cmd/incus/file.go:169
+#: cmd/incus/file.go:358 cmd/incus/file.go:359
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2541,12 +2550,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1213
+#: cmd/incus/file.go:1404
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1236
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2561,12 +2570,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1263
+#: cmd/incus/file.go:1454
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1048
+#: cmd/incus/file.go:1239
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2596,7 +2605,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1169
+#: cmd/incus/file.go:1360
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2636,7 +2645,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1174
+#: cmd/incus/file.go:1365
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2651,12 +2660,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1074
+#: cmd/incus/file.go:1265
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1201
+#: cmd/incus/file.go:1392
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2750,7 +2759,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1186
+#: cmd/incus/file.go:1377
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2848,7 +2857,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:796
+#: cmd/incus/file.go:987
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2884,6 +2893,10 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1156
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: cmd/incus/file.go:141
+msgid "Force creating files or directories"
 msgstr ""
 
 #: cmd/incus/cluster.go:1183
@@ -3158,22 +3171,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1286
+#: cmd/incus/file.go:1477
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1275
+#: cmd/incus/file.go:1466
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1098
+#: cmd/incus/file.go:1289
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1108
+#: cmd/incus/file.go:1299
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3361,11 +3374,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1100
+#: cmd/incus/file.go:1291
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1277
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3379,7 +3392,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1020
+#: cmd/incus/file.go:1211
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3468,7 +3481,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1015
+#: cmd/incus/file.go:1206
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3503,7 +3516,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:334
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3519,14 +3532,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: cmd/incus/file.go:304
+#: cmd/incus/file.go:494
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:486
+#: cmd/incus/file.go:174 cmd/incus/file.go:676
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: cmd/incus/file.go:160
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: cmd/incus/info.go:230
@@ -3960,12 +3978,12 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/file.go:1192
+#: cmd/incus/file.go:1383
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1385
 msgid "Login without username and password"
 msgstr ""
 
@@ -4073,7 +4091,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:79 cmd/incus/file.go:80
+#: cmd/incus/file.go:83 cmd/incus/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4465,7 +4483,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:581
+#: cmd/incus/file.go:771
 msgid "Missing target directory"
 msgstr ""
 
@@ -4503,11 +4521,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:279
+#: cmd/incus/file.go:469
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:961 cmd/incus/file.go:962
+#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5008,7 +5026,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1353
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5072,7 +5090,7 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/file.go:1078
+#: cmd/incus/file.go:1269
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5330,20 +5348,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:238 cmd/incus/file.go:239
+#: cmd/incus/file.go:428 cmd/incus/file.go:429
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:407 cmd/incus/file.go:743
+#: cmd/incus/file.go:597 cmd/incus/file.go:934
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:457 cmd/incus/file.go:458
+#: cmd/incus/file.go:647 cmd/incus/file.go:648
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:677 cmd/incus/file.go:843
+#: cmd/incus/file.go:868 cmd/incus/file.go:1034
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5403,7 +5421,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:246 cmd/incus/file.go:464
+#: cmd/incus/file.go:436 cmd/incus/file.go:654
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5732,17 +5750,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1189
+#: cmd/incus/file.go:1380
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1397
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1207
+#: cmd/incus/file.go:1398
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5828,7 +5846,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:971
+#: cmd/incus/file.go:1162
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6023,15 +6041,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:467
+#: cmd/incus/file.go:142
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: cmd/incus/file.go:657
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:144
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: cmd/incus/file.go:658
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:466
+#: cmd/incus/file.go:143
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: cmd/incus/file.go:656
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6091,7 +6121,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:969
+#: cmd/incus/file.go:1160
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6487,6 +6517,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: cmd/incus/file.go:164
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: cmd/incus/alias.go:141
 msgid "TARGET"
 msgstr ""
@@ -6508,11 +6542,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1008
+#: cmd/incus/file.go:1199
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1002
+#: cmd/incus/file.go:1193
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6785,6 +6819,10 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
+#: cmd/incus/file.go:145
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
+
 #: cmd/incus/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
@@ -6847,7 +6885,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:370
+#: cmd/incus/file.go:560
 msgid "Too many links"
 msgstr ""
 
@@ -6972,7 +7010,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:194
+#: cmd/incus/file.go:384
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6986,7 +7024,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1229
+#: cmd/incus/file.go:1420
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7002,7 +7040,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:783
+#: cmd/incus/file.go:974
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7217,7 +7255,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:68
+#: cmd/incus/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7654,20 +7692,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:357
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:130
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: cmd/incus/file.go:307
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:237
+#: cmd/incus/file.go:427
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:960
+#: cmd/incus/file.go:1151
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -8136,20 +8178,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:964
+#: cmd/incus/file.go:134
+msgid ""
+"incus file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"incus file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: cmd/incus/file.go:1155
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:241
+#: cmd/incus/file.go:431
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:650
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8373,16 +8423,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1118
+#: cmd/incus/file.go:1309
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1077
+#: cmd/incus/file.go:1268
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1030
+#: cmd/incus/file.go:1221
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-19 22:59-0500\n"
+"POT-Creation-Date: 2024-01-21 22:35-0500\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -597,12 +597,12 @@ msgstr "%s (%d mais)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:911
+#: cmd/incus/file.go:1102
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: cmd/incus/file.go:801
+#: cmd/incus/file.go:992
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -715,7 +715,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr "Criar perfis"
 
-#: cmd/incus/file.go:456
+#: cmd/incus/file.go:646
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -1224,7 +1224,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: cmd/incus/file.go:331
+#: cmd/incus/file.go:521
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: cmd/incus/file.go:533
+#: cmd/incus/file.go:723
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1718,9 +1718,14 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:245 cmd/incus/file.go:465
+#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
 msgid "Create any directories necessary"
 msgstr ""
+
+#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Editar arquivos no container"
 
 #: cmd/incus/export.go:80
 #, fuzzy, c-format
@@ -1829,6 +1834,11 @@ msgstr "Criado: %s"
 msgid "Creating %s"
 msgstr "Criando %s"
 
+#: cmd/incus/file.go:270
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Criando %s"
+
 #: cmd/incus/create.go:164
 #, fuzzy
 msgid "Creating the instance"
@@ -1899,7 +1909,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/file.go:119 cmd/incus/file.go:120
+#: cmd/incus/file.go:309 cmd/incus/file.go:310
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
@@ -2033,22 +2043,22 @@ msgstr ""
 #: cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733
 #: cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40
 #: cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120
-#: cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458
-#: cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493
-#: cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021
-#: cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479
-#: cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24
-#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
-#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
-#: cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24
-#: cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32
-#: cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317
-#: cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559
-#: cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873
-#: cmd/incus/network.go:1004 cmd/incus/network.go:1105
+#: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:132
+#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
+#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
+#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
+#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
+#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
+#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
+#: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232
+#: cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462
+#: cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792
+#: cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105
 #: cmd/incus/network.go:1184 cmd/incus/network.go:1244
 #: cmd/incus/network.go:1340 cmd/incus/network.go:1412
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
@@ -2229,7 +2239,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:970
+#: cmd/incus/file.go:1161
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2323,7 +2333,7 @@ msgstr "DATA DE VALIDADE"
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: cmd/incus/file.go:71
+#: cmd/incus/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/file.go:168 cmd/incus/file.go:169
+#: cmd/incus/file.go:358 cmd/incus/file.go:359
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -2665,12 +2675,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1213
+#: cmd/incus/file.go:1404
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1236
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2685,12 +2695,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1263
+#: cmd/incus/file.go:1454
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1048
+#: cmd/incus/file.go:1239
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2720,7 +2730,7 @@ msgstr "Aceitar certificado"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1169
+#: cmd/incus/file.go:1360
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2760,7 +2770,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1174
+#: cmd/incus/file.go:1365
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2775,12 +2785,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1074
+#: cmd/incus/file.go:1265
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1201
+#: cmd/incus/file.go:1392
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2874,7 +2884,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1186
+#: cmd/incus/file.go:1377
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2972,7 +2982,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to update cluster member state: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:796
+#: cmd/incus/file.go:987
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3008,6 +3018,10 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1156
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: cmd/incus/file.go:141
+msgid "Force creating files or directories"
 msgstr ""
 
 #: cmd/incus/cluster.go:1183
@@ -3302,22 +3316,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1286
+#: cmd/incus/file.go:1477
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/file.go:1275
+#: cmd/incus/file.go:1466
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/file.go:1098
+#: cmd/incus/file.go:1289
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: cmd/incus/file.go:1108
+#: cmd/incus/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -3508,11 +3522,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1100
+#: cmd/incus/file.go:1291
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1277
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3526,7 +3540,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1020
+#: cmd/incus/file.go:1211
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3617,7 +3631,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:1015
+#: cmd/incus/file.go:1206
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -3652,7 +3666,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:334
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3669,15 +3683,20 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:304
+#: cmd/incus/file.go:494
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:486
+#: cmd/incus/file.go:174 cmd/incus/file.go:676
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: cmd/incus/file.go:160
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Editar arquivos no container"
 
 #: cmd/incus/info.go:230
 #, fuzzy, c-format
@@ -4121,12 +4140,12 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/file.go:1192
+#: cmd/incus/file.go:1383
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1385
 msgid "Login without username and password"
 msgstr ""
 
@@ -4238,7 +4257,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:79 cmd/incus/file.go:80
+#: cmd/incus/file.go:83 cmd/incus/file.go:84
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
@@ -4664,7 +4683,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:581
+#: cmd/incus/file.go:771
 msgid "Missing target directory"
 msgstr ""
 
@@ -4704,11 +4723,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:279
+#: cmd/incus/file.go:469
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:961 cmd/incus/file.go:962
+#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -5211,7 +5230,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1353
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5276,7 +5295,7 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/file.go:1078
+#: cmd/incus/file.go:1269
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5539,21 +5558,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:238 cmd/incus/file.go:239
+#: cmd/incus/file.go:428 cmd/incus/file.go:429
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:407 cmd/incus/file.go:743
+#: cmd/incus/file.go:597 cmd/incus/file.go:934
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:457 cmd/incus/file.go:458
+#: cmd/incus/file.go:647 cmd/incus/file.go:648
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:677 cmd/incus/file.go:843
+#: cmd/incus/file.go:868 cmd/incus/file.go:1034
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5615,7 +5634,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:246 cmd/incus/file.go:464
+#: cmd/incus/file.go:436 cmd/incus/file.go:654
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5972,17 +5991,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1189
+#: cmd/incus/file.go:1380
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1397
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1207
+#: cmd/incus/file.go:1398
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6069,7 +6088,7 @@ msgstr "Em cache: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/file.go:971
+#: cmd/incus/file.go:1162
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6275,15 +6294,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:467
+#: cmd/incus/file.go:142
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: cmd/incus/file.go:657
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:144
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: cmd/incus/file.go:658
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:466
+#: cmd/incus/file.go:143
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: cmd/incus/file.go:656
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6350,7 +6381,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:969
+#: cmd/incus/file.go:1160
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6768,6 +6799,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: cmd/incus/file.go:164
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: cmd/incus/alias.go:141
 msgid "TARGET"
 msgstr ""
@@ -6789,12 +6824,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1008
+#: cmd/incus/file.go:1199
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/file.go:1002
+#: cmd/incus/file.go:1193
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7070,6 +7105,10 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
+#: cmd/incus/file.go:145
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
+
 #: cmd/incus/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
@@ -7133,7 +7172,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:370
+#: cmd/incus/file.go:560
 msgid "Too many links"
 msgstr ""
 
@@ -7260,7 +7299,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:194
+#: cmd/incus/file.go:384
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7275,7 +7314,7 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1229
+#: cmd/incus/file.go:1420
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7291,7 +7330,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:783
+#: cmd/incus/file.go:974
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7532,7 +7571,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:68
+#: cmd/incus/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7996,20 +8035,25 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:357
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:130
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "Editar templates de arquivo do container"
+
+#: cmd/incus/file.go:307
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:237
+#: cmd/incus/file.go:427
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:960
+#: cmd/incus/file.go:1151
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -8525,20 +8569,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:964
+#: cmd/incus/file.go:134
+msgid ""
+"incus file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"incus file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: cmd/incus/file.go:1155
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:241
+#: cmd/incus/file.go:431
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:650
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8762,16 +8814,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1118
+#: cmd/incus/file.go:1309
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1077
+#: cmd/incus/file.go:1268
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1030
+#: cmd/incus/file.go:1221
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8796,6 +8848,10 @@ msgstr ""
 #: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr "sim"
+
+#, fuzzy
+#~ msgid "The content of the created file"
+#~ msgstr "Editar templates de arquivo do container"
 
 #, fuzzy
 #~ msgid "The --mode flag can't be used with --storage"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-19 22:59-0500\n"
+"POT-Creation-Date: 2024-01-21 22:35-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -606,12 +606,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:911
+#: cmd/incus/file.go:1102
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:801
+#: cmd/incus/file.go:992
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -717,7 +717,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:456
+#: cmd/incus/file.go:646
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1224,7 +1224,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:331
+#: cmd/incus/file.go:521
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1254,7 +1254,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:533
+#: cmd/incus/file.go:723
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1707,9 +1707,14 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:245 cmd/incus/file.go:465
+#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
 msgid "Create any directories necessary"
 msgstr ""
+
+#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: cmd/incus/export.go:80
 #, fuzzy, c-format
@@ -1817,6 +1822,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: cmd/incus/file.go:270
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: cmd/incus/create.go:164
 #, fuzzy
 msgid "Creating the instance"
@@ -1885,7 +1895,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/file.go:119 cmd/incus/file.go:120
+#: cmd/incus/file.go:309 cmd/incus/file.go:310
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2018,22 +2028,22 @@ msgstr ""
 #: cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733
 #: cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40
 #: cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120
-#: cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458
-#: cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493
-#: cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021
-#: cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479
-#: cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24
-#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
-#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
-#: cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24
-#: cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32
-#: cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317
-#: cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559
-#: cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873
-#: cmd/incus/network.go:1004 cmd/incus/network.go:1105
+#: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:132
+#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
+#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
+#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
+#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
+#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
+#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
+#: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232
+#: cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462
+#: cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792
+#: cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105
 #: cmd/incus/network.go:1184 cmd/incus/network.go:1244
 #: cmd/incus/network.go:1340 cmd/incus/network.go:1412
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
@@ -2212,7 +2222,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:970
+#: cmd/incus/file.go:1161
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/file.go:71
+#: cmd/incus/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2321,7 +2331,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:168 cmd/incus/file.go:169
+#: cmd/incus/file.go:358 cmd/incus/file.go:359
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2650,12 +2660,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1213
+#: cmd/incus/file.go:1404
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1236
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2670,12 +2680,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1263
+#: cmd/incus/file.go:1454
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1048
+#: cmd/incus/file.go:1239
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2705,7 +2715,7 @@ msgstr "Принять сертификат"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1169
+#: cmd/incus/file.go:1360
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2745,7 +2755,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1174
+#: cmd/incus/file.go:1365
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2760,12 +2770,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1074
+#: cmd/incus/file.go:1265
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1201
+#: cmd/incus/file.go:1392
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2859,7 +2869,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1186
+#: cmd/incus/file.go:1377
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2957,7 +2967,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to update cluster member state: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:796
+#: cmd/incus/file.go:987
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2993,6 +3003,10 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1156
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: cmd/incus/file.go:141
+msgid "Force creating files or directories"
 msgstr ""
 
 #: cmd/incus/cluster.go:1183
@@ -3284,22 +3298,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1286
+#: cmd/incus/file.go:1477
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1275
+#: cmd/incus/file.go:1466
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1098
+#: cmd/incus/file.go:1289
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1108
+#: cmd/incus/file.go:1299
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3492,11 +3506,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1100
+#: cmd/incus/file.go:1291
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1277
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1020
+#: cmd/incus/file.go:1211
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3602,7 +3616,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1015
+#: cmd/incus/file.go:1206
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -3637,7 +3651,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:334
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3654,15 +3668,20 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:304
+#: cmd/incus/file.go:494
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:486
+#: cmd/incus/file.go:174 cmd/incus/file.go:676
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: cmd/incus/file.go:160
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Имя контейнера: %s"
 
 #: cmd/incus/info.go:230
 #, c-format
@@ -4113,12 +4132,12 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/file.go:1192
+#: cmd/incus/file.go:1383
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1385
 msgid "Login without username and password"
 msgstr ""
 
@@ -4231,7 +4250,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:79 cmd/incus/file.go:80
+#: cmd/incus/file.go:83 cmd/incus/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4661,7 +4680,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:581
+#: cmd/incus/file.go:771
 msgid "Missing target directory"
 msgstr ""
 
@@ -4700,11 +4719,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:279
+#: cmd/incus/file.go:469
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:961 cmd/incus/file.go:962
+#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5213,7 +5232,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1353
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Пароль администратора для %s: "
@@ -5278,7 +5297,7 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/file.go:1078
+#: cmd/incus/file.go:1269
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5536,20 +5555,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:238 cmd/incus/file.go:239
+#: cmd/incus/file.go:428 cmd/incus/file.go:429
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:407 cmd/incus/file.go:743
+#: cmd/incus/file.go:597 cmd/incus/file.go:934
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:457 cmd/incus/file.go:458
+#: cmd/incus/file.go:647 cmd/incus/file.go:648
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:677 cmd/incus/file.go:843
+#: cmd/incus/file.go:868 cmd/incus/file.go:1034
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5611,7 +5630,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:246 cmd/incus/file.go:464
+#: cmd/incus/file.go:436 cmd/incus/file.go:654
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5961,17 +5980,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1189
+#: cmd/incus/file.go:1380
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1397
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1207
+#: cmd/incus/file.go:1398
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6058,7 +6077,7 @@ msgstr "Авто-обновление: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:971
+#: cmd/incus/file.go:1162
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6259,15 +6278,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:467
+#: cmd/incus/file.go:142
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: cmd/incus/file.go:657
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:144
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: cmd/incus/file.go:658
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:466
+#: cmd/incus/file.go:143
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: cmd/incus/file.go:656
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6335,7 +6366,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:969
+#: cmd/incus/file.go:1160
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6753,6 +6784,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: cmd/incus/file.go:164
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: cmd/incus/alias.go:141
 msgid "TARGET"
 msgstr ""
@@ -6774,11 +6809,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1008
+#: cmd/incus/file.go:1199
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1002
+#: cmd/incus/file.go:1193
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7051,6 +7086,10 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
+#: cmd/incus/file.go:145
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
+
 #: cmd/incus/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
@@ -7114,7 +7153,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:370
+#: cmd/incus/file.go:560
 msgid "Too many links"
 msgstr ""
 
@@ -7241,7 +7280,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:194
+#: cmd/incus/file.go:384
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7255,7 +7294,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1229
+#: cmd/incus/file.go:1420
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7271,7 +7310,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:783
+#: cmd/incus/file.go:974
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7508,7 +7547,7 @@ msgstr "Копирование образа: %s"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:68
+#: cmd/incus/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8158,7 +8197,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:357
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -8166,7 +8205,15 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:130
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: cmd/incus/file.go:307
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -8174,7 +8221,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:237
+#: cmd/incus/file.go:427
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -8183,7 +8230,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:960
+#: cmd/incus/file.go:1151
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8992,20 +9039,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:964
+#: cmd/incus/file.go:134
+msgid ""
+"incus file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"incus file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: cmd/incus/file.go:1155
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:241
+#: cmd/incus/file.go:431
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:650
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9229,16 +9284,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1118
+#: cmd/incus/file.go:1309
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1077
+#: cmd/incus/file.go:1268
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1030
+#: cmd/incus/file.go:1221
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -9263,6 +9318,10 @@ msgstr ""
 #: cmd/incus/image.go:1117 cmd/incus/snapshot.go:220
 msgid "yes"
 msgstr "да"
+
+#, fuzzy
+#~ msgid "The content of the created file"
+#~ msgstr "Невозможно добавить имя контейнера в список"
 
 #, fuzzy
 #~ msgid ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-01-19 22:59-0500\n"
+"POT-Creation-Date: 2024-01-21 22:35-0500\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -554,12 +554,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:911
+#: cmd/incus/file.go:1102
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: cmd/incus/file.go:801
+#: cmd/incus/file.go:992
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -660,7 +660,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:456
+#: cmd/incus/file.go:646
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -1148,7 +1148,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:331
+#: cmd/incus/file.go:521
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:533
+#: cmd/incus/file.go:723
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1626,8 +1626,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:245 cmd/incus/file.go:465
+#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
 msgid "Create any directories necessary"
+msgstr ""
+
+#: cmd/incus/file.go:131 cmd/incus/file.go:132
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: cmd/incus/export.go:80
@@ -1723,6 +1727,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: cmd/incus/file.go:270
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: cmd/incus/create.go:164
 msgid "Creating the instance"
 msgstr ""
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/file.go:119 cmd/incus/file.go:120
+#: cmd/incus/file.go:309 cmd/incus/file.go:310
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1912,22 +1921,22 @@ msgstr ""
 #: cmd/incus/config_trust.go:687 cmd/incus/config_trust.go:733
 #: cmd/incus/config_trust.go:804 cmd/incus/console.go:36 cmd/incus/copy.go:40
 #: cmd/incus/create.go:42 cmd/incus/delete.go:31 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:80 cmd/incus/file.go:120
-#: cmd/incus/file.go:169 cmd/incus/file.go:239 cmd/incus/file.go:458
-#: cmd/incus/file.go:962 cmd/incus/image.go:40 cmd/incus/image.go:148
-#: cmd/incus/image.go:315 cmd/incus/image.go:366 cmd/incus/image.go:493
-#: cmd/incus/image.go:653 cmd/incus/image.go:886 cmd/incus/image.go:1021
-#: cmd/incus/image.go:1340 cmd/incus/image.go:1420 cmd/incus/image.go:1479
-#: cmd/incus/image.go:1531 cmd/incus/image.go:1587 cmd/incus/image_alias.go:24
-#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
-#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
-#: cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24
-#: cmd/incus/list.go:49 cmd/incus/main.go:84 cmd/incus/manpage.go:22
-#: cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32
-#: cmd/incus/network.go:135 cmd/incus/network.go:232 cmd/incus/network.go:317
-#: cmd/incus/network.go:404 cmd/incus/network.go:462 cmd/incus/network.go:559
-#: cmd/incus/network.go:656 cmd/incus/network.go:792 cmd/incus/network.go:873
-#: cmd/incus/network.go:1004 cmd/incus/network.go:1105
+#: cmd/incus/export.go:32 cmd/incus/file.go:84 cmd/incus/file.go:132
+#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
+#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/image.go:148 cmd/incus/image.go:315 cmd/incus/image.go:366
+#: cmd/incus/image.go:493 cmd/incus/image.go:653 cmd/incus/image.go:886
+#: cmd/incus/image.go:1021 cmd/incus/image.go:1340 cmd/incus/image.go:1420
+#: cmd/incus/image.go:1479 cmd/incus/image.go:1531 cmd/incus/image.go:1587
+#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
+#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
+#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
+#: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:84
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/network.go:32 cmd/incus/network.go:135 cmd/incus/network.go:232
+#: cmd/incus/network.go:317 cmd/incus/network.go:404 cmd/incus/network.go:462
+#: cmd/incus/network.go:559 cmd/incus/network.go:656 cmd/incus/network.go:792
+#: cmd/incus/network.go:873 cmd/incus/network.go:1004 cmd/incus/network.go:1105
 #: cmd/incus/network.go:1184 cmd/incus/network.go:1244
 #: cmd/incus/network.go:1340 cmd/incus/network.go:1412
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
@@ -2104,7 +2113,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:970
+#: cmd/incus/file.go:1161
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2195,7 +2204,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/file.go:71
+#: cmd/incus/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2209,7 +2218,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:168 cmd/incus/file.go:169
+#: cmd/incus/file.go:358 cmd/incus/file.go:359
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2522,12 +2531,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1213
+#: cmd/incus/file.go:1404
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1236
+#: cmd/incus/file.go:1427
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2542,12 +2551,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1263
+#: cmd/incus/file.go:1454
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1048
+#: cmd/incus/file.go:1239
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2577,7 +2586,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1169
+#: cmd/incus/file.go:1360
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2617,7 +2626,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1174
+#: cmd/incus/file.go:1365
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2632,12 +2641,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1074
+#: cmd/incus/file.go:1265
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1201
+#: cmd/incus/file.go:1392
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2731,7 +2740,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1186
+#: cmd/incus/file.go:1377
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2829,7 +2838,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:796
+#: cmd/incus/file.go:987
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2865,6 +2874,10 @@ msgstr ""
 
 #: cmd/incus/cluster.go:1156
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: cmd/incus/file.go:141
+msgid "Force creating files or directories"
 msgstr ""
 
 #: cmd/incus/cluster.go:1183
@@ -3139,22 +3152,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1286
+#: cmd/incus/file.go:1477
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1275
+#: cmd/incus/file.go:1466
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1098
+#: cmd/incus/file.go:1289
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1108
+#: cmd/incus/file.go:1299
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3342,11 +3355,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1100
+#: cmd/incus/file.go:1291
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1277
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3360,7 +3373,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1020
+#: cmd/incus/file.go:1211
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3449,7 +3462,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1015
+#: cmd/incus/file.go:1206
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3484,7 +3497,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:334
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3500,14 +3513,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: cmd/incus/file.go:304
+#: cmd/incus/file.go:494
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:486
+#: cmd/incus/file.go:174 cmd/incus/file.go:676
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: cmd/incus/file.go:160
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: cmd/incus/info.go:230
@@ -3941,12 +3959,12 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: cmd/incus/file.go:1192
+#: cmd/incus/file.go:1383
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1194
+#: cmd/incus/file.go:1385
 msgid "Login without username and password"
 msgstr ""
 
@@ -4054,7 +4072,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:79 cmd/incus/file.go:80
+#: cmd/incus/file.go:83 cmd/incus/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4446,7 +4464,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:581
+#: cmd/incus/file.go:771
 msgid "Missing target directory"
 msgstr ""
 
@@ -4484,11 +4502,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:279
+#: cmd/incus/file.go:469
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:961 cmd/incus/file.go:962
+#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4989,7 +5007,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1353
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5053,7 +5071,7 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/file.go:1078
+#: cmd/incus/file.go:1269
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5311,20 +5329,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:238 cmd/incus/file.go:239
+#: cmd/incus/file.go:428 cmd/incus/file.go:429
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:407 cmd/incus/file.go:743
+#: cmd/incus/file.go:597 cmd/incus/file.go:934
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:457 cmd/incus/file.go:458
+#: cmd/incus/file.go:647 cmd/incus/file.go:648
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:677 cmd/incus/file.go:843
+#: cmd/incus/file.go:868 cmd/incus/file.go:1034
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5384,7 +5402,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:246 cmd/incus/file.go:464
+#: cmd/incus/file.go:436 cmd/incus/file.go:654
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5713,17 +5731,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1189
+#: cmd/incus/file.go:1380
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1397
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1207
+#: cmd/incus/file.go:1398
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5809,7 +5827,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:971
+#: cmd/incus/file.go:1162
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6004,15 +6022,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:467
+#: cmd/incus/file.go:142
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: cmd/incus/file.go:657
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:144
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: cmd/incus/file.go:658
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:466
+#: cmd/incus/file.go:143
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: cmd/incus/file.go:656
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6072,7 +6102,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:969
+#: cmd/incus/file.go:1160
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6468,6 +6498,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: cmd/incus/file.go:164
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: cmd/incus/alias.go:141
 msgid "TARGET"
 msgstr ""
@@ -6489,11 +6523,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1008
+#: cmd/incus/file.go:1199
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1002
+#: cmd/incus/file.go:1193
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6766,6 +6800,10 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
+#: cmd/incus/file.go:145
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
+
 #: cmd/incus/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
@@ -6828,7 +6866,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:370
+#: cmd/incus/file.go:560
 msgid "Too many links"
 msgstr ""
 
@@ -6953,7 +6991,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:194
+#: cmd/incus/file.go:384
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6967,7 +7005,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1229
+#: cmd/incus/file.go:1420
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6983,7 +7021,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:783
+#: cmd/incus/file.go:974
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7198,7 +7236,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:68
+#: cmd/incus/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7635,20 +7673,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:357
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:117
+#: cmd/incus/file.go:130
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: cmd/incus/file.go:307
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:237
+#: cmd/incus/file.go:427
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:960
+#: cmd/incus/file.go:1151
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -8117,20 +8159,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:964
+#: cmd/incus/file.go:134
+msgid ""
+"incus file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"incus file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: cmd/incus/file.go:1155
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:241
+#: cmd/incus/file.go:431
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:460
+#: cmd/incus/file.go:650
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8354,16 +8404,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1118
+#: cmd/incus/file.go:1309
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1077
+#: cmd/incus/file.go:1268
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1030
+#: cmd/incus/file.go:1221
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/test/suites/filemanip.sh
+++ b/test/suites/filemanip.sh
@@ -117,6 +117,31 @@ test_filemanip() {
     incus delete idmap --force
   fi
 
+  # Test incus file create.
+
+  # Create a new empty file.
+  incus file create filemanip/tmp/create-test
+  [ -z "$(incus exec filemanip --project=test -- cat /tmp/create-test)" ]
+
+  # This fails because the parent directory doesn't exist.
+  ! incus file create filemanip/tmp/create-test-dir/foo || false
+
+  # Create foo along with the parent directory.
+  incus file create --create-dirs filemanip/tmp/create-test-dir/foo
+  [ -z "$(incus exec filemanip --project=test -- cat /tmp/create-test-dir/foo)" ]
+
+  # Create directory using --type flag.
+  incus file create --type=directory filemanip/tmp/create-test-dir/sub-dir
+  incus exec filemanip --project=test -- test -d /tmp/create-test-dir/sub-dir
+
+  # Create directory using trailing "/".
+  incus file create filemanip/tmp/create-test-dir/sub-dir-1/
+  incus exec filemanip --project=test -- test -d /tmp/create-test-dir/sub-dir-1
+
+  # Create symlink.
+  incus file create --type=symlink filemanip/tmp/create-symlink foo
+  [ "$(incus exec filemanip --project=test -- readlink /tmp/create-symlink)" = "foo" ]
+
   # Test SFTP functionality.
   cmd=$(unset -f incus; command -v incus)
   $cmd file mount filemanip --listen=127.0.0.1:2022 --no-auth &


### PR DESCRIPTION
This adds a new `incus file create` subcommand which allows creating files,
symlinks, and directories without having to specify a source.
