### PR TITLE
Improve time & date handling

### DIFF
--- a/cmd/incus/cluster.go
+++ b/cmd/incus/cluster.go
@@ -934,7 +934,7 @@ func (c *cmdClusterListTokens) Run(cmd *cobra.Command, args []string) error {
 		displayTokens = append(displayTokens, displayToken{
 			ServerName: joinToken.ServerName,
 			Token:      joinToken.String(),
-			ExpiresAt:  joinToken.ExpiresAt.Format("2006/01/02 15:04 MST"),
+			ExpiresAt:  joinToken.ExpiresAt.Local().Format(dateLayout),
 		})
 	}
 

--- a/cmd/incus/config_trust.go
+++ b/cmd/incus/config_trust.go
@@ -373,8 +373,6 @@ func (c *cmdConfigTrustEdit) Run(cmd *cobra.Command, args []string) error {
 }
 
 // List.
-const layout = "Jan 2, 2006 at 3:04pm (MST)"
-
 type cmdConfigTrustList struct {
 	global      *cmdGlobal
 	config      *cmdConfig
@@ -483,11 +481,11 @@ func (c *cmdConfigTrustList) descriptionColumnData(rowData rowData) string {
 }
 
 func (c *cmdConfigTrustList) issueDateColumnData(rowData rowData) string {
-	return rowData.TlsCert.NotBefore.Format(layout)
+	return rowData.TlsCert.NotBefore.Local().Format(dateLayout)
 }
 
 func (c *cmdConfigTrustList) expiryDateColumnData(rowData rowData) string {
-	return rowData.TlsCert.NotAfter.Format(layout)
+	return rowData.TlsCert.NotAfter.Local().Format(dateLayout)
 }
 
 func (c *cmdConfigTrustList) restrictedColumnData(rowData rowData) string {
@@ -645,7 +643,7 @@ func (c *cmdConfigTrustListTokens) Run(cmd *cobra.Command, args []string) error 
 
 		// Only show the expiry date if available, otherwise show an empty string.
 		if !joinToken.ExpiresAt.IsZero() {
-			expiresAt = joinToken.ExpiresAt.Format("2006/01/02 15:04 MST")
+			expiresAt = joinToken.ExpiresAt.Local().Format(dateLayout)
 		}
 
 		displayTokens = append(displayTokens, displayToken{

--- a/cmd/incus/config_trust.go
+++ b/cmd/incus/config_trust.go
@@ -644,7 +644,7 @@ func (c *cmdConfigTrustListTokens) Run(cmd *cobra.Command, args []string) error 
 		var expiresAt string
 
 		// Only show the expiry date if available, otherwise show an empty string.
-		if joinToken.ExpiresAt.Unix() > 0 {
+		if !joinToken.ExpiresAt.IsZero() {
 			expiresAt = joinToken.ExpiresAt.Format("2006/01/02 15:04 MST")
 		}
 

--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -1002,19 +1002,19 @@ func (c *cmdImageInfo) Run(cmd *cobra.Command, args []string) error {
 	fmt.Printf(i18n.G("Timestamps:") + "\n")
 
 	const layout = "2006/01/02 15:04 UTC"
-	if info.CreatedAt.Unix() != 0 {
+	if !info.CreatedAt.IsZero() {
 		fmt.Printf("    "+i18n.G("Created: %s")+"\n", info.CreatedAt.UTC().Format(layout))
 	}
 
 	fmt.Printf("    "+i18n.G("Uploaded: %s")+"\n", info.UploadedAt.UTC().Format(layout))
 
-	if info.ExpiresAt.Unix() != 0 {
+	if !info.ExpiresAt.IsZero() {
 		fmt.Printf("    "+i18n.G("Expires: %s")+"\n", info.ExpiresAt.UTC().Format(layout))
 	} else {
 		fmt.Printf("    " + i18n.G("Expires: never") + "\n")
 	}
 
-	if info.LastUsedAt.Unix() != 0 {
+	if !info.LastUsedAt.IsZero() {
 		fmt.Printf("    "+i18n.G("Last used: %s")+"\n", info.LastUsedAt.UTC().Format(layout))
 	} else {
 		fmt.Printf("    " + i18n.G("Last used: never") + "\n")

--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -1001,21 +1001,20 @@ func (c *cmdImageInfo) Run(cmd *cobra.Command, args []string) error {
 	fmt.Printf(i18n.G("Public: %s")+"\n", public)
 	fmt.Printf(i18n.G("Timestamps:") + "\n")
 
-	const layout = "2006/01/02 15:04 UTC"
 	if !info.CreatedAt.IsZero() {
-		fmt.Printf("    "+i18n.G("Created: %s")+"\n", info.CreatedAt.UTC().Format(layout))
+		fmt.Printf("    "+i18n.G("Created: %s")+"\n", info.CreatedAt.Local().Format(dateLayout))
 	}
 
-	fmt.Printf("    "+i18n.G("Uploaded: %s")+"\n", info.UploadedAt.UTC().Format(layout))
+	fmt.Printf("    "+i18n.G("Uploaded: %s")+"\n", info.UploadedAt.Local().Format(dateLayout))
 
 	if !info.ExpiresAt.IsZero() {
-		fmt.Printf("    "+i18n.G("Expires: %s")+"\n", info.ExpiresAt.UTC().Format(layout))
+		fmt.Printf("    "+i18n.G("Expires: %s")+"\n", info.ExpiresAt.Local().Format(dateLayout))
 	} else {
 		fmt.Printf("    " + i18n.G("Expires: never") + "\n")
 	}
 
 	if !info.LastUsedAt.IsZero() {
-		fmt.Printf("    "+i18n.G("Last used: %s")+"\n", info.LastUsedAt.UTC().Format(layout))
+		fmt.Printf("    "+i18n.G("Last used: %s")+"\n", info.LastUsedAt.Local().Format(dateLayout))
 	} else {
 		fmt.Printf("    " + i18n.G("Last used: never") + "\n")
 	}
@@ -1213,7 +1212,7 @@ func (c *cmdImageList) typeColumnData(image api.Image) string {
 }
 
 func (c *cmdImageList) uploadDateColumnData(image api.Image) string {
-	return image.UploadedAt.UTC().Format("Jan 2, 2006 at 3:04pm (MST)")
+	return image.UploadedAt.Local().Format(dateLayout)
 }
 
 func (c *cmdImageList) shortestAlias(list []api.ImageAlias) string {

--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -465,8 +465,6 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 		return err
 	}
 
-	const layout = "2006/01/02 15:04 MST"
-
 	fmt.Printf(i18n.G("Name: %s")+"\n", inst.Name)
 
 	fmt.Printf(i18n.G("Status: %s")+"\n", strings.ToUpper(inst.Status))
@@ -492,11 +490,11 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 	}
 
 	if !inst.CreatedAt.IsZero() {
-		fmt.Printf(i18n.G("Created: %s")+"\n", inst.CreatedAt.Local().Format(layout))
+		fmt.Printf(i18n.G("Created: %s")+"\n", inst.CreatedAt.Local().Format(dateLayout))
 	}
 
 	if !inst.LastUsedAt.IsZero() {
-		fmt.Printf(i18n.G("Last Used: %s")+"\n", inst.LastUsedAt.Local().Format(layout))
+		fmt.Printf(i18n.G("Last Used: %s")+"\n", inst.LastUsedAt.Local().Format(dateLayout))
 	}
 
 	if inst.State.Pid != 0 {
@@ -611,13 +609,13 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 			row = append(row, fields[len(fields)-1])
 
 			if !snap.CreatedAt.IsZero() {
-				row = append(row, snap.CreatedAt.Local().Format(layout))
+				row = append(row, snap.CreatedAt.Local().Format(dateLayout))
 			} else {
 				row = append(row, " ")
 			}
 
 			if !snap.ExpiresAt.IsZero() {
-				row = append(row, snap.ExpiresAt.Local().Format(layout))
+				row = append(row, snap.ExpiresAt.Local().Format(dateLayout))
 			} else {
 				row = append(row, " ")
 			}
@@ -656,13 +654,13 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 			row = append(row, backup.Name)
 
 			if !backup.CreatedAt.IsZero() {
-				row = append(row, backup.CreatedAt.Local().Format(layout))
+				row = append(row, backup.CreatedAt.Local().Format(dateLayout))
 			} else {
 				row = append(row, " ")
 			}
 
 			if !backup.ExpiresAt.IsZero() {
-				row = append(row, backup.ExpiresAt.Local().Format(layout))
+				row = append(row, backup.ExpiresAt.Local().Format(dateLayout))
 			} else {
 				row = append(row, " ")
 			}

--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -491,11 +491,11 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 		fmt.Printf(i18n.G("PID: %d")+"\n", inst.State.Pid)
 	}
 
-	if inst.CreatedAt.Unix() != 0 {
+	if !inst.CreatedAt.IsZero() {
 		fmt.Printf(i18n.G("Created: %s")+"\n", inst.CreatedAt.Local().Format(layout))
 	}
 
-	if inst.LastUsedAt.Unix() != 0 {
+	if !inst.LastUsedAt.IsZero() {
 		fmt.Printf(i18n.G("Last Used: %s")+"\n", inst.LastUsedAt.Local().Format(layout))
 	}
 
@@ -610,13 +610,13 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 			fields := strings.Split(snap.Name, instance.SnapshotDelimiter)
 			row = append(row, fields[len(fields)-1])
 
-			if snap.CreatedAt.Unix() != 0 {
+			if !snap.CreatedAt.IsZero() {
 				row = append(row, snap.CreatedAt.Local().Format(layout))
 			} else {
 				row = append(row, " ")
 			}
 
-			if snap.ExpiresAt.Unix() != 0 {
+			if !snap.ExpiresAt.IsZero() {
 				row = append(row, snap.ExpiresAt.Local().Format(layout))
 			} else {
 				row = append(row, " ")
@@ -655,13 +655,13 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 			var row []string
 			row = append(row, backup.Name)
 
-			if backup.CreatedAt.Unix() != 0 {
+			if !backup.CreatedAt.IsZero() {
 				row = append(row, backup.CreatedAt.Local().Format(layout))
 			} else {
 				row = append(row, " ")
 			}
 
-			if backup.ExpiresAt.Unix() != 0 {
+			if !backup.ExpiresAt.IsZero() {
 				row = append(row, backup.ExpiresAt.Local().Format(layout))
 			} else {
 				row = append(row, " ")

--- a/cmd/incus/list.go
+++ b/cmd/incus/list.go
@@ -906,7 +906,7 @@ func (c *cmdList) ProfilesColumnData(cInfo api.InstanceFull) string {
 func (c *cmdList) CreatedColumnData(cInfo api.InstanceFull) string {
 	layout := "2006/01/02 15:04 UTC"
 
-	if cInfo.CreatedAt.Unix() != 0 {
+	if !cInfo.CreatedAt.IsZero() {
 		return cInfo.CreatedAt.UTC().Format(layout)
 	}
 
@@ -916,7 +916,7 @@ func (c *cmdList) CreatedColumnData(cInfo api.InstanceFull) string {
 func (c *cmdList) LastUsedColumnData(cInfo api.InstanceFull) string {
 	layout := "2006/01/02 15:04 UTC"
 
-	if cInfo.LastUsedAt.Unix() != 0 {
+	if !cInfo.LastUsedAt.IsZero() {
 		return cInfo.LastUsedAt.UTC().Format(layout)
 	}
 

--- a/cmd/incus/list.go
+++ b/cmd/incus/list.go
@@ -904,20 +904,16 @@ func (c *cmdList) ProfilesColumnData(cInfo api.InstanceFull) string {
 }
 
 func (c *cmdList) CreatedColumnData(cInfo api.InstanceFull) string {
-	layout := "2006/01/02 15:04 UTC"
-
 	if !cInfo.CreatedAt.IsZero() {
-		return cInfo.CreatedAt.UTC().Format(layout)
+		return cInfo.CreatedAt.Local().Format(dateLayout)
 	}
 
 	return ""
 }
 
 func (c *cmdList) LastUsedColumnData(cInfo api.InstanceFull) string {
-	layout := "2006/01/02 15:04 UTC"
-
 	if !cInfo.LastUsedAt.IsZero() {
-		return cInfo.LastUsedAt.UTC().Format(layout)
+		return cInfo.LastUsedAt.Local().Format(dateLayout)
 	}
 
 	return ""

--- a/cmd/incus/operation.go
+++ b/cmd/incus/operation.go
@@ -157,7 +157,7 @@ func (c *cmdOperationList) Run(cmd *cobra.Command, args []string) error {
 			cancelable = i18n.G("YES")
 		}
 
-		entry := []string{op.ID, strings.ToUpper(op.Class), op.Description, strings.ToUpper(op.Status), cancelable, op.CreatedAt.UTC().Format("2006/01/02 15:04 UTC")}
+		entry := []string{op.ID, strings.ToUpper(op.Class), op.Description, strings.ToUpper(op.Status), cancelable, op.CreatedAt.Local().Format(dateLayout)}
 		if resource.server.IsClustered() {
 			entry = append(entry, op.Location)
 		}

--- a/cmd/incus/snapshot.go
+++ b/cmd/incus/snapshot.go
@@ -321,13 +321,13 @@ func (c *cmdSnapshotList) listSnapshots(d incus.InstanceServer, name string) err
 		fields := strings.Split(snap.Name, instance.SnapshotDelimiter)
 		row = append(row, fields[len(fields)-1])
 
-		if snap.CreatedAt.Unix() != 0 {
+		if !snap.CreatedAt.IsZero() {
 			row = append(row, snap.CreatedAt.Local().Format(layout))
 		} else {
 			row = append(row, " ")
 		}
 
-		if snap.ExpiresAt.Unix() != 0 {
+		if !snap.ExpiresAt.IsZero() {
 			row = append(row, snap.ExpiresAt.Local().Format(layout))
 		} else {
 			row = append(row, " ")

--- a/cmd/incus/snapshot.go
+++ b/cmd/incus/snapshot.go
@@ -311,8 +311,6 @@ func (c *cmdSnapshotList) listSnapshots(d incus.InstanceServer, name string) err
 		return err
 	}
 
-	const layout = "2006/01/02 15:04 MST"
-
 	// List snapshots
 	snapData := [][]string{}
 	for _, snap := range snapshots {
@@ -322,13 +320,13 @@ func (c *cmdSnapshotList) listSnapshots(d incus.InstanceServer, name string) err
 		row = append(row, fields[len(fields)-1])
 
 		if !snap.CreatedAt.IsZero() {
-			row = append(row, snap.CreatedAt.Local().Format(layout))
+			row = append(row, snap.CreatedAt.Local().Format(dateLayout))
 		} else {
 			row = append(row, " ")
 		}
 
 		if !snap.ExpiresAt.IsZero() {
-			row = append(row, snap.ExpiresAt.Local().Format(layout))
+			row = append(row, snap.ExpiresAt.Local().Format(dateLayout))
 		} else {
 			row = append(row, " ")
 		}

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -1269,7 +1269,7 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if vol.CreatedAt.Unix() != 0 {
+	if !vol.CreatedAt.IsZero() {
 		fmt.Printf(i18n.G("Created: %s")+"\n", vol.CreatedAt.Local().Format(layout))
 	}
 
@@ -1322,13 +1322,13 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 			var row []string
 			row = append(row, backup.Name)
 
-			if backup.CreatedAt.Unix() != 0 {
+			if !backup.CreatedAt.IsZero() {
 				row = append(row, backup.CreatedAt.Local().Format(layout))
 			} else {
 				row = append(row, " ")
 			}
 
-			if backup.ExpiresAt.Unix() != 0 {
+			if !backup.ExpiresAt.IsZero() {
 				row = append(row, backup.ExpiresAt.Local().Format(layout))
 			} else {
 				row = append(row, " ")
@@ -2308,13 +2308,13 @@ func (c *cmdStorageVolumeSnapshotList) listSnapshots(d incus.InstanceServer, poo
 		fields := strings.Split(snap.Name, instance.SnapshotDelimiter)
 		row = append(row, fields[len(fields)-1])
 
-		if snap.CreatedAt.Unix() != 0 {
+		if !snap.CreatedAt.IsZero() {
 			row = append(row, snap.CreatedAt.Local().Format(layout))
 		} else {
 			row = append(row, " ")
 		}
 
-		if snap.ExpiresAt != nil && snap.ExpiresAt.Unix() != 0 {
+		if snap.ExpiresAt != nil && !snap.ExpiresAt.IsZero() {
 			row = append(row, snap.ExpiresAt.Local().Format(layout))
 		} else {
 			row = append(row, " ")

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -1239,8 +1239,6 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Render the overview.
-	const layout = "2006/01/02 15:04 MST"
-
 	fmt.Printf(i18n.G("Name: %s")+"\n", vol.Name)
 	if vol.Description != "" {
 		fmt.Printf(i18n.G("Description: %s")+"\n", vol.Description)
@@ -1270,7 +1268,7 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if !vol.CreatedAt.IsZero() {
-		fmt.Printf(i18n.G("Created: %s")+"\n", vol.CreatedAt.Local().Format(layout))
+		fmt.Printf(i18n.G("Created: %s")+"\n", vol.CreatedAt.Local().Format(dateLayout))
 	}
 
 	// List snapshots
@@ -1290,7 +1288,7 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 			row = append(row, snap.Description)
 
 			if snap.ExpiresAt != nil {
-				row = append(row, snap.ExpiresAt.Local().Format(layout))
+				row = append(row, snap.ExpiresAt.Local().Format(dateLayout))
 			} else {
 				row = append(row, " ")
 			}
@@ -1323,13 +1321,13 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 			row = append(row, backup.Name)
 
 			if !backup.CreatedAt.IsZero() {
-				row = append(row, backup.CreatedAt.Local().Format(layout))
+				row = append(row, backup.CreatedAt.Local().Format(dateLayout))
 			} else {
 				row = append(row, " ")
 			}
 
 			if !backup.ExpiresAt.IsZero() {
-				row = append(row, backup.ExpiresAt.Local().Format(layout))
+				row = append(row, backup.ExpiresAt.Local().Format(dateLayout))
 			} else {
 				row = append(row, " ")
 			}
@@ -2297,8 +2295,6 @@ func (c *cmdStorageVolumeSnapshotList) listSnapshots(d incus.InstanceServer, poo
 		return err
 	}
 
-	const layout = "2006/01/02 15:04 MST"
-
 	// List snapshots
 	snapData := [][]string{}
 
@@ -2309,13 +2305,13 @@ func (c *cmdStorageVolumeSnapshotList) listSnapshots(d incus.InstanceServer, poo
 		row = append(row, fields[len(fields)-1])
 
 		if !snap.CreatedAt.IsZero() {
-			row = append(row, snap.CreatedAt.Local().Format(layout))
+			row = append(row, snap.CreatedAt.Local().Format(dateLayout))
 		} else {
 			row = append(row, " ")
 		}
 
 		if snap.ExpiresAt != nil && !snap.ExpiresAt.IsZero() {
-			row = append(row, snap.ExpiresAt.Local().Format(layout))
+			row = append(row, snap.ExpiresAt.Local().Format(dateLayout))
 		} else {
 			row = append(row, " ")
 		}

--- a/cmd/incus/utils.go
+++ b/cmd/incus/utils.go
@@ -18,6 +18,9 @@ import (
 	"github.com/lxc/incus/shared/termios"
 )
 
+// Date layout to be used throughout the client.
+const dateLayout = "2006/01/02 15:04 MST"
+
 // Batch operations.
 type batchResult struct {
 	err  error

--- a/cmd/incus/warning.go
+++ b/cmd/incus/warning.go
@@ -174,11 +174,11 @@ func (c *cmdWarningList) countColumnData(warning api.Warning) string {
 }
 
 func (c *cmdWarningList) firstSeenColumnData(warning api.Warning) string {
-	return warning.FirstSeenAt.UTC().Format("Jan 2, 2006 at 3:04pm (MST)")
+	return warning.FirstSeenAt.Local().Format(dateLayout)
 }
 
 func (c *cmdWarningList) lastSeenColumnData(warning api.Warning) string {
-	return warning.LastSeenAt.UTC().Format("Jan 2, 2006 at 3:04pm (MST)")
+	return warning.LastSeenAt.Local().Format(dateLayout)
 }
 
 func (c *cmdWarningList) locationColumnData(warning api.Warning) string {


### PR DESCRIPTION
This cleans up the rather messy time & date handling we've had in the CLI tool.

With this, we now properly use IsZero() to check whether a timestamp is null and should be ignored. We also now have a `dateLayout` global variable that can be used instead of the past patchwork of dozens of mostly similar date layouts. And lastly, all timestamps are now made to consistently use the local timezone information for rendering.