### PR TITLE
lxd-to-incus: Add support for LXD 5.21

### DIFF
--- a/cmd/lxd-to-incus/validate.go
+++ b/cmd/lxd-to-incus/validate.go
@@ -12,7 +12,7 @@ import (
 )
 
 var minLXDVersion = &version.DottedVersion{Major: 4, Minor: 0, Patch: 0}
-var maxLXDVersion = &version.DottedVersion{Major: 5, Minor: 20, Patch: 0}
+var maxLXDVersion = &version.DottedVersion{Major: 5, Minor: 21, Patch: 0}
 
 func (c *cmdMigrate) validate(source source, target target) error {
 	srcClient, err := source.connect()


### PR DESCRIPTION
This is a bit of a trickier one as LXD 5.21 has added new DB tables and so requires a DB downgrade to the 5.20 schema prior to being able to move the data over to Incus.