### PR TITLE
incusd/apparmor/qemu: Silence apparmor failures

### DIFF
--- a/internal/server/apparmor/instance_qemu.go
+++ b/internal/server/apparmor/instance_qemu.go
@@ -71,6 +71,8 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   deny @{PROC}/@{pid}/cgroup r,
   deny /sys/module/apparmor/parameters/enabled r,
   deny /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
+  deny /etc/gss/mech.d/ r,
+  deny /etc/ssl/openssl.cnf r,
 
 {{if .agentPath -}}
   {{ .agentPath }}/ r,


### PR DESCRIPTION
Specifically deny a couple of files that we don't need and were causing some DENIED entries.