### PR TITLE
incus-agent: Load virtio_net before configuring NICs

### DIFF
--- a/cmd/incus-agent/network.go
+++ b/cmd/incus-agent/network.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lxc/incus/internal/revert"
 	deviceConfig "github.com/lxc/incus/internal/server/device/config"
+	"github.com/lxc/incus/internal/linux"
 	"github.com/lxc/incus/internal/server/ip"
 	"github.com/lxc/incus/internal/server/util"
 	"github.com/lxc/incus/shared/logger"
@@ -71,6 +72,9 @@ func reconfigureNetworkInterfaces() {
 		logger.Error("Could not read network interface configuration directory", logger.Ctx{"err": err})
 		return
 	}
+
+	// Attempt to load the virtio_net driver in case it's not be loaded yet.
+	_ = linux.LoadModule("virtio_net")
 
 	// nicData is a map of MAC address to NICConfig.
 	nicData := make(map[string]deviceConfig.NICConfig, len(nicDirEntries))


### PR DESCRIPTION
On some distros, virtio_net may not be loaded by the time the agent starts up.

This isn't really a problem normally as the agent doesn't need access to the network, but it is a problem if the user is using agent.nic_config to rename network interfaces.

So just attempt to load virtio_net prior to performing any reconfiguration.