### PR TITLE
Add support for creating external interfaces

### DIFF
--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -110,6 +110,10 @@ Key                                  | Type      | Condition             | Defau
 `tunnel.NAME.ttl`                    | integer   | `vxlan`               | `1`                       | Specific TTL to use for multicast routing topologies
 `user.*`                             | string    | -                     | -                         | User-provided free-form key/value pairs
 
+```{note}
+The `bridge.external_interfaces` option supports extended format for the external interfaces when using the `native` driver. The extended format is `<interfaceName>/<parentInterfaceName>/<vlanId>`. When the external interface is added to the list with the extended format, the system will automatically create the interface upon the network's creation and subsequently delete it when the network is terminated. The system verifies that the <interfaceName> does not already exist. If the interface name is in use with a different parent or VLAN ID, or if the creation of the interface is unsuccessful, the system will revert with an error message.
+```
+
 (network-bridge-features)=
 ## Supported features
 

--- a/internal/server/db/networks.go
+++ b/internal/server/db/networks.go
@@ -680,6 +680,13 @@ func (c *ClusterTx) GetNetworkWithInterface(ctx context.Context, devName string)
 		for _, entry := range strings.Split(r[2].(string), ",") {
 			entry = strings.TrimSpace(entry)
 
+			// Test for extended configuration of external interface.
+			entryParts := strings.Split(entry, "/")
+			if len(entryParts) == 3 {
+				// The first part is the interface name.
+				entry = strings.TrimSpace(entryParts[0])
+			}
+
 			if entry == devName {
 				id = r[0].(int64)
 				name = r[1].(string)

--- a/internal/server/db/networks_test.go
+++ b/internal/server/db/networks_test.go
@@ -68,7 +68,7 @@ func TestCreatePendingNetwork(t *testing.T) {
 	_, err = tx.NetworkNodeConfigs(context.Background(), networkID)
 	require.EqualError(t, err, "Network not defined on nodes: none")
 
-	config = map[string]string{"bridge.external_interfaces": "egg"}
+	config = map[string]string{"bridge.external_interfaces": "egg,if1/eth0/1001"}
 	err = tx.CreatePendingNetwork(context.Background(), "none", api.ProjectDefaultName, "network1", db.NetworkTypeBridge, config)
 	require.NoError(t, err)
 
@@ -78,7 +78,7 @@ func TestCreatePendingNetwork(t *testing.T) {
 	assert.Len(t, configs, 3)
 	assert.Equal(t, map[string]string{"bridge.external_interfaces": "foo"}, configs["buzz"])
 	assert.Equal(t, map[string]string{"bridge.external_interfaces": "bar"}, configs["rusp"])
-	assert.Equal(t, map[string]string{"bridge.external_interfaces": "egg"}, configs["none"])
+	assert.Equal(t, map[string]string{"bridge.external_interfaces": "egg,if1/eth0/1001"}, configs["none"])
 }
 
 // If an entry for the given network and node already exists, an error is

--- a/internal/server/ip/utils.go
+++ b/internal/server/ip/utils.go
@@ -1,7 +1,77 @@
 package ip
 
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
 // FamilyV4 represents IPv4 protocol family.
 const FamilyV4 = "-4"
 
 // FamilyV6 represents IPv6 protocol family.
 const FamilyV6 = "-6"
+
+// LinkInfo represents the IP link details.
+type LinkInfo struct {
+	InterfaceName    string `json:"ifname"`
+	Link             string `json:"link"`
+	Master           string `json:"master"`
+	Address          string `json:"address"`
+	TXQueueLength    uint32 `json:"txqlen"`
+	MTU              uint32 `json:"mtu"`
+	OperationalState string `json:"operstate"`
+	Info             struct {
+		Kind      string `json:"info_kind"`
+		SlaveKind string `json:"info_slave_kind"`
+		Data      struct {
+			Protocol string `json:"protocol"`
+			Id       int    `json:"id"`
+		} `json:"info_data"`
+	} `json:"linkinfo"`
+}
+
+// GetLinkInfoByName returns the detailed information for the given link.
+func GetLinkInfoByName(name string) (LinkInfo, error) {
+	ipPath, err := exec.LookPath("ip")
+	if err != nil {
+		return LinkInfo{}, fmt.Errorf("ip command not found")
+	}
+
+	cmd := exec.Command(ipPath, "-j", "-d", "link", "show", name)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return LinkInfo{}, err
+	}
+
+	defer func() { _ = stdout.Close() }()
+
+	err = cmd.Start()
+	if err != nil {
+		return LinkInfo{}, err
+	}
+
+	defer func() { _ = cmd.Wait() }()
+
+	// Struct to decode ip output into.
+	var linkInfoJson []LinkInfo
+
+	// Decode JSON output.
+	dec := json.NewDecoder(stdout)
+	err = dec.Decode(&linkInfoJson)
+	if err != nil && err != io.EOF {
+		return LinkInfo{}, err
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return LinkInfo{}, fmt.Errorf("no matching link found")
+	}
+
+	if len(linkInfoJson) == 0 {
+		return LinkInfo{}, fmt.Errorf("no matching link found")
+	}
+
+	return linkInfoJson[0], nil
+}

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -193,6 +193,7 @@ func (n *bridge) Validate(config map[string]string) error {
 					if err != nil {
 						return fmt.Errorf("Invalid VLAN ID %q: %w", entryParts[2], err)
 					}
+
 					if vlanID < 1 || vlanID > 4094 {
 						return fmt.Errorf("Invalid VLAN ID %q", entryParts[2])
 					}
@@ -779,6 +780,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 					if ok {
 						iface, err = net.InterfaceByName(entry)
 					}
+
 					if !ok || err != nil {
 						return fmt.Errorf("failed to create external interface %q", entry)
 					}
@@ -793,6 +795,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 					if err != nil {
 						return fmt.Errorf("failed to get link info for external interface %q", entry)
 					}
+
 					if linkInfo.Info.Kind != "vlan" || linkInfo.Link != ifParent || linkInfo.Info.Data.Id != vlanID || !(linkInfo.Master == "" || linkInfo.Master == n.name) {
 						return fmt.Errorf("external interface %q already in use", entry)
 					}

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/mdlayher/netx/eui64"
 
-	"github.com/lxc/incus/client"
+	incus "github.com/lxc/incus/client"
 	"github.com/lxc/incus/internal/revert"
 	"github.com/lxc/incus/internal/server/apparmor"
 	"github.com/lxc/incus/internal/server/cluster"
@@ -167,9 +167,35 @@ func (n *bridge) Validate(config map[string]string) error {
 		"bridge.external_interfaces": validate.Optional(func(value string) error {
 			for _, entry := range strings.Split(value, ",") {
 				entry = strings.TrimSpace(entry)
+
+				// Test for extended configuration of external interface.
+				entryParts := strings.Split(entry, "/")
+				if len(entryParts) == 3 {
+					// The first part is the interface name.
+					entry = strings.TrimSpace(entryParts[0])
+				}
+
 				err := validate.IsInterfaceName(entry)
 				if err != nil {
 					return fmt.Errorf("Invalid interface name %q: %w", entry, err)
+				}
+
+				if len(entryParts) == 3 {
+					// Check if the parent interface is valid.
+					parent := strings.TrimSpace(entryParts[1])
+					err := validate.IsInterfaceName(parent)
+					if err != nil {
+						return fmt.Errorf("Invalid interface name %q: %w", parent, err)
+					}
+
+					// Check if the VLAN ID is valid.
+					vlanID, err := strconv.Atoi(entryParts[2])
+					if err != nil {
+						return fmt.Errorf("Invalid VLAN ID %q: %w", entryParts[2], err)
+					}
+					if vlanID < 1 || vlanID > 4094 {
+						return fmt.Errorf("Invalid VLAN ID %q", entryParts[2])
+					}
 				}
 			}
 
@@ -423,6 +449,24 @@ func (n *bridge) Delete(clientType request.ClientType) error {
 		err := n.Stop()
 		if err != nil {
 			return err
+		}
+	}
+
+	// Clean up extended external interfaces
+	if n.config["bridge.external_interfaces"] != "" {
+		for _, entry := range strings.Split(n.config["bridge.external_interfaces"], ",") {
+			entry = strings.TrimSpace(entry)
+			entryParts := strings.Split(entry, "/")
+			if len(entryParts) == 3 {
+				ifName := strings.TrimSpace(entryParts[0])
+				_, err := net.InterfaceByName(ifName)
+				if err == nil {
+					err = InterfaceRemove(ifName)
+					if err != nil {
+						return err
+					}
+				}
+			}
 		}
 	}
 
@@ -711,10 +755,48 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 	if n.config["bridge.external_interfaces"] != "" {
 		for _, entry := range strings.Split(n.config["bridge.external_interfaces"], ",") {
 			entry = strings.TrimSpace(entry)
+
+			// Test for extended configuration of external interface.
+			entryParts := strings.Split(entry, "/")
+			ifParent := ""
+			vlanID := 0
+			if len(entryParts) == 3 && n.config["bridge.driver"] == "native" {
+				vlanID, err = strconv.Atoi(entryParts[2])
+				if err != nil || vlanID < 1 || vlanID > 4094 {
+					vlanID = 0
+					n.logger.Warn("Ignoring invalid VLAN ID", logger.Ctx{"interface": entry, "vlanID": entryParts[2]})
+				} else {
+					entry = strings.TrimSpace(entryParts[0])
+					ifParent = strings.TrimSpace(entryParts[1])
+				}
+			}
+
 			iface, err := net.InterfaceByName(entry)
 			if err != nil {
-				n.logger.Warn("Skipping attaching missing external interface", logger.Ctx{"interface": entry})
-				continue
+				if vlanID > 0 {
+					// If the interface doesn't exist and VLAN ID was provided, create the missing interface.
+					ok, err := VLANInterfaceCreate(ifParent, entry, strconv.Itoa(vlanID), false)
+					if ok {
+						iface, err = net.InterfaceByName(entry)
+					}
+					if !ok || err != nil {
+						return fmt.Errorf("failed to create external interface %q", entry)
+					}
+				} else {
+					n.logger.Warn("Skipping attaching missing external interface", logger.Ctx{"interface": entry})
+					continue
+				}
+			} else {
+				if vlanID > 0 {
+					// If the interface exists and VLAN ID was provided, ensure it has the same parent and VLAN ID and is not attached to a different network.
+					linkInfo, err := ip.GetLinkInfoByName(entry)
+					if err != nil {
+						return fmt.Errorf("failed to get link info for external interface %q", entry)
+					}
+					if linkInfo.Info.Kind != "vlan" || linkInfo.Link != ifParent || linkInfo.Info.Data.Id != vlanID || !(linkInfo.Master == "" || linkInfo.Master == n.name) {
+						return fmt.Errorf("external interface %q already in use", entry)
+					}
+				}
 			}
 
 			unused := true
@@ -1580,10 +1662,26 @@ func (n *bridge) Update(newNetwork api.NetworkPut, targetNode string, clientType
 					continue
 				}
 
-				if !slices.Contains(devices, dev) && InterfaceExists(dev) {
-					err = DetachInterface(n.name, dev)
+				// Test for extended configuration of external interface.
+				ifName := dev
+				devParts := strings.Split(dev, "/")
+				if len(devParts) == 3 {
+					ifName = strings.TrimSpace(devParts[0])
+				}
+
+				if !slices.Contains(devices, dev) && InterfaceExists(ifName) {
+					err = DetachInterface(n.name, ifName)
 					if err != nil {
 						return err
+					}
+
+					// Remove the interface if it exists.
+					_, err := net.InterfaceByName(ifName)
+					if err == nil {
+						err = InterfaceRemove(ifName)
+						if err != nil {
+							return err
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This change extends the format for the `bridge.external_interfaces` value when using the `native` driver. The extended format is `<interfaceName>/<parentInterfaceName>/<vlanId>`. When the external interface is added to the list with the extended format, the system will automatically create the interface upon the network's creation and subsequently delete it when the network is terminated. The system verifies that the <interfaceName> does not already exist. If the interface name is in use with a different parent or VLAN ID, or if the creation of the interface is unsuccessful, the system will revert with an error message.