### PR TITLE
fix: use genisoimage when mkisofs is not found

### DIFF
--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -2208,10 +2208,15 @@ func (d *disk) generateVMAgentDrive() (string, error) {
 	scratchDir := filepath.Join(d.inst.DevicesPath(), linux.PathNameEncode(d.name))
 	defer func() { _ = os.RemoveAll(scratchDir) }()
 
-	// Check we have the mkisofs tool available.
-	mkisofsPath, err := exec.LookPath("mkisofs")
+	// Check we have the mkisofs or genisoimage tool available.
+	var mkisofsPath string
+	var err error
+	mkisofsPath, err = exec.LookPath("mkisofs")
 	if err != nil {
-		return "", err
+		mkisofsPath, err = exec.LookPath("genisoimage")
+		if err != nil {
+			return "", fmt.Errorf("Neither mkisofs nor genisoimage could be found in $PATH")
+		}
 	}
 
 	// Create agent drive dir.


### PR DESCRIPTION
Fedora variants don't include `mkisofs`, but do include `genisoimage` which is a command compatible substitute. This change checks for `genisoimage` and uses if `mkisofs` isn't found.