### PR TITLE
cmd/incus: Remove unused `flagContent` variable in `incus file create`

### DIFF
--- a/cmd/incus/file.go
+++ b/cmd/incus/file.go
@@ -119,9 +119,8 @@ type cmdFileCreate struct {
 	global *cmdGlobal
 	file   *cmdFile
 
-	flagContent string
-	flagForce   bool
-	flagType    string
+	flagForce bool
+	flagType  string
 }
 
 // Command returns the cobra command for `file create`.


### PR DESCRIPTION
This removes the leftover `flagContent` variable in `incus file create`.
