### PR TITLE
incusd/storage/lvm: Tweak locking in cluster

### DIFF
--- a/internal/server/storage/drivers/driver_lvm_utils.go
+++ b/internal/server/storage/drivers/driver_lvm_utils.go
@@ -778,14 +778,7 @@ func (d *lvm) activateVolume(vol Volume) (bool, error) {
 	}
 
 	if !util.PathExists(volDevPath) {
-		var err error
-		if d.clustered && vol.volType == VolumeTypeVM {
-			// In the clustered case, use a shared activation to allow for live migration.
-			_, err = subprocess.RunCommand("lvchange", "--activate", "sy", "--ignoreactivationskip", volDevPath)
-		} else {
-			_, err = subprocess.RunCommand("lvchange", "--activate", "y", "--ignoreactivationskip", volDevPath)
-		}
-
+		_, err := subprocess.RunCommand("lvchange", "--activate", "y", "--ignoreactivationskip", volDevPath)
 		if err != nil {
 			return false, fmt.Errorf("Failed to activate LVM logical volume %q: %w", volDevPath, err)
 		}


### PR DESCRIPTION
When using a clustered LVM setup and performing live migrations, the logical volumes must be mappable on both the source and target concurently.

This is usually a bad idea and having a volume in that mode also prevents a number of other LVM operations like making snapshots.

So rather than keeping all our VM related volumes in shared mode, let's instead only flip them into sharable mode as part of a migration and flip them back to exclusive mode as soon as possible.