### PR TITLE
incusd/project: Allow managed volumes under "allow"

### DIFF
--- a/internal/server/project/permissions.go
+++ b/internal/server/project/permissions.go
@@ -623,10 +623,11 @@ func checkRestrictions(project api.Project, instances []api.Instance, profiles [
 					}
 
 				case "allow":
-					var allowed bool
-					allowed, _ = CheckRestrictedDevicesDiskPaths(project.Config, device["source"])
-					if !allowed {
-						return fmt.Errorf("Disk source path %q not allowed", device["source"])
+					if device["pool"] == "" {
+						allowed, _ := CheckRestrictedDevicesDiskPaths(project.Config, device["source"])
+						if !allowed {
+							return fmt.Errorf("Disk source path %q not allowed", device["source"])
+						}
 					}
 				}
 


### PR DESCRIPTION
There are currently three valid values for `restricted.devices.disk`.

`block` will block everything, `managed` allows only managed volumes and `allow` allows not only managed volumes but also other types like shared host paths.

When under `allow`, `restricted.devices.disk.paths` can be used to limit the host paths that can be passed into the instance.

But that particular restriction should only apply to unmanaged volumes.

Closes #706