### PR TITLE
Adding USB support to `incus info --resources`

### DIFF
--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -337,6 +337,18 @@ func (c *cmdInfo) renderCPU(cpu api.ResourcesCPUSocket, prefix string) {
 	}
 }
 
+func (c *cmdInfo) renderUSB(usb api.ResourcesUSBDevice, prefix string) {
+	fmt.Printf(prefix+i18n.G("Vendor: %v")+"\n", usb.Vendor)
+	fmt.Printf(prefix+i18n.G("Vendor ID: %v")+"\n", usb.VendorID)
+	fmt.Printf(prefix+i18n.G("Product: %v")+"\n", usb.Product)
+	fmt.Printf(prefix+i18n.G("Product ID: %v")+"\n", usb.ProductID)
+	fmt.Printf(prefix+i18n.G("Bus Address: %v")+"\n", usb.BusAddress)
+	fmt.Printf(prefix+i18n.G("Device Address: %v")+"\n", usb.DeviceAddress)
+	if len(usb.Serial) > 0 {
+		fmt.Printf(prefix+i18n.G("Serial Number: %v")+"\n", usb.Serial)
+	}
+}
+
 func (c *cmdInfo) remoteInfo(d incus.InstanceServer) error {
 	// Targeting
 	if c.flagTarget != "" {
@@ -519,6 +531,17 @@ func (c *cmdInfo) remoteInfo(d incus.InstanceServer) error {
 			}
 		}
 
+		// USB
+		if len(resources.USB.Devices) == 1 {
+			fmt.Printf("\n" + i18n.G("USB device:") + "\n")
+			c.renderUSB(resources.USB.Devices[0], "  ")
+		} else if len(resources.USB.Devices) > 1 {
+			fmt.Printf("\n" + i18n.G("USB devices:") + "\n")
+			for id, usb := range resources.USB.Devices {
+				fmt.Printf("  "+i18n.G("Device %d:")+"\n", id)
+				c.renderUSB(usb, "    ")
+			}
+		}
 		return nil
 	}
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-31 22:12-0400\n"
+"POT-Creation-Date: 2024-04-01 22:06-0400\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid "  Motherboard:"
 msgstr ""
 
@@ -704,7 +704,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:822 cmd/incus/info.go:567
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -1142,7 +1142,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1193,11 +1193,16 @@ msgstr "Erstellt: %s"
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, fuzzy, c-format
+msgid "Bus Address: %v"
+msgstr "Profil %s erstellt\n"
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1217,7 +1222,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, c-format
 msgid "CPU (%s):"
 msgstr "Prozessorauslastung (%s):"
@@ -1226,15 +1231,15 @@ msgstr "Prozessorauslastung (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 msgid "CPU usage:"
 msgstr "Prozessorauslastung:"
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1368,7 +1373,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1899,7 +1904,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1964,7 +1969,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Erstellt: %s"
@@ -2270,6 +2275,15 @@ msgstr "Profil %s erstellt\n"
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
+#: cmd/incus/info.go:542
+#, fuzzy, c-format
+msgid "Device %d:"
+msgstr ""
+"Benutzung: %s\n"
+"\n"
+"Optionen:\n"
+"\n"
+
 #: cmd/incus/config_device.go:197
 #, fuzzy, c-format
 msgid "Device %s added to %s"
@@ -2284,6 +2298,11 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #, fuzzy, c-format
 msgid "Device %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
+
+#: cmd/incus/info.go:347
+#, fuzzy, c-format
+msgid "Device Address: %v"
+msgstr "Profil %s erstellt\n"
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
 #, fuzzy, c-format
@@ -2348,22 +2367,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 #, fuzzy
 msgid "Disk:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 #, fuzzy
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
@@ -2724,7 +2743,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3144,7 +3163,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed validation request: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3262,8 +3281,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476
-#: cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3282,11 +3301,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid "GPUs:"
 msgstr ""
 
@@ -3479,12 +3498,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3530,7 +3549,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
@@ -3708,7 +3727,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 msgid "Instance Only"
 msgstr ""
 
@@ -3939,7 +3958,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
@@ -4359,7 +4378,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4368,7 +4387,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid "Log:"
 msgstr ""
 
@@ -4407,7 +4426,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
@@ -4455,7 +4474,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid "MTU"
 msgstr ""
 
@@ -4728,19 +4747,19 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 msgid "Memory:"
 msgstr ""
 
@@ -5093,11 +5112,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid "NICs:"
 msgstr ""
 
@@ -5113,7 +5132,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5126,7 +5145,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5192,7 +5211,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929
+#: cmd/incus/info.go:576 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5313,7 +5332,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -5403,7 +5422,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5460,7 +5479,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5485,7 +5504,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5519,11 +5538,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5637,7 +5656,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -5647,12 +5666,17 @@ msgstr "Profil %s erstellt\n"
 msgid "Processing aliases failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, fuzzy, c-format
+msgid "Product ID: %v"
+msgstr "Erstellt: %s"
+
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Erstellt: %s"
@@ -6195,7 +6219,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid "Resources:"
 msgstr ""
 
@@ -6298,7 +6322,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6373,7 +6397,12 @@ msgstr "Erstellt: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, fuzzy, c-format
+msgid "Serial Number: %v"
+msgstr "Erstellt: %s"
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr ""
@@ -6382,7 +6411,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Erstellt: %s"
@@ -6979,11 +7008,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7017,7 +7046,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
@@ -7027,11 +7056,11 @@ msgstr "Erstellt: %s"
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7164,11 +7193,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7184,7 +7213,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid "System:"
 msgstr ""
 
@@ -7205,7 +7234,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7481,7 +7510,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7564,7 +7593,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7578,8 +7607,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478
-#: cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7633,7 +7662,7 @@ msgstr "Administrator Passwort für %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 msgid "Type"
 msgstr ""
 
@@ -7652,14 +7681,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391
-#: cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
+#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7680,6 +7709,16 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
+#: cmd/incus/info.go:537
+#, fuzzy
+msgid "USB device:"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
+#: cmd/incus/info.go:540
+#, fuzzy
+msgid "USB devices:"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
 #: cmd/incus/network_zone.go:147 cmd/incus/profile.go:736
@@ -7692,7 +7731,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7919,7 +7958,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7967,8 +8006,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477
-#: cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8008,12 +8047,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, fuzzy, c-format
+msgid "Vendor ID: %v"
+msgstr "Fehler: %v\n"
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "Fehler: %v\n"
@@ -8032,12 +8076,12 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Fehler: %v\n"
@@ -9910,6 +9954,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Usb %d:"
+#~ msgstr " Prozessorauslastung:"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-31 22:12-0400\n"
+"POT-Creation-Date: 2024-04-01 22:06-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.1\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid "  Motherboard:"
 msgstr ""
 
@@ -688,7 +688,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:822 cmd/incus/info.go:567
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -1101,7 +1101,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1153,11 +1153,16 @@ msgstr "Creado: %s"
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, fuzzy, c-format
+msgid "Bus Address: %v"
+msgstr "Expira: %s"
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1177,7 +1182,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
@@ -1186,15 +1191,15 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1322,7 +1327,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1834,7 +1839,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1899,7 +1904,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Auto actualización: %s"
@@ -2198,6 +2203,11 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
+#: cmd/incus/info.go:542
+#, fuzzy, c-format
+msgid "Device %d:"
+msgstr "Dispositivo: %s"
+
 #: cmd/incus/config_device.go:197
 #, c-format
 msgid "Device %s added to %s"
@@ -2212,6 +2222,11 @@ msgstr ""
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
+
+#: cmd/incus/info.go:347
+#, fuzzy, c-format
+msgid "Device Address: %v"
+msgstr "Expira: %s"
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
 #, c-format
@@ -2270,20 +2285,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, c-format
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 msgid "Disk:"
 msgstr "Disco:"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 msgid "Disks:"
 msgstr "Discos:"
 
@@ -2626,7 +2641,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 #, fuzzy
@@ -3045,7 +3060,7 @@ msgstr "Acepta certificado"
 msgid "Failed validation request: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3160,8 +3175,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476
-#: cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3180,11 +3195,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid "GPUs:"
 msgstr ""
 
@@ -3370,12 +3385,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3421,7 +3436,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
@@ -3597,7 +3612,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
@@ -3822,7 +3837,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Creado: %s"
@@ -4224,7 +4239,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4233,7 +4248,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid "Log:"
 msgstr "Registro:"
 
