### PR TITLE
Add support for multiple agent binaries

### DIFF
--- a/doc/environment.md
+++ b/doc/environment.md
@@ -29,6 +29,7 @@ Name                            | Description
 
 Name                            | Description
 :---                            | :----
+`INCUS_AGENT_PATH`              | Path to the directory including the `incus-agent` builds
 `INCUS_CLUSTER_UPDATE`          | Script to call on a cluster update
 `INCUS_DEVMONITOR_DIR`          | Path to be monitored by the device monitor. This is primarily for testing
 `INCUS_DOCUMENTATION`           | Path to the documentation to serve through the web server

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -43,3 +43,22 @@ On top of those, the following optional binaries may also be made available:
 - `incus-migrate`
 - `lxc-to-incus`
 - `lxd-to-incus` (should be kept to root only)
+
+## Incus agent binaries
+
+There are two ways to provide the `incus-agent` binary.
+
+### Single agent setup
+
+The simplest way is to have `incus-agent` be available in the `PATH` of `incusd`.
+
+In this scenario the agent should be a static build of `incus-agent` for the primary architecture of the system.
+
+### Multiple agent setup
+
+Alternatively, it's possible to provide multiple builds of the `incus-agent` binary, offering support for multiple architectures or operating systems.
+
+To do that, the `INCUS_AGENT_PATH` environment variable should be set for the `incusd` process and point to a path that includes the `incus-agent` builds.
+
+Those builds should be named after the operating system name and architecture.
+For example `incus-agent.linux.x86_64`, `incus-agent.linux.i686` or `incus-agent.linux.aarch64`.

--- a/internal/server/apparmor/instance.go
+++ b/internal/server/apparmor/instance.go
@@ -200,6 +200,14 @@ func instanceProfile(sysOS *sys.OS, inst instance, extraBinaries []string) (stri
 			return "", err
 		}
 
