### PR TITLE
Use /1.0/events when under OpenFGA

### DIFF
--- a/client/incus.go
+++ b/client/incus.go
@@ -366,8 +366,13 @@ func (r *ProtocolIncus) queryStruct(method string, path string, data any, ETag s
 // It sets up an early event listener, performs the query, processes the response, and manages the lifecycle of the event listener.
 func (r *ProtocolIncus) queryOperation(method string, path string, data any, ETag string) (Operation, string, error) {
 	// Attempt to setup an early event listener
+	skipListener := false
 	listener, err := r.GetEvents()
 	if err != nil {
+		if api.StatusErrorCheck(err, http.StatusForbidden) {
+			skipListener = true
+		}
+
 		listener = nil
 	}
 
@@ -393,10 +398,11 @@ func (r *ProtocolIncus) queryOperation(method string, path string, data any, ETa
 
 	// Setup an Operation wrapper
 	op := operation{
-		Operation: *respOperation,
-		r:         r,
-		listener:  listener,
-		chActive:  make(chan bool),
+		Operation:    *respOperation,
+		r:            r,
+		listener:     listener,
+		skipListener: skipListener,
+		chActive:     make(chan bool),
 	}
 
 	// Log the data

--- a/client/incus.go
+++ b/client/incus.go
@@ -197,7 +197,7 @@ func (r *ProtocolIncus) RawWebsocket(path string) (*websocket.Conn, error) {
 // RawOperation allows direct querying of an Incus API endpoint returning
 // background operations.
 func (r *ProtocolIncus) RawOperation(method string, path string, data any, ETag string) (Operation, string, error) {
-	return r.queryOperation(method, path, data, ETag, true)
+	return r.queryOperation(method, path, data, ETag)
 }
 
 // Internal functions.
@@ -363,14 +363,12 @@ func (r *ProtocolIncus) queryStruct(method string, path string, data any, ETag s
 }
 
 // queryOperation sends a query to the Incus server and then converts the response metadata into an Operation object.
-// If useEventListener is true it will set up an early event listener and manage its lifecycle.
-// If useEventListener is false, it will not set up an event listener and calls to Operation.Wait will use the operations API instead.
-// In this case the returned Operation will error if the user calls Operation.AddHandler or Operation.RemoveHandler.
-func (r *ProtocolIncus) queryOperation(method string, path string, data any, ETag string, useEventListener bool) (Operation, string, error) {
-	// Attempt to setup an early event listener if requested.
-	var listener *EventListener
-	if useEventListener {
-		listener, _ = r.GetEvents()
+// It sets up an early event listener, performs the query, processes the response, and manages the lifecycle of the event listener.
+func (r *ProtocolIncus) queryOperation(method string, path string, data any, ETag string) (Operation, string, error) {
+	// Attempt to setup an early event listener
+	listener, err := r.GetEvents()
+	if err != nil {
+		listener = nil
 	}
 
 	// Send the query
@@ -395,11 +393,10 @@ func (r *ProtocolIncus) queryOperation(method string, path string, data any, ETa
 
 	// Setup an Operation wrapper
 	op := operation{
-		Operation:    *respOperation,
-		r:            r,
-		listener:     listener,
-		chActive:     make(chan bool),
-		skipListener: !useEventListener,
+		Operation: *respOperation,
+		r:         r,
+		listener:  listener,
+		chActive:  make(chan bool),
 	}
 
 	// Log the data

--- a/client/incus_certificates.go
+++ b/client/incus_certificates.go
@@ -97,7 +97,7 @@ func (r *ProtocolIncus) CreateCertificateToken(certificate api.CertificatesPost)
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/certificates", certificate, "", true)
+	op, _, err := r.queryOperation("POST", "/certificates", certificate, "")
 	if err != nil {
 		return nil, err
 	}

--- a/client/incus_cluster.go
+++ b/client/incus_cluster.go
@@ -33,7 +33,7 @@ func (r *ProtocolIncus) UpdateCluster(cluster api.ClusterPut, ETag string) (Oper
 		}
 	}
 
-	op, _, err := r.queryOperation("PUT", "/cluster", cluster, "", true)
+	op, _, err := r.queryOperation("PUT", "/cluster", cluster, "")
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (r *ProtocolIncus) CreateClusterMember(member api.ClusterMembersPost) (Oper
 		return nil, fmt.Errorf("The server is missing the required \"clustering_join_token\" API extension")
 	}
 
-	op, _, err := r.queryOperation("POST", "/cluster/members", member, "", true)
+	op, _, err := r.queryOperation("POST", "/cluster/members", member, "")
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func (r *ProtocolIncus) UpdateClusterMemberState(name string, state api.ClusterM
 		return nil, fmt.Errorf("The server is missing the required \"clustering_evacuation\" API extension")
 	}
 
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/cluster/members/%s/state", name), state, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/cluster/members/%s/state", name), state, "")
 	if err != nil {
 		return nil, err
 	}

--- a/client/incus_images.go
+++ b/client/incus_images.go
@@ -415,7 +415,7 @@ func (r *ProtocolIncus) CreateImage(image api.ImagesPost, args *ImageCreateArgs)
 
 	// Send the JSON based request
 	if args == nil {
-		op, _, err := r.queryOperation("POST", "/images", image, "", true)
+		op, _, err := r.queryOperation("POST", "/images", image, "")
 		if err != nil {
 			return nil, err
 		}
@@ -938,7 +938,7 @@ func (r *ProtocolIncus) UpdateImage(fingerprint string, image api.ImagePut, ETag
 // DeleteImage requests that Incus removes an image from the store.
 func (r *ProtocolIncus) DeleteImage(fingerprint string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/images/%s", url.PathEscape(fingerprint)), nil, "", true)
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/images/%s", url.PathEscape(fingerprint)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -953,7 +953,7 @@ func (r *ProtocolIncus) RefreshImage(fingerprint string) (Operation, error) {
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/refresh", url.PathEscape(fingerprint)), nil, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/refresh", url.PathEscape(fingerprint)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -964,7 +964,7 @@ func (r *ProtocolIncus) RefreshImage(fingerprint string) (Operation, error) {
 // CreateImageSecret requests that Incus issues a temporary image secret.
 func (r *ProtocolIncus) CreateImageSecret(fingerprint string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/secret", url.PathEscape(fingerprint)), nil, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/secret", url.PathEscape(fingerprint)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1023,7 +1023,7 @@ func (r *ProtocolIncus) ExportImage(fingerprint string, image api.ImageExportPos
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/export", url.PathEscape(fingerprint)), &image, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/export", url.PathEscape(fingerprint)), &image, "")
 	if err != nil {
 		return nil, err
 	}

--- a/client/incus_instances.go
+++ b/client/incus_instances.go
@@ -1117,8 +1117,7 @@ func (r *ProtocolIncus) ExecInstance(instanceName string, exec api.InstanceExecP
 	}
 
 	// Send the request
-	useEventListener := r.CheckExtension("operation_wait") != nil
-	op, _, err := r.queryOperation("POST", uri, exec, "", useEventListener)
+	op, _, err := r.queryOperation("POST", uri, exec, "", false)
 	if err != nil {
 		return nil, err
 	}
@@ -2436,8 +2435,7 @@ func (r *ProtocolIncus) ConsoleInstance(instanceName string, console api.Instanc
 	}
 
 	// Send the request
-	useEventListener := r.CheckExtension("operation_wait") != nil
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "", useEventListener)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/client/incus_instances.go
+++ b/client/incus_instances.go
@@ -193,7 +193,7 @@ func (r *ProtocolIncus) UpdateInstances(state api.InstancesPut, ETag string) (Op
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s?%s", path, v.Encode()), state, ETag, true)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s?%s", path, v.Encode()), state, ETag)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (r *ProtocolIncus) rebuildInstance(instanceName string, instance api.Instan
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/rebuild", path, url.PathEscape(instanceName)), instance, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/rebuild", path, url.PathEscape(instanceName)), instance, "")
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +523,7 @@ func (r *ProtocolIncus) CreateInstanceFromBackup(args InstanceBackupArgs) (Opera
 
 	if args.PoolName == "" && args.Name == "" {
 		// Send the request
-		op, _, err := r.queryOperation("POST", path, args.BackupFile, "", true)
+		op, _, err := r.queryOperation("POST", path, args.BackupFile, "")
 		if err != nil {
 			return nil, err
 		}
@@ -604,7 +604,7 @@ func (r *ProtocolIncus) CreateInstance(instance api.InstancesPost) (Operation, e
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path, instance, "", true)
+	op, _, err := r.queryOperation("POST", path, instance, "")
 	if err != nil {
 		return nil, err
 	}
@@ -943,7 +943,7 @@ func (r *ProtocolIncus) UpdateInstance(name string, instance api.InstancePut, ET
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, ETag, true)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, ETag)
 	if err != nil {
 		return nil, err
 	}
@@ -964,7 +964,7 @@ func (r *ProtocolIncus) RenameInstance(name string, instance api.InstancePost) (
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1060,7 +1060,7 @@ func (r *ProtocolIncus) MigrateInstance(name string, instance api.InstancePost) 
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1076,7 +1076,7 @@ func (r *ProtocolIncus) DeleteInstance(name string) (Operation, error) {
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), nil, "", true)
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1117,7 +1117,7 @@ func (r *ProtocolIncus) ExecInstance(instanceName string, exec api.InstanceExecP
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", uri, exec, "", false)
+	op, _, err := r.queryOperation("POST", uri, exec, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1711,7 +1711,7 @@ func (r *ProtocolIncus) CreateInstanceSnapshot(instanceName string, snapshot api
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots", path, url.PathEscape(instanceName)), snapshot, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots", path, url.PathEscape(instanceName)), snapshot, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1958,7 +1958,7 @@ func (r *ProtocolIncus) RenameInstanceSnapshot(instanceName string, name string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, "")
 	if err != nil {
 		return nil, err
 	}
@@ -2034,7 +2034,7 @@ func (r *ProtocolIncus) MigrateInstanceSnapshot(instanceName string, name string
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, "")
 	if err != nil {
 		return nil, err
 	}
@@ -2050,7 +2050,7 @@ func (r *ProtocolIncus) DeleteInstanceSnapshot(instanceName string, name string)
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), nil, "", true)
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -2070,7 +2070,7 @@ func (r *ProtocolIncus) UpdateInstanceSnapshot(instanceName string, name string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, ETag, true)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, ETag)
 	if err != nil {
 		return nil, err
 	}
@@ -2112,7 +2112,7 @@ func (r *ProtocolIncus) UpdateInstanceState(name string, state api.InstanceState
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s/state", path, url.PathEscape(name)), state, ETag, true)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s/state", path, url.PathEscape(name)), state, ETag)
 	if err != nil {
 		return nil, err
 	}
@@ -2435,7 +2435,7 @@ func (r *ProtocolIncus) ConsoleInstance(instanceName string, console api.Instanc
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "", false)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "")
 	if err != nil {
 		return nil, err
 	}
@@ -2523,7 +2523,7 @@ func (r *ProtocolIncus) ConsoleInstanceDynamic(instanceName string, console api.
 	}
 
 	// Send the request.
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2729,7 +2729,7 @@ func (r *ProtocolIncus) CreateInstanceBackup(instanceName string, backup api.Ins
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/backups", path, url.PathEscape(instanceName)), backup, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/backups", path, url.PathEscape(instanceName)), backup, "")
 	if err != nil {
 		return nil, err
 	}
@@ -2749,7 +2749,7 @@ func (r *ProtocolIncus) RenameInstanceBackup(instanceName string, name string, b
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/backups/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), backup, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/backups/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), backup, "")
 	if err != nil {
 		return nil, err
 	}
@@ -2769,7 +2769,7 @@ func (r *ProtocolIncus) DeleteInstanceBackup(instanceName string, name string) (
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s/backups/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), nil, "", true)
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s/backups/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/client/incus_projects.go
+++ b/client/incus_projects.go
@@ -115,7 +115,7 @@ func (r *ProtocolIncus) RenameProject(name string, project api.ProjectPost) (Ope
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/projects/%s", url.PathEscape(name)), project, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/projects/%s", url.PathEscape(name)), project, "")
 	if err != nil {
 		return nil, err
 	}