@@ -4270,7 +4285,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
@@ -4314,7 +4329,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid "MTU"
 msgstr ""
 
@@ -4567,19 +4582,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 msgid "Memory:"
 msgstr ""
 
@@ -4924,11 +4939,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid "NICs:"
 msgstr ""
 
@@ -4944,7 +4959,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4957,7 +4972,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5019,7 +5034,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929
+#: cmd/incus/info.go:576 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5139,7 +5154,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5225,7 +5240,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5282,7 +5297,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5307,7 +5322,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5341,11 +5356,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5457,7 +5472,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -5467,12 +5482,17 @@ msgstr "Procesos: %d"
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, fuzzy, c-format
+msgid "Product ID: %v"
+msgstr "Creado: %s"
+
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Creado: %s"
@@ -6000,7 +6020,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid "Resources:"
 msgstr ""
 
@@ -6101,7 +6121,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6176,12 +6196,17 @@ msgstr "Creado: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, fuzzy, c-format
+msgid "Serial Number: %v"
+msgstr "Creado: %s"
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Creado: %s"
@@ -6749,11 +6774,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6786,7 +6811,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
@@ -6796,11 +6821,11 @@ msgstr "Auto actualización: %s"
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6927,11 +6952,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6947,7 +6972,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid "System:"
 msgstr ""
 
@@ -6968,7 +6993,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7240,7 +7265,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7319,7 +7344,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7333,8 +7358,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478
-#: cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7388,7 +7413,7 @@ msgstr "Contraseña admin para %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
@@ -7408,14 +7433,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391
-#: cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
+#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7436,6 +7461,14 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
+#: cmd/incus/info.go:537
+msgid "USB device:"
+msgstr ""
+
+#: cmd/incus/info.go:540
+msgid "USB devices:"
+msgstr ""
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
 #: cmd/incus/network_zone.go:147 cmd/incus/profile.go:736
@@ -7448,7 +7481,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7666,7 +7699,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7713,8 +7746,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477
-#: cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7754,12 +7787,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, fuzzy, c-format
+msgid "Vendor ID: %v"
+msgstr "Cacheado: %s"
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7774,12 +7812,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Versión de CUDA: %v"
@@ -9154,6 +9192,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Usb %d:"
+#~ msgstr "Disco %d:"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-31 22:12-0400\n"
+"POT-Creation-Date: 2024-04-01 22:06-0400\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -18,16 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 #, fuzzy
 msgid "  Chassis:"
 msgstr "Châssis"
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid "  Motherboard:"
 msgstr ""
 
@@ -696,7 +696,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:822 cmd/incus/info.go:567
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
@@ -1004,7 +1004,7 @@ msgstr "Toutes les adresses serveurs sont indisponibles"
 msgid "Alternative certificate name"
 msgstr "Nom alternatif du certificat"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -1131,7 +1131,7 @@ msgstr "Sauvegarder le volume de stockage : %s"
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1184,11 +1184,16 @@ msgstr "Marque : %v"
 msgid "Bridge:"
 msgstr "Pont:"
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, fuzzy, c-format
+msgid "Bus Address: %v"
+msgstr "Addresse : %s"
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1208,7 +1213,7 @@ msgstr "Type de contenu"
 msgid "COUNT"
 msgstr "NOMBRE"
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s) :"
@@ -1217,15 +1222,15 @@ msgstr "CPU (%s) :"
 msgid "CPU USAGE"
 msgstr "UTILISATION CPU"
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs (%s):"
@@ -1361,7 +1366,7 @@ msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 msgid "Cannot set key: %s"
 msgstr "Impossible d'assigner les clés: %s"
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid "Card %d:"
 msgstr "Cartes %d:"
@@ -1930,7 +1935,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1995,7 +2000,7 @@ msgstr "Le démon ne fonctionne toujours pas après %ds d'attente (%v)"
 msgid "Daemon still running after %ds timeout"
 msgstr "Le démon continue de fonctionner après %ds d'attente"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "État : %s"
@@ -2306,6 +2311,11 @@ msgstr "Clé de configuration invalide"
 msgid "Detach storage volumes from profiles"
 msgstr "Détacher les volumes de stockage des profils"
 
+#: cmd/incus/info.go:542
+#, fuzzy, c-format
+msgid "Device %d:"
+msgstr "Serveur distant : %s"
+
 #: cmd/incus/config_device.go:197
 #, c-format
 msgid "Device %s added to %s"
@@ -2320,6 +2330,11 @@ msgstr "Périphérique %s retiré de %s"
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Périphérique %s retiré de %s"
+
+#: cmd/incus/info.go:347
+#, fuzzy, c-format
+msgid "Device Address: %v"
+msgstr "Addresse : %s"
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
 #, fuzzy, c-format
@@ -2385,20 +2400,20 @@ msgstr "Désactiver l'allocation pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Disque %d:"
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 msgid "Disk usage:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 msgid "Disk:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 msgid "Disks:"
 msgstr "Disque utilisé :"
 
@@ -2822,7 +2837,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 #, fuzzy
@@ -3262,7 +3277,7 @@ msgstr "Échec de l'écriture du fichier de certificat serveur %q : %w"
 msgid "Failed validation request: %w"
 msgstr "Échec de la demande de validation : %w"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, fuzzy, c-format
 msgid "Family: %v"
 msgstr "Nom : %s"
@@ -3405,8 +3420,8 @@ msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 "L'alias trouvé %q fait référence à un argument en dehors du nombre donné"
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476
-#: cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, fuzzy, c-format
 msgid "Free: %v"
 msgstr "Libre : %v"
@@ -3425,11 +3440,11 @@ msgstr "Fréquence : %vMhz (min : %vMhz, max : %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid "GPU:"
 msgstr "GPU :"
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid "GPUs:"
 msgstr "GPUs :"
 
@@ -3628,12 +3643,12 @@ msgstr "ADRESSE MATÉRIEL"
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3680,7 +3695,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "ADRESSE IP"
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
@@ -3878,7 +3893,7 @@ msgstr "Infiniband :"
 msgid "Input data"
 msgstr "Données d'entrée"
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
@@ -4115,7 +4130,7 @@ msgstr "ADRESSE D’ÉCOUTE"
 msgid "LOCATION"
 msgstr "LOCALISATION"
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
@@ -4581,7 +4596,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4590,7 +4605,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid "Log:"
 msgstr "Journal :"
 
@@ -4629,7 +4644,7 @@ msgstr "Création du conteneur"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
@@ -4673,7 +4688,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid "MTU"
 msgstr ""
 
@@ -4944,19 +4959,19 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 msgid "Memory usage:"
 msgstr "Mémoire utilisée :"
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 msgid "Memory:"
 msgstr "Mémoire utilisée :"
 
@@ -5313,11 +5328,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid "NICs:"
 msgstr ""
 
@@ -5333,7 +5348,7 @@ msgstr "NON"
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5346,7 +5361,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 #, fuzzy
@@ -5413,7 +5428,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929
+#: cmd/incus/info.go:576 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5534,7 +5549,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
@@ -5623,7 +5638,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5690,7 +5705,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5716,7 +5731,7 @@ msgstr ""
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, fuzzy, c-format
 msgid "PID: %d"
 msgstr "Pid : %d"
@@ -5750,11 +5765,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -5869,7 +5884,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -5879,12 +5894,17 @@ msgstr "Processus : %d"
 msgid "Processing aliases failed: %s"
 msgstr "Le traitement des alias a échoué : %s"
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, fuzzy, c-format
+msgid "Product ID: %v"
+msgstr "Marque : %v"
+
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Marque : %v"
@@ -6430,7 +6450,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -6549,7 +6569,7 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, fuzzy, c-format
 msgid "SKU: %v"
 msgstr "Publié : %s"
@@ -6626,12 +6646,17 @@ msgstr "Créé : %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, fuzzy, c-format
+msgid "Serial Number: %v"
+msgstr "Marque : %v"
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Marque : %v"
@@ -7233,11 +7258,11 @@ msgstr "Copie de l'image : %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7271,7 +7296,7 @@ msgstr "Démarrage de %s"
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
@@ -7281,12 +7306,12 @@ msgstr "État : %s"
 msgid "State: %s"
 msgstr "État : %s"
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
@@ -7418,11 +7443,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -7440,7 +7465,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid "System:"
 msgstr ""
 
