### PR TITLE
Introduce `incus-simplestreams`

### DIFF
--- a/cmd/incus-simplestreams/main.go
+++ b/cmd/incus-simplestreams/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lxc/incus/internal/version"
+)
+
+type cmdGlobal struct {
+	flagHelp    bool
+	flagVersion bool
+}
+
+func main() {
+	app := &cobra.Command{}
+	app.Use = "incus-simplestreams"
+	app.Short = "Maintain and Incus-compatible simplestreams tree"
+	app.Long = `Description:
+  Maintain an Incus-compatible simplestreams tree
+
+  This tool makes it easy to manage the files on a static image server
+  using simplestreams index files as the publishing mechanism.
+`
+	app.SilenceUsage = true
+	app.CompletionOptions = cobra.CompletionOptions{DisableDefaultCmd: true}
+
+	// Global flags.
+	globalCmd := cmdGlobal{}
+	app.PersistentFlags().BoolVar(&globalCmd.flagVersion, "version", false, "Print version number")
+	app.PersistentFlags().BoolVarP(&globalCmd.flagHelp, "help", "h", false, "Print help")
+
+	// Help handling.
+	app.SetHelpCommand(&cobra.Command{
+		Use:    "no-help",
+		Hidden: true,
+	})
+
+	// Version handling.
+	app.SetVersionTemplate("{{.Version}}\n")
+	app.Version = version.Version
+
+	// add sub-command.
+	addCmd := cmdAdd{global: &globalCmd}
+	app.AddCommand(addCmd.Command())
+
+	// generate-metadata sub-command.
+	generateMetadataCmd := cmdGenerateMetadata{global: &globalCmd}
+	app.AddCommand(generateMetadataCmd.Command())
+
+	// list sub-command.
+	listCmd := cmdList{global: &globalCmd}
+	app.AddCommand(listCmd.Command())
+
+	// remove sub-command.
+	removeCmd := cmdRemove{global: &globalCmd}
+	app.AddCommand(removeCmd.Command())
+
+	// verify sub-command.
+	verifyCmd := cmdVerify{global: &globalCmd}
+	app.AddCommand(verifyCmd.Command())
+
+	// Run the main command and handle errors.
+	err := app.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+// CheckArgs validates the number of arguments passed to the function and shows the help if incorrect.
+func (c *cmdGlobal) CheckArgs(cmd *cobra.Command, args []string, minArgs int, maxArgs int) (bool, error) {
+	if len(args) < minArgs || (maxArgs != -1 && len(args) > maxArgs) {
+		_ = cmd.Help()
+
+		if len(args) == 0 {
+			return true, nil
+		}
+
+		return true, fmt.Errorf("Invalid number of arguments")
+	}
+
+	return false, nil
+}

--- a/cmd/incus-simplestreams/main_add.go
+++ b/cmd/incus-simplestreams/main_add.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"archive/tar"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	cli "github.com/lxc/incus/internal/cmd"
+	internalUtil "github.com/lxc/incus/internal/util"
+	"github.com/lxc/incus/shared/api"
+	"github.com/lxc/incus/shared/archive"
+	"github.com/lxc/incus/shared/osarch"
+	"github.com/lxc/incus/shared/simplestreams"
+)
+
+type cmdAdd struct {
+	global *cmdGlobal
+}
+
+// Command generates the command definition.
+func (c *cmdAdd) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = "add <metadata tarball> <data file>"
+	cmd.Short = "Add an image"
+	cmd.Long = cli.FormatSection("Description",
+		`Add an image to the server
+
+This command parses the metadata tarball to retrieve the following fields from its metadata.yaml:
+ - architecture
+ - creation_date
+ - properties["description"]
+ - properties["os"]
+ - properties["release"]
+ - properties["variant"]
+ - properties["architecture"]
+
+It then check computes the hash for the new image, confirm it's not
+already on the image server and finally adds it to the index.
+`)
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+// Run runs the actual command logic.
+func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
+	if exit {
+		return err
+	}
+
+	// Open the metadata.
+	metaFile, err := os.Open(args[0])
+	if err != nil {
+		return err
+	}
+
+	defer metaFile.Close()
+
+	// Read the header.
+	_, _, unpacker, err := archive.DetectCompressionFile(metaFile)
+	if err != nil {
+		return err
+	}
+
+	// Get the size.
+	metaStat, err := metaFile.Stat()
+	if err != nil {
+		return err
+	}
+
+	metaSize := metaStat.Size()
+
+	// Get the sha256.
+	_, err = metaFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+
+	hash256 := sha256.New()
+	_, err = io.Copy(hash256, metaFile)
+	if err != nil {
+		return err
+	}
+
+	metaSha256 := fmt.Sprintf("%x", hash256.Sum(nil))
+
+	// Set the metadata paths.
+	metaPath := args[0]
+	metaTargetPath := fmt.Sprintf("images/%s.incus.tar.xz", metaSha256)
+
+	// Go through the tarball.
+	_, err = metaFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+
+	metaTar, metaTarCancel, err := archive.CompressedTarReader(context.Background(), metaFile, unpacker, "")
+	if err != nil {
+		return err
+	}
+
+	defer metaTarCancel()
+
+	var hdr *tar.Header
+	for {
+		hdr, err = metaTar.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return err
+		}
+
+		if hdr.Name == "metadata.yaml" {
+			break
+		}
+	}
+
+	if hdr == nil || hdr.Name != "metadata.yaml" {
+		return fmt.Errorf("Couldn't find metadata.yaml in metadata tarball")
+	}
+
+	// Parse the metadata.
+	metadata := api.ImageMetadata{}
+
+	body, err := io.ReadAll(metaTar)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(body, &metadata)
+	if err != nil {
+		return err
+	}
+
+	// Validate the metadata.
+	_, err = osarch.ArchitectureId(metadata.Architecture)
+	if err != nil {
+		return fmt.Errorf("Invalid architecture in metadata.yaml: %w", err)
+	}
+
+	if metadata.CreationDate == 0 {
+		return fmt.Errorf("Missing creation date in metadata.yaml")
+	}
+
+	for _, prop := range []string{"os", "release", "variant", "architecture", "description"} {
+		_, ok := metadata.Properties[prop]
+		if !ok {
+			return fmt.Errorf("Missing property %q in metadata.yaml", prop)
+		}
+	}
+
+	// Open the data.
+	dataFile, err := os.Open(args[1])
+	if err != nil {
+		return err
+	}
+
+	defer dataFile.Close()
+
+	// Read the header.
+	_, dataExtension, _, err := archive.DetectCompressionFile(dataFile)
+	if err != nil {
+		return err
+	}
+
+	var dataItemType string
+	if dataExtension == ".squashfs" {
+		dataItemType = "squashfs"
+	} else if dataExtension == ".qcow2" {
+		dataItemType = "disk-kvm.img"
+	} else {
+		return fmt.Errorf("Unsupported data type %q", dataExtension)
+	}
+
+	// Get the size.
+	dataStat, err := dataFile.Stat()
+	if err != nil {
+		return err
+	}
+
+	dataSize := dataStat.Size()
+
+	// Get the sha256.
+	_, err = dataFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+
+	hash256 = sha256.New()
+	_, err = io.Copy(hash256, dataFile)
+	if err != nil {
+		return err
+	}
+
+	dataSha256 := fmt.Sprintf("%x", hash256.Sum(nil))
+
+	// Get the combined sha256.
+	_, err = metaFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+
+	_, err = dataFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+
+	hash256 = sha256.New()
+	_, err = io.Copy(hash256, metaFile)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(hash256, dataFile)
+	if err != nil {
+		return err
+	}
+
+	combinedSha256 := fmt.Sprintf("%x", hash256.Sum(nil))
+
+	// Set the data paths.
+	dataPath := args[1]
+	dataTargetPath := fmt.Sprintf("images/%s%s", metaSha256, dataExtension)
+
+	// Create the paths if missing.
+	err = os.MkdirAll("images", 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	err = os.MkdirAll("streams/v1", 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	// Load the images file.
+	products := simplestreams.Products{}
+
+	body, err = os.ReadFile("streams/v1/images.json")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		// Create a blank images file.
+		products = simplestreams.Products{
+			ContentID: "images",
+			DataType:  "image-downloads",
+			Format:    "products:1.0",
+			Products:  map[string]simplestreams.Product{},
+		}
+	} else {
+		// Parse the existing images file.
+		err = json.Unmarshal(body, &products)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Check if the product already exists.
+	productName := fmt.Sprintf("%s:%s:%s:%s", metadata.Properties["os"], metadata.Properties["release"], metadata.Properties["variant"], metadata.Properties["architecture"])
+	product, ok := products.Products[productName]
+	if !ok {
+		// Create a new product.
+		product = simplestreams.Product{
+			Aliases:         fmt.Sprintf("%s/%s/%s", metadata.Properties["os"], metadata.Properties["release"], metadata.Properties["variant"]),
+			Architecture:    metadata.Properties["architecture"],
+			OperatingSystem: metadata.Properties["os"],
+			Release:         metadata.Properties["release"],
+			ReleaseTitle:    metadata.Properties["release"],
+			Variant:         metadata.Properties["variant"],
+			Versions:        map[string]simplestreams.ProductVersion{},
+		}
+	}
+
+	// Check if a version already exists.
+	versionName := time.Unix(metadata.CreationDate, 0).Format("200601021504")
+	version, ok := product.Versions[versionName]
+	if !ok {
+		// Create a new version.
+		version = simplestreams.ProductVersion{
+			Items: map[string]simplestreams.ProductVersionItem{
+				"incus.tar.xz": {
+					FileType:   "incus.tar.xz",
+					HashSha256: metaSha256,
+					Size:       metaSize,
+					Path:       metaTargetPath,
+				},
+			},
+		}
+	} else {
+		// Check that we're dealing with the same metadata.
+		_, ok := version.Items["incus.tar.xz"]
+		if !ok {
+			// No incus.tar.xz found, add it.
+			version.Items["incus.tar.xz"] = simplestreams.ProductVersionItem{
+				FileType:   "incus.tar.xz",
+				HashSha256: metaSha256,
+				Size:       metaSize,
+				Path:       metaTargetPath,
+			}
+		}
+	}
+
+	// Copy the metadata file if missing.
+	err = internalUtil.FileCopy(metaPath, metaTargetPath)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	// Check that the data file isn't already in.
+	_, ok = version.Items[dataItemType]
+	if ok {
+		return fmt.Errorf("Already have a %q file for this image", dataItemType)
+	}
+
+	// Add the file entry.
+	version.Items[dataItemType] = simplestreams.ProductVersionItem{
+		FileType:   dataItemType,
+		HashSha256: dataSha256,
+		Size:       dataSize,
+		Path:       dataTargetPath,
+	}
+
+	// Add the combined hash.
+	metaItem := version.Items["incus.tar.xz"]
+	if dataItemType == "squashfs" {
+		metaItem.CombinedSha256SquashFs = combinedSha256
+	} else if dataItemType == "disk-kvm.img" {
+		metaItem.CombinedSha256DiskKvmImg = combinedSha256
+	}
+
+	version.Items["incus.tar.xz"] = metaItem
+
+	// Copy the data file if missing.
+	err = internalUtil.FileCopy(dataPath, dataTargetPath)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	// Update the version.
+	product.Versions[versionName] = version
+
+	// Update the product.
+	products.Products[productName] = product
+
+	// Write back the images file.
+	body, err = json.Marshal(&products)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile("streams/v1/images.json", body, 0644)
+	if err != nil {
+		return err
+	}
+
+	// Re-generate the index.
+	err = writeIndex(&products)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/incus-simplestreams/main_generate_metadata.go
+++ b/cmd/incus-simplestreams/main_generate_metadata.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"archive/tar"
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+
+	cli "github.com/lxc/incus/internal/cmd"
+	"github.com/lxc/incus/shared/api"
+	"github.com/lxc/incus/shared/osarch"
+)
+
+type cmdGenerateMetadata struct {
+	global *cmdGlobal
+}
+
+// Command generates the command definition.
+func (c *cmdGenerateMetadata) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = "generate-metadata <path>"
+	cmd.Short = "Generate a metadata tarball"
+	cmd.Long = cli.FormatSection("Description",
+		`Generate a metadata tarball
+
+This command produces an incus.tar.xz tarball for use with an existing QCOW2 or squashfs disk image.
+
+This command will prompt for all of the metadata tarball fields:
+ - Operating system name
+ - Release
+ - Variant
+ - Architecture
+ - Description
+`)
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+// Run runs the actual command logic.
+func (c *cmdGenerateMetadata) Run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	if exit {
+		return err
+	}
+
+	// Setup asker.
+	asker := cli.NewAsker(bufio.NewReader(os.Stdin))
+
+	// Create the tarball.
+	metaFile, err := os.Create(args[0])
+	if err != nil {
+		return err
+	}
+
+	defer metaFile.Close()
+
+	// Generate the metadata.
+	timestamp := time.Now().UTC()
+	metadata := api.ImageMetadata{
+		Properties:   map[string]string{},
+		CreationDate: timestamp.Unix(),
+	}
+
+	// Question - os
+	metaOS, err := asker.AskString("Operating system name: ", "", nil)
+	if err != nil {
+		return err
+	}
+
+	metadata.Properties["os"] = metaOS
+
+	// Question - release
+	metaRelease, err := asker.AskString("Release name: ", "", nil)
+	if err != nil {
+		return err
+	}
+
+	metadata.Properties["release"] = metaRelease
+
+	// Question - variant
+	metaVariant, err := asker.AskString("Variant name [default=\"default\"]: ", "default", nil)
+	if err != nil {
+		return err
+	}
+
+	metadata.Properties["variant"] = metaVariant
+
+	// Question - architecture
+	var incusArch string
+	metaArchitecture, err := asker.AskString("Architecture name: ", "", func(value string) error {
+		id, err := osarch.ArchitectureId(value)
+		if err != nil {
+			return err
+		}
+
+		incusArch, err = osarch.ArchitectureName(id)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	metadata.Properties["architecture"] = metaArchitecture
+	metadata.Architecture = incusArch
+
+	// Question - description
+	defaultDescription := fmt.Sprintf("%s %s (%s) (%s) (%s)", metaOS, metaRelease, metaVariant, metaArchitecture, timestamp.Format("200601021504"))
+	metaDescription, err := asker.AskString(fmt.Sprintf("Description [default=\"%s\"]: ", defaultDescription), defaultDescription, nil)
+	if err != nil {
+		return err
+	}
+
+	metadata.Properties["description"] = metaDescription
+
+	// Generate YAML.
+	body, err := yaml.Marshal(&metadata)
+	if err != nil {
+		return err
+	}
+
+	// Prepare the tarball.
+	tarPipeReader, tarPipeWriter := io.Pipe()
+	tarWriter := tar.NewWriter(tarPipeWriter)
+
+	// Compress the tarball.
+	chDone := make(chan error)
+	go func() {
+		cmd := exec.Command("xz", "-9", "-c")
+		cmd.Stdin = tarPipeReader
+		cmd.Stdout = metaFile
+
+		err := cmd.Run()
+		chDone <- err
+	}()
+
+	// Add metadata.yaml.
+	hdr := &tar.Header{
+		Name:    "metadata.yaml",
+		Size:    int64(len(body)),
+		Mode:    0644,
+		Uname:   "root",
+		Gname:   "root",
+		ModTime: time.Now(),
+	}
+
+	err = tarWriter.WriteHeader(hdr)
+	if err != nil {
+		return err
+	}
+
+	_, err = tarWriter.Write(body)
+	if err != nil {
+		return err
+	}
+
+	// Close the tarball.
+	err = tarWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	err = tarPipeWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	err = <-chDone
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/incus-simplestreams/main_list.go
+++ b/cmd/incus-simplestreams/main_list.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	cli "github.com/lxc/incus/internal/cmd"
+	"github.com/lxc/incus/shared/simplestreams"
+)
+
+type cmdList struct {
+	global *cmdGlobal
+
+	flagFormat string
+}
+
+// Command generates the command definition.
+func (c *cmdList) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = "list"
+	cmd.Short = "List all images on the server"
+	cmd.Long = cli.FormatSection("Description",
+		`List all image on the server
+
+This renders a table with all images currently published on the server.
+`)
+	cmd.RunE = c.Run
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", "Format (csv|json|table|yaml|compact)"+"``")
+
+	return cmd
+}
+
+// Run runs the actual command logic.
+func (c *cmdList) Run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 0, 0)
+	if exit {
+		return err
+	}
+
+	// Get a simplestreams client.
+	ss := simplestreams.NewLocalClient("")
+
+	// Get all the images.
+	images, err := ss.ListImages()
+	if err != nil {
+		return err
+	}
+
+	// Generate the table.
+	data := [][]string{}
+	for _, image := range images {
+		data = append(data, []string{image.Fingerprint, image.Properties["description"], image.Properties["os"], image.Properties["release"], image.Properties["variant"], image.Architecture, image.Type, image.CreatedAt.Format("2006/01/02 15:04 MST")})
+	}
+
+	sort.Sort(cli.SortColumnsNaturally(data))
+
+	header := []string{
+		"FINGERPRINT",
+		"DESCRIPTION",
+		"OS",
+		"RELEASE",
+		"VARIANT",
+		"ARCHITECTURE",
+		"TYPE",
+		"CREATED",
+	}
+
+	return cli.RenderTable(c.flagFormat, header, data, data)
+}