--- a/client/incus_storage_buckets.go
+++ b/client/incus_storage_buckets.go
@@ -249,7 +249,7 @@ func (r *ProtocolIncus) CreateStoragePoolBucketBackup(poolName string, bucketNam
 		return nil, err
 	}
 
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/buckets/%s/backups", url.PathEscape(poolName), url.PathEscape(bucketName)), backup, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/buckets/%s/backups", url.PathEscape(poolName), url.PathEscape(bucketName)), backup, "")
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func (r *ProtocolIncus) DeleteStoragePoolBucketBackup(pool string, bucketName st
 		return nil, err
 	}
 
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/storage-pools/%s/buckets/%s/backups/%s", url.PathEscape(pool), url.PathEscape(bucketName), url.PathEscape(name)), nil, "", true)
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/storage-pools/%s/buckets/%s/backups/%s", url.PathEscape(pool), url.PathEscape(bucketName), url.PathEscape(name)), nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/client/incus_storage_volumes.go
+++ b/client/incus_storage_volumes.go
@@ -231,7 +231,7 @@ func (r *ProtocolIncus) CreateStoragePoolVolumeSnapshot(pool string, volumeType 
 		url.PathEscape(pool),
 		url.PathEscape(volumeType),
 		url.PathEscape(volumeName))