@@ -7461,7 +7486,7 @@ msgstr ""
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 #, fuzzy
 msgid "Taken at"
@@ -7744,7 +7769,7 @@ msgstr ""
 "Le pool de stockage demandé \"%s\" existe déjà. Veuillez choisir un autre "
 "nom."
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7828,7 +7853,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7842,8 +7867,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Publié : %s"
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478
-#: cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7897,7 +7922,7 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
@@ -7917,14 +7942,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391
-#: cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
+#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, fuzzy, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
@@ -7945,6 +7970,16 @@ msgstr "URL"
 msgid "USAGE"
 msgstr ""
 
+#: cmd/incus/info.go:537
+#, fuzzy
+msgid "USB device:"
+msgstr "Création du conteneur"
+
+#: cmd/incus/info.go:540
+#, fuzzy
+msgid "USB devices:"
+msgstr "Création du conteneur"
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
 #: cmd/incus/network_zone.go:147 cmd/incus/profile.go:736
@@ -7957,7 +7992,7 @@ msgstr "UTILISÉ PAR"
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8187,7 +8222,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8235,8 +8270,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477
-#: cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, fuzzy, c-format
 msgid "Used: %v"
 msgstr "Publié : %s"
@@ -8277,12 +8312,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, fuzzy, c-format
+msgid "Vendor ID: %v"
+msgstr "erreur : %v"
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "erreur : %v"
@@ -8297,12 +8337,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Version CUDA : %v"
@@ -10264,6 +10304,10 @@ msgstr "o"
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr "oui"
+
+#, fuzzy, c-format
+#~ msgid "Usb %d:"
+#~ msgstr "Disque %d:"
 
 #, fuzzy
 #~ msgid "STATUS"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-03-31 22:12-0400\n"
+        "POT-Creation-Date: 2024-04-01 22:06-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,15 +16,15 @@ msgstr  "Project-Id-Version: incus\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 msgid   "  Chassis:"
 msgstr  ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid   "  Firmware:"
 msgstr  ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid   "  Motherboard:"
 msgstr  ""
 
@@ -419,7 +419,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615 cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615 cmd/incus/config.go:822 cmd/incus/info.go:567
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -692,7 +692,7 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -808,7 +808,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid   "Backups:"
 msgstr  ""
 
@@ -854,11 +854,16 @@ msgstr  ""
 msgid   "Bridge:"
 msgstr  ""
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, c-format
+msgid   "Bus Address: %v"
+msgstr  ""
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid   "Bytes received"
 msgstr  ""
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -878,7 +883,7 @@ msgstr  ""
 msgid   "COUNT"
 msgstr  ""
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, c-format
 msgid   "CPU (%s):"
 msgstr  ""
@@ -887,15 +892,15 @@ msgstr  ""
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 msgid   "CPU usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, c-format
 msgid   "CPUs (%s):"
 msgstr  ""
@@ -1015,7 +1020,7 @@ msgstr  ""
 msgid   "Cannot set key: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid   "Card %d:"
 msgstr  ""
@@ -1453,7 +1458,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577 cmd/incus/storage_volume.go:1407
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1507,7 +1512,7 @@ msgstr  ""
 msgid   "Daemon still running after %ds timeout"
 msgstr  ""
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, c-format
 msgid   "Date: %s"
 msgstr  ""
@@ -1649,6 +1654,11 @@ msgstr  ""
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
+#: cmd/incus/info.go:542
+#, c-format
+msgid   "Device %d:"
+msgstr  ""
+
 #: cmd/incus/config_device.go:197
 #, c-format
 msgid   "Device %s added to %s"
@@ -1662,6 +1672,11 @@ msgstr  ""
 #: cmd/incus/config_device.go:599
 #, c-format
 msgid   "Device %s removed from %s"
+msgstr  ""
+
+#: cmd/incus/info.go:347
+#, c-format
+msgid   "Device Address: %v"
 msgstr  ""
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
@@ -1714,20 +1729,20 @@ msgstr  ""
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, c-format
 msgid   "Disk %d:"
 msgstr  ""
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 msgid   "Disk usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 msgid   "Disk:"
 msgstr  ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 msgid   "Disks:"
 msgstr  ""
 
@@ -2035,7 +2050,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346 cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490 cmd/incus/storage_volume.go:2575
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346 cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490 cmd/incus/storage_volume.go:2575
 msgid   "Expires at"
 msgstr  ""
 
@@ -2442,7 +2457,7 @@ msgstr  ""
 msgid   "Failed validation request: %w"
 msgstr  ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, c-format
 msgid   "Family: %v"
 msgstr  ""
@@ -2537,7 +2552,7 @@ msgstr  ""
 msgid   "Found alias %q references an argument outside the given number"
 msgstr  ""
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489 cmd/incus/info.go:495
 #, c-format
 msgid   "Free: %v"
 msgstr  ""
@@ -2556,11 +2571,11 @@ msgstr  ""
 msgid   "GLOBAL"
 msgstr  ""
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid   "GPU:"
 msgstr  ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid   "GPUs:"
 msgstr  ""
 
@@ -2729,11 +2744,11 @@ msgstr  ""
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 msgid   "Host interface"
 msgstr  ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid   "Hugepages:\n"
 msgstr  ""
 
@@ -2779,7 +2794,7 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 msgid   "IP addresses"
 msgstr  ""
 
@@ -2946,7 +2961,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 msgid   "Instance Only"
 msgstr  ""
 
@@ -3157,7 +3172,7 @@ msgstr  ""
 msgid   "LOCATION"
 msgstr  ""
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, c-format
 msgid   "Last Used: %s"
 msgstr  ""
@@ -3529,7 +3544,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3538,7 +3553,7 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid   "Log:"
 msgstr  ""
 
@@ -3575,7 +3590,7 @@ msgstr  ""
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 msgid   "MAC address"
 msgstr  ""
 
@@ -3618,7 +3633,7 @@ msgstr  ""
 msgid   "MII state"
 msgstr  ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid   "MTU"
 msgstr  ""
 
@@ -3849,19 +3864,19 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid   "Memory (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 msgid   "Memory usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 msgid   "Memory:"
 msgstr  ""
 
@@ -4084,11 +4099,11 @@ msgstr  ""
 msgid   "NEW: %q (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid   "NIC:"
 msgstr  ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid   "NICs:"
 msgstr  ""
 
@@ -4101,7 +4116,7 @@ msgstr  ""
 msgid   "NUMA node: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid   "NUMA nodes:\n"
 msgstr  ""
 
@@ -4114,7 +4129,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344 cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488 cmd/incus/storage_volume.go:2573
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344 cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488 cmd/incus/storage_volume.go:2573
 msgid   "Name"
 msgstr  ""
 
@@ -4173,7 +4188,7 @@ msgstr  ""
 msgid   "Name of the storage pool:"
 msgstr  ""
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1378
+#: cmd/incus/info.go:576 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1378
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -4291,7 +4306,7 @@ msgstr  ""
 msgid   "Network type"
 msgstr  ""
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 msgid   "Network usage:"
 msgstr  ""
 
@@ -4377,7 +4392,7 @@ msgstr  ""
 msgid   "No value found in %q"
 msgstr  ""
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid   "Node %d:\n"
 msgstr  ""
@@ -4431,7 +4446,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4456,7 +4471,7 @@ msgstr  ""
 msgid   "PID"
 msgstr  ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, c-format
 msgid   "PID: %d"
 msgstr  ""
@@ -4489,11 +4504,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid   "Packets received"
 msgstr  ""
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid   "Packets sent"
 msgstr  ""
 
@@ -4594,7 +4609,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -4604,12 +4619,17 @@ msgstr  ""
 msgid   "Processing aliases failed: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, c-format
+msgid   "Product ID: %v"
+msgstr  ""
+
+#: cmd/incus/info.go:432
 #, c-format
 msgid   "Product: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, c-format
 msgid   "Product: %v"
 msgstr  ""
@@ -5094,7 +5114,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid   "Resources:"
 msgstr  ""
 
@@ -5187,7 +5207,7 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, c-format
 msgid   "SKU: %v"
 msgstr  ""
@@ -5260,12 +5280,17 @@ msgstr  ""
 msgid   "Send a raw query to the server"
 msgstr  ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, c-format