--- a/cmd/incus-simplestreams/main_remove.go
+++ b/cmd/incus-simplestreams/main_remove.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	cli "github.com/lxc/incus/internal/cmd"
+	"github.com/lxc/incus/shared/simplestreams"
+)
+
+type cmdRemove struct {
+	global *cmdGlobal
+}
+
+// Command generates the command definition.
+func (c *cmdRemove) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = "remove <fingerprint>"
+	cmd.Short = "Remove an image"
+	cmd.Long = cli.FormatSection("Description",
+		`Remove an image from the server
+
+This command locates the image from its fingerprint and removes it from the index.
+`)
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+// Run runs the actual command logic.
+func (c *cmdRemove) Run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	if exit {
+		return err
+	}
+
+	// Get a simplestreams client.
+	ss := simplestreams.NewLocalClient("")
+
+	// Get the image.
+	image, err := ss.GetImage(args[0])
+	if err != nil {
+		return err
+	}
+
+	// Load the images file.
+	body, err := os.ReadFile("streams/v1/images.json")
+	if err != nil {
+		return err
+	}
+
+	products := simplestreams.Products{}
+	err = json.Unmarshal(body, &products)
+	if err != nil {
+		return err
+	}
+
+	// Delete the image entry.
+	for kProduct, product := range products.Products {
+		if product.OperatingSystem != image.Properties["os"] || product.Release != image.Properties["release"] || product.Variant != image.Properties["variant"] || product.Architecture != image.Properties["architecture"] {
+			continue
+		}
+
+		for kVersion, version := range product.Versions {
+			// Find the incus.tar.xz and figure out what to delete.
+			var deleteDisk bool
+			var deleteSquashfs bool
+			var metadataPath string
+
+			for _, item := range version.Items {
+				if item.FileType != "incus.tar.xz" {
+					continue
+				}
+
+				metadataPath = item.Path
+
+				if item.CombinedSha256DiskKvmImg == image.Fingerprint {
+					deleteDisk = true
+					break
+				}
+
+				if item.CombinedSha256SquashFs == image.Fingerprint {
+					deleteSquashfs = true
+					break
+				}
+			}
+
+			// Delete the entry and associated files.
+			for kItem, item := range version.Items {
+				if deleteDisk && item.FileType == "disk-kvm.img" {
+					err = os.Remove(item.Path)
+					if err != nil && !os.IsNotExist(err) {
+						return err
+					}
+
+					delete(version.Items, kItem)
+					break
+				}
+
+				if deleteSquashfs && item.FileType == "squashfs" {
+					err = os.Remove(item.Path)
+					if err != nil && !os.IsNotExist(err) {
+						return err
+					}
+
+					delete(version.Items, kItem)
+					break
+				}
+			}
+
+			// Delete the version if it's now empty.
+			if len(version.Items) == 1 {
+				err = os.Remove(metadataPath)
+				if err != nil && !os.IsNotExist(err) {
+					return err
+				}
+
+				delete(product.Versions, kVersion)
+			}
+
+			break
+		}
+
+		if len(product.Versions) == 0 {
+			delete(products.Products, kProduct)
+		}
+
+		break
+	}
+
+	// Write back the images file.
+	body, err = json.Marshal(&products)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile("streams/v1/images.json", body, 0644)
+	if err != nil {
+		return err
+	}
+
+	// Re-generate the index.
+	err = writeIndex(&products)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/incus-simplestreams/main_verify.go
+++ b/cmd/incus-simplestreams/main_verify.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	cli "github.com/lxc/incus/internal/cmd"
+	"github.com/lxc/incus/shared/simplestreams"
+)
+
+type cmdVerify struct {
+	global *cmdGlobal
+}
+
+// Command generates the command definition.
+func (c *cmdVerify) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = "verify"
+	cmd.Short = "Verify the integrity of the server"
+	cmd.Long = cli.FormatSection("Description",
+		`Verify the integrity of the server
+
+This command will analyze the image index and for every image and file
+in the index, will validate that the files on disk exist and are of the
+correct size and content.
+`)
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+// Run runs the actual command logic.
+func (c *cmdVerify) Run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 0, 0)
+	if exit {
+		return err
+	}
+
+	// Load the images file.
+	products := simplestreams.Products{}
+
+	body, err := os.ReadFile("streams/v1/images.json")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	// Parse the existing images file.
+	err = json.Unmarshal(body, &products)
+	if err != nil {
+		return err
+	}
+
+	// Go over all the files.
+	for _, product := range products.Products {
+		for _, version := range product.Versions {
+			for _, item := range version.Items {
+				// Open the data.
+				dataFile, err := os.Open(item.Path)
+				if err != nil {
+					if os.IsNotExist(err) {
+						return fmt.Errorf("Missing image file %q", item.Path)
+					}
+
+					return err
+				}
+
+				// Get the size.
+				dataStat, err := dataFile.Stat()
+				if err != nil {
+					return err
+				}
+
+				if item.Size != dataStat.Size() {
+					return fmt.Errorf("File %q has a different size than listed in the index", item.Path)
+				}
+
+				// Get the sha256.
+				_, err = dataFile.Seek(0, 0)
+				if err != nil {
+					return err
+				}
+
+				hash256 := sha256.New()
+				_, err = io.Copy(hash256, dataFile)
+				if err != nil {
+					return err
+				}
+
+				dataSha256 := fmt.Sprintf("%x", hash256.Sum(nil))
+				if item.HashSha256 != dataSha256 {
+					return fmt.Errorf("File %q has a different SHA256 hash than listed in the index", item.Path)
+				}
+
+				// Done with this file.
+				dataFile.Close()
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/incus-simplestreams/utils.go
+++ b/cmd/incus-simplestreams/utils.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/lxc/incus/shared/simplestreams"
+)
+
+func writeIndex(products *simplestreams.Products) error {
+	// Update the product list.
+	productNames := make([]string, 0, len(products.Products))
+	for name := range products.Products {
+		productNames = append(productNames, name)
+	}
+
+	// Write a new index file.
+	stream := simplestreams.Stream{
+		Format: "index:1.0",
+		Index: map[string]simplestreams.StreamIndex{
+			"images": {
+				DataType: "image-downloads",
+				Path:     "streams/v1/images.json",
+				Format:   "products:1.0",
+				Products: productNames,
+			},
+		},
+	}
+
+	body, err := json.Marshal(&stream)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile("streams/v1/index.json", body, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/shared/simplestreams/simplestreams.go
+++ b/shared/simplestreams/simplestreams.go
@@ -18,10 +18,6 @@ import (
 	"github.com/lxc/incus/shared/util"
 )
 
-var urlDefaultOS = map[string]string{
-	"https://cloud-images.ubuntu.com": "ubuntu",
-}
-
 // DownloadableFile represents a file with its URL, hash and size.
 type DownloadableFile struct {
 	Path   string
@@ -213,20 +209,7 @@ func (s *SimpleStreams) applyAliases(images []api.Image) ([]api.Image, []extende
 	// Sort the images so we tag the preferred ones
 	sort.Sort(sortedImages(images))
 
-	// Look for the default OS
-	defaultOS := ""
-	for k, v := range urlDefaultOS {
-		if strings.HasPrefix(s.url, k) {
-			defaultOS = v
-			break
-		}
-	}
-
 	addAlias := func(imageType string, architecture string, name string, fingerprint string) *api.ImageAlias {
-		if defaultOS != "" {
-			name = strings.TrimPrefix(name, fmt.Sprintf("%s/", defaultOS))
-		}
-
 		for _, entry := range aliasesList {
 			if entry.Name == name && entry.Type == imageType && entry.Architecture == architecture {
 				return nil


### PR DESCRIPTION
This adds a new `incus-simplestreams` command that can be used to generate and manage a basic simplestreams image server.