-	op, _, err := r.queryOperation("POST", path, snapshot, "", true)
+	op, _, err := r.queryOperation("POST", path, snapshot, "")
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (r *ProtocolIncus) RenameStoragePoolVolumeSnapshot(pool string, volumeType 
 
 	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots/%s", url.PathEscape(pool), url.PathEscape(volumeType), url.PathEscape(volumeName), url.PathEscape(snapshotName))
 	// Send the request
-	op, _, err := r.queryOperation("POST", path, snapshot, "", true)
+	op, _, err := r.queryOperation("POST", path, snapshot, "")
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func (r *ProtocolIncus) DeleteStoragePoolVolumeSnapshot(pool string, volumeType 
 		"/storage-pools/%s/volumes/%s/%s/snapshots/%s",
 		url.PathEscape(pool), url.PathEscape(volumeType), url.PathEscape(volumeName), url.PathEscape(snapshotName))
 
-	op, _, err := r.queryOperation("DELETE", path, nil, "", true)
+	op, _, err := r.queryOperation("DELETE", path, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +343,7 @@ func (r *ProtocolIncus) UpdateStoragePoolVolumeSnapshot(pool string, volumeType 
 
 	// Send the request
 	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots/%s", url.PathEscape(pool), url.PathEscape(volumeType), url.PathEscape(volumeName), url.PathEscape(snapshotName))
-	_, _, err := r.queryOperation("PUT", path, volume, ETag, true)
+	_, _, err := r.queryOperation("PUT", path, volume, ETag)
 	if err != nil {
 		return err
 	}
@@ -386,7 +386,7 @@ func (r *ProtocolIncus) MigrateStoragePoolVolume(pool string, volume api.Storage
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path, req, "", true)
+	op, _, err := r.queryOperation("POST", path, req, "")
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +475,7 @@ func (r *ProtocolIncus) tryCreateStoragePoolVolume(pool string, req api.StorageV
 
 			// Send the request
 			path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(req.Type))
-			top, _, err := r.queryOperation("POST", path, req, "", true)
+			top, _, err := r.queryOperation("POST", path, req, "")
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
@@ -573,7 +573,7 @@ func (r *ProtocolIncus) CopyStoragePoolVolume(pool string, source InstanceServer
 		}
 
 		// Send the request
-		op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type)), req, "", true)
+		op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type)), req, "")
 		if err != nil {
 			return nil, err
 		}