+msgid   "Serial Number: %v"
+msgstr  ""
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, c-format
 msgid   "Serial: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, c-format
 msgid   "Serial: %v"
 msgstr  ""
@@ -5771,11 +5796,11 @@ msgstr  ""
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid   "Snapshots:"
 msgstr  ""
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid   "Socket %d:"
 msgstr  ""
@@ -5806,7 +5831,7 @@ msgstr  ""
 msgid   "Starting recovery..."
 msgstr  ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 msgid   "State"
 msgstr  ""
 
@@ -5815,11 +5840,11 @@ msgstr  ""
 msgid   "State: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 msgid   "Stateful"
 msgstr  ""
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
@@ -5944,11 +5969,11 @@ msgstr  ""
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid   "Swap (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -5964,7 +5989,7 @@ msgstr  ""
 msgid   "Symlink target path can only be used for type \"symlink\""
 msgstr  ""
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid   "System:"
 msgstr  ""
 
@@ -5980,7 +6005,7 @@ msgstr  ""
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345 cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345 cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid   "Taken at"
 msgstr  ""
 
@@ -6232,7 +6257,7 @@ msgstr  ""
 msgid   "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr  ""
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
@@ -6304,7 +6329,7 @@ msgid   "To start your first container, try: incus launch images:ubuntu/22.04\n"
         "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr  ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344 cmd/incus/network.go:917 cmd/incus/storage.go:489
+#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357 cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -6317,7 +6342,7 @@ msgstr  ""
 msgid   "Total: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478 cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491 cmd/incus/info.go:497
 #, c-format
 msgid   "Total: %v"
 msgstr  ""
@@ -6371,7 +6396,7 @@ msgstr  ""
 msgid   "Try `incus info --show-log %s` for more info"
 msgstr  ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 msgid   "Type"
 msgstr  ""
 
@@ -6387,12 +6412,12 @@ msgstr  ""
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391 cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933 cmd/incus/storage_volume.go:1387
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404 cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933 cmd/incus/storage_volume.go:1387
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, c-format
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
@@ -6413,6 +6438,14 @@ msgstr  ""
 msgid   "USAGE"
 msgstr  ""
 
+#: cmd/incus/info.go:537
+msgid   "USB device:"
+msgstr  ""
+
+#: cmd/incus/info.go:540
+msgid   "USB devices:"
+msgstr  ""
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156 cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436 cmd/incus/network_zone.go:147 cmd/incus/profile.go:736 cmd/incus/project.go:551 cmd/incus/storage.go:698 cmd/incus/storage_volume.go:1638
 msgid   "USED BY"
 msgstr  ""
@@ -6421,7 +6454,7 @@ msgstr  ""
 msgid   "UUID"
 msgstr  ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid   "UUID: %v"
 msgstr  ""
@@ -6618,7 +6651,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
@@ -6661,7 +6694,7 @@ msgstr  ""
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477 cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490 cmd/incus/info.go:496
 #, c-format
 msgid   "Used: %v"
 msgstr  ""
@@ -6699,12 +6732,17 @@ msgstr  ""
 msgid   "VLAN:"
 msgstr  ""
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, c-format
+msgid   "Vendor ID: %v"
+msgstr  ""
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, c-format
 msgid   "Vendor: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, c-format
 msgid   "Vendor: %v"
 msgstr  ""
@@ -6719,12 +6757,12 @@ msgstr  ""
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, c-format
 msgid   "Version: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, c-format
 msgid   "Version: %v"
 msgstr  ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-31 22:12-0400\n"
+"POT-Creation-Date: 2024-04-01 22:06-0400\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid "  Motherboard:"
 msgstr ""
 
@@ -688,7 +688,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:822 cmd/incus/info.go:567
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -1101,7 +1101,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1152,11 +1152,16 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, c-format
+msgid "Bus Address: %v"
+msgstr ""
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1176,7 +1181,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Utilizzo CPU:"
@@ -1185,15 +1190,15 @@ msgstr "Utilizzo CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1318,7 +1323,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1828,7 +1833,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1893,7 +1898,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -2192,6 +2197,11 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
+#: cmd/incus/info.go:542
+#, fuzzy, c-format
+msgid "Device %d:"
+msgstr "Utilizzo disco:"
+
 #: cmd/incus/config_device.go:197
 #, c-format
 msgid "Device %s added to %s"
@@ -2206,6 +2216,11 @@ msgstr ""
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
+
+#: cmd/incus/info.go:347
+#, fuzzy, c-format
+msgid "Device Address: %v"
+msgstr "La periferica esiste già: %s"
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
 #, c-format
@@ -2264,21 +2279,21 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 #, fuzzy
 msgid "Disk:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 #, fuzzy
 msgid "Disks:"
 msgstr "Utilizzo disco:"
@@ -2622,7 +2637,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3040,7 +3055,7 @@ msgstr "Accetta certificato"
 msgid "Failed validation request: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3156,8 +3171,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476
-#: cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3176,11 +3191,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid "GPUs:"
 msgstr ""
 
@@ -3363,12 +3378,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3414,7 +3429,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 msgid "IP addresses"
 msgstr ""
 
@@ -3588,7 +3603,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
@@ -3813,7 +3828,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -4216,7 +4231,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4225,7 +4240,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid "Log:"
 msgstr ""
 
@@ -4264,7 +4279,7 @@ msgstr "Creazione del container in corso"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 msgid "MAC address"
 msgstr ""
 
@@ -4307,7 +4322,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid "MTU"
 msgstr ""
 
@@ -4564,19 +4579,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 msgid "Memory:"
 msgstr ""
 
@@ -4920,11 +4935,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid "NICs:"
 msgstr ""
 
@@ -4940,7 +4955,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4953,7 +4968,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5015,7 +5030,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929
+#: cmd/incus/info.go:576 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5135,7 +5150,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5221,7 +5236,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5278,7 +5293,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5303,7 +5318,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5337,11 +5352,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5454,7 +5469,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5464,12 +5479,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, fuzzy, c-format
+msgid "Product ID: %v"
+msgstr "Proprietà errata: %s"
+
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -5997,7 +6017,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid "Resources:"
 msgstr ""
 
@@ -6098,7 +6118,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6173,12 +6193,17 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, fuzzy, c-format
+msgid "Serial Number: %v"
+msgstr "Aggiornamento automatico: %s"
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6742,11 +6767,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6780,7 +6805,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
@@ -6790,11 +6815,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6921,11 +6946,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6941,7 +6966,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid "System:"
 msgstr ""
 
@@ -6962,7 +6987,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 #, fuzzy
 msgid "Taken at"
@@ -7234,7 +7259,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7313,7 +7338,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7327,8 +7352,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478
-#: cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7382,7 +7407,7 @@ msgstr "Password amministratore per %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 msgid "Type"
 msgstr ""
 
@@ -7401,14 +7426,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391
-#: cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
+#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7429,6 +7454,16 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
+#: cmd/incus/info.go:537
+#, fuzzy
+msgid "USB device:"
+msgstr "Creazione del container in corso"
+
+#: cmd/incus/info.go:540
+#, fuzzy
+msgid "USB devices:"
+msgstr "Creazione del container in corso"
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
 #: cmd/incus/network_zone.go:147 cmd/incus/profile.go:736
@@ -7441,7 +7476,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7655,7 +7690,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7703,8 +7738,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477
-#: cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7744,12 +7779,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, fuzzy, c-format
+msgid "Vendor ID: %v"
+msgstr "Aggiornamento automatico: %s"
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7764,12 +7804,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -9148,6 +9188,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr "si"
+
+#, fuzzy, c-format
+#~ msgid "Usb %d:"
+#~ msgstr "Utilizzo disco:"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-31 22:12-0400\n"
+"POT-Creation-Date: 2024-04-01 22:06-0400\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -18,16 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 #, fuzzy
 msgid "  Chassis:"
 msgstr "Chassis"
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid "  Motherboard:"
 msgstr ""
 
@@ -678,7 +678,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:822 cmd/incus/info.go:567
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
 
