### PR TITLE
test: Adapt test_database_no_disk_space() to newer libraft versions

### DIFF
--- a/test/suites/database.sh
+++ b/test/suites/database.sh
@@ -81,9 +81,19 @@ test_database_no_disk_space(){
     ! incus config set c "user.propX" - < "${DATA}" || false
     ! incus config set c "user.propY" - < "${DATA}" || false
 
-    # Removing the big file makes the database happy again.
+    # Removing the big file eventually makes the database happy again.
     rm "${BIG_FILE}"
-    incus config set c "user.propZ" - < "${DATA}"
+
+    succeeded=no
+    for i in $(seq 10); do
+        if incus config set c "user.propZ" - < "${DATA}"; then
+            succeeded=yes
+            break
+        fi
+        sleep 1
+    done
+    [ "${succeeded}" = "yes" ] || false
+
     incus delete -f c
   )
 


### PR DESCRIPTION
Starting from raft 0.21.0 (which will be released shortly), errors due to lack of disk space will be correctly reported not only in single-node situations, but also in case enough voting nodes run out of disk space so that no further entry can get committed until at least one of them recovers (currently the client would hit a timeout error, with now way for it to know what happened: the command might also eventually succeed far later in the future if disk space is recovered at a later point in time).

Although this is an improvement, it has the slight downside that for single-node situations there will be a short lag before the node actually notices that disk space has recovered and new entries can be committed again. Special-casing the single node situation would be tricky and I'd prefer to avoid that.

This lag is currently about 5 seconds by default, but it could be lowered to any amount if desired. Basically, every 5 seconds the raft engine will retry to allocate space for new entries, so decreasing the lag will increase the retry frequency.

If 5 seconds seems too convervative, it could be perhaps be lowered to 1 second?

In any case, the change in this PR will be needed, since there's no guarantee that running:

rm "${BIG_FILE}"

and then **immediately** running:

incus config set c "user.prop${i}" - < "${DATA}";

will succeed, so a small retry loop is needed.