### PR TITLE
internal/server/device: Support bus and device number

### DIFF
--- a/doc/reference/devices_usb.md
+++ b/doc/reference/devices_usb.md
@@ -22,6 +22,8 @@ When a device is passed to the instance, it vanishes from the host.
 
 Key         | Type      | Default           | Description
 :--         | :--       | :--               | :--
+`bus`       | string    | -                 | The bus number of the USB device
+`device`    | string    | -                 | The device number of the USB device
 `gid`       | int       | `0`               | Only for containers: GID of the device owner in the instance
 `mode`      | int       | `0660`            | Only for containers: Mode of the device in the instance
 `productid` | string    | -                 | The product ID of the USB device


### PR DESCRIPTION
If multiple devices with same vendorid and productid are present on the
host, all of these will be attached. There's currently no way of
distinguishing those devices.

This adds support for specifying the bus and device number which are
unique for all USB devices.

Closes #594