+		agentPath := ""
+		if os.Getenv("INCUS_AGENT_PATH") != "" {
+			agentPath, err = filepath.EvalSymlinks(os.Getenv("INCUS_AGENT_PATH"))
+			if err != nil {
+				return "", err
+			}
+		}
+
 		execPath := localUtil.GetExecPath()
 		execPathFull, err := filepath.EvalSymlinks(execPath)
 		if err == nil {
@@ -217,6 +225,7 @@ func instanceProfile(sysOS *sys.OS, inst instance, extraBinaries []string) (stri
 			"path":           path,
 			"raw":            rawContent,
 			"ovmfPath":       ovmfPath,
+			"agentPath":      agentPath,
 		})
 		if err != nil {
 			return "", err

--- a/internal/server/apparmor/instance.go
+++ b/internal/server/apparmor/instance.go
@@ -216,7 +216,6 @@ func instanceProfile(sysOS *sys.OS, inst instance, extraBinaries []string) (stri
 			"name":           InstanceProfileName(inst),
 			"path":           path,
 			"raw":            rawContent,
-			"userns":         sysOS.RunningInUserNS,
 			"ovmfPath":       ovmfPath,
 		})
 		if err != nil {

--- a/internal/server/apparmor/instance_qemu.go
+++ b/internal/server/apparmor/instance_qemu.go
@@ -56,11 +56,6 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # Used by qemu for live migration NBD server and client
   unix (bind, listen, accept, send, receive, connect) type=stream,
 
-  # Used by qemu when inside a container
-{{- if .userns }}
-  unix (send, receive) type=stream,
-{{- end }}
-
   # Instance specific paths
   {{ .logPath }}/** rwk,
   {{ .runPath }}/** rwk,

--- a/internal/server/apparmor/instance_qemu.go
+++ b/internal/server/apparmor/instance_qemu.go
@@ -72,6 +72,11 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   deny /sys/module/apparmor/parameters/enabled r,
   deny /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
 
+{{if .agentPath -}}
+  {{ .agentPath }}/ r,
+  {{ .agentPath }}/* r,
+{{- end }}
+
 {{if .libraryPath -}}
   # Entries from LD_LIBRARY_PATH
 {{range $index, $element := .libraryPath}}

--- a/internal/server/instance/drivers/agent-loader/incus-agent
+++ b/internal/server/instance/drivers/agent-loader/incus-agent
@@ -1,0 +1,27 @@
+#!/bin/sh
+PREFIX="/run/incus_agent"
+mkdir -p "${PREFIX}/.mnt"
+
+# Functions.
+mount_virtiofs() {
+    mount -t virtiofs agent "${PREFIX}/.mnt" -o ro >/dev/null 2>&1
+}
+
+mount_9p() {
+    modprobe 9pnet_virtio >/dev/null 2>&1 || true
+    mount -t 9p agent "${PREFIX}/.mnt" -o ro,access=0,trans=virtio,size=1048576 >/dev/null 2>&1
+}
+
+# Mount the agent share.
+mount_virtiofs || mount_9p || fail "Couldn't mount virtiofs or 9p, failing."
+
+# Transfer the agent binary.
+rm -f "${PREFIX}/incus-agent"
+cp -a --no-preserve=ownership  "${PREFIX}/.mnt/incus-agent.linux.$(uname -m)" "${PREFIX}/incus-agent"
+
+# Unmount the temporary mount.
+umount "${PREFIX}/.mnt"
+rmdir "${PREFIX}/.mnt"
+
+# Re-exec the agent.
+exec "${PREFIX}/incus-agent" "$@"

--- a/internal/server/instance/drivers/agent-loader/incus-agent
+++ b/internal/server/instance/drivers/agent-loader/incus-agent
@@ -3,17 +3,13 @@ PREFIX="/run/incus_agent"
 mkdir -p "${PREFIX}/.mnt"
 
 # Functions.
-mount_virtiofs() {
-    mount -t virtiofs agent "${PREFIX}/.mnt" -o ro >/dev/null 2>&1
-}
-
 mount_9p() {
     modprobe 9pnet_virtio >/dev/null 2>&1 || true
     mount -t 9p agent "${PREFIX}/.mnt" -o ro,access=0,trans=virtio,size=1048576 >/dev/null 2>&1
 }
 
 # Mount the agent share.
-mount_virtiofs || mount_9p || fail "Couldn't mount virtiofs or 9p, failing."
+mount_9p || fail "Couldn't mount 9p, failing."
 
 # Transfer the agent binary.
 rm -f "${PREFIX}/incus-agent"

--- a/internal/server/instance/drivers/agent-loader/incus-agent-setup
+++ b/internal/server/instance/drivers/agent-loader/incus-agent-setup
@@ -3,10 +3,6 @@ set -eu
 PREFIX="/run/incus_agent"
 
 # Functions.
-mount_virtiofs() {
-    mount -t virtiofs config "${PREFIX}/.mnt" -o ro >/dev/null 2>&1
-}
-
 mount_9p() {
     modprobe 9pnet_virtio >/dev/null 2>&1 || true
     mount -t 9p config "${PREFIX}/.mnt" -o ro,access=0,trans=virtio,size=1048576 >/dev/null 2>&1
@@ -26,7 +22,7 @@ mount -t tmpfs tmpfs "${PREFIX}" -o mode=0700,nodev,nosuid,noatime,size=25M
 mkdir -p "${PREFIX}/.mnt"
 
 # Try virtiofs first.
-mount_virtiofs || mount_9p || fail "Couldn't mount virtiofs or 9p, failing."
+mount_9p || fail "Couldn't mount 9p, failing."
 
 # Copy the data.
 cp -Ra --no-preserve=ownership "${PREFIX}/.mnt/"* "${PREFIX}"

--- a/internal/server/instance/drivers/agent-loader/incus-agent-setup
+++ b/internal/server/instance/drivers/agent-loader/incus-agent-setup
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+PREFIX="/run/incus_agent"
+
+# Functions.
+mount_virtiofs() {
+    mount -t virtiofs config "${PREFIX}/.mnt" -o ro >/dev/null 2>&1
+}
+
+mount_9p() {
+    modprobe 9pnet_virtio >/dev/null 2>&1 || true
+    mount -t 9p config "${PREFIX}/.mnt" -o ro,access=0,trans=virtio,size=1048576 >/dev/null 2>&1
+}
+
+fail() {
+    umount -l "${PREFIX}" >/dev/null 2>&1 || true
+    rmdir "${PREFIX}" >/dev/null 2>&1 || true
+    echo "${1}"
+    exit 1
+}
+
+# Setup the mount target.
+umount -l "${PREFIX}" >/dev/null 2>&1 || true
+mkdir -p "${PREFIX}"
+mount -t tmpfs tmpfs "${PREFIX}" -o mode=0700,nodev,nosuid,noatime,size=25M
+mkdir -p "${PREFIX}/.mnt"
+
+# Try virtiofs first.
+mount_virtiofs || mount_9p || fail "Couldn't mount virtiofs or 9p, failing."
+
+# Copy the data.
+cp -Ra --no-preserve=ownership "${PREFIX}/.mnt/"* "${PREFIX}"
+
+# Unmount the temporary mount.
+umount "${PREFIX}/.mnt"
+rmdir "${PREFIX}/.mnt"

--- a/internal/server/instance/drivers/agent-loader/install.sh
+++ b/internal/server/instance/drivers/agent-loader/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+if [ ! -e "systemd" ] || [ ! -e "incus-agent" ]; then
+    echo "This script must be run from within the 9p mount"
+    exit 1
+fi
+
+if [ ! -e "/lib/systemd/system" ]; then
+    echo "This script only works on systemd systems"
+    exit 1
+fi
+
+# Install the units.
+cp udev/99-incus-agent.rules /lib/udev/rules.d/
+cp systemd/incus-agent.service /lib/systemd/system/
+cp systemd/incus-agent-setup /lib/systemd/
+systemctl daemon-reload
+
+echo ""
+echo "Incus agent has been installed, reboot to confirm setup."
+echo "To start it now, unmount this filesystem and run: systemctl start incus-agent"

--- a/internal/server/instance/drivers/agent-loader/systemd/incus-agent.rules
+++ b/internal/server/instance/drivers/agent-loader/systemd/incus-agent.rules
@@ -1,0 +1,1 @@
+SYMLINK=="virtio-ports/org.linuxcontainers.incus", TAG+="systemd", ENV{SYSTEMD_WANTS}+="incus-agent.service"

--- a/internal/server/instance/drivers/agent-loader/systemd/incus-agent.service
+++ b/internal/server/instance/drivers/agent-loader/systemd/incus-agent.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Incus - agent
+Documentation=https://linuxcontainers.org/incus/docs/main/
+Before=multi-user.target cloud-init.target cloud-init.service cloud-init-local.service
+DefaultDependencies=no
+
+[Service]
+Type=notify
+WorkingDirectory=-/run/incus_agent
+ExecStartPre=/lib/systemd/incus-agent-setup
+ExecStart=/run/incus_agent/incus-agent
+Restart=on-failure
+RestartSec=5s
+StartLimitInterval=60
+StartLimitBurst=10

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3157,6 +3157,7 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 			devAddr:       devAddr,
 			multifunction: multi,
 		},
+		name:     "config",
 		protocol: "9p",
 		path:     d.configDriveMountPath(),
 	}
@@ -3195,6 +3196,7 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 				devAddr:       devAddr,
 				multifunction: multi,
 			},
+			name:     "config",
 			protocol: "virtio-fs",
 			path:     configSockPath,
 		}

--- a/internal/server/instance/drivers/driver_qemu_config_test.go
+++ b/internal/server/instance/drivers/driver_qemu_config_test.go
@@ -749,11 +749,12 @@ func TestQemuConfigTemplates(t *testing.T) {
 			expected string
 		}{{
 			qemuDriveConfigOpts{
+				name:     "config",
 				dev:      qemuDevOpts{"pci", "qemu_pcie0", "00.5", false},
 				path:     "/var/9p",
 				protocol: "9p",
 			},
-			`# Config drive (9p)
+			`# Shared config drive (9p)
 			[fsdev "qemu_config"]
 			fsdriver = "local"
 			security_model = "none"
@@ -768,11 +769,12 @@ func TestQemuConfigTemplates(t *testing.T) {
 			fsdev = "qemu_config"`,
 		}, {
 			qemuDriveConfigOpts{
+				name:     "config",
 				dev:      qemuDevOpts{"pcie", "qemu_pcie1", "10.2", true},
 				path:     "/dev/virtio-fs",
 				protocol: "virtio-fs",
 			},
-			`# Config drive (virtio-fs)
+			`# Shared config drive (virtio-fs)
 			[chardev "qemu_config"]
 			backend = "socket"
 			path = "/dev/virtio-fs"
@@ -786,11 +788,12 @@ func TestQemuConfigTemplates(t *testing.T) {
 			chardev = "qemu_config"`,
 		}, {
 			qemuDriveConfigOpts{
+				name:     "config",
 				dev:      qemuDevOpts{"ccw", "qemu_pcie0", "00.0", false},
 				path:     "/var/virtio-fs",
 				protocol: "virtio-fs",
 			},
-			`# Config drive (virtio-fs)
+			`# Shared config drive (virtio-fs)
 			[chardev "qemu_config"]
 			backend = "socket"
 			path = "/var/virtio-fs"
@@ -801,11 +804,12 @@ func TestQemuConfigTemplates(t *testing.T) {
 			chardev = "qemu_config"`,
 		}, {
 			qemuDriveConfigOpts{
+				name:     "config",
 				dev:      qemuDevOpts{"ccw", "qemu_pcie0", "00.0", true},
 				path:     "/dev/9p",
 				protocol: "9p",
 			},
-			`# Config drive (9p)
+			`# Shared config drive (9p)
 			[fsdev "qemu_config"]
 			fsdriver = "local"
 			security_model = "none"

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -694,6 +694,7 @@ func qemuHostDrive(opts *qemuHostDriveOpts) []cfgSection {
 }
 
 type qemuDriveConfigOpts struct {
+	name     string
 	dev      qemuDevOpts
 	protocol string
 	path     string
@@ -703,10 +704,10 @@ func qemuDriveConfig(opts *qemuDriveConfigOpts) []cfgSection {
 	return qemuHostDrive(&qemuHostDriveOpts{
 		dev: opts.dev,
 		// Devices use "qemu_" prefix indicating that this is a internally named device.
-		name:          "qemu_config",
+		name:          fmt.Sprintf("qemu_%s", opts.name),
 		nameSuffix:    "-drive",
-		comment:       fmt.Sprintf("Config drive (%s)", opts.protocol),
-		mountTag:      "config",
+		comment:       fmt.Sprintf("Shared %s drive (%s)", opts.name, opts.protocol),
+		mountTag:      opts.name,
 		protocol:      opts.protocol,
 		fsdriver:      "local",
 		readonly:      true,


### PR DESCRIPTION
This adds support for a separate 9p/virtiofs share for the agent which will be shared system-wide (saves us from data duplication) and can contain multiple binaries to handle multiple architectures and operating systems.

Closes #263 