@@ -622,7 +622,7 @@ func (r *ProtocolIncus) CopyStoragePoolVolume(pool string, source InstanceServer
 		path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type))
 
 		// Send the request
-		op, _, err := r.queryOperation("POST", path, req, "", true)
+		op, _, err := r.queryOperation("POST", path, req, "")
 		if err != nil {
 			return nil, err
 		}
@@ -674,7 +674,7 @@ func (r *ProtocolIncus) CopyStoragePoolVolume(pool string, source InstanceServer
 		path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type))
 
 		// Send the request
-		targetOp, _, err := r.queryOperation("POST", path, req, "", true)
+		targetOp, _, err := r.queryOperation("POST", path, req, "")
 		if err != nil {
 			return nil, err
 		}
@@ -742,7 +742,7 @@ func (r *ProtocolIncus) MoveStoragePoolVolume(pool string, source InstanceServer
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.PathEscape(sourcePool), url.PathEscape(volume.Type), volume.Name), req, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.PathEscape(sourcePool), url.PathEscape(volume.Type), volume.Name), req, "")
 	if err != nil {
 		return nil, err
 	}
@@ -872,7 +872,7 @@ func (r *ProtocolIncus) CreateStoragePoolVolumeBackup(pool string, volName strin
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups", url.PathEscape(pool), url.PathEscape(volName)), backup, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups", url.PathEscape(pool), url.PathEscape(volName)), backup, "")
 	if err != nil {
 		return nil, err
 	}
@@ -887,7 +887,7 @@ func (r *ProtocolIncus) RenameStoragePoolVolumeBackup(pool string, volName strin
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups/%s", url.PathEscape(pool), url.PathEscape(volName), url.PathEscape(name)), backup, "", true)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups/%s", url.PathEscape(pool), url.PathEscape(volName), url.PathEscape(name)), backup, "")
 	if err != nil {
 		return nil, err
 	}
@@ -902,7 +902,7 @@ func (r *ProtocolIncus) DeleteStoragePoolVolumeBackup(pool string, volName strin
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups/%s", url.PathEscape(pool), url.PathEscape(volName), url.PathEscape(name)), nil, "", true)
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups/%s", url.PathEscape(pool), url.PathEscape(volName), url.PathEscape(name)), nil, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
So I expected that this would need a bunch of work in the event handler and operation handler, but after doing a bit of poking, it looks like we've actually added all the needed filtering already and one can actually call `/1.0/events?all-projects=true` today and only get the events that they should be getting (no logging, only operation and lifecycle for projects that they have access to).

I've done a bunch of testing both from the CLI and UI and can indeed only see the expected events.

Closes #292 