### PR TITLE
incusd/instance/common: Fix CanMigrate mutating devices

### DIFF
--- a/internal/server/instance/drivers/driver_common.go
+++ b/internal/server/instance/drivers/driver_common.go
@@ -940,10 +940,8 @@ func (d *common) canMigrate(inst instance.Instance) string {
 	}
 
 	// Look at attached devices.
-	volatileGet := func() map[string]string { return map[string]string{} }
-	volatileSet := func(_ map[string]string) error { return nil }
-	for deviceName, rawConfig := range d.ExpandedDevices() {
-		dev, err := device.New(inst, d.state, deviceName, rawConfig, volatileGet, volatileSet)
+	for _, entry := range d.ExpandedDevices().Sorted() {
+		dev, err := d.deviceLoad(inst, entry.Name, entry.Config)
 		if err != nil {
 			logger.Warn("Instance will not be migrated due to a device error", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "device": dev.Name(), "err": err})
 			return "stop"


### PR DESCRIPTION
This was leading to very odd validation errors in some cases if the instance being considered as part of a cluster restore happened to have a network device that would get an otherwise restricted key be internally set.

The root of the issue was that CanMigrate didn't operate against a copy of the devices but would instead mutate the whole devices config, which would then trigger the validation error when sent through the devices logic for the second time as part of startup.

This issue would only hit if:
 - The setup is clustered
 - The cluster is evacuated with action=stop
 - The user askes for the cluster member to be restored
 - The cluster member has one or more instances using a device that internally expands its configuration (like an OVN network card).
 - Those instances process such a device prior to any other check failing CanMigrate.
 - One or more of those instances are local to the server performing the check.


Sponsored-by: Buddy (https://buddy.works)