### PR TITLE
Continue porting functions to OVSDB

### DIFF
--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -833,6 +833,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	lokiChanged := false
 	oidcChanged := false
 	openFGAChanged := false
+	ovnChanged := false
 	syslogChanged := false
 
 	for key := range clusterChanged {
@@ -866,6 +867,9 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 
 		case "loki.api.url", "loki.auth.username", "loki.auth.password", "loki.api.ca_cert", "loki.instance", "loki.labels", "loki.loglevel", "loki.types":
 			lokiChanged = true
+
+		case "network.ovn.northbound_connection", "network.ovn.ca_cert", "network.ovn.client_cert", "network.ovn.client_key":
+			ovnChanged = true
 
 		case "oidc.issuer", "oidc.client.id", "oidc.audience":
 			oidcChanged = true
@@ -1010,6 +1014,13 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	if openFGAChanged {
 		openfgaAPIURL, openfgaAPIToken, openfgaStoreID, openfgaAuthorizationModelID := d.globalConfig.OpenFGA()
 		err := d.setupOpenFGA(openfgaAPIURL, openfgaAPIToken, openfgaStoreID, openfgaAuthorizationModelID)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ovnChanged {
+		err := d.setupOVN()
 		if err != nil {
 			return err
 		}

--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -827,25 +827,19 @@ func doApi10PreNotifyTriggers(d *Daemon, clusterChanged map[string]string, newCl
 func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]string, nodeConfig *node.Config, clusterConfig *clusterConfig.Config) error {
 	s := d.State()
 
+	acmeChanged := false
 	bgpChanged := false
 	dnsChanged := false
 	lokiChanged := false
-	acmeDomainChanged := false
-	acmeCAURLChanged := false
 	oidcChanged := false
-	syslogSocketChanged := false
 	openFGAChanged := false
+	syslogChanged := false
 
 	for key := range clusterChanged {
 		switch key {
-		case "core.https_trusted_proxy":
-			s.Endpoints.NetworkUpdateTrustedProxy(clusterChanged[key])
-		case "core.proxy_http":
-			fallthrough
-		case "core.proxy_https":
-			fallthrough
-		case "core.proxy_ignore_hosts":
-			daemonConfigSetProxy(d, clusterConfig)
+		case "acme.ca_url", "acme.domain":
+			acmeChanged = true
+
 		case "cluster.images_minimal_replica":
 			err := autoSyncImages(s.ShutdownCtx, s)
 			if err != nil {
@@ -855,37 +849,27 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		case "cluster.offline_threshold":
 			d.gateway.HeartbeatOfflineThreshold = clusterConfig.OfflineThreshold()
 			d.taskClusterHeartbeat.Reset()
-		case "images.auto_update_interval":
-			fallthrough
-		case "images.remote_cache_expiry":
+
+		case "core.bgp_asn":
+			bgpChanged = true
+
+		case "core.https_trusted_proxy":
+			s.Endpoints.NetworkUpdateTrustedProxy(clusterChanged[key])
+
+		case "core.proxy_http", "core.proxy_https", "core.proxy_ignore_hosts":
+			daemonConfigSetProxy(d, clusterConfig)
+
+		case "images.auto_update_interval", "images.remote_cache_expiry":
 			if !s.OS.MockMode {
 				d.taskPruneImages.Reset()
 			}
 
-		case "core.bgp_asn":
-			bgpChanged = true
-		case "loki.api.url":
-			fallthrough
-		case "loki.auth.username":
-			fallthrough
-		case "loki.auth.password":
-			fallthrough
-		case "loki.api.ca_cert":
-			fallthrough
-		case "loki.instance":
-			fallthrough
-		case "loki.labels":
-			fallthrough
-		case "loki.loglevel":
-			fallthrough
-		case "loki.types":
+		case "loki.api.url", "loki.auth.username", "loki.auth.password", "loki.api.ca_cert", "loki.instance", "loki.labels", "loki.loglevel", "loki.types":
 			lokiChanged = true
-		case "acme.ca_url":
-			acmeCAURLChanged = true
-		case "acme.domain":
-			acmeDomainChanged = true
+
 		case "oidc.issuer", "oidc.client.id", "oidc.audience":
 			oidcChanged = true
+
 		case "openfga.api.url", "openfga.api.token", "openfga.store.id", "openfga.store.model_id":
 			openFGAChanged = true
 		}
@@ -893,14 +877,14 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 
 	for key := range nodeChanged {
 		switch key {
-		case "core.bgp_address":
-			fallthrough
-		case "core.bgp_routerid":
+		case "core.bgp_address", "core.bgp_routerid":
 			bgpChanged = true
+
 		case "core.dns_address":
 			dnsChanged = true
+
 		case "core.syslog_socket":
-			syslogSocketChanged = true
+			syslogChanged = true
 		}
 	}
 
@@ -908,7 +892,6 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	// correlated with others, and need to be processed first (for example
 	// core.https_address need to be processed before
 	// cluster.https_address).
-
 	value, ok := nodeChanged["core.https_address"]
 	if ok {
 		err := s.Endpoints.NetworkUpdateAddress(value)
@@ -969,6 +952,14 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		}
 	}
 
+	// Apply larger changes.
+	if acmeChanged {
+		err := autoRenewCertificate(s.ShutdownCtx, d, true)
+		if err != nil {
+			return err
+		}
+	}
+
 	if bgpChanged {
 		address := nodeConfig.BGPAddress()
 		asn := clusterConfig.BGPASN()
@@ -1002,22 +993,6 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		}
 	}
 
-	if acmeCAURLChanged || acmeDomainChanged {
-		err := autoRenewCertificate(s.ShutdownCtx, d, acmeCAURLChanged)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Compile and load the instance placement scriptlet.
-	value, ok = clusterChanged["instances.placement.scriptlet"]
-	if ok {
-		err := scriptletLoad.InstancePlacementSet(value)
-		if err != nil {
-			return fmt.Errorf("Failed saving instance placement scriptlet: %w", err)
-		}
-	}
-
 	if oidcChanged {
 		oidcIssuer, oidcClientID, oidcAudience := clusterConfig.OIDCServer()
 
@@ -1032,18 +1007,27 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		}
 	}
 
-	if syslogSocketChanged {
+	if openFGAChanged {
+		openfgaAPIURL, openfgaAPIToken, openfgaStoreID, openfgaAuthorizationModelID := d.globalConfig.OpenFGA()
+		err := d.setupOpenFGA(openfgaAPIURL, openfgaAPIToken, openfgaStoreID, openfgaAuthorizationModelID)
+		if err != nil {
+			return err
+		}
+	}
+
+	if syslogChanged {
 		err := d.setupSyslogSocket(nodeConfig.SyslogSocket())
 		if err != nil {
 			return err
 		}
 	}
 
-	if openFGAChanged {
-		openfgaAPIURL, openfgaAPIToken, openfgaStoreID, openfgaAuthorizationModelID := d.globalConfig.OpenFGA()
-		err := d.setupOpenFGA(openfgaAPIURL, openfgaAPIToken, openfgaStoreID, openfgaAuthorizationModelID)
+	// Compile and load the instance placement scriptlet.
+	value, ok = clusterChanged["instances.placement.scriptlet"]
+	if ok {
+		err := scriptletLoad.InstancePlacementSet(value)
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed saving instance placement scriptlet: %w", err)
 		}
 	}
 

--- a/internal/server/device/device_common.go
+++ b/internal/server/device/device_common.go
@@ -27,7 +27,7 @@ type deviceCommon struct {
 // It also needs to be provided with volatile get and set functions for the device to allow
 // persistent data to be accessed. This is implemented as part of deviceCommon so that the majority
 // of devices don't need to implement it and can just embed deviceCommon.
-func (d *deviceCommon) init(inst instance.Instance, state *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) {
+func (d *deviceCommon) init(inst instance.Instance, s *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) error {
 	logCtx := logger.Ctx{"driver": conf["type"], "device": name}
 	if inst != nil {
 		logCtx["project"] = inst.Project().Name
@@ -38,9 +38,11 @@ func (d *deviceCommon) init(inst instance.Instance, state *state.State, name str
 	d.inst = inst
 	d.name = name
 	d.config = conf
-	d.state = state
+	d.state = s
 	d.volatileGet = volatileGet
 	d.volatileSet = volatileSet
+
+	return nil
 }
 
 // Name returns the name of the device.

--- a/internal/server/device/device_interface.go
+++ b/internal/server/device/device_interface.go
@@ -76,7 +76,7 @@ type device interface {
 	Device
 
 	// init stores the Instance, daemon State and Config into device and performs any setup.
-	init(instance.Instance, *state.State, string, deviceConfig.Device, VolatileGetter, VolatileSetter)
+	init(instance.Instance, *state.State, string, deviceConfig.Device, VolatileGetter, VolatileSetter) error
 
 	// validateConfig checks Config stored by init() is valid for the instance type.
 	validateConfig(instance.ConfigReader) error

--- a/internal/server/device/device_load.go
+++ b/internal/server/device/device_load.go
@@ -100,7 +100,10 @@ func load(inst instance.Instance, state *state.State, projectName string, name s
 	}
 
 	// Setup the device's internal variables.
-	dev.init(inst, state, name, conf, volatileGet, volatileSet)
+	err = dev.init(inst, state, name, conf, volatileGet, volatileSet)
+	if err != nil {
+		return nil, fmt.Errorf("Failed loading device %q: %w", name, err)
+	}
 
 	return dev, nil
 }

--- a/internal/server/device/nic_ovn.go
+++ b/internal/server/device/nic_ovn.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lxc/incus/internal/server/network/ovs"
 	"github.com/lxc/incus/internal/server/project"
 	"github.com/lxc/incus/internal/server/resources"
+	"github.com/lxc/incus/internal/server/state"
 	localUtil "github.com/lxc/incus/internal/server/util"
 	"github.com/lxc/incus/shared/api"
 	"github.com/lxc/incus/shared/logger"
@@ -378,6 +379,15 @@ func (d *nicOVN) validateEnvironment() error {
 	}
 
 	return nil
+}
+
+func (d *nicOVN) init(inst instance.Instance, s *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) error {
+	// Check that OVN is available.
+	if s.OVNNB == nil {
+		return fmt.Errorf("OVN isn't currently available")
+	}
+
+	return d.deviceCommon.init(inst, s, name, conf, volatileGet, volatileSet)
 }
 
 // Start is run when the device is added to a running instance or instance is starting up.

--- a/internal/server/network/acl/driver_common.go
+++ b/internal/server/network/acl/driver_common.go
@@ -581,6 +581,7 @@ func (d *common) validatePorts(ports []string) error {
 
 // Update applies the supplied config to the ACL.
 func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType) error {
+	// Validate the configuration.
 	err := d.validateConfig(config)
 	if err != nil {
 		return err
@@ -645,6 +646,11 @@ func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType
 	// If there are affected OVN networks, then apply the changes, but only if the request type is normal.
 	// This way we won't apply the same changes multiple times for each cluster member.
 	if len(aclOVNNets) > 0 && clientType == request.ClientTypeNormal {
+		// Check that OVN is available.
+		if d.state.OVNNB == nil {
+			return fmt.Errorf("OVN isn't currently available")
+		}
+
 		var aclNameIDs map[string]int64
 
 		err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/internal/server/network/acl/driver_common.go
+++ b/internal/server/network/acl/driver_common.go
@@ -18,7 +18,6 @@ import (
 	"github.com/lxc/incus/internal/server/cluster/request"
 	"github.com/lxc/incus/internal/server/db"
 	dbCluster "github.com/lxc/incus/internal/server/db/cluster"
-	"github.com/lxc/incus/internal/server/network/ovn"
 	"github.com/lxc/incus/internal/server/state"
 	localUtil "github.com/lxc/incus/internal/server/util"
 	"github.com/lxc/incus/internal/version"
@@ -646,11 +645,6 @@ func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType
 	// If there are affected OVN networks, then apply the changes, but only if the request type is normal.
 	// This way we won't apply the same changes multiple times for each cluster member.
 	if len(aclOVNNets) > 0 && clientType == request.ClientTypeNormal {
-		ovnnb, err := ovn.NewNB(d.state)
-		if err != nil {
-			return fmt.Errorf("Failed to get OVN client: %w", err)
-		}
-
 		var aclNameIDs map[string]int64
 
 		err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
@@ -669,7 +663,7 @@ func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType
 		// apply those rules to each network affected by the ACL, so pass the full list of OVN networks
 		// affected by this ACL (either because the ACL is assigned directly or because it is assigned to
 		// an OVN NIC in an instance or profile).
-		cleanup, err := OVNEnsureACLs(d.state, d.logger, ovnnb, d.projectName, aclNameIDs, aclOVNNets, []string{d.info.Name}, true)
+		cleanup, err := OVNEnsureACLs(d.state, d.logger, d.state.OVNNB, d.projectName, aclNameIDs, aclOVNNets, []string{d.info.Name}, true)
 		if err != nil {
 			return fmt.Errorf("Failed ensuring ACL is configured in OVN: %w", err)
 		}
@@ -678,7 +672,7 @@ func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType
 
 		// Run unused port group cleanup in case any formerly referenced ACL in this ACL's rules means that
 		// an ACL port group is now considered unused.
-		err = OVNPortGroupDeleteIfUnused(d.state, d.logger, ovnnb, d.projectName, nil, "", d.info.Name)
+		err = OVNPortGroupDeleteIfUnused(d.state, d.logger, d.state.OVNNB, d.projectName, nil, "", d.info.Name)
 		if err != nil {
 			return fmt.Errorf("Failed removing unused OVN port groups: %w", err)
 		}

--- a/internal/server/network/driver_common.go
+++ b/internal/server/network/driver_common.go
@@ -95,18 +95,20 @@ type common struct {
 }
 
 // init initialise internal variables.
-func (n *common) init(state *state.State, id int64, projectName string, netInfo *api.Network, netNodes map[int64]db.NetworkNode) {
+func (n *common) init(s *state.State, id int64, projectName string, netInfo *api.Network, netNodes map[int64]db.NetworkNode) error {
 	n.logger = logger.AddContext(logger.Ctx{"project": projectName, "driver": netInfo.Type, "network": netInfo.Name})
 	n.id = id
 	n.project = projectName
 	n.name = netInfo.Name
 	n.netType = netInfo.Type
 	n.config = netInfo.Config
-	n.state = state
+	n.state = s
 	n.description = netInfo.Description
 	n.status = netInfo.Status
 	n.managed = netInfo.Managed
 	n.nodes = netNodes
+
+	return nil
 }
 
 // FillConfig fills requested config with any default values, by default this is a no-op.

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -2063,7 +2063,7 @@ func (n *ovn) setup(update bool) error {
 	}
 
 	// Create chassis group.
-	err = ovnnb.ChassisGroupAdd(n.getChassisGroupName(), update)
+	err = ovnnb.CreateChassisGroup(context.TODO(), n.getChassisGroupName(), update)
 	if err != nil {
 		return err
 	}
@@ -2101,7 +2101,7 @@ func (n *ovn) setup(update bool) error {
 	}
 
 	if len(extRouterIPs) > 0 {
-		err = ovnnb.LogicalSwitchAdd(n.getExtSwitchName(), update)
+		err = ovnnb.CreateLogicalSwitch(context.TODO(), n.getExtSwitchName(), update)
 		if err != nil {
 			return fmt.Errorf("Failed adding external switch: %w", err)
 		}
@@ -2111,19 +2111,13 @@ func (n *ovn) setup(update bool) error {
 		}
 
 		// Create external router port.
-		err = ovnnb.CreateLogicalRouterPort(context.TODO(), n.getRouterName(), n.getRouterExtPortName(), routerMAC, bridgeMTU, extRouterIPs, update)
+		err = ovnnb.CreateLogicalRouterPort(context.TODO(), n.getRouterName(), n.getRouterExtPortName(), routerMAC, bridgeMTU, extRouterIPs, n.getChassisGroupName(), update)
 		if err != nil {
 			return fmt.Errorf("Failed adding external router port: %w", err)
 		}
 
 		if !update {
 			revert.Add(func() { _ = ovnnb.LogicalRouterPortDelete(n.getRouterExtPortName()) })
-		}
-
-		// Associate external router port to chassis group.
-		err = ovnnb.LogicalRouterPortLinkChassisGroup(n.getRouterExtPortName(), n.getChassisGroupName())
-		if err != nil {
-			return fmt.Errorf("Failed linking external router port to chassis group: %w", err)
 		}
 
 		// Create external switch port and link to router port.
@@ -2304,7 +2298,7 @@ func (n *ovn) setup(update bool) error {
 	}
 
 	// Create internal logical switch if not updating.
-	err = ovnnb.LogicalSwitchAdd(n.getIntSwitchName(), update)
+	err = ovnnb.CreateLogicalSwitch(context.TODO(), n.getIntSwitchName(), update)
 	if err != nil {
 		return fmt.Errorf("Failed adding internal switch: %w", err)
 	}
@@ -2345,7 +2339,7 @@ func (n *ovn) setup(update bool) error {
 	}
 
 	// Create internal router port.
-	err = ovnnb.CreateLogicalRouterPort(context.TODO(), n.getRouterName(), n.getRouterIntPortName(), routerMAC, bridgeMTU, intRouterIPs, update)
+	err = ovnnb.CreateLogicalRouterPort(context.TODO(), n.getRouterName(), n.getRouterIntPortName(), routerMAC, bridgeMTU, intRouterIPs, "", update)
 	if err != nil {
 		return fmt.Errorf("Failed adding internal router port: %w", err)
 	}

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -2674,9 +2674,9 @@ func (n *ovn) addChassisGroupEntry() error {
 
 	// Generate a random priority from the seed for each node until we find a match for our node ID.
 	// In this way the chassis priority for this node will be set to a per-node stable random value.
-	var priority uint
+	var priority int
 	for _, memberID := range memberIDs {
-		priority = uint(r.Intn(ovnChassisPriorityMax + 1))
+		priority = r.Intn(ovnChassisPriorityMax + 1)
 		if memberID == ourMemberID {
 			break
 		}
@@ -2710,7 +2710,7 @@ func (n *ovn) deleteChassisGroupEntry() error {
 		return fmt.Errorf("Failed getting OVS Chassis ID: %w", err)
 	}
 
-	err = ovnnb.ChassisGroupChassisDelete(n.getChassisGroupName(), chassisID)
+	err = ovnnb.SetChassisGroupPriority(context.TODO(), n.getChassisGroupName(), chassisID, -1)
 	if err != nil {
 		return fmt.Errorf("Failed deleting OVS chassis %q from chassis group %q: %w", chassisID, n.getChassisGroupName(), err)
 	}

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -31,6 +31,7 @@ import (
 	networkOVN "github.com/lxc/incus/internal/server/network/ovn"
 	"github.com/lxc/incus/internal/server/network/ovs"
 	"github.com/lxc/incus/internal/server/project"
+	"github.com/lxc/incus/internal/server/state"
 	localUtil "github.com/lxc/incus/internal/server/util"
 	internalUtil "github.com/lxc/incus/internal/util"
 	"github.com/lxc/incus/shared/api"
@@ -89,6 +90,15 @@ type OVNInstanceNICStopOpts struct {
 // ovn represents an OVN network.
 type ovn struct {
 	common
+}
+
+func (n *ovn) init(s *state.State, id int64, projectName string, netInfo *api.Network, netNodes map[int64]db.NetworkNode) error {
+	// Check that OVN is available.
+	if s != nil && s.OVNNB == nil {
+		return fmt.Errorf("OVN isn't currently available")
+	}
+
+	return n.common.init(s, id, projectName, netInfo, netNodes)
 }
 
 // DBType returns the network type DB ID.

--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -2111,7 +2111,7 @@ func (n *ovn) setup(update bool) error {
 		}
 
 		// Create external router port.
-		err = ovnnb.LogicalRouterPortAdd(n.getRouterName(), n.getRouterExtPortName(), routerMAC, bridgeMTU, extRouterIPs, update)
+		err = ovnnb.CreateLogicalRouterPort(context.TODO(), n.getRouterName(), n.getRouterExtPortName(), routerMAC, bridgeMTU, extRouterIPs, update)
 		if err != nil {
 			return fmt.Errorf("Failed adding external router port: %w", err)
 		}
@@ -2345,7 +2345,7 @@ func (n *ovn) setup(update bool) error {
 	}
 
 	// Create internal router port.
-	err = ovnnb.LogicalRouterPortAdd(n.getRouterName(), n.getRouterIntPortName(), routerMAC, bridgeMTU, intRouterIPs, update)
+	err = ovnnb.CreateLogicalRouterPort(context.TODO(), n.getRouterName(), n.getRouterIntPortName(), routerMAC, bridgeMTU, intRouterIPs, update)
 	if err != nil {
 		return fmt.Errorf("Failed adding internal router port: %w", err)
 	}

--- a/internal/server/network/network_interface.go
+++ b/internal/server/network/network_interface.go
@@ -25,7 +25,7 @@ type Network interface {
 	Type
 
 	// Load.
-	init(state *state.State, id int64, projectName string, netInfo *api.Network, netNodes map[int64]db.NetworkNode)
+	init(s *state.State, id int64, projectName string, netInfo *api.Network, netNodes map[int64]db.NetworkNode) error
 
 	// Config.
 	Validate(config map[string]string) error

--- a/internal/server/network/network_load.go
+++ b/internal/server/network/network_load.go
@@ -35,7 +35,10 @@ func LoadByType(driverType string) (Type, error) {
 	}
 
 	n := driverFunc()
-	n.init(nil, -1, "", &api.Network{Type: driverType}, nil)
+	err := n.init(nil, -1, "", &api.Network{Type: driverType}, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return n, nil
 }
@@ -63,7 +66,10 @@ func LoadByName(s *state.State, projectName string, name string) (Network, error
 	}
 
 	n := driverFunc()
-	n.init(s, id, projectName, netInfo, netNodes)
+	err = n.init(s, id, projectName, netInfo, netNodes)
+	if err != nil {
+		return nil, err
+	}
 
 	return n, nil
 }

--- a/internal/server/network/ovn/ovn_icnb.go
+++ b/internal/server/network/ovn/ovn_icnb.go
@@ -13,7 +13,6 @@ import (
 	ovsdbClient "github.com/ovn-org/libovsdb/client"
 
 	ovnICNB "github.com/lxc/incus/internal/server/network/ovn/schema/ovn-ic-nb"
-	"github.com/lxc/incus/internal/server/state"
 )
 
 // ICNB client.
@@ -23,7 +22,7 @@ type ICNB struct {
 }
 
 // NewICNB initialises new OVN client for Northbound IC operations.
-func NewICNB(s *state.State, dbAddr string, sslCACert string, sslClientCert string, sslClientKey string) (*ICNB, error) {
+func NewICNB(dbAddr string, sslCACert string, sslClientCert string, sslClientKey string) (*ICNB, error) {
 	// Create the NB struct.
 	client := &ICNB{}
 

--- a/internal/server/network/ovn/ovn_icsb.go
+++ b/internal/server/network/ovn/ovn_icsb.go
@@ -14,7 +14,6 @@ import (
 	ovsdbModel "github.com/ovn-org/libovsdb/model"
 
 	ovnICSB "github.com/lxc/incus/internal/server/network/ovn/schema/ovn-ic-nb"
-	"github.com/lxc/incus/internal/server/state"
 )
 
 // ICSB client.
@@ -24,7 +23,7 @@ type ICSB struct {
 }
 
 // NewICSB initialises new OVN client for Southbound IC operations.
-func NewICSB(s *state.State, dbAddr string, sslCACert string, sslClientCert string, sslClientKey string) (*ICSB, error) {
+func NewICSB(dbAddr string, sslCACert string, sslClientCert string, sslClientKey string) (*ICSB, error) {
 	// Create the SB struct.
 	client := &ICSB{}
 

--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -543,17 +543,40 @@ func (o *NB) GetLogicalSwitch(ctx context.Context, switchName OVNSwitch) (*ovnNB
 	return logicalSwitch, nil
 }
 
-// LogicalSwitchAdd adds a named logical switch.
+// CreateLogicalSwitch adds a named logical switch.
 // If mayExist is true, then an existing resource of the same name is not treated as an error.
-func (o *NB) LogicalSwitchAdd(switchName OVNSwitch, mayExist bool) error {
-	args := []string{}
-
-	if mayExist {
-		args = append(args, "--may-exist")
+func (o *NB) CreateLogicalSwitch(ctx context.Context, switchName OVNSwitch, mayExist bool) error {
+	logicalSwitch := ovnNB.LogicalSwitch{
+		Name: string(switchName),
 	}
 
-	args = append(args, "ls-add", string(switchName))
-	_, err := o.nbctl(args...)
+	// Check if already exists.
+	err := o.get(ctx, &logicalSwitch)
+	if err != nil && err != ErrNotFound {
+		return err
+	}
+
+	if logicalSwitch.UUID != "" {
+		if mayExist {
+			return nil
+		}
+
+		return ErrExists
+	}
+
+	// Create the record.
+	operations, err := o.client.Create(&logicalSwitch)
+	if err != nil {
+		return err
+	}
+
+	// Apply the changes.
+	resp, err := o.client.Transact(ctx, operations...)
+	if err != nil {
+		return err
+	}
+
+	_, err = ovsdb.CheckOperationResults(resp, operations)
 	if err != nil {
 		return err
 	}

--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -495,6 +495,20 @@ func (o *NB) LogicalRouterPortLinkChassisGroup(portName OVNRouterPort, haChassis
 	return nil
 }
 
+// GetLogicalSwitch gets the OVN database record for the switch.
+func (o *NB) GetLogicalSwitch(ctx context.Context, switchName OVNSwitch) (*ovnNB.LogicalSwitch, error) {
+	logicalSwitch := &ovnNB.LogicalSwitch{
+		Name: string(switchName),
+	}
+
+	err := o.get(ctx, logicalSwitch)
+	if err != nil {
+		return nil, err
+	}
+
+	return logicalSwitch, nil
+}
+
 // LogicalSwitchAdd adds a named logical switch.
 // If mayExist is true, then an existing resource of the same name is not treated as an error.
 func (o *NB) LogicalSwitchAdd(switchName OVNSwitch, mayExist bool) error {

--- a/internal/server/state/state.go
+++ b/internal/server/state/state.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lxc/incus/internal/server/firewall"
 	"github.com/lxc/incus/internal/server/fsmonitor"
 	"github.com/lxc/incus/internal/server/instance/instancetype"
+	"github.com/lxc/incus/internal/server/network/ovn"
 	"github.com/lxc/incus/internal/server/node"
 	"github.com/lxc/incus/internal/server/sys"
 	localtls "github.com/lxc/incus/shared/tls"
@@ -80,4 +81,8 @@ type State struct {
 
 	// Authorizer.
 	Authorizer auth.Authorizer
+
+	// OVN.
+	OVNNB *ovn.NB
+	OVNSB *ovn.SB
 }


### PR DESCRIPTION
This ports a number of new functions to libovsdb, merges a couple of functions together and most importantly, moves the OVN clients to the state struct so they can be kept around between requests, significantly reducing resource usage.