### PR TITLE
Add note about scrape_interval and update examples

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -128,6 +128,10 @@ To do so, edit `/etc/prometheus/prometheus.yaml` and add a job for Incus.
 Here's what the configuration needs to look like:
 
 ```yaml
+global:
+  # How frequently to scrape targets by default. The Prometheus default value is 1m.
+  scrape_interval: 15s
+
 scrape_configs:
   - job_name: incus
     metrics_path: '/1.0/metrics'
@@ -144,7 +148,11 @@ scrape_configs:
 ```
 
 ````{note}
-The `server_name` must be specified if the Incus server certificate does not contain the same host name as used in the `targets` list.
+* The `scrape_interval` is assumed to be 15s by the Grafana Prometheus data source by default.
+If you decide to use a different `scrape_interval` value, you must change it in both the Prometheus configuration and the Grafana Prometheus data source configuration.
+Otherwise the Grafana `$__rate_interval` value will be calculated incorrectly and possibly cause a `no data` response in queries using it.
+
+* The `server_name` must be specified if the Incus server certificate does not contain the same host name as used in the `targets` list.
 To verify this, open `server.crt` and check the Subject Alternative Name (SAN) section.
 
 For example, assume that `server.crt` has the following content:
@@ -164,6 +172,10 @@ Since the Subject Alternative Name (SAN) list doesn't include the host name prov
 Here is an example of a `prometheus.yml` configuration where multiple jobs are used to scrape the metrics of multiple Incus servers:
 
 ```yaml
+global:
+  # How frequently to scrape targets by default. The Prometheus default value is 1m.
+  scrape_interval: 15s
+
 scrape_configs:
   # abydos, langara and orilla are part of a single cluster (called `hdc` here)
   # initially bootstrapped by abydos which is why all 3 targets


### PR DESCRIPTION
The `scrape_interval` is assumed to be 15s by the Grafana Prometheus data source by default.the Grafana `$__rate_interval` value will be calculated incorrectly and possibly cause a `no data` response in queries using it.