### PR TITLE
Add support for creating interfaces through `bridge.external_interfaces`

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2432,4 +2432,5 @@ Those integrations attach to network peers through some new fields:
 * `target_integration` (reference to the integration)
 
 ## `instance_memory_swap_bytes`
+
 This extends `limits.memory.swap` to allow for a total limit in bytes.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2434,3 +2434,7 @@ Those integrations attach to network peers through some new fields:
 ## `instance_memory_swap_bytes`
 
 This extends `limits.memory.swap` to allow for a total limit in bytes.
+
+## `network_bridge_external_create`
+
+This adds the ability for `bridge.external_interfaces` to create a parent interface using a `interface/parent/vlan` syntax.

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -110,6 +110,10 @@ Key                                  | Type      | Condition             | Defau
 `tunnel.NAME.ttl`                    | integer   | `vxlan`               | `1`                       | Specific TTL to use for multicast routing topologies
 `user.*`                             | string    | -                     | -                         | User-provided free-form key/value pairs
 
+```{note}
+The `bridge.external_interfaces` option supports extended format for the external interfaces when using the `native` driver. The extended format is `<interfaceName>/<parentInterfaceName>/<vlanId>`. When the external interface is added to the list with the extended format, the system will automatically create the interface upon the network's creation and subsequently delete it when the network is terminated. The system verifies that the <interfaceName> does not already exist. If the interface name is in use with a different parent or VLAN ID, or if the creation of the interface is unsuccessful, the system will revert with an error message.
+```
+
 (network-bridge-features)=
 ## Supported features
 

--- a/internal/server/db/networks_test.go
+++ b/internal/server/db/networks_test.go
@@ -68,7 +68,7 @@ func TestCreatePendingNetwork(t *testing.T) {
 	_, err = tx.NetworkNodeConfigs(context.Background(), networkID)
 	require.EqualError(t, err, "Network not defined on nodes: none")
 
-	config = map[string]string{"bridge.external_interfaces": "egg"}
+	config = map[string]string{"bridge.external_interfaces": "egg,if1/eth0/1001"}
 	err = tx.CreatePendingNetwork(context.Background(), "none", api.ProjectDefaultName, "network1", db.NetworkTypeBridge, config)
 	require.NoError(t, err)
 
@@ -78,7 +78,7 @@ func TestCreatePendingNetwork(t *testing.T) {
 	assert.Len(t, configs, 3)
 	assert.Equal(t, map[string]string{"bridge.external_interfaces": "foo"}, configs["buzz"])
 	assert.Equal(t, map[string]string{"bridge.external_interfaces": "bar"}, configs["rusp"])
-	assert.Equal(t, map[string]string{"bridge.external_interfaces": "egg"}, configs["none"])
+	assert.Equal(t, map[string]string{"bridge.external_interfaces": "egg,if1/eth0/1001"}, configs["none"])
 }
 
 // If an entry for the given network and node already exists, an error is

--- a/internal/server/ip/utils.go
+++ b/internal/server/ip/utils.go
@@ -1,7 +1,77 @@
 package ip
 
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
 // FamilyV4 represents IPv4 protocol family.
 const FamilyV4 = "-4"
 
 // FamilyV6 represents IPv6 protocol family.
 const FamilyV6 = "-6"
+
+// LinkInfo represents the IP link details.
+type LinkInfo struct {
+	InterfaceName    string `json:"ifname"`
+	Link             string `json:"link"`
+	Master           string `json:"master"`
+	Address          string `json:"address"`
+	TXQueueLength    uint32 `json:"txqlen"`
+	MTU              uint32 `json:"mtu"`
+	OperationalState string `json:"operstate"`
+	Info             struct {
+		Kind      string `json:"info_kind"`
+		SlaveKind string `json:"info_slave_kind"`
+		Data      struct {
+			Protocol string `json:"protocol"`
+			ID       int    `json:"id"`
+		} `json:"info_data"`
+	} `json:"linkinfo"`
+}
+
+// GetLinkInfoByName returns the detailed information for the given link.
+func GetLinkInfoByName(name string) (LinkInfo, error) {
+	ipPath, err := exec.LookPath("ip")
+	if err != nil {
+		return LinkInfo{}, fmt.Errorf("ip command not found")
+	}
+
+	cmd := exec.Command(ipPath, "-j", "-d", "link", "show", name)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return LinkInfo{}, err
+	}
+
+	defer func() { _ = stdout.Close() }()
+
+	err = cmd.Start()
+	if err != nil {
+		return LinkInfo{}, err
+	}
+
+	defer func() { _ = cmd.Wait() }()
+
+	// Struct to decode ip output into.
+	var linkInfoJSON []LinkInfo
+
+	// Decode JSON output.
+	dec := json.NewDecoder(stdout)
+	err = dec.Decode(&linkInfoJSON)
+	if err != nil && err != io.EOF {
+		return LinkInfo{}, err
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return LinkInfo{}, fmt.Errorf("no matching link found")
+	}
+
+	if len(linkInfoJSON) == 0 {
+		return LinkInfo{}, fmt.Errorf("no matching link found")
+	}
+
+	return linkInfoJSON[0], nil
+}

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -407,6 +407,7 @@ var APIExtensions = []string{
 	"image_restriction_nesting",
 	"network_integrations",
 	"instance_memory_swap_bytes",
+	"network_bridge_external_create",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Closes #672 

This includes all the changes from #672 with them split a bit differently, fixes some issues found with `make static-analysis`, adds an API extension and removes some dead code.