### PR TITLE
Disable the architecture check on `incus copy`/`incus mv`

### DIFF
--- a/cmd/incusd/api_internal.go
+++ b/cmd/incusd/api_internal.go
@@ -757,7 +757,7 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 		return err
 	}
 
-	_, instOp, cleanup, err := instance.CreateInternal(s, *instDBArgs, true)
+	_, instOp, cleanup, err := instance.CreateInternal(s, *instDBArgs, true, true)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -871,7 +871,7 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 			Name:         snapInstName,
 			Profiles:     profiles,
 			Stateful:     snap.Stateful,
-		}, true)
+		}, true, true)
 		if err != nil {
 			return fmt.Errorf("Failed creating instance snapshot record %q: %w", snap.Name, err)
 		}

--- a/cmd/incusd/api_internal_recover.go
+++ b/cmd/incusd/api_internal_recover.go
@@ -512,7 +512,7 @@ func internalRecoverImportInstance(s *state.State, pool storagePools.Pool, proje
 		return nil, nil, fmt.Errorf("Invalid instance type")
 	}
 
-	inst, instOp, cleanup, err := instance.CreateInternal(s, *dbInst, false)
+	inst, instOp, cleanup, err := instance.CreateInternal(s, *dbInst, false, true)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -563,7 +563,7 @@ func internalRecoverImportInstanceSnapshot(s *state.State, pool storagePools.Poo
 		Name:         poolVol.Container.Name + internalInstance.SnapshotDelimiter + snap.Name,
 		Profiles:     profiles,
 		Stateful:     snap.Stateful,
-	}, false)
+	}, false, true)
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating instance snapshot record %q: %w", snap.Name, err)
 	}

--- a/cmd/incusd/instance.go
+++ b/cmd/incusd/instance.go
@@ -38,7 +38,7 @@ func instanceCreateAsEmpty(s *state.State, args db.InstanceArgs) (instance.Insta
 	defer revert.Fail()
 
 	// Create the instance record.
-	inst, instOp, cleanup, err := instance.CreateInternal(s, args, true)
+	inst, instOp, cleanup, err := instance.CreateInternal(s, args, true, true)
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -154,7 +154,7 @@ func instanceCreateFromImage(s *state.State, r *http.Request, img *api.Image, ar
 	args.BaseImage = img.Fingerprint
 
 	// Create the instance.
-	inst, instOp, cleanup, err := instance.CreateInternal(s, args, true)
+	inst, instOp, cleanup, err := instance.CreateInternal(s, args, true, true)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance record: %w", err)
 	}
@@ -259,7 +259,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 	// If we are not in refresh mode, then create a new instance as we are in copy mode.
 	if !opts.refresh {
 		// Create the instance.
-		inst, instOp, cleanup, err = instance.CreateInternal(s, opts.targetInstance, true)
+		inst, instOp, cleanup, err = instance.CreateInternal(s, opts.targetInstance, true, false)
 		if err != nil {
 			return nil, fmt.Errorf("Failed creating instance record: %w", err)
 		}
@@ -394,7 +394,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 			}
 
 			// Create the snapshots.
-			_, snapInstOp, cleanup, err := instance.CreateInternal(s, snapInstArgs, true)
+			_, snapInstOp, cleanup, err := instance.CreateInternal(s, snapInstArgs, true, false)
 			if err != nil {
 				return nil, fmt.Errorf("Failed creating instance snapshot record %q: %w", newSnapName, err)
 			}

--- a/cmd/incusd/instance_test.go
+++ b/cmd/incusd/instance_test.go
@@ -31,7 +31,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -93,7 +93,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -129,7 +129,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 	})
 	suite.Req.Nil(err)
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	suite.True(c.IsPrivileged(), "This container should be privileged.")
@@ -169,7 +169,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	suite.Req.Nil(err)
 
 	// Create the container
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -216,7 +216,7 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -233,7 +233,7 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -249,7 +249,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
@@ -283,7 +283,7 @@ func (suite *containerTestSuite) TestContainer_AddRoutedNicValidation() {
 		Name: "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.NoError(err)
 	op.Done(nil)
 	err = c.Update(db.InstanceArgs{
@@ -335,7 +335,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
@@ -349,7 +349,7 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 		Name:      "testFoo",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c.Delete(true) }()
@@ -365,7 +365,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true)
+	}, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c1.Delete(true) }()
@@ -376,7 +376,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true)
+	}, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c2.Delete(true) }()
@@ -408,7 +408,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 		Config: map[string]string{
 			"security.idmap.isolated": "false",
 		},
-	}, true)
+	}, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c1.Delete(true) }()
@@ -419,7 +419,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
 		},