@@ -979,7 +979,7 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -1102,7 +1102,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1155,11 +1155,16 @@ msgstr "ブランド: %v"
 msgid "Bridge:"
 msgstr "ブリッジ:"
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, fuzzy, c-format
+msgid "Bus Address: %v"
+msgstr "アドレス: %s"
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1179,7 +1184,7 @@ msgstr "CONTENT-TYPE"
 msgid "COUNT"
 msgstr "COUNT"
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
@@ -1188,15 +1193,15 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs (%s):"
@@ -1326,7 +1331,7 @@ msgstr "スナップショットをコピーするときに --volume-only は指
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid "Card %d:"
 msgstr "カード %d:"
@@ -1855,7 +1860,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1920,7 +1925,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr "%d 秒のタイムアウトが経過しましたが、デーモンがまだ実行中です"
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "状態: %s"
@@ -2211,6 +2216,11 @@ msgstr "インスタンスからストレージボリュームを取り外しま
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
+#: cmd/incus/info.go:542
+#, fuzzy, c-format
+msgid "Device %d:"
+msgstr "デバイス: %s"
+
 #: cmd/incus/config_device.go:197
 #, c-format
 msgid "Device %s added to %s"
@@ -2225,6 +2235,11 @@ msgstr "デバイス %s が %s で上書きされました"
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "デバイス %s が %s から削除されました"
+
+#: cmd/incus/info.go:347
+#, fuzzy, c-format
+msgid "Device Address: %v"
+msgstr "アドレス: %s"
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
 #, c-format
@@ -2288,20 +2303,20 @@ msgstr "擬似端末の割り当てを無効にします"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, c-format
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 msgid "Disk:"
 msgstr "ディスク:"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 msgid "Disks:"
 msgstr "ディスク:"
 
@@ -2686,7 +2701,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3104,7 +3119,7 @@ msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 msgid "Failed validation request: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, fuzzy, c-format
 msgid "Family: %v"
 msgstr "名前: %v"
@@ -3233,8 +3248,8 @@ msgstr "Forward delay"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "エイリアス %q が指定した番号以外の引数を参照しているのが見つかりました"
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476
-#: cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Free: %v"
 msgstr "空き: %v"
@@ -3253,11 +3268,11 @@ msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid "GPU:"
 msgstr "GPU:"
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid "GPUs:"
 msgstr "GPUs:"
 
@@ -3440,11 +3455,11 @@ msgstr "MAC ADDRESS"
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
@@ -3490,7 +3505,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 msgid "IP addresses"
 msgstr "IP アドレス"
 
@@ -3678,7 +3693,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
@@ -3905,7 +3920,7 @@ msgstr "LISTEN ADDRESS"
 msgid "LOCATION"
 msgstr "LOCATION"
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, c-format
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
@@ -4470,7 +4485,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4479,7 +4494,7 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid "Log:"
 msgstr "ログ:"
 
@@ -4516,7 +4531,7 @@ msgstr "Lower devices"
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 msgid "MAC address"
 msgstr "MAC アドレス"
 
@@ -4559,7 +4574,7 @@ msgstr "MII 監視頻度"
 msgid "MII state"
 msgstr "MII 状態"
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid "MTU"
 msgstr "MTU"
 
@@ -4819,19 +4834,19 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 msgid "Memory:"
 msgstr "メモリ:"
 
@@ -5183,11 +5198,11 @@ msgstr "NETWORKS"
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr "新規: %q (バックエンド=%q, ソース=%q)"
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid "NIC:"
 msgstr "NIC:"
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid "NICs:"
 msgstr "NICs:"
 
@@ -5203,7 +5218,7 @@ msgstr "NO"
 msgid "NUMA node: %v"
 msgstr "NUMA ノード: %v"
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid "NUMA nodes:\n"
 msgstr "NUMA ノード:\n"
 
@@ -5216,7 +5231,7 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5282,7 +5297,7 @@ msgstr "使用するストレージバックエンド名 (%s)"
 msgid "Name of the storage pool:"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929
+#: cmd/incus/info.go:576 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5404,7 +5419,7 @@ msgstr ""
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -5493,7 +5508,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
@@ -5554,7 +5569,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -5579,7 +5594,7 @@ msgstr "PEER"
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, c-format
 msgid "PID: %d"
 msgstr "PID: %d"
@@ -5614,11 +5629,11 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -5732,7 +5747,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -5742,12 +5757,17 @@ msgstr "プロセス数: %d"
 msgid "Processing aliases failed: %s"
 msgstr "エイリアスの処理が失敗しました: %s"
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, fuzzy, c-format
+msgid "Product ID: %v"
+msgstr "製品名: %v (%v)"
+
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "製品名: %v (%v)"
@@ -6304,7 +6324,7 @@ msgstr "クラスターメンバーに join するためのトークンを要求
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -6405,7 +6425,7 @@ msgstr "SEVERITY"
 msgid "SIZE"
 msgstr "SIZE"
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, fuzzy, c-format
 msgid "SKU: %v"
 msgstr "UUID: %v"
@@ -6481,12 +6501,17 @@ msgstr "秘密鍵: %s"
 msgid "Send a raw query to the server"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, fuzzy, c-format
+msgid "Serial Number: %v"
+msgstr "合計: %v"
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "合計: %v"
@@ -7122,11 +7147,11 @@ msgstr "ストレージボリュームのスナップショットを取得しま
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid "Socket %d:"
 msgstr "ソケット %d:"
@@ -7161,7 +7186,7 @@ msgstr "%s を起動中"
 msgid "Starting recovery..."
 msgstr "リカバリーを開始します..."
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 msgid "State"
 msgstr "状態"
 
@@ -7170,11 +7195,11 @@ msgstr "状態"
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr "ステートフル"
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
@@ -7301,11 +7326,11 @@ msgstr "サポートするモード: %s"
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -7321,7 +7346,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr "シンボリックリンクのターゲットパスは \"symlink\" タイプにのみ使えます"
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid "System:"
 msgstr ""
 
@@ -7342,7 +7367,7 @@ msgstr "TOKEN"
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr "取得日時"
@@ -7657,7 +7682,7 @@ msgstr ""
 "入力したストレージプール \"%s\" はすでに存在しています。他の名前を入力してく"
 "ださい。"
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
@@ -7759,7 +7784,7 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7775,8 +7800,8 @@ msgstr "リンクが多すぎます"
 msgid "Total: %s"
 msgstr "合計: %s"
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478
-#: cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Total: %v"
 msgstr "合計: %v"
@@ -7830,7 +7855,7 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 msgid "Type"
 msgstr "タイプ"
 
@@ -7850,14 +7875,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391
-#: cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
+#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
@@ -7878,6 +7903,16 @@ msgstr "URL"
 msgid "USAGE"
 msgstr "USAGE"
 
+#: cmd/incus/info.go:537
+#, fuzzy
+msgid "USB device:"
+msgstr "device"
+
+#: cmd/incus/info.go:540
+#, fuzzy
+msgid "USB devices:"
+msgstr "上位デバイス"
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
 #: cmd/incus/network_zone.go:147 cmd/incus/profile.go:736
@@ -7890,7 +7925,7 @@ msgstr "USED BY"
 msgid "UUID"
 msgstr "UUID"
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid "UUID: %v"
 msgstr "UUID: %v"
@@ -8100,7 +8135,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr "インスタンスプロパティの設定を削除します"
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
@@ -8150,8 +8185,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477
-#: cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Used: %v"
 msgstr "使用済: %v"
@@ -8193,12 +8228,17 @@ msgstr "VLAN フィルタリング"
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, fuzzy, c-format
+msgid "Vendor ID: %v"
+msgstr "ベンダー: %v"
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, c-format
 msgid "Vendor: %v"
 msgstr "ベンダー: %v"
@@ -8213,12 +8253,12 @@ msgstr "ベンダ: %v (%v)"
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "CUDA バージョン: %v"
@@ -9700,6 +9740,10 @@ msgstr "y"
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr "yes"
+
+#, fuzzy, c-format
+#~ msgid "Usb %d:"
+#~ msgstr "ディスク %d:"
 
 #~ msgid "STATUS"
 #~ msgstr "STATUS"
@@ -12089,9 +12133,6 @@ msgstr "yes"
 #~ "lxc file mount foo/root fooroot\n"
 #~ "   インスタンス foo の /root をローカルの fooroot ディレクトリ上にマウント"
 #~ "します。"
-
-#~ msgid "device"
-#~ msgstr "device"
 
 #~ msgid "Format (csv|json|table|yaml)"
 #~ msgstr "フォーマット (csv|json|table|yaml)"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-31 22:12-0400\n"
