### PR TITLE
Improvements to JWT authentication

### DIFF
--- a/internal/server/util/http.go
+++ b/internal/server/util/http.go
@@ -3,7 +3,6 @@ package util
 import (
 	"bytes"
 	"context"
-	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
@@ -333,11 +332,6 @@ func CheckJwtToken(r *http.Request, trustedCerts map[string]x509.Certificate) (b
 		return false, "", nil // certificate not found
 	}
 
-	requestTokenCertPublicKey, ok := requestTokenCert.PublicKey.(*rsa.PublicKey)
-	if !ok {
-		return false, "", nil // certificate public key invalid
-	}
-
 	// Verify the token signature
 	requestTokenSigningString, err := requestToken.SigningString()
 	if err != nil {
@@ -349,7 +343,7 @@ func CheckJwtToken(r *http.Request, trustedCerts map[string]x509.Certificate) (b
 		return false, "", nil // could not decode JWT signature
 	}
 
-	err = requestToken.Method.Verify(requestTokenSigningString, requestTokenSignature, requestTokenCertPublicKey)
+	err = requestToken.Method.Verify(requestTokenSigningString, requestTokenSignature, requestTokenCert.PublicKey)
 	if err != nil {
 		return false, "", nil // signature verification failed
 	}

--- a/test/suites/tls2jwt.sh
+++ b/test/suites/tls2jwt.sh
@@ -17,15 +17,15 @@ test_tls_jwt() {
   [ "$(curl -k -s -H "Authorization: Bearer ${JWT}" "https://${INCUS_ADDR}/1.0/networks" | jq '.error_code')" -eq 403 ]
 
   # Ensure valid token is accepted
-  JWT="$(./tls2jwt/tls2jwt "${INCUS_CONF}/jwt-client.key" "${INCUS_CONF}/jwt-client.crt" now 60)"
+  JWT="$(./tls2jwt/tls2jwt "${INCUS_CONF}/jwt-client.crt" "${INCUS_CONF}/jwt-client.key" now 60)"
   [ "$(curl -k -s -H "Authorization: Bearer ${JWT}" "https://${INCUS_ADDR}/1.0/networks" | jq '.status_code')" -eq 200 ]
 
   # Ensure token not valid yet is not accepted
-  JWT="$(./tls2jwt/tls2jwt "${INCUS_CONF}/jwt-client.key" "${INCUS_CONF}/jwt-client.crt" "2100-01-01T12:00:00Z" 60)"
+  JWT="$(./tls2jwt/tls2jwt "${INCUS_CONF}/jwt-client.crt" "${INCUS_CONF}/jwt-client.key" "2100-01-01T12:00:00Z" 60)"
   [ "$(curl -k -s -H "Authorization: Bearer ${JWT}" "https://${INCUS_ADDR}/1.0/networks" | jq '.error_code')" -eq 403 ]
 
   # Ensure token no longer valid is not accepted
-  JWT="$(./tls2jwt/tls2jwt "${INCUS_CONF}/jwt-client.key" "${INCUS_CONF}/jwt-client.crt" now -60)"
+  JWT="$(./tls2jwt/tls2jwt "${INCUS_CONF}/jwt-client.crt" "${INCUS_CONF}/jwt-client.key" now -60)"
   [ "$(curl -k -s -H "Authorization: Bearer ${JWT}" "https://${INCUS_ADDR}/1.0/networks" | jq '.error_code')" -eq 403 ]
 
   # Cleanup

--- a/test/tls2jwt/tls2jwt.go
+++ b/test/tls2jwt/tls2jwt.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"crypto/rsa"
 	"crypto/sha256"
-	"crypto/x509"
-	"encoding/pem"
-	"errors"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"strconv"
@@ -15,67 +12,19 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-func loadPrivateKey(fileName string) (*rsa.PrivateKey, error) {
-	k, err := os.ReadFile(fileName)
-	if err != nil {
-		return nil, err
-	}
-
-	block, _ := pem.Decode(k)
-	if block == nil || block.Type != "PRIVATE KEY" {
-		return nil, errors.New("Failed to decode PEM block containing the private key")
-	}
-
-	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return key.(*rsa.PrivateKey), nil
-}
-
-func loadCertificate(fileName string) (*x509.Certificate, error) {
-	crt, err := os.ReadFile(fileName)
-	if err != nil {
-		return nil, err
-	}
-
-	block, _ := pem.Decode(crt)
-	if block == nil || block.Type != "CERTIFICATE" {
-		return nil, errors.New("Failed to decode PEM block containing the certificate")
-	}
-
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return cert, nil
-}
-
-func certFingerprint(cert *x509.Certificate) string {
-	return fmt.Sprintf("%x", sha256.Sum256(cert.Raw))
-}
-
 func main() {
 	if len(os.Args) < 5 {
-		fmt.Printf("Usage: %s <private-key-file> <public-certificate-file> <not-before-timestamp> <duration-seconds>\n", os.Args[0])
+		fmt.Printf("Usage: %s <public-certificate-file> <private-key-file> <not-before-timestamp> <duration-seconds>\n", os.Args[0])
 		os.Exit(1)
 	}
 
-	privateKey, err := loadPrivateKey(os.Args[1])
+	keypair, err := tls.LoadX509KeyPair(os.Args[1], os.Args[2])
 	if err != nil {
-		fmt.Printf("Error loading private key: %v\n", err)
+		fmt.Printf("Error loading certificate: %v\n", err)
 		os.Exit(1)
 	}
 
-	clientCert, err := loadCertificate(os.Args[2])
-	if err != nil {
-		fmt.Printf("Error loading client certificate: %v\n", err)
-		os.Exit(1)
-	}
-
-	clientCertFingerprint := certFingerprint(clientCert)
+	clientCertFingerprint := fmt.Sprintf("%x", sha256.Sum256(keypair.Certificate[0]))
 
 	var validFromTime time.Time
 	if strings.ToLower(os.Args[3]) == "now" {
@@ -94,20 +43,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	expirationTime := validFromTime.Add(time.Second * time.Duration(duration))
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, &jwt.RegisteredClaims{
-		Subject:   clientCertFingerprint,
-		IssuedAt:  jwt.NewNumericDate(time.Now()),
-		NotBefore: jwt.NewNumericDate(validFromTime),
-		ExpiresAt: jwt.NewNumericDate(expirationTime),
-	})
+	for _, alg := range []jwt.SigningMethod{jwt.SigningMethodES384, jwt.SigningMethodRS256} {
+		expirationTime := validFromTime.Add(time.Second * time.Duration(duration))
+		token := jwt.NewWithClaims(alg, &jwt.RegisteredClaims{
+			Subject:   clientCertFingerprint,
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(validFromTime),
+			ExpiresAt: jwt.NewNumericDate(expirationTime),
+		})
 
-	tokenString, err := token.SignedString(privateKey)
-	if err != nil {
-		fmt.Printf("Error signing the token: %v\n", err)
-		os.Exit(1)
+		tokenString, err := token.SignedString(keypair.PrivateKey)
+		if err != nil {
+			continue
+		}
+
+		fmt.Println(tokenString)
+		os.Exit(0)
 	}
 
-	fmt.Printf("%s", tokenString)
-	os.Exit(0)
+	fmt.Fprintf(os.Stderr, "Error: Couldn't sign the token (unsupported algorithm?)\n")
+	os.Exit(1)
 }


### PR DESCRIPTION
Includes #693 and adds:
 - Simplification of `tls2jwt`
 - Re-ordering of arguments in `tls2jwt` to be the usual `crt` and then `key`
 - Update tests to match
 - Update server-side logic to not be RSA-specific
 - Update server-side logic to be closer to our usual code-style, remove a type-cast and add a couple more checks

Closes #693