### PR TITLE
Allow to use `--target` flag all together with `--target-project`

### DIFF
--- a/cmd/incus/move.go
+++ b/cmd/incus/move.go
@@ -162,15 +162,11 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf(i18n.G("The --storage flag can't be used with --target"))
 			}
 
-			if c.flagTargetProject != "" {
-				return fmt.Errorf(i18n.G("The --target-project flag can't be used with --target"))
-			}
-
 			if c.flagMode != moveDefaultMode {
 				return fmt.Errorf(i18n.G("The --mode flag can't be used with --target"))
 			}
 
-			return moveClusterInstance(conf, sourceResource, destResource, c.flagTarget, c.global.flagQuiet, stateful)
+			return moveClusterInstance(conf, sourceResource, destResource, c.flagTarget, c.flagTargetProject, c.global.flagQuiet, stateful)
 		}
 
 		dest, err := conf.GetInstanceServer(destRemote)
@@ -252,7 +248,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 }
 
 // Move an instance using special POST /instances/<name>?target=<member> API.
-func moveClusterInstance(conf *config.Config, sourceResource string, destResource string, target string, quiet bool, stateful bool) error {
+func moveClusterInstance(conf *config.Config, sourceResource string, destResource string, target string, targetProject string, quiet bool, stateful bool) error {
 	// Parse the source.
 	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
 	if err != nil {
@@ -292,6 +288,7 @@ func moveClusterInstance(conf *config.Config, sourceResource string, destResourc
 		Name:      destName,
 		Migration: true,
 		Live:      stateful,
+		Project:   targetProject,
 	}
 
 	op, err := source.MigrateInstance(sourceName, req)

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-26 22:04-0400\n"
+"POT-Creation-Date: 2024-03-30 00:35+0100\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -2944,7 +2944,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to configure cluster: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2989,7 +2989,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4722,12 +4722,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -7188,12 +7188,12 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -7204,11 +7204,6 @@ msgstr ""
 #: cmd/incus/move.go:162
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
-msgstr "--refresh kann nur mit Containern verwendet werden"
-
-#: cmd/incus/move.go:166
-#, fuzzy
-msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -7243,7 +7238,7 @@ msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 msgid "The destination server is not clustered"
 msgstr ""
 
@@ -7430,7 +7425,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 msgid "The source server is not clustered"
 msgstr ""
 
@@ -7559,7 +7554,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -8144,7 +8139,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -9839,6 +9834,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-26 22:04-0400\n"
+"POT-Creation-Date: 2024-03-30 00:35+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1106,7 +1106,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -2845,7 +2845,7 @@ msgstr "Acepta certificado"
 msgid "Failed to configure cluster: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2890,7 +2890,7 @@ msgstr "Acepta certificado"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -4561,12 +4561,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -6954,12 +6954,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6970,11 +6970,6 @@ msgstr ""
 #: cmd/incus/move.go:162
 msgid "The --storage flag can't be used with --target"
 msgstr ""
-
-#: cmd/incus/move.go:166
-#, fuzzy
-msgid "The --target-project flag can't be used with --target"
-msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
 #: cmd/incus/admin_init_interactive.go:742
 msgid "The LVM thin provisioning tools couldn't be found on the system"
@@ -7008,7 +7003,7 @@ msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 msgid "The destination server is not clustered"
 msgstr ""
 
@@ -7193,7 +7188,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 msgid "The source server is not clustered"
 msgstr ""
 
@@ -7318,7 +7313,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7883,7 +7878,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -9087,6 +9082,11 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr ""
+#~ "--container-only no se puede pasar cuando la fuente es una instantánea"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-26 22:04-0400\n"
+"POT-Creation-Date: 2024-03-30 00:35+0100\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -1137,7 +1137,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -3055,7 +3055,7 @@ msgstr "Échec de la fermeture du fichier de certificat du serveur %q : %w"
 msgid "Failed to configure cluster: %w"
 msgstr "Échec de la configuration du cluster : %w"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Échec de la connexion au membre du cluster : %w"
@@ -3101,7 +3101,7 @@ msgstr "Échec de la création du certificat : %w"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Échec de la création de la sauvegarde du volume de stockage : %w"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -4937,12 +4937,12 @@ msgstr "Mémoire utilisée :"
 msgid "Memory:"
 msgstr "Mémoire utilisée :"
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -7447,11 +7447,11 @@ msgstr "Le périphérique n'existe pas"
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -7461,10 +7461,6 @@ msgstr ""
 
 #: cmd/incus/move.go:162
 msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -7499,7 +7495,7 @@ msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 msgid "The destination server is not clustered"
 msgstr ""
 
@@ -7696,7 +7692,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 msgid "The source server is not clustered"
 msgstr ""
 
@@ -7826,7 +7822,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -8412,7 +8408,7 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-03-26 22:04-0400\n"
+        "POT-Creation-Date: 2024-03-30 00:35+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -810,7 +810,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370 cmd/incus/network_integration.go:124 cmd/incus/project.go:138
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367 cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -2245,7 +2245,7 @@ msgstr  ""
 msgid   "Failed to configure cluster: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
@@ -2290,7 +2290,7 @@ msgstr  ""
 msgid   "Failed to create storage volume backup: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, c-format
 msgid   "Failed to delete original instance after copying it: %w"
 msgstr  ""
@@ -3843,12 +3843,12 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -5964,11 +5964,11 @@ msgstr  ""
 msgid   "The --instance-only flag can't be used with --target"
 msgstr  ""
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 msgid   "The --mode flag can't be used with --storage or --target-project"
 msgstr  ""
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
@@ -5978,10 +5978,6 @@ msgstr  ""
 
 #: cmd/incus/move.go:162
 msgid   "The --storage flag can't be used with --target"
-msgstr  ""
-
-#: cmd/incus/move.go:166
-msgid   "The --target-project flag can't be used with --target"
 msgstr  ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -6008,7 +6004,7 @@ msgstr  ""
 msgid   "The client automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 msgid   "The destination server is not clustered"
 msgstr  ""
 
@@ -6185,7 +6181,7 @@ msgstr  ""
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 msgid   "The source server is not clustered"
 msgstr  ""
 
@@ -6301,7 +6297,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -6816,7 +6812,7 @@ msgstr  ""
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 msgid   "You must specify a source instance name"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-26 22:04-0400\n"
+"POT-Creation-Date: 2024-03-30 00:35+0100\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -1106,7 +1106,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -2840,7 +2840,7 @@ msgstr "Accetta certificato"
 msgid "Failed to configure cluster: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
@@ -2885,7 +2885,7 @@ msgstr "Accetta certificato"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Accetta certificato"
@@ -4558,12 +4558,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -6949,11 +6949,11 @@ msgstr "La periferica esiste già"
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6963,10 +6963,6 @@ msgstr ""
 
 #: cmd/incus/move.go:162
 msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -7001,7 +6997,7 @@ msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 msgid "The destination server is not clustered"
 msgstr ""
 
@@ -7187,7 +7183,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 msgid "The source server is not clustered"
 msgstr ""
 
@@ -7312,7 +7308,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -7874,7 +7870,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-26 22:04-0400\n"
+"POT-Creation-Date: 2024-03-30 00:35+0100\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -1108,7 +1108,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -2903,7 +2903,7 @@ msgstr "サーバー証明書ファイル %q のクローズに失敗しまし�
 msgid "Failed to configure cluster: %w"
 msgstr "クラスターの設定に失敗しました: %w"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスターメンバへの接続に失敗しました: %w"
@@ -2948,7 +2948,7 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed to create storage volume backup: %w"
 msgstr "ストレージボリュームのバックアップ作成に失敗しました: %w"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "移動元のインスタンスをコピーしたあとの削除に失敗しました: %w"
@@ -4812,12 +4812,12 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -7336,12 +7336,12 @@ msgstr "デバイスはすでに存在します"
 msgid "The --instance-only flag can't be used with --target"
 msgstr "--instance-only と --target は同時に指定できません"
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--mode と --target-project は同時に指定できません"
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
@@ -7352,10 +7352,6 @@ msgstr "--show-log フラグは 'console' アウトプットタイプの時だ�
 #: cmd/incus/move.go:162
 msgid "The --storage flag can't be used with --target"
 msgstr "--storage と --target は同時に指定できません"
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
-msgstr "--target-project と --target は同時に指定できません"
 
 #: cmd/incus/admin_init_interactive.go:742
 msgid "The LVM thin provisioning tools couldn't be found on the system"
@@ -7408,7 +7404,7 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 #, fuzzy
 msgid "The destination server is not clustered"
 msgstr "移動先の LXD サーバはクラスタに属していません"
@@ -7609,7 +7605,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 #, fuzzy
 msgid "The source server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
@@ -7759,7 +7755,7 @@ msgstr "転送モード。pull, push, relay のいずれか。"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -8342,7 +8338,7 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -9632,6 +9628,9 @@ msgstr "y"
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr "yes"
+
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr "--target-project と --target は同時に指定できません"
 
 #~ msgid "STATUS"
 #~ msgstr "STATUS"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-26 22:04-0400\n"
+"POT-Creation-Date: 2024-03-30 00:35+0100\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -1126,7 +1126,7 @@ msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -2823,7 +2823,7 @@ msgstr ""
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -4482,12 +4482,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -6809,11 +6809,11 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6823,10 +6823,6 @@ msgstr ""
 
 #: cmd/incus/move.go:162
 msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -6861,7 +6857,7 @@ msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 msgid "The destination server is not clustered"
 msgstr ""
 
@@ -7046,7 +7042,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 msgid "The source server is not clustered"
 msgstr ""
 
@@ -7170,7 +7166,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -7710,7 +7706,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-26 22:04-0400\n"
+"POT-Creation-Date: 2024-03-30 00:35+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -849,7 +849,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -2542,7 +2542,7 @@ msgstr ""
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2587,7 +2587,7 @@ msgstr ""
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -4197,12 +4197,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -6519,11 +6519,11 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6533,10 +6533,6 @@ msgstr ""
 
 #: cmd/incus/move.go:162
 msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -6571,7 +6567,7 @@ msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 msgid "The destination server is not clustered"
 msgstr ""
 
@@ -6756,7 +6752,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 msgid "The source server is not clustered"
 msgstr ""
 
@@ -6880,7 +6876,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -7420,7 +7416,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-26 22:04-0400\n"
+"POT-Creation-Date: 2024-03-30 00:35+0100\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1116,7 +1116,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -2885,7 +2885,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to configure cluster: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
@@ -2930,7 +2930,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Aceitar certificado"
@@ -4611,12 +4611,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -7033,12 +7033,12 @@ msgstr "Alias %s já existe"
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -7049,11 +7049,6 @@ msgstr ""
 #: cmd/incus/move.go:162
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
-msgstr "--refresh só pode ser usado com containers"
-
-#: cmd/incus/move.go:166
-#, fuzzy
-msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -7088,7 +7083,7 @@ msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 msgid "The destination server is not clustered"
 msgstr ""
 
@@ -7273,7 +7268,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 msgid "The source server is not clustered"
 msgstr ""
 
@@ -7398,7 +7393,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -7970,7 +7965,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -9108,6 +9103,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr "sim"
+
+#, fuzzy
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr "--refresh só pode ser usado com containers"
 
 #, fuzzy
 #~ msgid "Path to the shared block device:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-26 22:04-0400\n"
+"POT-Creation-Date: 2024-03-30 00:35+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1132,7 +1132,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -2886,7 +2886,7 @@ msgstr "Принять сертификат"
 msgid "Failed to configure cluster: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
@@ -2931,7 +2931,7 @@ msgstr "Принять сертификат"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Принять сертификат"
@@ -4622,12 +4622,12 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -7034,11 +7034,11 @@ msgstr "Копирование образа: %s"
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -7048,10 +7048,6 @@ msgstr ""
 
 #: cmd/incus/move.go:162
 msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -7086,7 +7082,7 @@ msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 msgid "The destination server is not clustered"
 msgstr ""
 
@@ -7271,7 +7267,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 msgid "The source server is not clustered"
 msgstr ""
 
@@ -7396,7 +7392,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -7963,7 +7959,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-26 22:04-0400\n"
+"POT-Creation-Date: 2024-03-30 00:35+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -1061,7 +1061,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:367
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -2754,7 +2754,7 @@ msgstr ""
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:277 cmd/incus/move.go:354
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2799,7 +2799,7 @@ msgstr ""
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:244
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -4409,12 +4409,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:296 cmd/incus/move.go:409
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:321 cmd/incus/move.go:414
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -6731,11 +6731,11 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
+#: cmd/incus/move.go:192 cmd/incus/move.go:213
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: cmd/incus/move.go:170
+#: cmd/incus/move.go:166
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6745,10 +6745,6 @@ msgstr ""
 
 #: cmd/incus/move.go:162
 msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -6783,7 +6779,7 @@ msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/move.go:182
+#: cmd/incus/move.go:178
 msgid "The destination server is not clustered"
 msgstr ""
 
@@ -6968,7 +6964,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/move.go:286
+#: cmd/incus/move.go:282
 msgid "The source server is not clustered"
 msgstr ""
 
@@ -7092,7 +7088,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:301
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -7632,7 +7628,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:266 cmd/incus/move.go:343
 msgid "You must specify a source instance name"
 msgstr ""
 


### PR DESCRIPTION
Allow to use `--target` flag all together with `--target-project` when moving instances between cluster members.

Fixes: #590 