+"POT-Creation-Date: 2024-04-01 22:06-0400\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid "  Motherboard:"
 msgstr ""
 
@@ -699,7 +699,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh kan alleen worden gebruikt bij geïnstantieerden (instances)"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:822 cmd/incus/info.go:567
 msgid "--target cannot be used with instances"
 msgstr "--target kan niet gebruikt worden met: instances"
 
@@ -997,7 +997,7 @@ msgstr "Alle server adressen zijn onbeschikbaar"
 msgid "Alternative certificate name"
 msgstr "Alternatieve certificaat naam"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architectuur: %s"
@@ -1121,7 +1121,7 @@ msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1172,11 +1172,16 @@ msgstr "Merk (Brand): %v"
 msgid "Bridge:"
 msgstr "Brug (Bridge):"
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, fuzzy, c-format
+msgid "Bus Address: %v"
+msgstr "Adres: %s"
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes ontvangen (received)"
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes verzonden"
 
@@ -1196,7 +1201,7 @@ msgstr "INHOUDSTYPE"
 msgid "COUNT"
 msgstr "SOM"
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
@@ -1205,15 +1210,15 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU GEBRUIK"
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid "CPU usage (in seconds)"
 msgstr "CPU gebruik (in seconde)"
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 msgid "CPU usage:"
 msgstr "CPU gebruik:"
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, c-format
 msgid "CPUs (%s):"
 msgstr "CPU's (%s):"
@@ -1339,7 +1344,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1837,7 +1842,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1901,7 +1906,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Cached: %s"
@@ -2192,6 +2197,11 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
+#: cmd/incus/info.go:542
+#, fuzzy, c-format
+msgid "Device %d:"
+msgstr "Adres: %s"
+
 #: cmd/incus/config_device.go:197
 #, c-format
 msgid "Device %s added to %s"
@@ -2206,6 +2216,11 @@ msgstr ""
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
+
+#: cmd/incus/info.go:347
+#, fuzzy, c-format
+msgid "Device Address: %v"
+msgstr "Adres: %s"
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
 #, c-format
@@ -2263,20 +2278,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 msgid "Disks:"
 msgstr ""
 
@@ -2609,7 +2624,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3023,7 +3038,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3137,8 +3152,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476
-#: cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3157,11 +3172,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid "GPUs:"
 msgstr ""
 
@@ -3333,11 +3348,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3383,7 +3398,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 msgid "IP addresses"
 msgstr ""
 
@@ -3553,7 +3568,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 msgid "Instance Only"
 msgstr ""
 
@@ -3772,7 +3787,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4160,7 +4175,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4169,7 +4184,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid "Log:"
 msgstr ""
 
@@ -4206,7 +4221,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 msgid "MAC address"
 msgstr ""
 
@@ -4249,7 +4264,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid "MTU"
 msgstr ""
 
@@ -4488,19 +4503,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 msgid "Memory:"
 msgstr ""
 
@@ -4828,11 +4843,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid "NICs:"
 msgstr ""
 
@@ -4848,7 +4863,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4861,7 +4876,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4923,7 +4938,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929
+#: cmd/incus/info.go:576 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5043,7 +5058,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5129,7 +5144,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5186,7 +5201,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5211,7 +5226,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5245,11 +5260,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5360,7 +5375,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5370,12 +5385,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, fuzzy, c-format
+msgid "Product ID: %v"
+msgstr "Merk (Brand): %v"
+
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Merk (Brand): %v"
@@ -5888,7 +5908,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid "Resources:"
 msgstr ""
 
@@ -5982,7 +6002,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6057,12 +6077,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, fuzzy, c-format
+msgid "Serial Number: %v"
+msgstr "Merk (Brand): %v"
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Alias: %s"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Merk (Brand): %v"
@@ -6606,11 +6631,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6643,7 +6668,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 msgid "State"
 msgstr ""
 
@@ -6652,11 +6677,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6782,11 +6807,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6802,7 +6827,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid "System:"
 msgstr ""
 
@@ -6823,7 +6848,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7093,7 +7118,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7171,7 +7196,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7185,8 +7210,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478
-#: cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7240,7 +7265,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 msgid "Type"
 msgstr ""
 
@@ -7258,14 +7283,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391
-#: cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
+#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7286,6 +7311,14 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
+#: cmd/incus/info.go:537
+msgid "USB device:"
+msgstr ""
+
+#: cmd/incus/info.go:540
+msgid "USB devices:"
+msgstr ""
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
 #: cmd/incus/network_zone.go:147 cmd/incus/profile.go:736
@@ -7298,7 +7331,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7496,7 +7529,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7542,8 +7575,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477
-#: cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7582,12 +7615,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, fuzzy, c-format
+msgid "Vendor ID: %v"
+msgstr "Cached: %s"
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Cached: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7602,12 +7640,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "CUDA Versie: %v"
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "CUDA Versie: %v"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-31 22:12-0400\n"
+"POT-Creation-Date: 2024-04-01 22:06-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,15 +16,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid "  Motherboard:"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:822 cmd/incus/info.go:567
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -844,7 +844,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -895,11 +895,16 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, c-format
+msgid "Bus Address: %v"
+msgstr ""
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr ""
 
@@ -919,7 +924,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -928,15 +933,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1060,7 +1065,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1557,7 +1562,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1621,7 +1626,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -1911,6 +1916,11 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
+#: cmd/incus/info.go:542
+#, c-format
+msgid "Device %d:"
+msgstr ""
+
 #: cmd/incus/config_device.go:197
 #, c-format
 msgid "Device %s added to %s"
@@ -1924,6 +1934,11 @@ msgstr ""
 #: cmd/incus/config_device.go:599
 #, c-format
 msgid "Device %s removed from %s"
+msgstr ""
+
+#: cmd/incus/info.go:347
+#, c-format
+msgid "Device Address: %v"
 msgstr ""
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
@@ -1982,20 +1997,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 msgid "Disks:"
 msgstr ""
 
@@ -2328,7 +2343,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2742,7 +2757,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -2856,8 +2871,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476
-#: cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -2876,11 +2891,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid "GPUs:"
 msgstr ""
 
@@ -3050,11 +3065,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3100,7 +3115,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 msgid "IP addresses"
 msgstr ""
 
@@ -3270,7 +3285,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 msgid "Instance Only"
 msgstr ""
 
@@ -3489,7 +3504,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3876,7 +3891,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3885,7 +3900,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid "Log:"
 msgstr ""
 
@@ -3922,7 +3937,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 msgid "MAC address"
 msgstr ""
 
@@ -3965,7 +3980,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid "MTU"
 msgstr ""
 
@@ -4203,19 +4218,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 msgid "Memory:"
 msgstr ""
 
@@ -4542,11 +4557,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid "NICs:"
 msgstr ""
 
@@ -4562,7 +4577,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4575,7 +4590,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4637,7 +4652,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929
+#: cmd/incus/info.go:576 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -4757,7 +4772,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -4843,7 +4858,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4900,7 +4915,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4925,7 +4940,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4959,11 +4974,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5074,7 +5089,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5084,12 +5099,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, c-format
+msgid "Product ID: %v"
+msgstr ""
+
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -5601,7 +5621,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid "Resources:"
 msgstr ""
 
@@ -5695,7 +5715,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -5770,12 +5790,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, c-format
+msgid "Serial Number: %v"
+msgstr ""
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6316,11 +6341,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6353,7 +6378,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 msgid "State"
 msgstr ""
 
@@ -6362,11 +6387,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6492,11 +6517,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6512,7 +6537,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid "System:"
 msgstr ""
 
@@ -6533,7 +6558,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -6803,7 +6828,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6881,7 +6906,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6895,8 +6920,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478
-#: cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -6950,7 +6975,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 msgid "Type"
 msgstr ""
 
@@ -6968,14 +6993,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391
-#: cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
+#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6996,6 +7021,14 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
+#: cmd/incus/info.go:537
+msgid "USB device:"
+msgstr ""
+
+#: cmd/incus/info.go:540
+msgid "USB devices:"
+msgstr ""
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
 #: cmd/incus/network_zone.go:147 cmd/incus/profile.go:736
@@ -7008,7 +7041,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7206,7 +7239,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7252,8 +7285,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477
-#: cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7292,12 +7325,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, c-format
+msgid "Vendor ID: %v"
+msgstr ""
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7312,12 +7350,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, c-format
 msgid "Version: %v"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-31 22:12-0400\n"
