### PR TITLE
incusd/network/ovn: Handle chassis group having been deleted

### DIFF
--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -2698,7 +2698,7 @@ func (n *ovn) deleteChassisGroupEntry() error {
 	}
 
 	err = n.state.OVNNB.SetChassisGroupPriority(context.TODO(), n.getChassisGroupName(), chassisID, -1)
-	if err != nil {
+	if err != nil && err != ovs.ErrNotFound {
 		return fmt.Errorf("Failed deleting OVS chassis %q from chassis group %q: %w", chassisID, n.getChassisGroupName(), err)
 	}
 


### PR DESCRIPTION
This case happens when a network was deleted by the cluster leader but some other servers in the cluster are yet to stop the network and remove themselves as chassis in the HA group.

Closes #709