-	}, true)
+	}, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c2.Delete(true) }()
@@ -452,7 +452,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
 			"security.idmap.isolated": "false",
 			"raw.idmap":               "both 1000 1000",
 		},
-	}, true)
+	}, true, true)
 	suite.Req.Nil(err)
 	op.Done(nil)
 	defer func() { _ = c1.Delete(true) }()
@@ -489,7 +489,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 			Config: map[string]string{
 				"security.idmap.isolated": "true",
 			},
-		}, true)
+		}, true, true)
 
 		/* we should fail if there are no ids left */
 		if i != 6 {

--- a/cmd/incusd/instances_post.go
+++ b/cmd/incusd/instances_post.go
@@ -325,7 +325,7 @@ func createFromMigration(s *state.State, r *http.Request, projectName string, pr
 		// Note: At this stage we do not yet know if snapshots are going to be received and so we cannot
 		// create their DB records. This will be done if needed in the migrationSink.Do() function called
 		// as part of the operation below.
-		inst, instOp, cleanup, err = instance.CreateInternal(s, args, true)
+		inst, instOp, cleanup, err = instance.CreateInternal(s, args, true, false)
 		if err != nil {
 			return response.InternalError(fmt.Errorf("Failed creating instance record: %w", err))
 		}

--- a/cmd/incusd/snapshot_common_test.go
+++ b/cmd/incusd/snapshot_common_test.go
@@ -17,7 +17,7 @@ func (suite *containerTestSuite) TestSnapshotScheduling() {
 		Name:      "hal9000",
 	}
 
-	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true)
+	c, op, _, err := instance.CreateInternal(suite.d.State(), args, true, true)
 	suite.Req.Nil(err)
 	suite.Equal(true, snapshotIsScheduledNow("* * * * *",
 		int64(c.ID())),

--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -711,7 +711,7 @@ func (d *common) snapshotCommon(inst instance.Instance, name string, expiry time
 	}
 
 	// Create the snapshot.
-	snap, snapInstOp, cleanup, err := instance.CreateInternal(d.state, args, true)
+	snap, snapInstOp, cleanup, err := instance.CreateInternal(d.state, args, true, true)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance snapshot record %q: %w", name, err)
 	}
@@ -852,6 +852,11 @@ func (d *common) validateStartup(stateful bool, statusCode api.StatusCode) error
 
 	if !storagePools.IsAvailable(rootDiskConf["pool"]) {
 		return api.StatusErrorf(http.StatusServiceUnavailable, "Storage pool %q unavailable on this server", rootDiskConf["pool"])
+	}
+
+	// Validate architecture.
+	if !util.ValueInSlice(d.architecture, d.state.OS.Architectures) {
+		return fmt.Errorf("Requested architecture isn't supported by this host")
 	}
 
 	// Must happen before creating operation Start lock to avoid the status check returning Stopped due to the

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -6135,7 +6135,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 					}
 
 					// Create the snapshot instance.
-					_, snapInstOp, cleanup, err := instance.CreateInternal(d.state, *snapArgs, true)
+					_, snapInstOp, cleanup, err := instance.CreateInternal(d.state, *snapArgs, true, true)
 					if err != nil {
 						return fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
 					}

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -7086,7 +7086,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 					}
 
 					// Create the snapshot instance.
-					_, snapInstOp, cleanup, err := instance.CreateInternal(d.state, *snapArgs, true)
+					_, snapInstOp, cleanup, err := instance.CreateInternal(d.state, *snapArgs, true, true)
 					if err != nil {
 						return fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
 					}

--- a/internal/server/instance/instance_utils.go
+++ b/internal/server/instance/instance_utils.go
@@ -715,7 +715,7 @@ func ValidName(instanceName string, isSnapshot bool) error {
 // Returns the created instance, along with a "create" operation lock that needs to be marked as Done once the
 // instance is fully completed, and a revert fail function that can be used to undo this function if a subsequent
 // step fails.
-func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool) (Instance, *operationlock.InstanceOperation, revert.Hook, error) {
+func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool, checkArchitecture bool) (Instance, *operationlock.InstanceOperation, revert.Hook, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -797,7 +797,7 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool) (Ins
 		return nil, nil, nil, err
 	}
 
-	if !util.ValueInSlice(args.Architecture, s.OS.Architectures) {
+	if checkArchitecture && !util.ValueInSlice(args.Architecture, s.OS.Architectures) {
 		return nil, nil, nil, fmt.Errorf("Requested architecture isn't supported by this host")
 	}
 


### PR DESCRIPTION
1. Disable the architecture check when performing `incus cp`/`incus mv`.
2. Check architecture when trying to run instance.

Fixes: #478 