+"POT-Creation-Date: 2024-04-01 22:06-0400\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid "  Motherboard:"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:822 cmd/incus/info.go:567
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -986,7 +986,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
@@ -1111,7 +1111,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1162,11 +1162,16 @@ msgstr "Marca: %v"
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, c-format
+msgid "Bus Address: %v"
+msgstr ""
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1186,7 +1191,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Utilização do CPU:"
@@ -1195,15 +1200,15 @@ msgstr "Utilização do CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, fuzzy, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs:"
@@ -1329,7 +1334,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid "Card %d:"
 msgstr "Cartão %d:"
@@ -1858,7 +1863,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1923,7 +1928,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Criado: %s"
@@ -2231,6 +2236,11 @@ msgstr "Desconectar volumes de armazenamento dos containers"
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
+#: cmd/incus/info.go:542
+#, fuzzy, c-format
+msgid "Device %d:"
+msgstr "Em cache: %s"
+
 #: cmd/incus/config_device.go:197
 #, c-format
 msgid "Device %s added to %s"
@@ -2245,6 +2255,11 @@ msgstr "Dispositivo %s sobreposto em %s"
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Dispositivo %s removido de %s"
+
+#: cmd/incus/info.go:347
+#, fuzzy, c-format
+msgid "Device Address: %v"
+msgstr "O dispositivo já existe: %s"
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
 #, c-format
@@ -2303,21 +2318,21 @@ msgstr "Desabilitar alocação de pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desabilitar stdin (ler de /dev/null)"
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 #, fuzzy
 msgid "Disk:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso de disco:"
@@ -2669,7 +2684,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3085,7 +3100,7 @@ msgstr "Aceitar certificado"
 msgid "Failed validation request: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3200,8 +3215,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476
-#: cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3220,11 +3235,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid "GPUs:"
 msgstr ""
 
@@ -3416,11 +3431,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3466,7 +3481,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 msgid "IP addresses"
 msgstr ""
 
@@ -3641,7 +3656,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 msgid "Instance Only"
 msgstr ""
 
@@ -3864,7 +3879,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Criado: %s"
@@ -4263,7 +4278,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4272,7 +4287,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid "Log:"
 msgstr ""
 
@@ -4311,7 +4326,7 @@ msgstr "Editar arquivos no container"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 msgid "MAC address"
 msgstr ""
 
@@ -4354,7 +4369,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid "MTU"
 msgstr ""
 
@@ -4617,19 +4632,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 msgid "Memory:"
 msgstr ""
 
@@ -4973,11 +4988,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid "NICs:"
 msgstr ""
 
@@ -4993,7 +5008,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5006,7 +5021,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5068,7 +5083,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929
+#: cmd/incus/info.go:576 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5188,7 +5203,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5274,7 +5289,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5331,7 +5346,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5356,7 +5371,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5390,11 +5405,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5506,7 +5521,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5516,12 +5531,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, fuzzy, c-format
+msgid "Product ID: %v"
+msgstr "Marca: %v"
+
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Marca: %v"
@@ -6058,7 +6078,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid "Resources:"
 msgstr ""
 
@@ -6164,7 +6184,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6239,12 +6259,17 @@ msgstr "Criado: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, fuzzy, c-format
+msgid "Serial Number: %v"
+msgstr "Marca: %v"
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Marca: %v"
@@ -6827,11 +6852,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6864,7 +6889,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 msgid "State"
 msgstr ""
 
@@ -6873,11 +6898,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7005,11 +7030,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7025,7 +7050,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid "System:"
 msgstr ""
 
@@ -7046,7 +7071,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7320,7 +7345,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7399,7 +7424,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7413,8 +7438,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478
-#: cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7468,7 +7493,7 @@ msgstr "Senha de administrador para %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 msgid "Type"
 msgstr ""
 
@@ -7487,14 +7512,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391
-#: cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
+#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7515,6 +7540,16 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
+#: cmd/incus/info.go:537
+#, fuzzy
+msgid "USB device:"
+msgstr "Editar arquivos no container"
+
+#: cmd/incus/info.go:540
+#, fuzzy
+msgid "USB devices:"
+msgstr "Editar arquivos no container"
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
 #: cmd/incus/network_zone.go:147 cmd/incus/profile.go:736
@@ -7527,7 +7562,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7752,7 +7787,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7800,8 +7835,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477
-#: cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7841,12 +7876,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, fuzzy, c-format
+msgid "Vendor ID: %v"
+msgstr "Em cache: %s"
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7861,12 +7901,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Versão CUDA: %v"
@@ -9175,6 +9215,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr "sim"
+
+#, fuzzy, c-format
+#~ msgid "Usb %d:"
+#~ msgstr "Uso de disco:"
 
 #, fuzzy
 #~ msgid "Path to the shared block device:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-31 22:12-0400\n"
+"POT-Creation-Date: 2024-04-01 22:06-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,15 +20,15 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid "  Motherboard:"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:822 cmd/incus/info.go:567
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -1127,7 +1127,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1178,11 +1178,16 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, c-format
+msgid "Bus Address: %v"
+msgstr ""
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1202,7 +1207,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr " Использование ЦП:"
@@ -1211,16 +1216,16 @@ msgstr " Использование ЦП:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1345,7 +1350,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1862,7 +1867,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1927,7 +1932,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Авто-обновление: %s"
@@ -2231,6 +2236,11 @@ msgstr "Копирование образа: %s"
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
+#: cmd/incus/info.go:542
+#, fuzzy, c-format
+msgid "Device %d:"
+msgstr " Использование диска:"
+
 #: cmd/incus/config_device.go:197
 #, c-format
 msgid "Device %s added to %s"
@@ -2244,6 +2254,11 @@ msgstr ""
 #: cmd/incus/config_device.go:599
 #, c-format
 msgid "Device %s removed from %s"
+msgstr ""
+
+#: cmd/incus/info.go:347
+#, c-format
+msgid "Device Address: %v"
 msgstr ""
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
@@ -2302,22 +2317,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 #, fuzzy
 msgid "Disk:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 #, fuzzy
 msgid "Disks:"
 msgstr " Использование диска:"
@@ -2665,7 +2680,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3086,7 +3101,7 @@ msgstr "Принять сертификат"
 msgid "Failed validation request: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3201,8 +3216,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476
-#: cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3221,11 +3236,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid "GPUs:"
 msgstr ""
 
@@ -3413,12 +3428,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3464,7 +3479,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 msgid "IP addresses"
 msgstr ""
 
@@ -3640,7 +3655,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
@@ -3865,7 +3880,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
@@ -4271,7 +4286,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4280,7 +4295,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid "Log:"
 msgstr ""
 
@@ -4319,7 +4334,7 @@ msgstr "Копирование образа: %s"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 msgid "MAC address"
 msgstr ""
 
@@ -4362,7 +4377,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid "MTU"
 msgstr ""
 
@@ -4626,20 +4641,20 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 #, fuzzy
 msgid "Memory:"
 msgstr " Использование памяти:"
@@ -4985,11 +5000,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid "NICs:"
 msgstr ""
 
@@ -5005,7 +5020,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5018,7 +5033,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5084,7 +5099,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929
+#: cmd/incus/info.go:576 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5205,7 +5220,7 @@ msgstr ""
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -5293,7 +5308,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5350,7 +5365,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5375,7 +5390,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5409,11 +5424,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5525,7 +5540,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5535,12 +5550,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, fuzzy, c-format
+msgid "Product ID: %v"
+msgstr "Авто-обновление: %s"
+
+#: cmd/incus/info.go:432
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -6068,7 +6088,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid "Resources:"
 msgstr ""
 
@@ -6170,7 +6190,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6245,12 +6265,17 @@ msgstr "Авто-обновление: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, fuzzy, c-format
+msgid "Serial Number: %v"
+msgstr "Авто-обновление: %s"
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6826,11 +6851,11 @@ msgstr "Копирование образа: %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6863,7 +6888,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
@@ -6873,11 +6898,11 @@ msgstr "Авто-обновление: %s"
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7007,11 +7032,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7027,7 +7052,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid "System:"
 msgstr ""
 
@@ -7048,7 +7073,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7318,7 +7343,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7397,7 +7422,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7411,8 +7436,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478
-#: cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7466,7 +7491,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 msgid "Type"
 msgstr ""
 
