### PR TITLE
incusd/apparmor: Allow more mounts in unprivileged containers

### DIFF
--- a/internal/server/apparmor/instance_lxc.go
+++ b/internal/server/apparmor/instance_lxc.go
@@ -504,11 +504,12 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   mount options=(rw,unbindable) -> **,
   mount options=(rw,runbindable) -> **,
 
-  # Allow all bind-mounts
-  mount options=(rw,bind) / -> /**,
-  mount options=(rw,bind) /** -> /**,
-  mount options=(rw,rbind) / -> /**,
-  mount options=(rw,rbind) /** -> /**,
+  # Allow all bind-mounts.
+  mount options=(rw,bind) -> /**,
+  mount options=(rw,rbind) -> /**,
+
+  # Allow all move-mounts.
+  mount options=(rw,move) -> /**,
 
   # Allow common combinations of bind/remount
   # NOTE: AppArmor bug effectively turns those into wildcards mount allow


### PR DESCRIPTION
As AppArmor is slowly getting worse and worse at handling mounts due to its design failing to accomodate the new mount APIs, we have to keep relaxing mount rules.

This is another one of those which is required for recent systemd systems.