### PR TITLE
doc/installing.md: add a gentoo-wiki link under Gentoo section

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -105,6 +105,8 @@ Start the daemon:
 
 - **`openrc`**: `rc-service incus start`
 - **`systemd`**: `systemctl start incus`
+
+Continue in the [Gentoo Wiki](https://wiki.gentoo.org/wiki/Incus).
 ```
 
 ```{group-tab} NixOS


### PR DESCRIPTION
Slowly adding more (gentoo-related) wiki content.