### PR TITLE
incusd/instance/qemu/qmp: Don't risk blocking QMP on eject

### DIFF
--- a/internal/server/instance/drivers/qmp/monitor.go
+++ b/internal/server/instance/drivers/qmp/monitor.go
@@ -109,10 +109,12 @@ func (m *Monitor) start() error {
 				if e.Event == EventDiskEjected {
 					id, ok := e.Data["id"].(string)
 					if ok {
-						err = m.Eject(id)
-						if err != nil {
-							logger.Warnf("Unable to eject media %q: %v", id, err)
-						}
+						go func() {
+							err = m.Eject(id)
+							if err != nil {
+								logger.Warnf("Unable to eject media %q: %v", id, err)
+							}
+						}()
 					}
 				}
 


### PR DESCRIPTION
This would lead to occasional QMP dead locks when the instance would be queried while processing the eject request.