### PR TITLE
incusd/certificates: Improve token handling when clustered

### DIFF
--- a/cmd/incusd/certificates.go
+++ b/cmd/incusd/certificates.go
@@ -574,19 +574,24 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 					return response.Forbidden(fmt.Errorf("No matching certificate add operation found"))
 				}
 
-				tokenReq, ok := joinOp.Metadata["request"].(api.CertificatesPost)
-				if !ok {
-					return response.InternalError(fmt.Errorf("Bad certificate add operation data"))
-				}
-
 				// Create a new request from the token data as the user isn't allowed to override anything.
-				req = api.CertificatesPost{
-					CertificatePut: api.CertificatePut{
-						Name:       tokenReq.Name,
-						Type:       tokenReq.Type,
-						Restricted: tokenReq.Restricted,
-						Projects:   tokenReq.Projects,
-					},
+				req = api.CertificatesPost{}
+				switch tokenReq := joinOp.Metadata["request"].(type) {
+				case api.CertificatesPost:
+					req.Name = tokenReq.Name
+					req.Type = tokenReq.Type
+					req.Restricted = tokenReq.Restricted
+					req.Projects = tokenReq.Projects
+				case map[string]any:
+					req.Name = tokenReq["name"].(string)
+					req.Type = tokenReq["type"].(string)
+					req.Restricted = tokenReq["restricted"].(bool)
+					for _, project := range tokenReq["projects"].([]any) {
+						req.Projects = append(req.Projects, project.(string))
+					}
+
+				default:
+					return response.InternalError(fmt.Errorf("Bad certificate add operation data"))
 				}
 			} else {
 				return response.Forbidden(nil)


### PR DESCRIPTION
Hi,

I have an Incus cluster which is reachable through a VIP managed by Keepalived. The `core.https_address` of each node is set to listen on the VIP (net.ipv4.ip_nonlocal_bind=1 on each node). To add a remote client I followed this procedure:

1. From one of the node (**not the one with the VIP**), I created a token using `incus config trust add <client_name>`
2. On the client I created a new remote using `incus remote add <remote_name> <token>`

 But unfortunately it failed with a cryptic error message `Error: Failed to create certificate: Bad certificate add operation data`. If I create the token on the node with the VIP, everything is OK.

Digging through the code I discovered that the problem is due to the token operation retrieval. The code assume that the token operation is a local operation but in fact the operation can be a remote one : in my case, the token was created on one node, but the token processing was done on the node with the VIP. This PR fixes this issue.