### PR TITLE
Add support for an agent drive (ISO)

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2330,3 +2330,7 @@ This introduces new options for the `cluster.evacuate` option:
 
 This introduces a new `boot.host_shutdown_action` instance configuration key which can be used to override the default `stop` behavior on system shutdown.
 It supports the value `stop`, `stateful-stop` and `force-stop`.
+
+## `agent_config_drive`
+
+This introduces a new `agent:config` disk `source` which can be used to expose an ISO to the VM guest containing the agent and its configuration.

--- a/doc/reference/devices_disk.md
+++ b/doc/reference/devices_disk.md
@@ -67,6 +67,16 @@ VM `cloud-init`
 
       incus config device add <instance_name> <device_name> disk source=cloud-init:config
 
+VM `agent`
+: You can generate an `agent` configuration ISO which will contain the agent binary, configuration files and installation scripts.
+  This is required for environments where `9p` isn't supported and where an alternative way to load the agent is required.
+
+  This source type is applicable only to VMs.
+
+  To add such a device, use the following command:
+
+      incus config device add <instance_name> <device_name> disk source=agent:config
+
 (devices-disk-initial-config)=
 ## Initial volume configuration for instance root disk devices
 

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -2169,6 +2169,7 @@ func (d *disk) getParentBlocks(path string) ([]string, error) {
 // Returns the path to the ISO.
 func (d *disk) generateVMConfigDrive() (string, error) {
 	scratchDir := filepath.Join(d.inst.DevicesPath(), linux.PathNameEncode(d.name))
+	defer func() { _ = os.RemoveAll(scratchDir) }()
 
 	// Check we have the mkisofs tool available.
 	mkisofsPath, err := exec.LookPath("mkisofs")
@@ -2245,9 +2246,6 @@ local-hostname: %s
 	if err != nil {
 		return "", err
 	}
-
-	// Remove the config drive folder.
-	_ = os.RemoveAll(scratchDir)
 
 	return isoPath, nil
 }

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -17,6 +17,7 @@ import (
 	internalInstance "github.com/lxc/incus/internal/instance"
 	"github.com/lxc/incus/internal/linux"
 	"github.com/lxc/incus/internal/revert"
+	"github.com/lxc/incus/internal/rsync"
 	"github.com/lxc/incus/internal/server/cgroup"
 	"github.com/lxc/incus/internal/server/db"
 	"github.com/lxc/incus/internal/server/db/cluster"
@@ -40,6 +41,9 @@ import (
 
 // Special disk "source" value used for generating a VM cloud-init config ISO.
 const diskSourceCloudInit = "cloud-init:config"
+
+// Special disk "source" value used for generating a VM agent ISO.
+const diskSourceAgent = "agent:config"
 
 // DiskVirtiofsdSockMountOpt indicates the mount option prefix used to provide the virtiofsd socket path to
 // the QEMU driver.
@@ -150,6 +154,10 @@ func (d *disk) sourceIsLocalPath(source string) bool {
 	}
 
 	if source == diskSourceCloudInit {
+		return false
+	}
+
+	if source == diskSourceAgent {
 		return false
 	}
 
@@ -451,8 +459,8 @@ func (d *disk) validateEnvironmentSourcePath() error {
 
 // validateEnvironment checks the runtime environment for correctness.
 func (d *disk) validateEnvironment() error {
-	if d.inst.Type() != instancetype.VM && d.config["source"] == diskSourceCloudInit {
-		return fmt.Errorf("disks with source=%s are only supported by virtual machines", diskSourceCloudInit)
+	if d.inst.Type() != instancetype.VM && util.ValueInSlice(d.config["source"], []string{diskSourceCloudInit, diskSourceAgent}) {
+		return fmt.Errorf("disks with source=%s are only supported by virtual machines", d.config["source"])
 	}
 
 	err := d.validateEnvironmentSourcePath()
@@ -784,6 +792,35 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 			},
 		}
 
+		return &runConf, nil
+	} else if d.config["source"] == diskSourceAgent {
+		// This is a special virtual disk source that can be attached to a VM to provide agent binary and config.
+		isoPath, err := d.generateVMAgentDrive()
+		if err != nil {
+			return nil, err
+		}
+
+		// Open file handle to isoPath source.
+		f, err := os.OpenFile(isoPath, unix.O_PATH|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return nil, fmt.Errorf("Failed opening source path %q: %w", isoPath, err)
+		}
+
+		revert.Add(func() { _ = f.Close() })
+		runConf.PostHooks = append(runConf.PostHooks, f.Close)
+		runConf.Revert = func() { _ = f.Close() } // Close file on VM start failure.
+
+		// Encode the file descriptor and original isoPath into the DevPath field.
+		runConf.Mounts = []deviceConfig.MountEntryItem{
+			{
+				DevPath: fmt.Sprintf("%s:%d:%s", DiskFileDescriptorMountPrefix, f.Fd(), isoPath),
+				DevName: d.name,
+				FSType:  "iso9660",
+				Opts:    opts,
+			},
+		}
+
+		revert.Success()
 		return &runConf, nil
 	} else if d.config["source"] == diskSourceCloudInit {
 		// This is a special virtual disk source that can be attached to a VM to provide cloud-init config.
@@ -2163,6 +2200,64 @@ func (d *disk) getParentBlocks(path string) ([]string, error) {
 	}
 
 	return devices, nil
+}
+
+// generateVMAgent generates an ISO containing the VM agent binary and config.
+// Returns the path to the ISO.
+func (d *disk) generateVMAgentDrive() (string, error) {
+	scratchDir := filepath.Join(d.inst.DevicesPath(), linux.PathNameEncode(d.name))
+	defer func() { _ = os.RemoveAll(scratchDir) }()
+
+	// Check we have the mkisofs tool available.
+	mkisofsPath, err := exec.LookPath("mkisofs")
+	if err != nil {
+		return "", err
+	}
+
+	// Create agent drive dir.
+	err = os.MkdirAll(scratchDir, 0100)
+	if err != nil {
+		return "", err
+	}
+
+	// Copy the instance config data over.
+	configPath := filepath.Join(d.inst.Path(), "config")
+	_, err = rsync.LocalCopy(configPath, scratchDir, "", false)
+	if err != nil {
+		return "", err
+	}
+
+	// Include the most likely agent.
+	if util.PathExists(os.Getenv("INCUS_AGENT_PATH")) {
+		agentInstallPath := filepath.Join(scratchDir, "incus-agent")
+
+		os.Remove(agentInstallPath)
+
+		err = internalUtil.FileCopy(filepath.Join(os.Getenv("INCUS_AGENT_PATH"), fmt.Sprintf("incus-agent.linux.%s", d.state.OS.Uname.Machine)), agentInstallPath)
+		if err != nil {
+			return "", err
+		}
+
+		err = os.Chmod(agentInstallPath, 0500)
+		if err != nil {
+			return "", err
+		}
+
+		err = os.Chown(agentInstallPath, 0, 0)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Finally convert the agent drive dir into an ISO file. The incus-agent label is important
+	// as this is what incus-agent-loader uses to detect the drive.
+	isoPath := filepath.Join(d.inst.Path(), "agent.iso")
+	_, err = subprocess.RunCommand(mkisofsPath, "-joliet", "-rock", "-input-charset", "utf8", "-output-charset", "utf8", "-volid", "incus-agent", "-o", isoPath, scratchDir)
+	if err != nil {
+		return "", err
+	}
+
+	return isoPath, nil
 }
 
 // generateVMConfigDrive generates an ISO containing the cloud init config for a VM.

--- a/internal/server/instance/drivers/agent-loader/incus-agent-setup
+++ b/internal/server/instance/drivers/agent-loader/incus-agent-setup
@@ -9,8 +9,8 @@ mount_cdrom() {
 }
 
 mount_9p() {
-    /sbin/modprobe 9pnet_virtio >/dev/null 2>&1 || true
-    /bin/mount -t 9p config "${PREFIX}.mnt" -o access=0,trans=virtio,size=1048576 >/dev/null 2>&1
+    modprobe 9pnet_virtio >/dev/null 2>&1 || true
+    mount -t 9p config "${PREFIX}.mnt" -o access=0,trans=virtio,size=1048576 >/dev/null 2>&1
 }
 
 fail() {

--- a/internal/server/instance/drivers/agent-loader/incus-agent-setup
+++ b/internal/server/instance/drivers/agent-loader/incus-agent-setup
@@ -1,33 +1,60 @@
 #!/bin/sh
 set -eu
 PREFIX="/run/incus_agent"
+CDROM="/dev/disk/by-id/scsi-0QEMU_QEMU_CD-ROM_incus_agent"
 
 # Functions.
+mount_cdrom() {
+    mount "${CDROM}" "${PREFIX}.mnt" >/dev/null 2>&1
+}
+
 mount_9p() {
-    modprobe 9pnet_virtio >/dev/null 2>&1 || true
-    mount -t 9p config "${PREFIX}/.mnt" -o ro,access=0,trans=virtio,size=1048576 >/dev/null 2>&1
+    /sbin/modprobe 9pnet_virtio >/dev/null 2>&1 || true
+    /bin/mount -t 9p config "${PREFIX}.mnt" -o access=0,trans=virtio,size=1048576 >/dev/null 2>&1
 }
 
 fail() {
+    # Check if we already have an agent in place.
+    # This will typically be true during restart in the case of a cdrom-based setup.
+    if [ -x "${PREFIX}/incus-agent" ]; then
+        echo "${1}, re-using existing agent"
+        exit 0
+    fi
+
+    # Cleanup and fail.
     umount -l "${PREFIX}" >/dev/null 2>&1 || true
+    eject "${CDROM}" >/dev/null 2>&1 || true
     rmdir "${PREFIX}" >/dev/null 2>&1 || true
-    echo "${1}"
+    echo "${1}, failing"
+
     exit 1
 }
+
+# Try getting an agent drive.
+mkdir -p "${PREFIX}.mnt"
+mount_9p || mount_cdrom || fail "Couldn't mount 9p or cdrom"
 
 # Setup the mount target.
 umount -l "${PREFIX}" >/dev/null 2>&1 || true
 mkdir -p "${PREFIX}"
-mount -t tmpfs tmpfs "${PREFIX}" -o mode=0700,nodev,nosuid,noatime,size=25M
-mkdir -p "${PREFIX}/.mnt"
-
-# Try virtiofs first.
-mount_9p || fail "Couldn't mount 9p, failing."
+mount -t tmpfs tmpfs "${PREFIX}" -o mode=0700,size=50M
 
 # Copy the data.
-cp -Ra "${PREFIX}/.mnt/"* "${PREFIX}"
-chown -R root:root "${PREFIX}"
+cp -Ra "${PREFIX}.mnt/"* "${PREFIX}"
 
 # Unmount the temporary mount.
-umount "${PREFIX}/.mnt"
-rmdir "${PREFIX}/.mnt"
+umount "${PREFIX}.mnt"
+rmdir "${PREFIX}.mnt"
+
+# Eject the cdrom in case it's present.
+eject "${CDROM}" >/dev/null 2>&1 || true
+
+# Fix up permissions.
+chown -R root:root "${PREFIX}"
+
+# Legacy.
+if [ ! -e "${PREFIX}/incus-agent" ] && [ -e "${PREFIX}/lxd-agent" ]; then
+    ln -s lxd-agent "${PREFIX}"/incus-agent
+fi
+
+exit 0

--- a/internal/server/instance/drivers/qmp/commands.go
+++ b/internal/server/instance/drivers/qmp/commands.go
@@ -998,3 +998,19 @@ func (m *Monitor) BlockJobComplete(deviceNodeName string) error {
 
 	return nil
 }
+
+// Eject ejects a removable drive.
+func (m *Monitor) Eject(id string) error {
+	var args struct {
+		ID string `json:"id"`
+	}
+
+	args.ID = id
+
+	err := m.run("eject", args, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/server/project/permissions.go
+++ b/internal/server/project/permissions.go
@@ -609,6 +609,11 @@ func checkRestrictions(project api.Project, instances []api.Instance, profiles [
 					return nil
 				}
 
+				// Always allow the agent config drive.
+				if device["path"] == "" && device["source"] == "agent:config" {
+					return nil
+				}
+
 				switch restrictionValue {
 				case "block":
 					return fmt.Errorf("Disk devices are forbidden")

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -393,6 +393,7 @@ var APIExtensions = []string{
 	"instance_create_start",
 	"clustering_evacuation_stop_options",
 	"boot_host_shutdown_action",
+	"agent_config_drive",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
With this, a new `agent:config` disk source can be used to attach a custom ISO to a VM.
This ISO then contains roughly the same data as the normal `9p` config drive.

The goal behind this is to provide a way for VMs that don't support 9p but do support virtio-serial and virtio-vsock to still run a functional incus-agent.