### PR TITLE
incus/image: add dynamic command line completions

### DIFF
--- a/cmd/incus/completion.go
+++ b/cmd/incus/completion.go
@@ -23,7 +23,7 @@ func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDi
 		for _, instance := range instances {
 			var name string
 
-			if resource.remote == g.conf.DefaultRemote {
+			if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = instance
 			} else {
 				name = fmt.Sprintf("%s:%s", resource.remote, instance)
@@ -34,7 +34,7 @@ func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDi
 	}
 
 	if !strings.Contains(toComplete, ":") {
-		remotes, _ := g.cmpRemotes()
+		remotes, _ := g.cmpRemotes(false)
 		results = append(results, remotes...)
 	}
 
@@ -57,7 +57,7 @@ func (g *cmdGlobal) cmpNetworks(toComplete string) ([]string, cobra.ShellCompDir
 		for _, network := range networks {
 			var name string
 
-			if resource.remote == g.conf.DefaultRemote {
+			if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = network.Name
 			} else {
 				name = fmt.Sprintf("%s:%s", resource.remote, network.Name)
@@ -68,7 +68,7 @@ func (g *cmdGlobal) cmpNetworks(toComplete string) ([]string, cobra.ShellCompDir
 	}
 
 	if !strings.Contains(toComplete, ":") {
-		remotes, _ := g.cmpRemotes()
+		remotes, _ := g.cmpRemotes(false)
 		results = append(results, remotes...)
 	}
 
@@ -167,7 +167,7 @@ func (g *cmdGlobal) cmpProfiles(toComplete string) ([]string, cobra.ShellCompDir
 		for _, profile := range profiles {
 			var name string
 
-			if resource.remote == g.conf.DefaultRemote {
+			if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = profile
 			} else {
 				name = fmt.Sprintf("%s:%s", resource.remote, profile)
@@ -178,18 +178,18 @@ func (g *cmdGlobal) cmpProfiles(toComplete string) ([]string, cobra.ShellCompDir
 	}
 
 	if !strings.Contains(toComplete, ":") {
-		remotes, _ := g.cmpRemotes()
+		remotes, _ := g.cmpRemotes(false)
 		results = append(results, remotes...)
 	}
 
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
-func (g *cmdGlobal) cmpRemotes() ([]string, cobra.ShellCompDirective) {
+func (g *cmdGlobal) cmpRemotes(includeAll bool) ([]string, cobra.ShellCompDirective) {
 	results := []string{}
 
 	for remoteName, rc := range g.conf.Remotes {
-		if rc.Protocol != "incus" && rc.Protocol != "" {
+		if !includeAll && rc.Protocol != "incus" && rc.Protocol != "" {
 			continue
 		}
 

--- a/cmd/incus/completion.go
+++ b/cmd/incus/completion.go
@@ -8,6 +8,42 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func (g *cmdGlobal) cmpImages(toComplete string) ([]string, cobra.ShellCompDirective) {
+	results := []string{}
+	var remote string
+
+	if strings.Contains(toComplete, ":") {
+		remote = strings.Split(toComplete, ":")[0]
+	} else {
+		remote = g.conf.DefaultRemote
+	}
+
+	remoteServer, _ := g.conf.GetImageServer(remote)
+
+	images, _ := remoteServer.GetImages()
+
+	for _, image := range images {
+		for _, alias := range image.Aliases {
+			var name string
+
+			if remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
+				name = alias.Name
+			} else {
+				name = fmt.Sprintf("%s:%s", remote, alias.Name)
+			}
+
+			results = append(results, name)
+		}
+	}
+
+	if !strings.Contains(toComplete, ":") {
+		remotes, _ := g.cmpRemotes(true)
+		results = append(results, remotes...)
+	}
+
+	return results, cobra.ShellCompDirectiveNoFileComp
+}
+
 func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDirective) {
 	results := []string{}
 

--- a/cmd/incus/create.go
+++ b/cmd/incus/create.go
@@ -59,6 +59,14 @@ incus create images:ubuntu/22.04 u1 < config.yaml
 	cmd.Flags().BoolVar(&c.flagEmpty, "empty", false, i18n.G("Create an empty instance"))
 	cmd.Flags().BoolVar(&c.flagVM, "vm", false, i18n.G("Create a virtual machine"))
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpImages(toComplete)
+	}
+
 	return cmd
 }
 

--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -161,6 +161,18 @@ It requires the source to be an alias and for it to be public.`))
 	cmd.Flags().StringArrayVarP(&c.flagProfile, "profile", "p", nil, i18n.G("Profile to apply to the new image")+"``")
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpImages(toComplete)
+		}
+
+		if len(args) == 1 {
+			return c.global.cmpRemotes(false)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 
@@ -317,6 +329,10 @@ func (c *cmdImageDelete) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return c.global.cmpImages(toComplete)
+	}
+
 	return cmd
 }
 
@@ -373,6 +389,14 @@ incus image edit <image> < image.yaml
     Load the image properties from a YAML file`))
 
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpImages(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }
@@ -497,6 +521,14 @@ The output target is optional and defaults to the working directory.`))
 
 	cmd.Flags().BoolVar(&c.flagVM, "vm", false, i18n.G("Query virtual machine images"))
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpImages(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }
@@ -658,6 +690,18 @@ Directory import is only available on Linux and must be performed as root.`))
 	cmd.Flags().BoolVar(&c.flagPublic, "public", false, i18n.G("Make image public"))
 	cmd.Flags().StringArrayVar(&c.flagAliases, "alias", nil, i18n.G("New aliases to add to the image")+"``")
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return nil, cobra.ShellCompDirectiveDefault
+		}
+
+		if len(args) == 1 {
+			return c.global.cmpRemotes(false)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }
@@ -889,6 +933,14 @@ func (c *cmdImageInfo) Command() *cobra.Command {
 	cmd.Flags().BoolVar(&c.flagVM, "vm", false, i18n.G("Query virtual machine images"))
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpImages(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 
@@ -1046,6 +1098,14 @@ Column shorthand chars:
 	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", "lfpdatsu", i18n.G("Columns")+"``")
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpImages(toComplete)
+	}
 
 	return cmd
 }
@@ -1342,6 +1402,10 @@ func (c *cmdImageRefresh) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return c.global.cmpImages(toComplete)
+	}
+
 	return cmd
 }
 
@@ -1423,6 +1487,14 @@ func (c *cmdImageShow) Command() *cobra.Command {
 	cmd.Flags().BoolVar(&c.flagVM, "vm", false, i18n.G("Query virtual machine images"))
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpImages(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 
@@ -1481,6 +1553,19 @@ func (c *cmdImageGetProp) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpImages(toComplete)
+		}
+
+		if len(args) == 1 {
+			// individual image prop could complete here
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 
@@ -1532,6 +1617,14 @@ func (c *cmdImageSetProp) Command() *cobra.Command {
 		`Set image properties`))
 
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpImages(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }
@@ -1588,6 +1681,14 @@ func (c *cmdImageUnsetProp) Command() *cobra.Command {
 		`Unset image properties`))
 
 	cmd.RunE = c.Run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpImages(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }

--- a/cmd/incus/launch.go
+++ b/cmd/incus/launch.go
@@ -41,6 +41,14 @@ incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB
 	cmd.Flags().StringVar(&c.flagConsole, "console", "", i18n.G("Immediately attach to the console")+"``")
 	cmd.Flags().Lookup("console").NoOptDefVal = "console"
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpImages(toComplete)
+	}
+
 	return cmd
 }
 

--- a/cmd/incus/network.go
+++ b/cmd/incus/network.go
@@ -331,7 +331,7 @@ incus network create bar network=baz --type ovn
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return c.global.cmpRemotes()
+		return c.global.cmpRemotes(false)
 	}
 
 	return cmd
@@ -1015,7 +1015,7 @@ func (c *cmdNetworkList) Command() *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		return c.global.cmpRemotes()
+		return c.global.cmpRemotes(false)
 	}
 
 	return cmd


### PR DESCRIPTION
This covers all the `incus image` subcommands, with the only exception being `incus image get-property myimagename <TAB>` will not complete available properties.