### PR TITLE
incusd/device/gpu_sriov: Fix default handling

### DIFF
--- a/internal/server/device/gpu_sriov.go
+++ b/internal/server/device/gpu_sriov.go
@@ -178,7 +178,7 @@ func (d *gpuSRIOV) getVF() (string, int, error) {
 		}
 
 		// Prioritize less busy cards.
-		if (float64(len(vfs)) / float64(gpu.SRIOV.CurrentVFs)) > (float64(cardAvailable) / float64(cardTotal)) {
+		if pciAddress == "" || (float64(len(vfs))/float64(gpu.SRIOV.CurrentVFs)) > (float64(cardAvailable)/float64(cardTotal)) {
 			pciAddress = gpu.PCIAddress
 			vfID = vfs[0]
 			cardAvailable = len(vfs)


### PR DESCRIPTION
The NUMA awareness logic re-shuffled some logic which made it so when no NUMA restrictions are in place, no GPU would be found.


Sponsored-by: ActivePort (https://www.activeport.com.au)