### PR TITLE
Change incus-agent install location to writeable location

### DIFF
--- a/internal/server/instance/drivers/agent-loader/systemd/incus-agent.service
+++ b/internal/server/instance/drivers/agent-loader/systemd/incus-agent.service
@@ -7,7 +7,7 @@ DefaultDependencies=no
 [Service]
 Type=notify
 WorkingDirectory=-/run/incus_agent
-ExecStartPre=/lib/systemd/incus-agent-setup
+ExecStartPre=TARGET/systemd/incus-agent-setup
 ExecStart=/run/incus_agent/incus-agent
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
By default the install script for incus agent attempts to install to `/lib`. This changes it to write to `/etc` instead. Many systems mount `/usr` read-only and `/lib` is usually a symlink to `/usr/lib`. `/etc/` is normally a writable location on all systems.