### PR TITLE
incusd/device: Bump base VM filesystem volume to 500MiB

### DIFF
--- a/internal/server/device/config/consts.go
+++ b/internal/server/device/config/consts.go
@@ -1,4 +1,4 @@
 package config
 
 // DefaultVMBlockFilesystemSize is the size of a VM root device block volume's associated filesystem volume.
-const DefaultVMBlockFilesystemSize = "100MiB"
+const DefaultVMBlockFilesystemSize = "500MiB"


### PR DESCRIPTION
This avoids an issue on XFS where the base filesystem size is now 300MiB.

Closes #498