### PR TITLE
Show the count values in snapshot count mismatch error

### DIFF
--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -6339,7 +6339,7 @@ func (b *backend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Conf
 
 	if len(backupConf.Snapshots) != len(driverSnapshots) {
 		if !deleteMissing {
-			return nil, fmt.Errorf("Snapshot count in backup config and storage device are different: %w", ErrBackupSnapshotsMismatch)
+			return nil, fmt.Errorf("Snapshot count in backup config (%d) and storage device (%d) are different: %w", len(backupConf.Snapshots), len(driverSnapshots), ErrBackupSnapshotsMismatch)
 		}
 	}
 


### PR DESCRIPTION
Should the error message "Snapshot count in backup config and storage device are different" occur, I think it is clearer if the actual count values are shown.

(This is one of the errors which can cause `incus admin recover` to fail)