@@ -7485,14 +7510,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391
-#: cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
+#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7513,6 +7538,16 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
+#: cmd/incus/info.go:537
+#, fuzzy
+msgid "USB device:"
+msgstr "Копирование образа: %s"
+
+#: cmd/incus/info.go:540
+#, fuzzy
+msgid "USB devices:"
+msgstr "Копирование образа: %s"
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
 #: cmd/incus/network_zone.go:147 cmd/incus/profile.go:736
@@ -7525,7 +7560,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7745,7 +7780,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7793,8 +7828,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477
-#: cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7834,12 +7869,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, fuzzy, c-format
+msgid "Vendor ID: %v"
+msgstr "Авто-обновление: %s"
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7854,12 +7894,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -9679,6 +9719,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr "да"
+
+#, fuzzy, c-format
+#~ msgid "Usb %d:"
+#~ msgstr " Использование диска:"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-03-31 22:12-0400\n"
+"POT-Creation-Date: 2024-04-01 22:06-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:408
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:444
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:413
+#: cmd/incus/info.go:426
 msgid "  Motherboard:"
 msgstr ""
 
@@ -655,7 +655,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:543
+#: cmd/incus/config.go:822 cmd/incus/info.go:567
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -938,7 +938,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:566
+#: cmd/incus/image.go:999 cmd/incus/info.go:590
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1056,7 +1056,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:734 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1107,11 +1107,16 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:657 cmd/incus/network.go:947
+#: cmd/incus/info.go:346
+#, c-format
+msgid "Bus Address: %v"
+msgstr ""
+
+#: cmd/incus/info.go:681 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:658 cmd/incus/network.go:948
+#: cmd/incus/info.go:682 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr ""
 
@@ -1131,7 +1136,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:446
+#: cmd/incus/info.go:459
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -1140,15 +1145,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:607
+#: cmd/incus/info.go:631
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:635
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:449
+#: cmd/incus/info.go:462
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1272,7 +1277,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:493 cmd/incus/info.go:505
+#: cmd/incus/info.go:506 cmd/incus/info.go:518
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1769,7 +1774,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:577
+#: cmd/incus/image.go:1005 cmd/incus/info.go:601
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1833,7 +1838,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:441
+#: cmd/incus/info.go:454
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -2123,6 +2128,11 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
+#: cmd/incus/info.go:542
+#, c-format
+msgid "Device %d:"
+msgstr ""
+
 #: cmd/incus/config_device.go:197
 #, c-format
 msgid "Device %s added to %s"
@@ -2136,6 +2146,11 @@ msgstr ""
 #: cmd/incus/config_device.go:599
 #, c-format
 msgid "Device %s removed from %s"
+msgstr ""
+
+#: cmd/incus/info.go:347
+#, c-format
+msgid "Device Address: %v"
 msgstr ""
 
 #: cmd/incus/utils.go:58 cmd/incus/utils.go:82
@@ -2194,20 +2209,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:517
+#: cmd/incus/info.go:530
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:600
+#: cmd/incus/info.go:624
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:525
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:528
 msgid "Disks:"
 msgstr ""
 
@@ -2540,7 +2555,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/info.go:771 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2954,7 +2969,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:375
+#: cmd/incus/info.go:388
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3068,8 +3083,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:460 cmd/incus/info.go:471 cmd/incus/info.go:476
-#: cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3088,11 +3103,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:488
+#: cmd/incus/info.go:501
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:491
+#: cmd/incus/info.go:504
 msgid "GPUs:"
 msgstr ""
 
@@ -3262,11 +3277,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:670
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:470
+#: cmd/incus/info.go:472 cmd/incus/info.go:483
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3312,7 +3327,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:686
 msgid "IP addresses"
 msgstr ""
 
@@ -3482,7 +3497,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:772
+#: cmd/incus/info.go:796
 msgid "Instance Only"
 msgstr ""
 
@@ -3701,7 +3716,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:581
+#: cmd/incus/info.go:605
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4088,7 +4103,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:569 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4097,7 +4112,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:800
+#: cmd/incus/info.go:824
 msgid "Log:"
 msgstr ""
 
@@ -4134,7 +4149,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:674
 msgid "MAC address"
 msgstr ""
 
@@ -4177,7 +4192,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:678
 msgid "MTU"
 msgstr ""
 
@@ -4415,19 +4430,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:642
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:622
+#: cmd/incus/info.go:646
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:658
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:470
 msgid "Memory:"
 msgstr ""
 
@@ -4754,11 +4769,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:513
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:516
 msgid "NICs:"
 msgstr ""
 
@@ -4774,7 +4789,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:466
+#: cmd/incus/info.go:479
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4787,7 +4802,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:718 cmd/incus/info.go:769 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4849,7 +4864,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:552 cmd/incus/network.go:929
+#: cmd/incus/info.go:576 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -4969,7 +4984,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:675 cmd/incus/network.go:946
+#: cmd/incus/info.go:699 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5055,7 +5070,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:468
+#: cmd/incus/info.go:481
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5112,7 +5127,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:773 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5137,7 +5152,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:573
+#: cmd/incus/info.go:597
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5171,11 +5186,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:659 cmd/incus/network.go:949
+#: cmd/incus/info.go:683 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:660 cmd/incus/network.go:950
+#: cmd/incus/info.go:684 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5286,7 +5301,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:587
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5296,12 +5311,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:419
+#: cmd/incus/info.go:345
+#, c-format
+msgid "Product ID: %v"
+msgstr ""
+
+#: cmd/incus/info.go:432
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:371
+#: cmd/incus/info.go:344 cmd/incus/info.go:384
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -5813,7 +5833,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:609
 msgid "Resources:"
 msgstr ""
 
@@ -5907,7 +5927,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:383
+#: cmd/incus/info.go:396
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -5982,12 +6002,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:423
+#: cmd/incus/info.go:349
+#, c-format
+msgid "Serial Number: %v"
+msgstr ""
+
+#: cmd/incus/info.go:422 cmd/incus/info.go:436
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:400
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6528,11 +6553,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:687 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:451
+#: cmd/incus/info.go:464
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6565,7 +6590,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:644
+#: cmd/incus/info.go:668
 msgid "State"
 msgstr ""
 
@@ -6574,11 +6599,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:554
+#: cmd/incus/info.go:578
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6704,11 +6729,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:626
+#: cmd/incus/info.go:650
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:654
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6724,7 +6749,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:361
+#: cmd/incus/info.go:374
 msgid "System:"
 msgstr ""
 
@@ -6745,7 +6770,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:719 cmd/incus/info.go:770 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7015,7 +7040,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:352
+#: cmd/incus/info.go:365
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7093,7 +7118,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:344
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7107,8 +7132,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:462 cmd/incus/info.go:473 cmd/incus/info.go:478
-#: cmd/incus/info.go:484
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7162,7 +7187,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:667
 msgid "Type"
 msgstr ""
 
@@ -7180,14 +7205,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:391
-#: cmd/incus/info.go:401 cmd/incus/info.go:563 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
+#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:561
+#: cmd/incus/info.go:585
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7208,6 +7233,14 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
+#: cmd/incus/info.go:537
+msgid "USB device:"
+msgstr ""
+
+#: cmd/incus/info.go:540
+msgid "USB devices:"
+msgstr ""
+
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
 #: cmd/incus/network_zone.go:147 cmd/incus/profile.go:736
@@ -7220,7 +7253,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:363
+#: cmd/incus/info.go:140 cmd/incus/info.go:376
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7418,7 +7451,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:792
+#: cmd/incus/info.go:816
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7464,8 +7497,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:461 cmd/incus/info.go:472 cmd/incus/info.go:477
-#: cmd/incus/info.go:483
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7504,12 +7537,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:397 cmd/incus/info.go:415 cmd/incus/info.go:433
+#: cmd/incus/info.go:343
+#, c-format
+msgid "Vendor ID: %v"
+msgstr ""
+
+#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:367
+#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7524,12 +7562,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:405 cmd/incus/info.go:427 cmd/incus/info.go:437
+#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:379
+#: cmd/incus/info.go:392
 #, c-format
 msgid "Version: %v"
 msgstr ""


### PR DESCRIPTION
This PR is in reference to #702 . It adds Usb information to cmd output of resources.