### PR TITLE
incusd/instance/qemu: Cap hotplug CPU slots to 64

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -807,12 +807,16 @@ func (d *qemu) ovmfPath() string {
 func (d *qemu) killQemuProcess(pid int) error {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
+		if err == os.ErrProcessDone {
+			return nil
+		}
+
 		return err
 	}
 
 	err = proc.Kill()
 	if err != nil {
-		if strings.Contains(err.Error(), "process already finished") {
+		if err == os.ErrProcessDone {
 			return nil
 		}
 

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -484,8 +484,16 @@ func qemuCPU(opts *qemuCPUOpts, pinning bool) []cfgSection {
 			return nil
 		}
 
+		// Cap the max number of CPUs to 64 unless directly assigned more.
+		max := 64
+		if int(cpu.Total) < max {
+			max = int(cpu.Total)
+		} else if opts.cpuCount > max {
+			max = opts.cpuCount
+		}
+
 		entries = append(entries, cfgEntry{
-			key: "maxcpus", value: fmt.Sprintf("%d", cpu.Total),
+			key: "maxcpus", value: fmt.Sprintf("%d", max),
 		})
 	}
 

--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -185,7 +185,7 @@ func (d *lvm) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 						break
 					}
 
-					time.Sleep(10*time.Second)
+					time.Sleep(10 * time.Second)
 				}
 			}(volDevPath)
 


### PR DESCRIPTION
QEMU doesn't like dealing with more than 240 hotplug CPU slots and some OS struggle with more than 64, so put a cap to the max exposed CPUs to 64 unless the user has purposefully exposed more.


Sponsored-by: ActivePort (https://www.activeport.com.au)