### PR TITLE
Fix live-migration with extra disks

### DIFF
--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -456,6 +456,25 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		}
 	}
 
+	// Restrict disks allowed when live-migratable.
+	if instConf.Type() == instancetype.VM && util.IsTrue(instConf.ExpandedConfig()["migration.stateful"]) {
+		if d.config["path"] != "" && d.config["path"] != "/" {
+			return fmt.Errorf("Shared filesystem are incompatible with migration.stateful=true")
+		}
+
+		if d.config["pool"] == "" {
+			return fmt.Errorf("Only Incus-managed disks are allowed with migration.stateful=true")
+		}
+
+		if d.config["io.bus"] == "nvme" {
+			return fmt.Errorf("NVME disks aren't supported with migration.stateful=true")
+		}
+
+		if d.config["path"] != "/" && d.pool != nil && !d.pool.Driver().Info().Remote {
+			return fmt.Errorf("Only additional disks coming from a shared storage pool are supported with migration.stateful=true")
+		}
+	}
+
 	return nil
 }
 

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -125,7 +125,6 @@ func (d *disk) CanHotPlug() bool {
 	return true
 }
 
-// validateConfig checks the supplied config for correctness.
 // isRequired indicates whether the supplied device config requires this device to start OK.
 func (d *disk) isRequired(devConfig deviceConfig.Device) bool {
 	// Defaults to required.

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -121,18 +121,7 @@ func (d *disk) sourceIsCeph() bool {
 
 // CanHotPlug returns whether the device can be managed whilst the instance is running.
 func (d *disk) CanHotPlug() bool {
-	// Containers support hot-plugging all disk types.
-	if d.inst.Type() == instancetype.Container {
-		return true
-	}
-
-	// Only VirtioFS works with path hotplug.
-	// As migration.stateful turns off VirtioFS, this also turns off hotplugging of paths.
-	if util.IsTrue(d.inst.ExpandedConfig()["migration.stateful"]) {
-		return false
-	}
-
-	// Block disks can be hot-plugged into VMs.
+	// All disks can be hot-plugged.
 	return true
 }
 

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -387,7 +387,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 					return fmt.Errorf("Failed checking if custom volume is exclusively attached to another instance: %w", err)
 				}
 
-				if remoteInstance != nil {
+				if remoteInstance != nil && remoteInstance.ID != instConf.ID() {
 					return fmt.Errorf("Custom volume is already attached to an instance on a different node")
 				}
 

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -6687,6 +6687,17 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 		defer revert.Fail() // Run the revert fail before the earlier defers.
 
 		d.logger.Debug("Setup temporary migration storage snapshot")
+	} else {
+		// Still set some options for shared storage.
+		capabilities := map[string]bool{
+			// Automatically throttle down the guest to speed up convergence of RAM migration.
+			"auto-converge": true,
+		}
+
+		err = monitor.MigrateSetCapabilities(capabilities)
+		if err != nil {
+			return fmt.Errorf("Failed setting migration capabilities: %w", err)
+		}
 	}
 
 	// Perform storage transfer while instance is still running.

--- a/internal/server/instance/instance_interface.go
+++ b/internal/server/instance/instance_interface.go
@@ -62,6 +62,8 @@ type ConfigReader interface {
 	Project() api.Project
 	Type() instancetype.Type
 	Architecture() int
+	ID() int
+
 	ExpandedConfig() map[string]string
 	ExpandedDevices() deviceConfig.Devices
 	LocalConfig() map[string]string
@@ -127,7 +129,6 @@ type Instance interface {
 	OnHook(hookName string, args map[string]string) error
 
 	// Properties.
-	ID() int
 	Location() string
 	Name() string
 	CloudInitID() string

--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -168,7 +168,7 @@ func (d *lvm) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 		}
 
 		// Mark the volume for shared locking during live migration.
-		if vol.volType == VolumeTypeVM {
+		if vol.volType == VolumeTypeVM || vol.IsCustomBlock() {
 			volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.Name())
 			_, err := subprocess.RunCommand("lvchange", "--activate", "sy", "--ignoreactivationskip", volDevPath)
 			if err != nil {
@@ -870,7 +870,7 @@ func (d *lvm) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 func (d *lvm) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
 	if d.clustered && volSrcArgs.ClusterMove {
 		// Mark the volume for shared locking during live migration.
-		if vol.volType == VolumeTypeVM {
+		if vol.volType == VolumeTypeVM || vol.IsCustomBlock() {
 			// Block volume.
 			volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.Name())
 			_, err := subprocess.RunCommand("lvchange", "--activate", "sy", "--ignoreactivationskip", volDevPath)


### PR DESCRIPTION
This adds a bunch of extra tests for instance disks when `migration.stateful` is set to `true`.
With those checks in place, it's now possible to live-migrate an instance with extra disks so long as those disks are also on a remote storage pool (ceph or lvmcluster).