### PR TITLE
Rework server-side instance move

### DIFF
--- a/cmd/incus/move.go
+++ b/cmd/incus/move.go
@@ -9,7 +9,6 @@ import (
 	cli "github.com/lxc/incus/internal/cmd"
 	"github.com/lxc/incus/internal/i18n"
 	"github.com/lxc/incus/shared/api"
-	config "github.com/lxc/incus/shared/cliconfig"
 )
 
 type cmdMove struct {
@@ -118,7 +117,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// As an optimization, if the source an destination are the same, do
+	// As an optimization, if the source and destination are the same, do
 	// this via a simple rename. This only works for instances that aren't
 	// running, instances that are running should be live migrated (of
 	// course, this changing of hostname isn't supported right now, so this
@@ -150,75 +149,54 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 
 	stateful := !c.flagStateless
 
-	if c.flagTarget != "" {
-		// If the target option was specified, we're moving an instance from a
-		// cluster member to another, let's use the dedicated API.
-		if sourceRemote == destRemote {
-			if c.flagInstanceOnly {
-				return fmt.Errorf(i18n.G("The --instance-only flag can't be used with --target"))
-			}
-
-			if c.flagStorage != "" {
-				return fmt.Errorf(i18n.G("The --storage flag can't be used with --target"))
-			}
-
-			if c.flagTargetProject != "" {
-				return fmt.Errorf(i18n.G("The --target-project flag can't be used with --target"))
-			}
-
-			if c.flagMode != moveDefaultMode {
-				return fmt.Errorf(i18n.G("The --mode flag can't be used with --target"))
-			}
-
-			return moveClusterInstance(conf, sourceResource, destResource, c.flagTarget, c.global.flagQuiet, stateful)
+	isServerSide := func() bool {
+		// Check if same source and destination.
+		if sourceRemote != destRemote {
+			return false
 		}
 
-		dest, err := conf.GetInstanceServer(destRemote)
-		if err != nil {
-			return err
+		// Check if asked for specific client mode.
+		if c.flagMode != moveDefaultMode {
+			return false
 		}
 
-		if !dest.IsClustered() {
-			return fmt.Errorf(i18n.G("The destination server is not clustered"))
-		}
-	}
-
-	// Support for server-side move. Currently, such migration can only move an instance to different project
-	// or storage pool. If specific profile, device or config is provided, the instance should be copied (move using copy).
-	if sourceRemote == destRemote && (c.flagStorage != "" || c.flagTargetProject != "") {
+		// Connect to the server.
 		source, err := conf.GetInstanceServer(sourceRemote)
 		if err != nil {
-			return err
+			return false
 		}
 
-		if source.HasExtension("instance_move_config") {
-			if c.flagMode != moveDefaultMode {
-				return fmt.Errorf(i18n.G("The --mode flag can't be used with --storage or --target-project"))
+		// Check if override is requested with a server lacking support.
+		if !source.HasExtension("instance_move_config") {
+			if len(c.flagConfig) > 0 {
+				return false
 			}
 
-			// Evaluate provided profiles. If no profiles were provided and flag noProfiles is false,
-			// existing instance profiles will be retained. Otherwise, flags are respected.
-			var profiles *[]string
+			if len(c.flagDevice) > 0 {
+				return false
+			}
+
 			if len(c.flagProfile) > 0 {
-				profiles = &c.flagProfile
-			} else if c.flagNoProfiles {
-				profiles = &[]string{}
+				return false
 			}
-
-			return moveInstance(conf, sourceResource, destResource, c.flagStorage, c.flagTargetProject, c.flagConfig, c.flagDevice, profiles, c.flagInstanceOnly, stateful)
 		}
 
-		if source.HasExtension("instance_pool_move") && source.HasExtension("instance_project_move") {
-			if len(c.flagConfig) != 0 || len(c.flagDevice) != 0 || len(c.flagProfile) != 0 || c.flagNoProfiles {
-				return fmt.Errorf("The move command does not support flags --config, --device, --profile, and --no-profiles. Please use copy instead")
-			}
-
-			if c.flagMode != moveDefaultMode {
-				return fmt.Errorf(i18n.G("The --mode flag can't be used with --storage or --target-project"))
-			}
-
-			return moveInstance(conf, sourceResource, destResource, c.flagStorage, c.flagTargetProject, []string{}, []string{}, nil, c.flagInstanceOnly, stateful)
+		// Check if server supports moving pools.
+		if c.flagStorage != "" && !source.HasExtension("instance_pool_move") {
+			return false
 		}
+
+		// Check if server supports moving projects.
+		if c.flagTargetProject != "" && !source.HasExtension("instance_project_move") {
+			return false
+		}
+
+		return true
+	}()
+
+	// Support for server-side move in clusters.
+	if isServerSide {
+		return c.moveInstance(sourceResource, destResource, stateful)
 	}
 
 	cpy := cmdCopy{}
@@ -251,84 +229,10 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// Move an instance using special POST /instances/<name>?target=<member> API.
-func moveClusterInstance(conf *config.Config, sourceResource string, destResource string, target string, quiet bool, stateful bool) error {
-	// Parse the source.
-	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
-	if err != nil {
-		return err
-	}
-
-	// Parse the destination.
-	_, destName, err := conf.ParseRemote(destResource)
-	if err != nil {
-		return err
-	}
-
-	// Make sure we have an instance or snapshot name.
-	if sourceName == "" {
-		return fmt.Errorf(i18n.G("You must specify a source instance name"))
-	}
-
-	// The destination name is optional.
-	if destName == "" {
-		destName = sourceName
-	}
-
-	// Connect to the source host
-	source, err := conf.GetInstanceServer(sourceRemote)
-	if err != nil {
-		return fmt.Errorf(i18n.G("Failed to connect to cluster member: %w"), err)
-	}
-
-	// Check that it's a cluster
-	if !source.IsClustered() {
-		return fmt.Errorf(i18n.G("The source server is not clustered"))
-	}
-
-	// The migrate API will do the right thing when passed a target.
-	source = source.UseTarget(target)
-	req := api.InstancePost{
-		Name:      destName,
-		Migration: true,
-		Live:      stateful,
-	}
-
-	op, err := source.MigrateInstance(sourceName, req)
-	if err != nil {
-		return fmt.Errorf(i18n.G("Migration API failure: %w"), err)
-	}
-
-	// Watch the background operation
-	progress := cli.ProgressRenderer{
-		Format: i18n.G("Transferring instance: %s"),
-		Quiet:  quiet,
-	}
-
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
-	}
-	// Wait for the move to complete
-	err = cli.CancelableWait(op, &progress)
-	if err != nil {
-		progress.Done("")
-		return err
-	}
-
-	progress.Done("")
-
-	err = op.Wait()
-	if err != nil {
-		return fmt.Errorf(i18n.G("Migration operation failure: %w"), err)
-	}
-
-	return nil
-}
-
 // Move an instance between pools and projects using special POST /instances/<name> API.
-func moveInstance(conf *config.Config, sourceResource string, destResource string, storage string, targetProject string, config []string, devices []string, profiles *[]string, instanceOnly bool, stateful bool) error {
+func (c *cmdMove) moveInstance(sourceResource string, destResource string, stateful bool) error {
+	conf := c.global.conf
+
 	// Parse the source.
 	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
 	if err != nil {
@@ -357,65 +261,103 @@ func moveInstance(conf *config.Config, sourceResource string, destResource strin
 		return fmt.Errorf(i18n.G("Failed to connect to cluster member: %w"), err)
 	}
 
-	// Copy of an instance into a new instance.
-	inst, _, err := source.GetInstance(sourceName)
-	if err != nil {
-		return err
+	if !source.IsClustered() && c.flagTarget != "" {
+		return fmt.Errorf(i18n.G("--target can only be used with clusters"))
 	}
 
-	// Overwrite the config values.
-	for _, entry := range config {
-		key, value, found := strings.Cut(entry, "=")
-		if !found {
-			return fmt.Errorf(i18n.G("Bad key=value pair: %q"), entry)
-		}
-
-		inst.Config[key] = value
-	}
-
-	// Parse device map and overwrite device settings.
-	deviceMap, err := parseDeviceOverrides(devices)
-	if err != nil {
-		return err
-	}
-
-	for k, m := range deviceMap {
-		if inst.Devices[k] == nil {
-			inst.Devices[k] = m
-			continue
-		}
-
-		for key, value := range m {
-			inst.Devices[k][key] = value
-		}
+	// Set the target if specified.
+	if c.flagTarget != "" {
+		source = source.UseTarget(c.flagTarget)
 	}
 
 	// Pass the new pool to the migration API.
 	req := api.InstancePost{
 		Name:         destName,
 		Migration:    true,
-		InstanceOnly: instanceOnly,
-		Pool:         storage,
-		Project:      targetProject,
+		InstanceOnly: c.flagInstanceOnly,
+		Pool:         c.flagStorage,
+		Project:      c.flagTargetProject,
 		Live:         stateful,
-		Config:       inst.Config,
-		Devices:      inst.Devices,
 	}
 
-	// Overwrite profiles.
+	// Override profiles.
+	var profiles *[]string
+	if len(c.flagProfile) > 0 {
+		profiles = &c.flagProfile
+	} else if c.flagNoProfiles {
+		profiles = &[]string{}
+	}
+
 	if profiles != nil {
 		req.Profiles = *profiles
 	}
 
+	// Override config.
+	if len(c.flagConfig) > 0 {
+		req.Config = map[string]string{}
+
+		for _, entry := range c.flagConfig {
+			key, value, found := strings.Cut(entry, "=")
+			if !found {
+				return fmt.Errorf(i18n.G("Bad key=value pair: %q"), entry)
+			}
+
+			req.Config[key] = value
+		}
+	}
+
+	// Override devices.
+	if len(c.flagDevice) > 0 {
+		req.Devices = map[string]map[string]string{}
+
+		// Parse the overrides.
+		deviceMap, err := parseDeviceOverrides(c.flagDevice)
+		if err != nil {
+			return err
+		}
+
+		// Fetch the current isntance.
+		inst, _, err := source.GetInstance(sourceName)
+		if err != nil {
+			return err
+		}
+
+		for devName, dev := range deviceMap {
+			fullDev := inst.ExpandedDevices[devName]
+			for k, v := range dev {
+				fullDev[k] = v
+			}
+
+			req.Devices[devName] = fullDev
+		}
+	}
+
+	// Move the instance.
 	op, err := source.MigrateInstance(sourceName, req)
 	if err != nil {
 		return fmt.Errorf(i18n.G("Migration API failure: %w"), err)
 	}
 
-	err = op.Wait()
+	// Watch the background operation
+	progress := cli.ProgressRenderer{
+		Format: i18n.G("Transferring instance: %s"),
+		Quiet:  c.global.flagQuiet,
+	}
+
+	_, err = op.AddHandler(progress.UpdateOp)
 	if err != nil {
+		progress.Done("")
+		return err
+	}
+
+	// Wait for the move to complete
+	err = cli.CancelableWait(op, &progress)
+	if err != nil {
+		progress.Done("")
 		return fmt.Errorf(i18n.G("Migration operation failure: %w"), err)
 	}
+
+	progress.Done("")
 
 	return nil
 }

--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -57,7 +57,7 @@ import (
 )
 
 type evacuateStopFunc func(inst instance.Instance, action string) error
-type evacuateMigrateFunc func(ctx context.Context, s *state.State, r *http.Request, inst instance.Instance, targetMemberInfo *db.NodeInfo, live bool, startInstance bool, metadata map[string]any, op *operations.Operation) error
+type evacuateMigrateFunc func(ctx context.Context, s *state.State, r *http.Request, inst instance.Instance, sourceMemberInfo *db.NodeInfo, targetMemberInfo *db.NodeInfo, live bool, startInstance bool, metadata map[string]any, op *operations.Operation) error
 
 type evacuateOpts struct {
 	s               *state.State
@@ -598,7 +598,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		// As ServerAddress field is required to be set it means that we're using the new join API
 		// introduced with the 'clustering_join' extension.
 		// Connect to ourselves to initialize storage pools and networks using the API.
-		localClient, err := incus.ConnectIncusUnix(d.UnixSocket(), &incus.ConnectionArgs{UserAgent: clusterRequest.UserAgentJoiner})
+		localClient, err := incus.ConnectIncusUnix(d.os.GetUnixSocket(), &incus.ConnectionArgs{UserAgent: clusterRequest.UserAgentJoiner})
 		if err != nil {
 			return fmt.Errorf("Failed to connect to local server: %w", err)
 		}
@@ -3064,14 +3064,14 @@ func clusterNodeStatePost(d *Daemon, r *http.Request) response.Response {
 			return nil
 		}
 
-		migrateFunc := func(ctx context.Context, s *state.State, r *http.Request, inst instance.Instance, targetMemberInfo *db.NodeInfo, live bool, startInstance bool, metadata map[string]any, op *operations.Operation) error {
+		migrateFunc := func(ctx context.Context, s *state.State, r *http.Request, inst instance.Instance, sourceMemberInfo *db.NodeInfo, targetMemberInfo *db.NodeInfo, live bool, startInstance bool, metadata map[string]any, op *operations.Operation) error {
 			// Migrate the instance.
 			req := api.InstancePost{
-				Name: inst.Name(),
-				Live: live,
+				Migration: true,
+				Live:      live,
 			}
 
-			err := migrateInstance(ctx, s, r, inst, targetMemberInfo.Name, req, op)
+			err := migrateInstance(ctx, s, inst, req, sourceMemberInfo, targetMemberInfo, op)
 			if err != nil {
 				return fmt.Errorf("Failed to migrate instance %q in project %q: %w", inst.Name(), inst.Project().Name, err)
 			}
@@ -3115,7 +3115,7 @@ func clusterNodeStatePost(d *Daemon, r *http.Request) response.Response {
 }
 
 func internalClusterHeal(d *Daemon, r *http.Request) response.Response {
-	migrateFunc := func(ctx context.Context, s *state.State, r *http.Request, inst instance.Instance, targetMemberInfo *db.NodeInfo, live bool, startInstance bool, metadata map[string]any, op *operations.Operation) error {
+	migrateFunc := func(ctx context.Context, s *state.State, r *http.Request, inst instance.Instance, sourceMemberInfo *db.NodeInfo, targetMemberInfo *db.NodeInfo, live bool, startInstance bool, metadata map[string]any, op *operations.Operation) error {
 		// This returns an error if the instance's storage pool is local.
 		// Since we only care about remote backed instances, this can be ignored and return nil instead.
 		poolName, err := inst.StoragePool()
@@ -3333,7 +3333,7 @@ func evacuateInstances(ctx context.Context, opts evacuateOpts) error {
 		}
 
 		// Find a new location for the instance.
-		targetMemberInfo, err := evacuateClusterSelectTarget(ctx, opts.s, opts.gateway, inst)
+		sourceMemberInfo, targetMemberInfo, err := evacuateClusterSelectTarget(ctx, opts.s, opts.gateway, inst)
 		if err != nil {
 			if api.StatusErrorCheck(err, http.StatusNotFound) {
 				// Skip migration if no target is available.
@@ -3352,7 +3352,7 @@ func evacuateInstances(ctx context.Context, opts evacuateOpts) error {
 		}
 
 		start := isRunning || instanceShouldAutoStart(inst)
-		err = opts.migrateInstance(ctx, opts.s, opts.r, inst, targetMemberInfo, action == "live-migrate", start, metadata, opts.op)
+		err = opts.migrateInstance(ctx, opts.s, opts.r, inst, sourceMemberInfo, targetMemberInfo, action == "live-migrate", start, metadata, opts.op)
 		if err != nil {
 			return err
 		}
@@ -4351,12 +4351,21 @@ func clusterGroupValidateName(name string) error {
 	return nil
 }
 
-func evacuateClusterSelectTarget(ctx context.Context, s *state.State, gateway *cluster.Gateway, inst instance.Instance) (*db.NodeInfo, error) {
+func evacuateClusterSelectTarget(ctx context.Context, s *state.State, gateway *cluster.Gateway, inst instance.Instance) (*db.NodeInfo, *db.NodeInfo, error) {
+	var sourceMemberInfo *db.NodeInfo
 	var targetMemberInfo *db.NodeInfo
 
 	// Get candidate cluster members to move instances to.
 	var candidateMembers []db.NodeInfo
 	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get the source member info.
+		srcMember, err := tx.GetNodeByName(ctx, inst.Location())
+		if err != nil {
+			return fmt.Errorf("Failed getting current cluster member of instance %q", inst.Name())
+		}
+
+		sourceMemberInfo = &srcMember
+
 		allMembers, err := tx.GetNodes(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed getting cluster members: %w", err)
@@ -4386,14 +4395,14 @@ func evacuateClusterSelectTarget(ctx context.Context, s *state.State, gateway *c
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Run instance placement scriptlet if enabled.
 	if s.GlobalConfig.InstancesPlacementScriptlet() != "" {
 		leaderAddress, err := gateway.LeaderAddress()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// Copy request so we don't modify it when expanding the config.
@@ -4412,7 +4421,7 @@ func evacuateClusterSelectTarget(ctx context.Context, s *state.State, gateway *c
 
 		reqExpanded.Architecture, err = osarch.ArchitectureName(inst.Architecture())
 		if err != nil {
-			return nil, fmt.Errorf("Failed getting architecture for instance %q in project %q: %w", inst.Name(), inst.Project().Name, err)
+			return nil, nil, fmt.Errorf("Failed getting architecture for instance %q in project %q: %w", inst.Name(), inst.Project().Name, err)
 		}
 
 		for _, p := range inst.Profiles() {
@@ -4423,7 +4432,7 @@ func evacuateClusterSelectTarget(ctx context.Context, s *state.State, gateway *c
 		targetMemberInfo, err = scriptlet.InstancePlacementRun(ctx, logger.Log, s, &reqExpanded, candidateMembers, leaderAddress)
 		if err != nil {
 			cancel()
-			return nil, fmt.Errorf("Failed instance placement scriptlet for instance %q in project %q: %w", inst.Name(), inst.Project().Name, err)
+			return nil, nil, fmt.Errorf("Failed instance placement scriptlet for instance %q in project %q: %w", inst.Name(), inst.Project().Name, err)
 		}
 
 		cancel()
@@ -4443,11 +4452,11 @@ func evacuateClusterSelectTarget(ctx context.Context, s *state.State, gateway *c
 			return nil
 		})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return targetMemberInfo, nil
+	return sourceMemberInfo, targetMemberInfo, nil
 }
 
 func autoHealClusterTask(d *Daemon) (task.Func, task.Schedule) {

--- a/cmd/incusd/api_cluster_test.go
+++ b/cmd/incusd/api_cluster_test.go
@@ -59,10 +59,10 @@ func TestCluster_Get(t *testing.T) {
 	daemon, cleanup := newTestDaemon(t)
 	defer cleanup()
 
-	client, err := incus.ConnectIncusUnix(daemon.UnixSocket(), nil)
+	c, err := incus.ConnectIncusUnix(daemon.os.GetUnixSocket(), nil)
 	require.NoError(t, err)
 
-	cluster, _, err := client.GetCluster()
+	cluster, _, err := c.GetCluster()
 	require.NoError(t, err)
 	assert.Equal(t, "", cluster.ServerName)
 	assert.False(t, cluster.Enabled)
@@ -145,7 +145,7 @@ func (f *clusterFixture) ClientUnix(daemon *Daemon) incus.InstanceServer {
 	client, ok := f.clients[daemon]
 	if !ok {
 		var err error
-		client, err = incus.ConnectIncusUnix(daemon.UnixSocket(), nil)
+		client, err = incus.ConnectIncusUnix(daemon.os.GetUnixSocket(), nil)
 		require.NoError(f.t, err)
 	}
 

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -523,17 +523,6 @@ func (d *Daemon) State() *state.State {
 	}
 }
 
-// UnixSocket returns the full path to the unix.socket file that this daemon is
-// listening on. Used by tests.
-func (d *Daemon) UnixSocket() string {
-	path := os.Getenv("INCUS_SOCKET")
-	if path != "" {
-		return path
-	}
-
-	return filepath.Join(d.os.VarDir, "unix.socket")
-}
-
 func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 	var uri string
 	if c.Path == "" {
@@ -831,7 +820,7 @@ func (d *Daemon) init() error {
 	d.internalListener = events.NewInternalListener(d.shutdownCtx, d.events)
 
 	// Lets check if there's an existing daemon running
-	err = endpoints.CheckAlreadyRunning(d.UnixSocket())
+	err = endpoints.CheckAlreadyRunning(d.os.GetUnixSocket())
 	if err != nil {
 		return err
 	}
@@ -1160,7 +1149,7 @@ func (d *Daemon) init() error {
 	/* Setup the web server */
 	config := &endpoints.Config{
 		Dir:                  d.os.VarDir,
-		UnixSocket:           d.UnixSocket(),
+		UnixSocket:           d.os.GetUnixSocket(),
 		Cert:                 networkCert,
 		RestServer:           restServer(d),
 		DevIncusServer:       devIncusServer(d),

--- a/cmd/incusd/daemon_integration_test.go
+++ b/cmd/incusd/daemon_integration_test.go
@@ -17,14 +17,14 @@ import (
 func TestIntegration_UnixSocket(t *testing.T) {
 	daemon, cleanup := newTestDaemon(t)
 	defer cleanup()
-	client, err := incus.ConnectIncusUnix(daemon.UnixSocket(), nil)
+	c, err := incus.ConnectIncusUnix(daemon.os.GetUnixSocket(), nil)
 	require.NoError(t, err)
 
-	server, _, err := client.GetServer()
+	server, _, err := c.GetServer()
 	require.NoError(t, err)
 	assert.Equal(t, "trusted", server.Auth)
 	assert.False(t, server.Environment.ServerClustered)
-	assert.False(t, client.IsClustered())
+	assert.False(t, c.IsClustered())
 }
 
 // Create a new daemon for testing.

--- a/cmd/incusd/instance_post.go
+++ b/cmd/incusd/instance_post.go
@@ -1,26 +1,22 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/incus/client"
 	internalInstance "github.com/lxc/incus/internal/instance"
-	"github.com/lxc/incus/internal/jmap"
 	"github.com/lxc/incus/internal/server/auth"
 	"github.com/lxc/incus/internal/server/cluster"
 	"github.com/lxc/incus/internal/server/db"
 	dbCluster "github.com/lxc/incus/internal/server/db/cluster"
 	"github.com/lxc/incus/internal/server/db/operationtype"
 	"github.com/lxc/incus/internal/server/instance"
-	"github.com/lxc/incus/internal/server/instance/instancetype"
 	"github.com/lxc/incus/internal/server/operations"
 	"github.com/lxc/incus/internal/server/project"
 	"github.com/lxc/incus/internal/server/request"
@@ -72,55 +68,36 @@ import (
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
 func instancePost(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
 	// Don't mess with instance while in setup mode.
 	<-d.waitReady.Done()
 
-	s := d.State()
-
+	// Parse the request URL.
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
 	projectName := request.ProjectParam(r)
+	target := request.QueryParam(r, "target")
 
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
 	}
 
+	// Quick checks.
 	if internalInstance.IsSnapshot(name) {
 		return response.BadRequest(fmt.Errorf("Invalid instance name"))
 	}
 
-	// Flag indicating whether the node running the container is offline.
-	sourceNodeOffline := false
-
-	var targetProject *api.Project
-	var targetMemberInfo *db.NodeInfo
-	var candidateMembers []db.NodeInfo
-
-	target := request.QueryParam(r, "target")
-	if !s.ServerClustered && target != "" {
+	if target != "" && !s.ServerClustered {
 		return response.BadRequest(fmt.Errorf("Target only allowed when clustered"))
 	}
 
-	// A POST to /instances/<name>?target=<member> is meant to be used to
-	// move an instance from one member to another within a cluster.
-	//
-	// Determine if either the source node (the one currently
-	// running the instance) or the target node are offline.
-	//
-	// If the target node is offline, we return an error.
-	//
-	// If the source node is offline and the instance is backed by
-	// a remote storage pool, we'll just assume that the instance is not running
-	// and it's safe to move it.
-	//
-	// TODO: add some sort of "force" flag to the API, to signal
-	//       that the user really wants to move the instance even
-	//       if we can't know for sure that it's indeed not
-	//       running?
+	// Check if the server the instance is running on is currently online.
+	var sourceMemberInfo *db.NodeInfo
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Load source node.
 		sourceAddress, err := tx.GetNodeAddressOfInstance(ctx, projectName, name, instanceType)
@@ -130,16 +107,15 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 
 		if sourceAddress == "" {
 			// Local node.
-			sourceNodeOffline = false
 			return nil
 		}
 
-		sourceMemberInfo, err := tx.GetNodeByAddress(ctx, sourceAddress)
+		info, err := tx.GetNodeByAddress(ctx, sourceAddress)
 		if err != nil {
 			return fmt.Errorf("Failed to get source member for %q: %w", sourceAddress, err)
 		}
 
-		sourceNodeOffline = sourceMemberInfo.IsOffline(s.GlobalConfig.OfflineThreshold())
+		sourceMemberInfo = &info
 
 		return nil
 	})
@@ -147,28 +123,20 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	// Check whether to forward the request to the node that is running the
-	// instance. Here are the possible cases:
-	//
-	// 1. No "?target=<member>" parameter was passed. In this case this is
-	//    just an instance rename, with no move, and we want the request to be
-	//    handled by the node which is actually running the instance.
-	//
-	// 2. The "?target=<member>" parameter was set and the node running the
-	//    instance is online. In this case we want to forward the request to
-	//    that node so it can perform any needed local action.
-	//
-	// 3. The "?target=<member>" parameter was set but the node running the
-	//    instance is offline. We don't want to forward to the request to
-	//    that node and we don't want to load the instance here (since
-	//    it's not a local instance): we'll be able to handle the request
-	//    at all only if the instance is backed by a remote storage
-	//    pool. We'll check for that just below.
-	//
-	// Cases 1. and 2. are the ones for which the conditional will be true
-	// and we'll either forward the request or load the instance.
-	if target == "" || !sourceNodeOffline {
-		// Handle requests targeted to a container on a different node.
+	// More checks.
+	if target == "" && sourceMemberInfo != nil && sourceMemberInfo.IsOffline(s.GlobalConfig.OfflineThreshold()) {
+		return response.BadRequest(fmt.Errorf("Can't perform action as server is currently offline"))
+	}
+
+	// Handle request forwarding.
+	if sourceMemberInfo != nil && sourceMemberInfo.IsOffline(s.GlobalConfig.OfflineThreshold()) {
+		// Current location of the instance isn't available and we've been asked to relocate it, forward to target.
+		resp := forwardedResponseIfTargetIsRemote(s, r)
+		if resp != nil {
+			return resp
+		}
+	} else if target == "" || sourceMemberInfo == nil || !sourceMemberInfo.IsOffline(s.GlobalConfig.OfflineThreshold()) {
+		// Forward the request to the instance's current location (if not local).
 		resp, err := forwardedResponseIfInstanceIsRemote(s, r, projectName, name, instanceType)
 		if err != nil {
 			return response.SmartError(err)
@@ -177,48 +145,161 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		if resp != nil {
 			return resp
 		}
-	} else if sourceNodeOffline {
-		// If a target was specified, forward the request to the relevant node.
-		resp := forwardedResponseIfTargetIsRemote(s, r)
-		if resp != nil {
-			return resp
+	}
+
+	// Parse the request.
+	req := api.InstancePost{}
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	// Target instance properties.
+	instProject := projectName
+	instLocation := target
+
+	// Clear instance name if it's the same.
+	if req.Name != "" && req.Name == name {
+		req.Name = ""
+	}
+
+	// Validate the new target project (if provided).
+	if req.Project != "" {
+		// Confirm access to target project.
+		err := s.Authorizer.CheckPermission(r.Context(), r, auth.ObjectProject(req.Project), auth.EntitlementCanCreateInstances)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		instProject = req.Project
+	}
+
+	// Validate the new instance name (if provided).
+	if req.Name != "" {
+		// Check the new instance name is valid.
+		err = instance.ValidName(req.Name, false)
+		if err != nil {
+			return response.BadRequest(err)
+		}
+
+		// Check that the new isn't already in use.
+		var id int
+		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			// Check that the name isn't already in use.
+			id, _ = tx.GetInstanceID(ctx, instProject, req.Name)
+
+			return nil
+		})
+		if id > 0 {
+			return response.Conflict(fmt.Errorf("Name %q already in use", req.Name))
 		}
 	}
 
+	// Load the local instance.
 	inst, err := instance.LoadByProjectAndName(s, projectName, name)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	// Run the cluster placement after potentially forwarding the request to another member.
-	if target != "" && s.ServerClustered {
+	// Handle simple instance renaming.
+	if !req.Migration {
+		run := func(*operations.Operation) error {
+			return inst.Rename(req.Name, true)
+		}
+
+		resources := map[string][]api.URL{}
+		resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", name)}
+
+		op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask, operationtype.InstanceRename, resources, nil, run, nil, nil, r)
+		if err != nil {
+			return response.InternalError(err)
+		}
+
+		return operations.OperationResponse(op)
+	}
+
+	// Start handling migrations.
+	if inst.IsSnapshot() {
+		return response.BadRequest(fmt.Errorf("Instance snapshots cannot be moved on their own"))
+	}
+
+	// Checks for running instances.
+	if inst.IsRunning() && (req.Pool != "" || req.Project != "" || target != "") {
+		// Stateless migrations need the instance stopped.
+		if !req.Live {
+			return response.BadRequest(fmt.Errorf("Instance must be stopped to be moved statelessly"))
+		}
+
+		// Storage pool changes require a stopped instance.
+		if req.Pool != "" {
+			return response.BadRequest(fmt.Errorf("Instance must be stopped to be moved across storage pools"))
+		}
+
+		// Project changes require a stopped instance.
+		if req.Project != "" {
+			return response.BadRequest(fmt.Errorf("Instance must be stopped to be moved across projects"))
+		}
+
+		// Name changes require a stopped instance.
+		if req.Name != "" {
+			return response.BadRequest(fmt.Errorf("Instance must be stopped to change their names"))
+		}
+	} else {
+		// Clear Live flag if instance isn't running.
+		req.Live = false
+	}
+
+	// Check for offline sources.
+	if sourceMemberInfo != nil && sourceMemberInfo.IsOffline(s.GlobalConfig.OfflineThreshold()) && (req.Pool != "" || req.Project != "" || req.Name != "") {
+		return response.BadRequest(fmt.Errorf("Instance server is currently offline"))
+	}
+
+	// When in a cluster, default to keeping current location.
+	if instLocation == "" && inst.Location() != "" {
+		instLocation = inst.Location()
+	}
+
+	// If clustered, consider a new location for the instance.
+	var targetMemberInfo *db.NodeInfo
+	var targetCandidates []db.NodeInfo
+	if s.ServerClustered && (target != "" || req.Project != "") {
 		err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-			p, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
+			var targetGroupName string
+
+			// Load the target project.
+			p, err := dbCluster.GetProject(ctx, tx.Tx(), instProject)
 			if err != nil {
 				return err
 			}
 
-			targetProject, err = p.ToAPI(ctx, tx.Tx())
+			targetProject, err := p.ToAPI(ctx, tx.Tx())
 			if err != nil {
 				return err
 			}
 
+			// Load the cluster members.
 			allMembers, err := tx.GetNodes(ctx)
 			if err != nil {
 				return fmt.Errorf("Failed getting cluster members: %w", err)
 			}
 
-			var targetGroupName string
+			// Check if the current location is fine.
+			targetMemberInfo, _, err = project.CheckTarget(ctx, s.Authorizer, r, tx, targetProject, instLocation, allMembers)
+			if err == nil && targetMemberInfo != nil {
+				return nil
+			}
 
+			// If we must change location, validate access to requested member/group (if provided).
 			targetMemberInfo, targetGroupName, err = project.CheckTarget(ctx, s.Authorizer, r, tx, targetProject, target, allMembers)
 			if err != nil {
 				return err
 			}
 
+			// If no specific server, get a list of allowed candidates.
 			if targetMemberInfo == nil {
 				clusterGroupsAllowed := project.GetRestrictedClusterGroups(targetProject)
 
-				candidateMembers, err = tx.GetCandidateMembers(ctx, allMembers, []int{inst.Architecture()}, targetGroupName, clusterGroupsAllowed, s.GlobalConfig.OfflineThreshold())
+				targetCandidates, err = tx.GetCandidateMembers(ctx, allMembers, []int{inst.Architecture()}, targetGroupName, clusterGroupsAllowed, s.GlobalConfig.OfflineThreshold())
 				if err != nil {
 					return err
 				}
@@ -230,6 +311,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
+		// If no specific server and a placement scriplet exists, call it with the candidates.
 		if targetMemberInfo == nil && s.GlobalConfig.InstancesPlacementScriptlet() != "" {
 			leaderAddress, err := d.gateway.LeaderAddress()
 			if err != nil {
@@ -249,7 +331,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				Reason:  apiScriptlet.InstancePlacementReasonRelocation,
 			}
 
-			targetMemberInfo, err = scriptlet.InstancePlacementRun(r.Context(), logger.Log, s, &req, candidateMembers, leaderAddress)
+			targetMemberInfo, err = scriptlet.InstancePlacementRun(r.Context(), logger.Log, s, &req, targetCandidates, leaderAddress)
 			if err != nil {
 				return response.BadRequest(fmt.Errorf("Failed instance placement scriptlet: %w", err))
 			}
@@ -261,7 +343,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 
 			// The instance might already be placed on the node with least number of instances.
 			// Therefore remove it from the list of possible candidates if existent.
-			for _, candidateMember := range candidateMembers {
+			for _, candidateMember := range targetCandidates {
 				if candidateMember.Name != inst.Location() {
 					filteredCandidateMembers = append(filteredCandidateMembers, candidateMember)
 				}
@@ -281,139 +363,44 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return response.InternalError(err)
+	// Check that we're not requested to move to the same location we're currently on.
+	if target != "" && targetMemberInfo.Name == inst.Location() {
+		return response.BadRequest(fmt.Errorf("Requested target server is the same as current server"))
 	}
 
-	rdr1 := io.NopCloser(bytes.NewBuffer(body))
-	rdr2 := io.NopCloser(bytes.NewBuffer(body))
-
-	reqRaw := jmap.Map{}
-	err = json.NewDecoder(rdr1).Decode(&reqRaw)
-	if err != nil {
-		return response.BadRequest(err)
-	}
-
-	req := api.InstancePost{}
-	err = json.NewDecoder(rdr2).Decode(&req)
-	if err != nil {
-		return response.BadRequest(err)
-	}
-
-	// Check if stateful indicator supplied and default to true if not (for backward compatibility).
-	_, err = reqRaw.GetBool("live")
-	if err != nil {
-		req.Live = true
-	}
-
-	// If new instance name not supplied, assume it will be keeping its current name.
-	if req.Name == "" {
-		req.Name = inst.Name()
-	}
-
-	// Check the new instance name is valid.
-	err = instance.ValidName(req.Name, false)
-	if err != nil {
-		return response.BadRequest(err)
-	}
-
-	if req.Migration {
-		// Server-side instance migration.
-		if req.Pool != "" || req.Project != "" {
-			// Check if user has access to target project.
-			if req.Project != "" {
-				err := s.Authorizer.CheckPermission(r.Context(), r, auth.ObjectProject(req.Project), auth.EntitlementCanCreateInstances)
-				if err != nil {
-					return response.SmartError(err)
-				}
-			}
-
-			// Setup the instance move operation.
-			run := func(op *operations.Operation) error {
-				return instancePostMigration(context.TODO(), s, inst, req.Name, req.Pool, req.Project, req.Config, req.Devices, req.Profiles, req.InstanceOnly, req.Live, req.AllowInconsistent, op)
-			}
-
-			resources := map[string][]api.URL{}
-			resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", name)}
-			op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask, operationtype.InstanceMigrate, resources, nil, run, nil, nil, r)
-			if err != nil {
-				return response.InternalError(err)
-			}
-
-			return operations.OperationResponse(op)
-		}
-
-		if targetMemberInfo != nil {
-			var backups []string
-
-			// Check if instance has backups.
-			err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-				backups, err = tx.GetInstanceBackups(ctx, projectName, name)
-				return err
-			})
-			if err != nil {
-				err = fmt.Errorf("Failed to fetch instance's backups: %w", err)
-				return response.SmartError(err)
-			}
-
-			if len(backups) > 0 {
-				return response.BadRequest(fmt.Errorf("Instance has backups"))
-			}
-
-			run := func(op *operations.Operation) error {
-				return migrateInstance(context.TODO(), s, r, inst, targetMemberInfo.Name, req, op)
-			}
-
-			resources := map[string][]api.URL{}
-			resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", name)}
-
-			if inst.Type() == instancetype.Container {
-				resources["containers"] = resources["instances"]
-			}
-
-			op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask, operationtype.InstanceMigrate, resources, nil, run, nil, nil, r)
-			if err != nil {
-				return response.InternalError(err)
-			}
-
-			return operations.OperationResponse(op)
-		}
-
-		instanceOnly := req.InstanceOnly
-		ws, err := newMigrationSource(inst, req.Live, instanceOnly, req.AllowInconsistent, "", req.Target)
+	// If the instance needs to move, make sure it doesn't have backups.
+	if targetMemberInfo != nil && targetMemberInfo.Name != inst.Location() {
+		// Check if instance has backups.
+		var backups []string
+		err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			backups, err = tx.GetInstanceBackups(ctx, projectName, name)
+			return err
+		})
 		if err != nil {
-			return response.InternalError(err)
+			err = fmt.Errorf("Failed to fetch instance's backups: %w", err)
+			return response.SmartError(err)
+		}
+
+		if len(backups) > 0 {
+			return response.BadRequest(fmt.Errorf("Instances with backups cannot be moved"))
+		}
+	}
+
+	// Server-side instance migration.
+	if req.Pool != "" || req.Project != "" || target != "" {
+		// Clear targetMemberInfo if no target change required.
+		if targetMemberInfo != nil && inst.Location() == targetMemberInfo.Name {
+			targetMemberInfo = nil
+		}
+
+		// Setup the instance move operation.
+		run := func(op *operations.Operation) error {
+			return migrateInstance(context.TODO(), s, inst, req, sourceMemberInfo, targetMemberInfo, op)
 		}
 
 		resources := map[string][]api.URL{}
 		resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", name)}
-
-		if inst.Type() == instancetype.Container {
-			resources["containers"] = resources["instances"]
-		}
-
-		run := func(op *operations.Operation) error {
-			return ws.Do(s, op)
-		}
-
-		cancel := func(op *operations.Operation) error {
-			ws.disconnect()
-			return nil
-		}
-
-		if req.Target != nil {
-			// Push mode.
-			op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask, operationtype.InstanceMigrate, resources, nil, run, nil, nil, r)
-			if err != nil {
-				return response.InternalError(err)
-			}
-
-			return operations.OperationResponse(op)
-		}
-
-		// Pull mode.
-		op, err := operations.OperationCreate(s, projectName, operations.OperationClassWebsocket, operationtype.InstanceMigrate, resources, ws.Metadata(), run, cancel, ws.Connect, r)
+		op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask, operationtype.InstanceMigrate, resources, nil, run, nil, nil, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -421,30 +408,35 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		return operations.OperationResponse(op)
 	}
 
-	var id int
-
-	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		// Check that the name isn't already in use.
-		id, _ = tx.GetInstanceID(ctx, projectName, req.Name)
-
-		return nil
-	})
-	if id > 0 {
-		return response.Conflict(fmt.Errorf("Name %q already in use", req.Name))
-	}
-
-	run := func(*operations.Operation) error {
-		return inst.Rename(req.Name, true)
+	// Cross-server instance migration.
+	ws, err := newMigrationSource(inst, req.Live, req.InstanceOnly, req.AllowInconsistent, "", req.Target)
+	if err != nil {
+		return response.InternalError(err)
 	}
 
 	resources := map[string][]api.URL{}
 	resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", name)}
-
-	if inst.Type() == instancetype.Container {
-		resources["containers"] = resources["instances"]
+	run := func(op *operations.Operation) error {
+		return ws.Do(s, op)
 	}
 
-	op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask, operationtype.InstanceRename, resources, nil, run, nil, nil, r)
+	cancel := func(op *operations.Operation) error {
+		ws.disconnect()
+		return nil
+	}
+
+	if req.Target != nil {
+		// Push mode.
+		op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask, operationtype.InstanceMigrate, resources, nil, run, nil, nil, r)
+		if err != nil {
+			return response.InternalError(err)
+		}
+
+		return operations.OperationResponse(op)
+	}
+
+	// Pull mode.
+	op, err := operations.OperationCreate(s, projectName, operations.OperationClassWebsocket, operationtype.InstanceMigrate, resources, ws.Metadata(), run, cancel, ws.Connect, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -452,324 +444,225 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 	return operations.OperationResponse(op)
 }
 
-// Move an instance.
-func instancePostMigration(ctx context.Context, s *state.State, inst instance.Instance, newName string, newPool string, newProject string, config map[string]string, devices map[string]map[string]string, profiles []string, instanceOnly bool, stateful bool, allowInconsistent bool, op *operations.Operation) error {
-	if inst.IsSnapshot() {
-		return fmt.Errorf("Instance snapshots cannot be moved between pools")
+// Perform the server-side migration.
+func migrateInstance(ctx context.Context, s *state.State, inst instance.Instance, req api.InstancePost, sourceMemberInfo *db.NodeInfo, targetMemberInfo *db.NodeInfo, op *operations.Operation) error {
+	// Load the instance storage pool.
+	sourcePool, err := storagePools.LoadByInstance(s, inst)
+	if err != nil {
+		return fmt.Errorf("Failed loading instance storage pool: %w", err)
 	}
 
-	if newProject == "" {
-		newProject = inst.Project().Name
+	// Get the DB volume type for the instance.
+	volType, err := storagePools.InstanceTypeToVolumeType(inst.Type())
+	if err != nil {
+		return err
 	}
 
-	statefulStart := false
-	if inst.IsRunning() {
-		if stateful {
-			statefulStart = true
-			err := inst.Stop(true)
+	volDBType, err := storagePools.VolumeTypeToDBType(volType)
+	if err != nil {
+		return err
+	}
+
+	// Handle migration of an instance away from an offline server (on shared storage).
+	if targetMemberInfo != nil && sourceMemberInfo != nil && sourceMemberInfo.IsOffline(s.GlobalConfig.OfflineThreshold()) && sourcePool.Driver().Info().Remote {
+		// Update the database records.
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			err := tx.UpdateInstanceNode(ctx, inst.Project().Name, inst.Name(), inst.Name(), targetMemberInfo.Name, sourcePool.ID(), volDBType)
 			if err != nil {
-				return err
-			}
-		} else {
-			return api.StatusErrorf(http.StatusBadRequest, "Instance must be stopped to move between pools statelessly")
-		}
-	}
-
-	// Copy config from instance to avoid modifying it.
-	localConfig := make(map[string]string)
-	for k, v := range inst.LocalConfig() {
-		localConfig[k] = v
-	}
-
-	// Set user defined configuration entries.
-	for k, v := range config {
-		localConfig[k] = v
-	}
-
-	// Get instance local devices and then set user defined devices.
-	localDevices := inst.LocalDevices().Clone()
-	for devName, dev := range devices {
-		localDevices[devName] = dev
-	}
-
-	// Apply previous profiles, if provided profiles are nil.
-	if profiles == nil {
-		profiles = make([]string, 0, len(inst.Profiles()))
-		for _, p := range inst.Profiles() {
-			profiles = append(profiles, p.Name)
-		}
-	}
-
-	apiProfiles := []api.Profile{}
-	if len(profiles) > 0 {
-		err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-			profiles, err := dbCluster.GetProfilesIfEnabled(ctx, tx.Tx(), newProject, profiles)
-			if err != nil {
-				return err
-			}
-
-			apiProfiles = make([]api.Profile, 0, len(profiles))
-			for _, profile := range profiles {
-				apiProfile, err := profile.ToAPI(ctx, tx.Tx())
-				if err != nil {
-					return err
-				}
-
-				apiProfiles = append(apiProfiles, *apiProfile)
+				return fmt.Errorf("Failed updating cluster member to %q for instance %q: %w", targetMemberInfo.Name, inst.Name(), err)
 			}
 
 			return nil
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed to relink instance database data: %w", err)
 		}
-	}
 
-	// Check if root disk device is present in the instance config. If instance config has no
-	// root disk device configured, check if the same root disk device will be applied with new
-	// profiles in the target project. If the new root disk device differs from the existing
-	// one, add the existing one as a local device to the instance (we don't want to move root
-	// disk device if not necessary, as this is an expensive operation).
-	rootDevKey, rootDev, err := internalInstance.GetRootDiskDevice(localDevices.CloneNative())
-	if err != nil && !errors.Is(err, internalInstance.ErrNoRootDisk) {
-		return err
-	} else if errors.Is(err, internalInstance.ErrNoRootDisk) {
-		// Find currently applied root disk device from expanded devices.
-		rootDevKey, rootDev, err = internalInstance.GetRootDiskDevice(inst.ExpandedDevices().CloneNative())
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed creating mount point of instance on target node: %w", err)
 		}
 
-		// Iterate over profiles that will be applied in the target project and find
-		// the new root disk device. Iterate in reverse order to respect profile
-		// precedence.
-		var profileRootDev map[string]string
-		for i := len(apiProfiles) - 1; i >= 0; i-- {
-			_, profileRootDev, err = internalInstance.GetRootDiskDevice(apiProfiles[i].Devices)
-			if err == nil {
-				break
+		// Import the instance into the storage.
+		_, err = sourcePool.ImportInstance(inst, nil, nil)
+		if err != nil {
+			return fmt.Errorf("Failed creating mount point of instance on target node: %w", err)
+		}
+
+		// Perform any remaining instance rename.
+		if req.Name != "" {
+			err = inst.Rename(req.Name, true)
+			if err != nil {
+				return err
 			}
 		}
 
-		// If current root disk device would be replaced according to the new profiles,
-		// add current root disk device to local instance devices (to retain it).
-		if profileRootDev == nil ||
-			profileRootDev["pool"] != rootDev["pool"] ||
-			profileRootDev["size"] != rootDev["size"] ||
-			profileRootDev["size.state"] != rootDev["size.state"] {
-			localDevices[rootDevKey] = rootDev
-		}
-	}
-
-	// Set specific storage pool for the instance, if provided.
-	if newPool != "" {
-		rootDev["pool"] = newPool
-		localDevices[rootDevKey] = rootDev
-	}
-
-	// Specify the target instance config with the new name.
-	args := db.InstanceArgs{
-		Name:         newName,
-		BaseImage:    localConfig["volatile.base_image"],
-		Config:       localConfig,
-		Devices:      localDevices,
-		Profiles:     apiProfiles,
-		Project:      newProject,
-		Type:         inst.Type(),
-		Architecture: inst.Architecture(),
-		Description:  inst.Description(),
-		Ephemeral:    inst.IsEphemeral(),
-		Stateful:     inst.IsStateful(),
-	}
-
-	// If we are moving the instance to a new pool but keeping the same instance name, then we need to create
-	// the copy of the instance on the new pool with a temporary name that is different from the source to
-	// avoid conflicts. Then after the source instance has been deleted we will rename the new instance back
-	// to the original name.
-	if newName == inst.Name() && newProject == inst.Project().Name {
-		args.Name, err = instance.MoveTemporaryName(inst)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Copy instance to new target instance.
-	targetInst, err := instanceCreateAsCopy(s, instanceCreateAsCopyOpts{
-		sourceInstance:       inst,
-		targetInstance:       args,
-		instanceOnly:         instanceOnly,
-		applyTemplateTrigger: false, // Don't apply templates when moving.
-		allowInconsistent:    allowInconsistent,
-	}, op)
-	if err != nil {
-		return err
-	}
-
-	// Delete original instance.
-	err = inst.Delete(true)
-	if err != nil {
-		return err
-	}
-
-	// Rename copy from temporary name to original name if needed.
-	if newName == inst.Name() && newProject == inst.Project().Name {
-		err = targetInst.Rename(newName, false) // Don't apply templates when moving.
-		if err != nil {
-			return err
-		}
-	}
-
-	if statefulStart {
-		err = targetInst.Start(true)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// Move a local instance to another cluster node.
-func instancePostClusteringMigrate(s *state.State, r *http.Request, srcPool storagePools.Pool, srcInst instance.Instance, newInstName string, srcMember db.NodeInfo, newMember db.NodeInfo, stateful bool, allowInconsistent bool) (func(op *operations.Operation) error, error) {
-	srcMemberOffline := srcMember.IsOffline(s.GlobalConfig.OfflineThreshold())
-
-	// Make sure that the source member is online if we end up being called from another member after a
-	// redirection due to the source member being offline.
-	if srcMemberOffline {
-		return nil, fmt.Errorf("The cluster member hosting the instance is offline")
+		return nil
 	}
 
 	// Save the original value of the "volatile.apply_template" config key,
 	// since we'll want to preserve it in the copied container.
-	origVolatileApplyTemplate := srcInst.LocalConfig()["volatile.apply_template"]
+	instVolatileApplyTemplate := inst.LocalConfig()["volatile.apply_template"]
 
-	// Check we can convert the instance to the volume types needed.
-	volType, err := storagePools.InstanceTypeToVolumeType(srcInst.Type())
+	// Get the current instance info.
+	instInfoRaw, _, err := inst.Render()
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("Failed getting source instance info: %w", err)
 	}
 
-	volDBType, err := storagePools.VolumeTypeToDBType(volType)
-	if err != nil {
-		return nil, err
+	targetInstInfo, ok := instInfoRaw.(*api.Instance)
+	if !ok {
+		return fmt.Errorf("Unexpected result from source instance render: %w", err)
 	}
 
-	run := func(op *operations.Operation) error {
-		srcInstName := srcInst.Name()
-		projectName := srcInst.Project().Name
+	// Apply the config overrides.
+	for k, v := range req.Config {
+		targetInstInfo.Config[k] = v
+	}
 
-		if newInstName == "" {
-			newInstName = srcInstName
-		}
+	// Apply the device overrides.
+	for k, v := range req.Devices {
+		targetInstInfo.Devices[k] = v
+	}
 
-		networkCert := s.Endpoints.NetworkCert()
+	// Apply the profile overrides.
+	if req.Profiles != nil {
+		targetInstInfo.Profiles = req.Profiles
+	}
 
-		// Connect to the destination member, i.e. the member to migrate the instance to.
-		// Use the notify argument to indicate to the destination that we are moving an instance between
-		// cluster members.
-		dest, err := cluster.Connect(newMember.Address, networkCert, s.ServerCert(), r, true)
-		if err != nil {
-			return fmt.Errorf("Failed to connect to destination server %q: %w", newMember.Address, err)
-		}
-
-		dest = dest.UseTarget(newMember.Name).UseProject(projectName)
-
-		resources := map[string][]api.URL{}
-		resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", srcInstName)}
-
-		srcInstRunning := srcInst.IsRunning()
-		live := stateful && srcInstRunning
-
-		// During a stateful migration we expect the migration process to stop the instance on the source
-		// once the migration is complete. However when doing a stateless migration and the instance is
-		// running we must forcefully stop the instance on the source before starting the migration copy
-		// so that it is as consistent as possible.
-		if !stateful && srcInstRunning {
-			err := srcInst.Stop(false)
-			if err != nil {
-				return fmt.Errorf("Failed statelessly stopping instance %q: %w", srcInstName, err)
-			}
-		}
-
-		// Rename instance if requested.
-		if newInstName != srcInstName {
-			err = srcInst.Rename(newInstName, true)
-			if err != nil {
-				return fmt.Errorf("Failed renaming instance %q to %q: %w", srcInstName, newInstName, err)
-			}
-
-			srcInst, err = instance.LoadByProjectAndName(s, projectName, newInstName)
-			if err != nil {
-				return fmt.Errorf("Failed loading renamed instance: %w", err)
-			}
-
-			srcInstName = srcInst.Name()
-		}
-
-		snapshots, err := srcInst.Snapshots()
-		if err != nil {
-			return fmt.Errorf("Failed getting source instance snapshots: %w", err)
-		}
-
-		// Setup migration source.
-		srcRenderRes, _, err := srcInst.Render()
-		if err != nil {
-			return fmt.Errorf("Failed getting source instance info: %w", err)
-		}
-
-		srcInstInfo, ok := srcRenderRes.(*api.Instance)
-		if !ok {
-			return fmt.Errorf("Unexpected result from source instance render: %w", err)
-		}
-
-		srcMigration, err := newMigrationSource(srcInst, live, false, allowInconsistent, srcInstName, nil)
-		if err != nil {
-			return fmt.Errorf("Failed setting up instance migration on source: %w", err)
-		}
-
-		run := func(op *operations.Operation) error {
-			return srcMigration.Do(s, op)
-		}
-
-		cancel := func(op *operations.Operation) error {
-			srcMigration.disconnect()
-			return nil
-		}
-
-		srcOp, err := operations.OperationCreate(s, projectName, operations.OperationClassWebsocket, operationtype.InstanceMigrate, resources, srcMigration.Metadata(), run, cancel, srcMigration.Connect, r)
+	// Handle storage pool override.
+	if req.Pool != "" {
+		rootDevKey, rootDev, err := internalInstance.GetRootDiskDevice(inst.ExpandedDevices().CloneNative())
 		if err != nil {
 			return err
 		}
 
-		err = srcOp.Start()
+		// Apply the override.
+		rootDev["pool"] = req.Pool
+
+		// Add the device to local config.
+		targetInstInfo.Devices[rootDevKey] = rootDev
+	}
+
+	// Handle local changes (name, project, storage).
+
+	// Handle the renames first.
+	if req.Name != "" {
+		err := inst.Rename(req.Name, true)
 		if err != nil {
-			return fmt.Errorf("Failed starting migration source operation: %w", err)
+			return err
 		}
 
-		sourceSecrets := make(map[string]string, len(srcMigration.conns))
-		for connName, conn := range srcMigration.conns {
-			sourceSecrets[connName] = conn.Secret()
+		inst, err = instance.LoadByProjectAndName(s, inst.Project().Name, req.Name)
+		if err != nil {
+			return err
 		}
 
-		// Request pull mode migration on destination.
-		destOp, err := dest.CreateInstance(api.InstancesPost{
-			Name:        newInstName,
-			InstancePut: srcInstInfo.Writable(),
-			Type:        api.InstanceType(srcInstInfo.Type),
+		// Clear the rename part of the request.
+		req.Name = ""
+	}
+
+	// Handle pool and project moves.
+	if req.Project != "" || req.Pool != "" {
+		// Get a local client.
+		target, err := incus.ConnectIncusUnix(s.OS.GetUnixSocket(), nil)
+		if err != nil {
+			return err
+		}
+
+		if targetMemberInfo != nil {
+			target = target.UseTarget(targetMemberInfo.Name)
+		} else if s.ServerClustered {
+			target = target.UseTarget(inst.Location())
+		}
+
+		targetProject := inst.Project().Name
+		if req.Project != "" {
+			target = target.UseProject(req.Project)
+			targetProject = req.Project
+		}
+
+		// Check if we have a root disk in local config.
+		_, _, err = internalInstance.GetRootDiskDevice(targetInstInfo.Devices)
+		if err != nil && req.Project != "" {
+			// If not and we're dealing with project copy, let's get one.
+			var newRootDev map[string]string
+
+			// Get current root disk.
+			currentRootDevKey, currentRootDev, err := internalInstance.GetRootDiskDevice(inst.ExpandedDevices().CloneNative())
+			if err != nil {
+				return err
+			}
+
+			// Load the profiles.
+			profiles := []api.Profile{}
+
+			err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+				rawProfiles, err := dbCluster.GetProfilesIfEnabled(ctx, tx.Tx(), targetProject, targetInstInfo.Profiles)
+				if err != nil {
+					return err
+				}
+
+				for _, profile := range rawProfiles {
+					apiProfile, err := profile.ToAPI(ctx, tx.Tx())
+					if err != nil {
+						return err
+					}
+
+					profiles = append(profiles, *apiProfile)
+				}
+
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			// Go through expected profiles and look for a root disk.
+			for _, profile := range profiles {
+				_, dev, err := internalInstance.GetRootDiskDevice(profile.Devices)
+				if err != nil {
+					continue
+				}
+
+				newRootDev = dev
+				break
+			}
+
+			// Check if root disk coming from profiles is suitable, if not, copy the current one.
+			if newRootDev == nil ||
+				newRootDev["pool"] != currentRootDev["pool"] ||
+				newRootDev["size"] != currentRootDev["size"] ||
+				newRootDev["size.state"] != currentRootDev["size.state"] {
+				targetInstInfo.Devices[currentRootDevKey] = currentRootDev
+			}
+		}
+
+		// Use a temporary instance name if needed.
+		targetInstName := inst.Name()
+		if req.Project == "" {
+			targetInstName, err = instance.MoveTemporaryName(inst)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Create the target instance.
+		destOp, err := target.CreateInstance(api.InstancesPost{
+			Name:        targetInstName,
+			InstancePut: targetInstInfo.Writable(),
+			Type:        api.InstanceType(targetInstInfo.Type),
 			Source: api.InstanceSource{
-				Type:        "migration",
-				Mode:        "pull",
-				Operation:   fmt.Sprintf("https://%s%s", srcMember.Address, srcOp.URL()),
-				Websockets:  sourceSecrets,
-				Certificate: string(networkCert.PublicKey()),
-				Live:        live,
-				Source:      srcInstName,
+				Type:         "copy",
+				Source:       inst.Name(),
+				Project:      inst.Project().Name,
+				InstanceOnly: req.InstanceOnly,
 			},
 		})
 		if err != nil {
 			return fmt.Errorf("Failed requesting instance create on destination: %w", err)
 		}
 
+		// Setup a progress handler.
 		handler := func(newOp api.Operation) {
 			_ = op.UpdateMetadata(newOp.Metadata)
 		}
@@ -779,25 +672,163 @@ func instancePostClusteringMigrate(s *state.State, r *http.Request, srcPool stor
 			return err
 		}
 
+		// Wait for the migration to complete.
 		err = destOp.Wait()
 		if err != nil {
 			return fmt.Errorf("Instance move to destination failed: %w", err)
 		}
 
-		err = srcOp.Wait(context.Background())
+		// Delete the source instance.
+		err = inst.Delete(true)
+		if err != nil {
+			return err
+		}
+
+		// If using a temporary name, rename it.
+		if targetInstName != inst.Name() {
+			op, err := target.RenameInstance(targetInstName, api.InstancePost{Name: inst.Name()})
+			if err != nil {
+				return err
+			}
+
+			err = op.Wait()
+			if err != nil {
+				return err
+			}
+		}
+
+		// Reload the instance.
+		inst, err = instance.LoadByProjectAndName(s, targetProject, inst.Name())
+		if err != nil {
+			return err
+		}
+
+		// Clear the pool and project part of the request.
+		req.Pool = ""
+		req.Project = ""
+	}
+
+	// Handle remote migrations (location changes).
+	if targetMemberInfo != nil && inst.Location() != targetMemberInfo.Name {
+		// Get the client.
+		networkCert := s.Endpoints.NetworkCert()
+		target, err := cluster.Connect(targetMemberInfo.Address, networkCert, s.ServerCert(), nil, true)
+		if err != nil {
+			return fmt.Errorf("Failed to connect to destination server %q: %w", targetMemberInfo.Address, err)
+		}
+
+		target = target.UseProject(inst.Project().Name)
+		if targetMemberInfo != nil {
+			target = target.UseTarget(targetMemberInfo.Name)
+		}
+
+		// Get the source member info if missing.
+		if sourceMemberInfo == nil {
+			err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+				// Get the source member info.
+				srcMember, err := tx.GetNodeByName(ctx, inst.Location())
+				if err != nil {
+					return fmt.Errorf("Failed getting current cluster member of instance %q", inst.Name())
+				}
+
+				sourceMemberInfo = &srcMember
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		// Get the current instance snapshot list.
+		snapshots, err := inst.Snapshots()
+		if err != nil {
+			return fmt.Errorf("Failed getting source instance snapshots: %w", err)
+		}
+
+		// Setup a new migration source.
+		sourceMigration, err := newMigrationSource(inst, req.Live, false, req.AllowInconsistent, inst.Name(), nil)
+		if err != nil {
+			return fmt.Errorf("Failed setting up instance migration on source: %w", err)
+		}
+
+		run := func(op *operations.Operation) error {
+			return sourceMigration.Do(s, op)
+		}
+
+		cancel := func(op *operations.Operation) error {
+			sourceMigration.disconnect()
+			return nil
+		}
+
+		resources := map[string][]api.URL{}
+		resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", inst.Name())}
+		sourceOp, err := operations.OperationCreate(s, inst.Project().Name, operations.OperationClassWebsocket, operationtype.InstanceMigrate, resources, sourceMigration.Metadata(), run, cancel, sourceMigration.Connect, nil)
+		if err != nil {
+			return err
+		}
+
+		// Start the migration source.
+		err = sourceOp.Start()
+		if err != nil {
+			return fmt.Errorf("Failed starting migration source operation: %w", err)
+		}
+
+		// Extract the migration secrets.
+		sourceSecrets := make(map[string]string, len(sourceMigration.conns))
+		for connName, conn := range sourceMigration.conns {
+			sourceSecrets[connName] = conn.Secret()
+		}
+
+		// Create the target instance.
+		destOp, err := target.CreateInstance(api.InstancesPost{
+			Name:        inst.Name(),
+			InstancePut: targetInstInfo.Writable(),
+			Type:        api.InstanceType(targetInstInfo.Type),
+			Source: api.InstanceSource{
+				Type:        "migration",
+				Mode:        "pull",
+				Operation:   fmt.Sprintf("https://%s%s", sourceMemberInfo.Address, sourceOp.URL()),
+				Websockets:  sourceSecrets,
+				Certificate: string(networkCert.PublicKey()),
+				Live:        req.Live,
+				Source:      inst.Name(),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("Failed requesting instance create on destination: %w", err)
+		}
+
+		// Setup a progress handler.
+		handler := func(newOp api.Operation) {
+			_ = op.UpdateMetadata(newOp.Metadata)
+		}
+
+		_, err = destOp.AddHandler(handler)
+		if err != nil {
+			return err
+		}
+
+		// Wait for the migration to complete.
+		err = destOp.Wait()
+		if err != nil {
+			return fmt.Errorf("Instance move to destination failed: %w", err)
+		}
+
+		err = sourceOp.Wait(context.Background())
 		if err != nil {
 			return fmt.Errorf("Instance move to destination failed on source: %w", err)
 		}
 
+		// Update the database post-migration.
 		err = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Update instance DB record to indicate its location on the new cluster member.
-			err = tx.UpdateInstanceNode(ctx, projectName, srcInstName, newInstName, newMember.Name, srcPool.ID(), volDBType)
+			err = tx.UpdateInstanceNode(ctx, inst.Project().Name, inst.Name(), inst.Name(), targetMemberInfo.Name, sourcePool.ID(), volDBType)
 			if err != nil {
-				return fmt.Errorf("Failed updating cluster member to %q for instance %q: %w", newMember.Name, newInstName, err)
+				return fmt.Errorf("Failed updating cluster member to %q for instance %q: %w", targetMemberInfo.Name, inst.Name(), err)
 			}
 
 			// Restore the original value of "volatile.apply_template".
-			id, err := dbCluster.GetInstanceID(ctx, tx.Tx(), projectName, newInstName)
+			id, err := dbCluster.GetInstanceID(ctx, tx.Tx(), inst.Project().Name, inst.Name())
 			if err != nil {
 				return fmt.Errorf("Failed to get ID of moved instance: %w", err)
 			}
@@ -807,9 +838,9 @@ func instancePostClusteringMigrate(s *state.State, r *http.Request, srcPool stor
 				return fmt.Errorf("Failed to remove volatile.apply_template config key: %w", err)
 			}
 
-			if origVolatileApplyTemplate != "" {
+			if instVolatileApplyTemplate != "" {
 				config := map[string]string{
-					"volatile.apply_template": origVolatileApplyTemplate,
+					"volatile.apply_template": instVolatileApplyTemplate,
 				}
 
 				err = tx.CreateInstanceConfig(ctx, int(id), config)
@@ -825,8 +856,8 @@ func instancePostClusteringMigrate(s *state.State, r *http.Request, srcPool stor
 		}
 
 		// Cleanup instance paths on source member if using remote shared storage.
-		if srcPool.Driver().Info().Remote {
-			err = srcPool.CleanupInstancePaths(srcInst, nil)
+		if sourcePool.Driver().Info().Remote {
+			err = sourcePool.CleanupInstancePaths(inst, nil)
 			if err != nil {
 				return fmt.Errorf("Failed cleaning up instance paths on source member: %w", err)
 			}
@@ -839,154 +870,18 @@ func instancePostClusteringMigrate(s *state.State, r *http.Request, srcPool stor
 				// Delete the snapshots in reverse order.
 				k = snapshotCount - 1 - k
 
-				err = srcPool.DeleteInstanceSnapshot(snapshots[k], nil)
+				err = sourcePool.DeleteInstanceSnapshot(snapshots[k], nil)
 				if err != nil {
 					return fmt.Errorf("Failed delete instance snapshot %q on source member: %w", snapshots[k].Name(), err)
 				}
 			}
 
-			err = srcPool.DeleteInstance(srcInst, nil)
+			err = sourcePool.DeleteInstance(inst, nil)
 			if err != nil {
 				return fmt.Errorf("Failed deleting instance on source member: %w", err)
 			}
 		}
-
-		if !stateful && srcInstRunning {
-			req := api.InstanceStatePut{
-				Action: "start",
-			}
-
-			op, err := dest.UpdateInstanceState(newInstName, req, "")
-			if err != nil {
-				return err
-			}
-
-			err = op.Wait()
-			if err != nil {
-				return fmt.Errorf("Failed starting instance %q: %w", newInstName, err)
-			}
-		}
-
-		return nil
 	}
 
-	return run, nil
-}
-
-// instancePostClusteringMigrateRemoteStorage handles moving an instance from a source member that is offline.
-// This function must be run on the target cluster member to move the instance to.
-func instancePostClusteringMigrateRemoteStorage(s *state.State, r *http.Request, srcPool storagePools.Pool, srcInst instance.Instance, newInstName string, newMember db.NodeInfo, stateful bool) (func(op *operations.Operation) error, error) {
-	// Quick checks to avoid unexpected behaviour.
-	if !srcPool.Driver().Info().Remote {
-		return nil, fmt.Errorf("Source instance's storage pool is not remote")
-	}
-
-	// Check this function is only run on the target member.
-	if s.ServerName != newMember.Name {
-		return nil, fmt.Errorf("Remote instance move when source member is offline must be run on target member")
-	}
-
-	// Check we can convert the instance to the volume types needed.
-	volType, err := storagePools.InstanceTypeToVolumeType(srcInst.Type())
-	if err != nil {
-		return nil, err
-	}
-
-	volDBType, err := storagePools.VolumeTypeToDBType(volType)
-	if err != nil {
-		return nil, err
-	}
-
-	run := func(op *operations.Operation) error {
-		projectName := srcInst.Project().Name
-		srcInstName := srcInst.Name()
-
-		// Re-link the database entries against the new member name.
-		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			err := tx.UpdateInstanceNode(ctx, projectName, srcInstName, srcInstName, newMember.Name, srcPool.ID(), volDBType)
-			if err != nil {
-				return fmt.Errorf("Failed updating cluster member to %q for instance %q: %w", newMember.Name, srcInstName, err)
-			}
-
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("Failed to relink instance database data: %w", err)
-		}
-
-		if srcInstName != newInstName {
-			err = srcInst.Rename(newInstName, true)
-			if err != nil {
-				return fmt.Errorf("Failed renaming instance %q to %q: %w", srcInstName, newInstName, err)
-			}
-
-			srcInst, err = instance.LoadByProjectAndName(s, projectName, newInstName)
-			if err != nil {
-				return fmt.Errorf("Failed loading renamed instance: %w", err)
-			}
-
-			srcInstName = srcInst.Name()
-		}
-
-		_, err = srcPool.ImportInstance(srcInst, nil, nil)
-		if err != nil {
-			return fmt.Errorf("Failed creating mount point of instance on target node: %w", err)
-		}
-
-		return nil
-	}
-
-	return run, nil
-}
-
-func migrateInstance(ctx context.Context, s *state.State, r *http.Request, inst instance.Instance, targetNode string, req api.InstancePost, op *operations.Operation) error {
-	// If target isn't the same as the instance's location.
-	if targetNode == inst.Location() {
-		return fmt.Errorf("Target must be different than instance's current location")
-	}
-
-	var err error
-	var srcMember, newMember db.NodeInfo
-
-	// If the source member is online then get its address so we can connect to it and see if the
-	// instance is running later.
-	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
-		srcMember, err = tx.GetNodeByName(ctx, inst.Location())
-		if err != nil {
-			return fmt.Errorf("Failed getting current cluster member of instance %q", inst.Name())
-		}
-
-		newMember, err = tx.GetNodeByName(ctx, targetNode)
-		if err != nil {
-			return fmt.Errorf("Failed loading new cluster member for instance: %w", err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	// Check if we are migrating a remote instance.
-	srcPool, err := storagePools.LoadByInstance(s, inst)
-	if err != nil {
-		return fmt.Errorf("Failed loading instance storage pool: %w", err)
-	}
-
-	// Only use instancePostClusteringMigrateRemoteStorage when source member is offline.
-	if srcMember.IsOffline(s.GlobalConfig.OfflineThreshold()) && srcPool.Driver().Info().Remote {
-		f, err := instancePostClusteringMigrateRemoteStorage(s, r, srcPool, inst, req.Name, newMember, req.Live)
-		if err != nil {
-			return err
-		}
-
-		return f(op)
-	}
-
-	f, err := instancePostClusteringMigrate(s, r, srcPool, inst, req.Name, srcMember, newMember, req.Live, req.AllowInconsistent)
-	if err != nil {
-		return err
-	}
-
-	return f(op)
+	return nil
 }

--- a/internal/server/sys/os.go
+++ b/internal/server/sys/os.go
@@ -230,6 +230,16 @@ func (s *OS) InitStorage() error {
 	return s.initStorageDirs()
 }
 
+// GetUnixSocket returns the full path to the unix.socket file that this daemon is listening on. Used by tests.
+func (s *OS) GetUnixSocket() string {
+	path := os.Getenv("INCUS_SOCKET")
+	if path != "" {
+		return path
+	}
+
+	return filepath.Join(s.VarDir, "unix.socket")
+}
+
 func getIdmapset() *idmap.Set {
 	// Try getting the system map.
 	idmapset, err := idmap.NewSetFromSystem("", "root")

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-01 22:06-0400\n"
+"POT-Creation-Date: 2024-04-03 13:39-0400\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid "  Motherboard:"
 msgstr ""
 
@@ -703,8 +703,13 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
+#: cmd/incus/move.go:265
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--refresh kann nur mit Containern verwendet werden"
+
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/config.go:822 cmd/incus/info.go:566
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -1016,7 +1021,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -1142,7 +1147,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1159,7 +1164,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1193,16 +1198,16 @@ msgstr "Erstellt: %s"
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1222,7 +1227,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, c-format
 msgid "CPU (%s):"
 msgstr "Prozessorauslastung (%s):"
@@ -1231,15 +1236,15 @@ msgstr "Prozessorauslastung (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 msgid "CPU usage:"
 msgstr "Prozessorauslastung:"
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1282,7 +1287,7 @@ msgstr ""
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1373,7 +1378,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1485,7 +1490,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65
+#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
@@ -1570,7 +1575,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1624,7 +1629,7 @@ msgstr "Erstellt: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1688,7 +1693,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
 #: cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1904,7 +1909,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1969,7 +1974,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Erstellt: %s"
@@ -2144,7 +2149,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
 #: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85
-#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236
 #: cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466
 #: cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796
@@ -2275,7 +2280,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2299,7 +2304,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Device %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "Profil %s erstellt\n"
@@ -2367,22 +2372,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 #, fuzzy
 msgid "Disk:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 #, fuzzy
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
@@ -2743,7 +2748,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2980,7 +2985,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to configure cluster: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3025,7 +3030,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3163,7 +3168,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed validation request: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3281,8 +3286,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
+#: cmd/incus/info.go:494
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3301,11 +3306,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid "GPUs:"
 msgstr ""
 
@@ -3498,12 +3503,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3549,7 +3554,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
@@ -3597,7 +3602,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3727,7 +3732,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 msgid "Instance Only"
 msgstr ""
 
@@ -3958,7 +3963,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
@@ -4378,7 +4383,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4387,7 +4392,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid "Log:"
 msgstr ""
 
@@ -4426,7 +4431,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
@@ -4474,7 +4479,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid "MTU"
 msgstr ""
 
@@ -4747,28 +4752,28 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5026,12 +5031,12 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "Move instances within or in between servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5052,7 +5057,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5112,11 +5117,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid "NICs:"
 msgstr ""
 
@@ -5132,7 +5137,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5145,7 +5150,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5211,7 +5216,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929
+#: cmd/incus/info.go:575 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5332,7 +5337,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5422,7 +5427,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5479,7 +5484,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5504,7 +5509,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5538,11 +5543,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5656,7 +5661,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -5666,17 +5671,17 @@ msgstr "Profil %s erstellt\n"
 msgid "Processing aliases failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Erstellt: %s"
@@ -5726,7 +5731,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6219,7 +6224,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid "Resources:"
 msgstr ""
 
@@ -6322,7 +6327,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6397,12 +6402,12 @@ msgstr "Erstellt: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr ""
@@ -6411,7 +6416,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Erstellt: %s"
@@ -7008,11 +7013,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7046,7 +7051,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
@@ -7056,11 +7061,11 @@ msgstr "Erstellt: %s"
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7138,7 +7143,7 @@ msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
 #: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
-#: cmd/incus/move.go:64
+#: cmd/incus/move.go:63
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -7193,11 +7198,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7213,7 +7218,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid "System:"
 msgstr ""
 
@@ -7234,7 +7239,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7268,32 +7273,9 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/move.go:158
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-#, fuzzy
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr "--refresh kann nur mit Containern verwendet werden"
-
-#: cmd/incus/move.go:170
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: cmd/incus/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
-
-#: cmd/incus/move.go:162
-#, fuzzy
-msgid "The --storage flag can't be used with --target"
-msgstr "--refresh kann nur mit Containern verwendet werden"
-
-#: cmd/incus/move.go:166
-#, fuzzy
-msgid "The --target-project flag can't be used with --target"
-msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: cmd/incus/admin_init_interactive.go:742
 msgid "The LVM thin provisioning tools couldn't be found on the system"
@@ -7325,10 +7307,6 @@ msgstr ""
 #: cmd/incus/console.go:378
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
-msgstr ""
-
-#: cmd/incus/move.go:182
-msgid "The destination server is not clustered"
 msgstr ""
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
@@ -7510,12 +7488,8 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid "The server doesn't implement the newer v2 resources API"
-msgstr ""
-
-#: cmd/incus/move.go:286
-msgid "The source server is not clustered"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
@@ -7593,7 +7567,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7607,8 +7581,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7634,7 +7608,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -7643,7 +7617,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -7662,7 +7636,7 @@ msgstr "Administrator Passwort für %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 msgid "Type"
 msgstr ""
 
@@ -7681,14 +7655,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
-#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
+#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7709,12 +7683,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 #, fuzzy
 msgid "USB device:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 #, fuzzy
 msgid "USB devices:"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -7731,7 +7705,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7792,7 +7766,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -7958,7 +7932,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8006,8 +7980,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8047,17 +8021,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "Fehler: %v\n"
@@ -8076,12 +8050,12 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Fehler: %v\n"
@@ -8259,7 +8233,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -8675,7 +8649,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
@@ -9733,7 +9707,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 #, fuzzy
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
@@ -9954,6 +9928,18 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "The --mode flag can't be used with --storage or --target-project"
+#~ msgstr "--refresh kann nur mit Containern verwendet werden"
+
+#, fuzzy
+#~ msgid "The --storage flag can't be used with --target"
+#~ msgstr "--refresh kann nur mit Containern verwendet werden"
+
+#, fuzzy
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #, fuzzy, c-format
 #~ msgid "Usb %d:"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-01 22:06-0400\n"
+"POT-Creation-Date: 2024-04-03 13:39-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.1\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid "  Motherboard:"
 msgstr ""
 
@@ -687,8 +687,13 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: cmd/incus/move.go:265
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
+
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/config.go:822 cmd/incus/info.go:566
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -982,7 +987,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -1101,7 +1106,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1118,7 +1123,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1153,16 +1158,16 @@ msgstr "Creado: %s"
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1182,7 +1187,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
@@ -1191,15 +1196,15 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1233,7 +1238,7 @@ msgstr "Cacheado: %s"
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 "No se puede anular la configuración o los perfiles en el cambio de nombre "
@@ -1327,7 +1332,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1435,7 +1440,7 @@ msgstr "Perfil %s eliminado de %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65
+#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
@@ -1520,7 +1525,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1574,7 +1579,7 @@ msgstr "Auto actualización: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1634,7 +1639,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
 #: cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1839,7 +1844,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1904,7 +1909,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Auto actualización: %s"
@@ -2074,7 +2079,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
 #: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85
-#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236
 #: cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466
 #: cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796
@@ -2203,7 +2208,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Dispositivo: %s"
@@ -2223,7 +2228,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "Expira: %s"
@@ -2285,20 +2290,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, c-format
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 msgid "Disk:"
 msgstr "Disco:"
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 msgid "Disks:"
 msgstr "Discos:"
 
@@ -2641,7 +2646,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 #, fuzzy
@@ -2877,7 +2882,7 @@ msgstr "Acepta certificado"
 msgid "Failed to configure cluster: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2922,7 +2927,7 @@ msgstr "Acepta certificado"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -3060,7 +3065,7 @@ msgstr "Acepta certificado"
 msgid "Failed validation request: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3175,8 +3180,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
+#: cmd/incus/info.go:494
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3195,11 +3200,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid "GPUs:"
 msgstr ""
 
@@ -3385,12 +3390,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3436,7 +3441,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
@@ -3484,7 +3489,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3612,7 +3617,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
@@ -3837,7 +3842,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Creado: %s"
@@ -4239,7 +4244,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4248,7 +4253,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid "Log:"
 msgstr "Registro:"
 
@@ -4285,7 +4290,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
@@ -4329,7 +4334,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid "MTU"
 msgstr ""
 
@@ -4582,28 +4587,28 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4857,11 +4862,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Aliases:"
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -4881,7 +4886,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4939,11 +4944,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid "NICs:"
 msgstr ""
 
@@ -4959,7 +4964,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4972,7 +4977,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5034,7 +5039,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929
+#: cmd/incus/info.go:575 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5154,7 +5159,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5176,7 +5181,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5240,7 +5245,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5297,7 +5302,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5322,7 +5327,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5356,11 +5361,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5472,7 +5477,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -5482,17 +5487,17 @@ msgstr "Procesos: %d"
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Creado: %s"
@@ -5542,7 +5547,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -6020,7 +6025,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid "Resources:"
 msgstr ""
 
@@ -6121,7 +6126,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6196,17 +6201,17 @@ msgstr "Creado: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Creado: %s"
@@ -6774,11 +6779,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6811,7 +6816,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
@@ -6821,11 +6826,11 @@ msgstr "Auto actualización: %s"
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6901,7 +6906,7 @@ msgid "Storage pool %s pending on member %s"
 msgstr ""
 
 #: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
-#: cmd/incus/move.go:64
+#: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
 
@@ -6952,11 +6957,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6972,7 +6977,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid "System:"
 msgstr ""
 
@@ -6993,7 +6998,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7026,31 +7031,9 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/move.go:158
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-#, fuzzy
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
-
-#: cmd/incus/move.go:170
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: cmd/incus/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
-
-#: cmd/incus/move.go:162
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-#, fuzzy
-msgid "The --target-project flag can't be used with --target"
-msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
 #: cmd/incus/admin_init_interactive.go:742
 msgid "The LVM thin provisioning tools couldn't be found on the system"
@@ -7082,10 +7065,6 @@ msgstr ""
 #: cmd/incus/console.go:378
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
-msgstr ""
-
-#: cmd/incus/move.go:182
-msgid "The destination server is not clustered"
 msgstr ""
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
@@ -7265,12 +7244,8 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid "The server doesn't implement the newer v2 resources API"
-msgstr ""
-
-#: cmd/incus/move.go:286
-msgid "The source server is not clustered"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
@@ -7344,7 +7319,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7358,8 +7333,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7385,7 +7360,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -7394,7 +7369,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7413,7 +7388,7 @@ msgstr "Contraseña admin para %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
@@ -7433,14 +7408,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
-#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
+#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7461,11 +7436,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 msgid "USB devices:"
 msgstr ""
 
@@ -7481,7 +7456,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7541,7 +7516,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -7699,7 +7674,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7746,8 +7721,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7787,17 +7762,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7812,12 +7787,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Versión de CUDA: %v"
@@ -7988,7 +7963,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8245,7 +8220,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <template>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8975,7 +8950,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -9192,6 +9167,16 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "The --mode flag can't be used with --storage or --target-project"
+#~ msgstr ""
+#~ "--container-only no se puede pasar cuando la fuente es una instantánea"
+
+#, fuzzy
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr ""
+#~ "--container-only no se puede pasar cuando la fuente es una instantánea"
 
 #, fuzzy, c-format
 #~ msgid "Usb %d:"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-01 22:06-0400\n"
+"POT-Creation-Date: 2024-04-03 13:39-0400\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -18,16 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 #, fuzzy
 msgid "  Chassis:"
 msgstr "Châssis"
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid "  Motherboard:"
 msgstr ""
 
@@ -695,8 +695,13 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
+#: cmd/incus/move.go:265
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--target ne peut pas être utilisé avec des instances"
+
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/config.go:822 cmd/incus/info.go:566
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
@@ -1004,7 +1009,7 @@ msgstr "Toutes les adresses serveurs sont indisponibles"
 msgid "Alternative certificate name"
 msgstr "Nom alternatif du certificat"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -1131,7 +1136,7 @@ msgstr "Sauvegarder le volume de stockage : %s"
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1150,7 +1155,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1184,16 +1189,16 @@ msgstr "Marque : %v"
 msgid "Bridge:"
 msgstr "Pont:"
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "Addresse : %s"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1213,7 +1218,7 @@ msgstr "Type de contenu"
 msgid "COUNT"
 msgstr "NOMBRE"
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s) :"
@@ -1222,15 +1227,15 @@ msgstr "CPU (%s) :"
 msgid "CPU USAGE"
 msgstr "UTILISATION CPU"
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs (%s):"
@@ -1264,7 +1269,7 @@ msgstr "Caches mémoire:"
 msgid "Can't bind address %q: %w"
 msgstr "Impossible de se lier à l’adresse %q: %w"
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 "Impossible de surcharger la configuration ou les profiles lors du renommage "
@@ -1366,7 +1371,7 @@ msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 msgid "Cannot set key: %s"
 msgstr "Impossible d'assigner les clés: %s"
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid "Card %d:"
 msgstr "Cartes %d:"
@@ -1476,7 +1481,7 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65
+#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
@@ -1569,7 +1574,7 @@ msgstr "Configuration clef/valeur à associer à la nouvelle instance"
 msgid "Config key/value to apply to the new project"
 msgstr "Configuration clef/valeur à associer au nouveau projet"
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuration clef/valeur à associer pour l'instance cible"
 
@@ -1622,7 +1627,7 @@ msgstr "Type de contenu : %s"
 msgid "Control: %s (%s)"
 msgstr "Contrôle: %s (%s)"
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr "Copie une instance avec état"
 
@@ -1700,7 +1705,7 @@ msgstr "Copier l'instance sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copier le volume sans ses instantanés"
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
 #: cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid "Copy to a project different from the source"
 msgstr "Copie dans un projet différent de la source"
@@ -1935,7 +1940,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -2000,7 +2005,7 @@ msgstr "Le démon ne fonctionne toujours pas après %ds d'attente (%v)"
 msgid "Daemon still running after %ds timeout"
 msgstr "Le démon continue de fonctionner après %ds d'attente"
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "État : %s"
@@ -2181,7 +2186,7 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
 #: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85
-#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236
 #: cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466
 #: cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796
@@ -2311,7 +2316,7 @@ msgstr "Clé de configuration invalide"
 msgid "Detach storage volumes from profiles"
 msgstr "Détacher les volumes de stockage des profils"
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Serveur distant : %s"
@@ -2331,7 +2336,7 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Device %s removed from %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "Addresse : %s"
@@ -2400,20 +2405,20 @@ msgstr "Désactiver l'allocation pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Disque %d:"
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 msgid "Disk usage:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 msgid "Disk:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 msgid "Disks:"
 msgstr "Disque utilisé :"
 
@@ -2837,7 +2842,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 #, fuzzy
@@ -3088,7 +3093,7 @@ msgstr "Échec de la fermeture du fichier de certificat du serveur %q : %w"
 msgid "Failed to configure cluster: %w"
 msgstr "Échec de la configuration du cluster : %w"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Échec de la connexion au membre du cluster : %w"
@@ -3134,7 +3139,7 @@ msgstr "Échec de la création du certificat : %w"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Échec de la création de la sauvegarde du volume de stockage : %w"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -3277,7 +3282,7 @@ msgstr "Échec de l'écriture du fichier de certificat serveur %q : %w"
 msgid "Failed validation request: %w"
 msgstr "Échec de la demande de validation : %w"
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, fuzzy, c-format
 msgid "Family: %v"
 msgstr "Nom : %s"
@@ -3420,8 +3425,8 @@ msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 "L'alias trouvé %q fait référence à un argument en dehors du nombre donné"
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
+#: cmd/incus/info.go:494
 #, fuzzy, c-format
 msgid "Free: %v"
 msgstr "Libre : %v"
@@ -3440,11 +3445,11 @@ msgstr "Fréquence : %vMhz (min : %vMhz, max : %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid "GPU:"
 msgstr "GPU :"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid "GPUs:"
 msgstr "GPUs :"
 
@@ -3643,12 +3648,12 @@ msgstr "ADRESSE MATÉRIEL"
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3695,7 +3700,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "ADRESSE IP"
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
@@ -3751,7 +3756,7 @@ msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 "Ignorer toute expiration automatique configurée pour le volume de stockage"
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr "Ignorer les erreurs de copie pour les fichiers non permanents"
 
@@ -3893,7 +3898,7 @@ msgstr "Infiniband :"
 msgid "Input data"
 msgstr "Données d'entrée"
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
@@ -4130,7 +4135,7 @@ msgstr "ADRESSE D’ÉCOUTE"
 msgid "LOCATION"
 msgstr "LOCALISATION"
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
@@ -4596,7 +4601,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4605,7 +4610,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid "Log:"
 msgstr "Journal :"
 
@@ -4644,7 +4649,7 @@ msgstr "Création du conteneur"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
@@ -4688,7 +4693,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid "MTU"
 msgstr ""
 
@@ -4959,28 +4964,28 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 msgid "Memory usage:"
 msgstr "Mémoire utilisée :"
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 msgid "Memory:"
 msgstr "Mémoire utilisée :"
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -5242,12 +5247,12 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "Move instances within or in between servers"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -5268,7 +5273,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -5328,11 +5333,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid "NICs:"
 msgstr ""
 
@@ -5348,7 +5353,7 @@ msgstr "NON"
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5361,7 +5366,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 #, fuzzy
@@ -5428,7 +5433,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929
+#: cmd/incus/info.go:575 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5549,7 +5554,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
@@ -5572,7 +5577,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -5638,7 +5643,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5705,7 +5710,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5731,7 +5736,7 @@ msgstr ""
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, fuzzy, c-format
 msgid "PID: %d"
 msgstr "Pid : %d"
@@ -5765,11 +5770,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -5884,7 +5889,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -5894,17 +5899,17 @@ msgstr "Processus : %d"
 msgid "Processing aliases failed: %s"
 msgstr "Le traitement des alias a échoué : %s"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Marque : %v"
@@ -5954,7 +5959,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -6450,7 +6455,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -6569,7 +6574,7 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, fuzzy, c-format
 msgid "SKU: %v"
 msgstr "Publié : %s"
@@ -6646,17 +6651,17 @@ msgstr "Créé : %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Marque : %v"
@@ -7258,11 +7263,11 @@ msgstr "Copie de l'image : %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7296,7 +7301,7 @@ msgstr "Démarrage de %s"
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
@@ -7306,12 +7311,12 @@ msgstr "État : %s"
 msgid "State: %s"
 msgstr "État : %s"
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
@@ -7389,7 +7394,7 @@ msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
 #: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
-#: cmd/incus/move.go:64
+#: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
@@ -7443,11 +7448,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -7465,7 +7470,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid "System:"
 msgstr ""
 
@@ -7486,7 +7491,7 @@ msgstr ""
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 #, fuzzy
 msgid "Taken at"
@@ -7520,28 +7525,8 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: cmd/incus/move.go:158
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: cmd/incus/move.go:170
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: cmd/incus/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: cmd/incus/move.go:162
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -7574,10 +7559,6 @@ msgstr ""
 #: cmd/incus/console.go:378
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
-msgstr ""
-
-#: cmd/incus/move.go:182
-msgid "The destination server is not clustered"
 msgstr ""
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
@@ -7769,12 +7750,8 @@ msgstr ""
 "Le pool de stockage demandé \"%s\" existe déjà. Veuillez choisir un autre "
 "nom."
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid "The server doesn't implement the newer v2 resources API"
-msgstr ""
-
-#: cmd/incus/move.go:286
-msgid "The source server is not clustered"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
@@ -7853,7 +7830,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7867,8 +7844,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Publié : %s"
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7894,7 +7871,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -7903,7 +7880,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -7922,7 +7899,7 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
@@ -7942,14 +7919,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
-#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
+#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, fuzzy, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
@@ -7970,12 +7947,12 @@ msgstr "URL"
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 #, fuzzy
 msgid "USB device:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 #, fuzzy
 msgid "USB devices:"
 msgstr "Création du conteneur"
@@ -7992,7 +7969,7 @@ msgstr "UTILISÉ PAR"
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8053,7 +8030,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -8222,7 +8199,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8270,8 +8247,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, fuzzy, c-format
 msgid "Used: %v"
 msgstr "Publié : %s"
@@ -8312,17 +8289,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "erreur : %v"
@@ -8337,12 +8314,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Version CUDA : %v"
@@ -8520,7 +8497,7 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -8935,7 +8912,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
@@ -10073,7 +10050,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 #, fuzzy
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-04-01 22:06-0400\n"
+        "POT-Creation-Date: 2024-04-03 13:39-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,15 +16,15 @@ msgstr  "Project-Id-Version: incus\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 msgid   "  Chassis:"
 msgstr  ""
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid   "  Firmware:"
 msgstr  ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid   "  Motherboard:"
 msgstr  ""
 
@@ -419,7 +419,11 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615 cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/move.go:265
+msgid   "--target can only be used with clusters"
+msgstr  ""
+
+#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615 cmd/incus/config.go:822 cmd/incus/info.go:566
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -692,7 +696,7 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -808,7 +812,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid   "Backups:"
 msgstr  ""
 
@@ -822,7 +826,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370 cmd/incus/network_integration.go:124 cmd/incus/project.go:138
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302 cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -854,16 +858,16 @@ msgstr  ""
 msgid   "Bridge:"
 msgstr  ""
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, c-format
 msgid   "Bus Address: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid   "Bytes received"
 msgstr  ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -883,7 +887,7 @@ msgstr  ""
 msgid   "COUNT"
 msgstr  ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, c-format
 msgid   "CPU (%s):"
 msgstr  ""
@@ -892,15 +896,15 @@ msgstr  ""
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 msgid   "CPU usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, c-format
 msgid   "CPUs (%s):"
 msgstr  ""
@@ -932,7 +936,7 @@ msgstr  ""
 msgid   "Can't bind address %q: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
@@ -1020,7 +1024,7 @@ msgstr  ""
 msgid   "Cannot set key: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid   "Card %d:"
 msgstr  ""
@@ -1123,7 +1127,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65 cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880 cmd/incus/network.go:1257 cmd/incus/network.go:1350 cmd/incus/network.go:1422 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441 cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747 cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:256 cmd/incus/network_load_balancer.go:427 cmd/incus/network_load_balancer.go:562 cmd/incus/network_load_balancer.go:717 cmd/incus/network_load_balancer.go:805 cmd/incus/network_load_balancer.go:881 cmd/incus/network_load_balancer.go:994 cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:98 cmd/incus/storage.go:370 cmd/incus/storage.go:453 cmd/incus/storage.go:722 cmd/incus/storage.go:824 cmd/incus/storage.go:917 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392 cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642 cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941 cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939 cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294 cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834 cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083 cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598 cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773 cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64 cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880 cmd/incus/network.go:1257 cmd/incus/network.go:1350 cmd/incus/network.go:1422 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441 cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747 cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:256 cmd/incus/network_load_balancer.go:427 cmd/incus/network_load_balancer.go:562 cmd/incus/network_load_balancer.go:717 cmd/incus/network_load_balancer.go:805 cmd/incus/network_load_balancer.go:881 cmd/incus/network_load_balancer.go:994 cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:98 cmd/incus/storage.go:370 cmd/incus/storage.go:453 cmd/incus/storage.go:722 cmd/incus/storage.go:824 cmd/incus/storage.go:917 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392 cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642 cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941 cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939 cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294 cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834 cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083 cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598 cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773 cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1168,7 +1172,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
@@ -1212,7 +1216,7 @@ msgstr  ""
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
@@ -1266,7 +1270,7 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66 cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65 cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1458,7 +1462,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1512,7 +1516,7 @@ msgstr  ""
 msgid   "Daemon still running after %ds timeout"
 msgstr  ""
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, c-format
 msgid   "Date: %s"
 msgstr  ""
@@ -1625,7 +1629,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:30 cmd/incus/cluster.go:123 cmd/incus/cluster.go:215 cmd/incus/cluster.go:272 cmd/incus/cluster.go:331 cmd/incus/cluster.go:404 cmd/incus/cluster.go:484 cmd/incus/cluster.go:528 cmd/incus/cluster.go:586 cmd/incus/cluster.go:677 cmd/incus/cluster.go:770 cmd/incus/cluster.go:891 cmd/incus/cluster.go:963 cmd/incus/cluster.go:1073 cmd/incus/cluster.go:1161 cmd/incus/cluster.go:1285 cmd/incus/cluster.go:1314 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:234 cmd/incus/cluster_group.go:294 cmd/incus/cluster_group.go:418 cmd/incus/cluster_group.go:500 cmd/incus/cluster_group.go:585 cmd/incus/cluster_group.go:641 cmd/incus/cluster_group.go:703 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:117 cmd/incus/config_template.go:171 cmd/incus/config_template.go:271 cmd/incus/config_template.go:339 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543 cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725 cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839 cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348 cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543 cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154 cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323 cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454 cmd/incus/network_integration.go:508 cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:622 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:351 cmd/incus/network_load_balancer.go:419 cmd/incus/network_load_balancer.go:529 cmd/incus/network_load_balancer.go:559 cmd/incus/network_load_balancer.go:714 cmd/incus/network_load_balancer.go:787 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:878 cmd/incus/network_load_balancer.go:976 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84 cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226 cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521 cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704 cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839 cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979 cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162 cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339 cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415 cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:414 cmd/incus/profile.go:472 cmd/incus/profile.go:608 cmd/incus/profile.go:682 cmd/incus/profile.go:751 cmd/incus/profile.go:839 cmd/incus/profile.go:899 cmd/incus/profile.go:988 cmd/incus/profile.go:1052 cmd/incus/project.go:30 cmd/incus/project.go:94 cmd/incus/project.go:167 cmd/incus/project.go:238 cmd/incus/project.go:374 cmd/incus/project.go:448 cmd/incus/project.go:568 cmd/incus/project.go:633 cmd/incus/project.go:721 cmd/incus/project.go:765 cmd/incus/project.go:826 cmd/incus/project.go:893 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:29 cmd/incus/snapshot.go:76 cmd/incus/snapshot.go:183 cmd/incus/snapshot.go:268 cmd/incus/snapshot.go:365 cmd/incus/snapshot.go:426 cmd/incus/snapshot.go:508 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:177 cmd/incus/storage.go:235 cmd/incus/storage.go:367 cmd/incus/storage.go:449 cmd/incus/storage.go:629 cmd/incus/storage.go:716 cmd/incus/storage.go:820 cmd/incus/storage.go:914 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:30 cmd/incus/cluster.go:123 cmd/incus/cluster.go:215 cmd/incus/cluster.go:272 cmd/incus/cluster.go:331 cmd/incus/cluster.go:404 cmd/incus/cluster.go:484 cmd/incus/cluster.go:528 cmd/incus/cluster.go:586 cmd/incus/cluster.go:677 cmd/incus/cluster.go:770 cmd/incus/cluster.go:891 cmd/incus/cluster.go:963 cmd/incus/cluster.go:1073 cmd/incus/cluster.go:1161 cmd/incus/cluster.go:1285 cmd/incus/cluster.go:1314 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:234 cmd/incus/cluster_group.go:294 cmd/incus/cluster_group.go:418 cmd/incus/cluster_group.go:500 cmd/incus/cluster_group.go:585 cmd/incus/cluster_group.go:641 cmd/incus/cluster_group.go:703 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:117 cmd/incus/config_template.go:171 cmd/incus/config_template.go:271 cmd/incus/config_template.go:339 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543 cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725 cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839 cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348 cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543 cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154 cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323 cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454 cmd/incus/network_integration.go:508 cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:622 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:351 cmd/incus/network_load_balancer.go:419 cmd/incus/network_load_balancer.go:529 cmd/incus/network_load_balancer.go:559 cmd/incus/network_load_balancer.go:714 cmd/incus/network_load_balancer.go:787 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:878 cmd/incus/network_load_balancer.go:976 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84 cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226 cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521 cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704 cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839 cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979 cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162 cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339 cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415 cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:414 cmd/incus/profile.go:472 cmd/incus/profile.go:608 cmd/incus/profile.go:682 cmd/incus/profile.go:751 cmd/incus/profile.go:839 cmd/incus/profile.go:899 cmd/incus/profile.go:988 cmd/incus/profile.go:1052 cmd/incus/project.go:30 cmd/incus/project.go:94 cmd/incus/project.go:167 cmd/incus/project.go:238 cmd/incus/project.go:374 cmd/incus/project.go:448 cmd/incus/project.go:568 cmd/incus/project.go:633 cmd/incus/project.go:721 cmd/incus/project.go:765 cmd/incus/project.go:826 cmd/incus/project.go:893 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:29 cmd/incus/snapshot.go:76 cmd/incus/snapshot.go:183 cmd/incus/snapshot.go:268 cmd/incus/snapshot.go:365 cmd/incus/snapshot.go:426 cmd/incus/snapshot.go:508 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:177 cmd/incus/storage.go:235 cmd/incus/storage.go:367 cmd/incus/storage.go:449 cmd/incus/storage.go:629 cmd/incus/storage.go:716 cmd/incus/storage.go:820 cmd/incus/storage.go:914 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1654,7 +1658,7 @@ msgstr  ""
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, c-format
 msgid   "Device %d:"
 msgstr  ""
@@ -1674,7 +1678,7 @@ msgstr  ""
 msgid   "Device %s removed from %s"
 msgstr  ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, c-format
 msgid   "Device Address: %v"
 msgstr  ""
@@ -1729,20 +1733,20 @@ msgstr  ""
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, c-format
 msgid   "Disk %d:"
 msgstr  ""
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 msgid   "Disk usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 msgid   "Disk:"
 msgstr  ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 msgid   "Disks:"
 msgstr  ""
 
@@ -2050,7 +2054,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346 cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490 cmd/incus/storage_volume.go:2575
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346 cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490 cmd/incus/storage_volume.go:2575
 msgid   "Expires at"
 msgstr  ""
 
@@ -2277,7 +2281,7 @@ msgstr  ""
 msgid   "Failed to configure cluster: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
@@ -2322,7 +2326,7 @@ msgstr  ""
 msgid   "Failed to create storage volume backup: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, c-format
 msgid   "Failed to delete original instance after copying it: %w"
 msgstr  ""
@@ -2457,7 +2461,7 @@ msgstr  ""
 msgid   "Failed validation request: %w"
 msgstr  ""
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, c-format
 msgid   "Family: %v"
 msgstr  ""
@@ -2552,7 +2556,7 @@ msgstr  ""
 msgid   "Found alias %q references an argument outside the given number"
 msgstr  ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489 cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488 cmd/incus/info.go:494
 #, c-format
 msgid   "Free: %v"
 msgstr  ""
@@ -2571,11 +2575,11 @@ msgstr  ""
 msgid   "GLOBAL"
 msgstr  ""
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid   "GPU:"
 msgstr  ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid   "GPUs:"
 msgstr  ""
 
@@ -2744,11 +2748,11 @@ msgstr  ""
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 msgid   "Host interface"
 msgstr  ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid   "Hugepages:\n"
 msgstr  ""
 
@@ -2794,7 +2798,7 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 msgid   "IP addresses"
 msgstr  ""
 
@@ -2838,7 +2842,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid   "Ignore copy errors for volatile files"
 msgstr  ""
 
@@ -2961,7 +2965,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 msgid   "Instance Only"
 msgstr  ""
 
@@ -3172,7 +3176,7 @@ msgstr  ""
 msgid   "LOCATION"
 msgstr  ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, c-format
 msgid   "Last Used: %s"
 msgstr  ""
@@ -3544,7 +3548,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3553,7 +3557,7 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid   "Log:"
 msgstr  ""
 
@@ -3590,7 +3594,7 @@ msgstr  ""
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 msgid   "MAC address"
 msgstr  ""
 
@@ -3633,7 +3637,7 @@ msgstr  ""
 msgid   "MII state"
 msgstr  ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid   "MTU"
 msgstr  ""
 
@@ -3864,28 +3868,28 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid   "Memory (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 msgid   "Memory usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 msgid   "Memory:"
 msgstr  ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -4030,11 +4034,11 @@ msgstr  ""
 msgid   "Mount files from instances"
 msgstr  ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 msgid   "Move instances within or in between servers"
 msgstr  ""
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 msgid   "Move instances within or in between servers\n"
         "\n"
         "Transfer modes (--mode):\n"
@@ -4049,7 +4053,7 @@ msgstr  ""
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
@@ -4099,11 +4103,11 @@ msgstr  ""
 msgid   "NEW: %q (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid   "NIC:"
 msgstr  ""
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid   "NICs:"
 msgstr  ""
 
@@ -4116,7 +4120,7 @@ msgstr  ""
 msgid   "NUMA node: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid   "NUMA nodes:\n"
 msgstr  ""
 
@@ -4129,7 +4133,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344 cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488 cmd/incus/storage_volume.go:2573
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344 cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488 cmd/incus/storage_volume.go:2573
 msgid   "Name"
 msgstr  ""
 
@@ -4188,7 +4192,7 @@ msgstr  ""
 msgid   "Name of the storage pool:"
 msgstr  ""
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1378
+#: cmd/incus/info.go:575 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1378
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -4306,7 +4310,7 @@ msgstr  ""
 msgid   "Network type"
 msgstr  ""
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 msgid   "Network usage:"
 msgstr  ""
 
@@ -4328,7 +4332,7 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
@@ -4392,7 +4396,7 @@ msgstr  ""
 msgid   "No value found in %q"
 msgstr  ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid   "Node %d:\n"
 msgstr  ""
@@ -4446,7 +4450,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4471,7 +4475,7 @@ msgstr  ""
 msgid   "PID"
 msgstr  ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, c-format
 msgid   "PID: %d"
 msgstr  ""
@@ -4504,11 +4508,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid   "Packets received"
 msgstr  ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid   "Packets sent"
 msgstr  ""
 
@@ -4609,7 +4613,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -4619,17 +4623,17 @@ msgstr  ""
 msgid   "Processing aliases failed: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, c-format
 msgid   "Product ID: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, c-format
 msgid   "Product: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, c-format
 msgid   "Product: %v"
 msgstr  ""
@@ -4677,7 +4681,7 @@ msgstr  ""
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
@@ -5114,7 +5118,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid   "Resources:"
 msgstr  ""
 
@@ -5207,7 +5211,7 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, c-format
 msgid   "SKU: %v"
 msgstr  ""
@@ -5280,17 +5284,17 @@ msgstr  ""
 msgid   "Send a raw query to the server"
 msgstr  ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, c-format
 msgid   "Serial Number: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, c-format
 msgid   "Serial: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, c-format
 msgid   "Serial: %v"
 msgstr  ""
@@ -5796,11 +5800,11 @@ msgstr  ""
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid   "Snapshots:"
 msgstr  ""
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid   "Socket %d:"
 msgstr  ""
@@ -5831,7 +5835,7 @@ msgstr  ""
 msgid   "Starting recovery..."
 msgstr  ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 msgid   "State"
 msgstr  ""
 
@@ -5840,11 +5844,11 @@ msgstr  ""
 msgid   "State: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 msgid   "Stateful"
 msgstr  ""
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
@@ -5919,7 +5923,7 @@ msgstr  ""
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34 cmd/incus/move.go:64
+#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34 cmd/incus/move.go:63
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -5969,11 +5973,11 @@ msgstr  ""
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid   "Swap (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -5989,7 +5993,7 @@ msgstr  ""
 msgid   "Symlink target path can only be used for type \"symlink\""
 msgstr  ""
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid   "System:"
 msgstr  ""
 
@@ -6005,7 +6009,7 @@ msgstr  ""
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345 cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345 cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid   "Taken at"
 msgstr  ""
 
@@ -6036,28 +6040,8 @@ msgstr  ""
 msgid   "The %s storage pool already exists"
 msgstr  ""
 
-#: cmd/incus/move.go:158
-msgid   "The --instance-only flag can't be used with --target"
-msgstr  ""
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-msgid   "The --mode flag can't be used with --storage or --target-project"
-msgstr  ""
-
-#: cmd/incus/move.go:170
-msgid   "The --mode flag can't be used with --target"
-msgstr  ""
-
 #: cmd/incus/console.go:126
 msgid   "The --show-log flag is only supported for by 'console' output type"
-msgstr  ""
-
-#: cmd/incus/move.go:162
-msgid   "The --storage flag can't be used with --target"
-msgstr  ""
-
-#: cmd/incus/move.go:166
-msgid   "The --target-project flag can't be used with --target"
 msgstr  ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -6082,10 +6066,6 @@ msgstr  ""
 
 #: cmd/incus/console.go:378
 msgid   "The client automatically uses either spicy or remote-viewer when present."
-msgstr  ""
-
-#: cmd/incus/move.go:182
-msgid   "The destination server is not clustered"
 msgstr  ""
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180 cmd/incus/config_device.go:444
@@ -6257,12 +6237,8 @@ msgstr  ""
 msgid   "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr  ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid   "The server doesn't implement the newer v2 resources API"
-msgstr  ""
-
-#: cmd/incus/move.go:286
-msgid   "The source server is not clustered"
 msgstr  ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633 cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
@@ -6329,7 +6305,7 @@ msgid   "To start your first container, try: incus launch images:ubuntu/22.04\n"
         "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr  ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357 cmd/incus/network.go:917 cmd/incus/storage.go:489
+#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356 cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -6342,7 +6318,7 @@ msgstr  ""
 msgid   "Total: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491 cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490 cmd/incus/info.go:496
 #, c-format
 msgid   "Total: %v"
 msgstr  ""
@@ -6368,7 +6344,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull, push or relay"
 msgstr  ""
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
@@ -6377,7 +6353,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -6396,7 +6372,7 @@ msgstr  ""
 msgid   "Try `incus info --show-log %s` for more info"
 msgstr  ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 msgid   "Type"
 msgstr  ""
 
@@ -6412,12 +6388,12 @@ msgstr  ""
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404 cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933 cmd/incus/storage_volume.go:1387
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403 cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933 cmd/incus/storage_volume.go:1387
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, c-format
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
@@ -6438,11 +6414,11 @@ msgstr  ""
 msgid   "USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 msgid   "USB device:"
 msgstr  ""
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 msgid   "USB devices:"
 msgstr  ""
 
@@ -6454,7 +6430,7 @@ msgstr  ""
 msgid   "UUID"
 msgstr  ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid   "UUID: %v"
 msgstr  ""
@@ -6511,7 +6487,7 @@ msgstr  ""
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 msgid   "Unset all profiles on the target instance"
 msgstr  ""
 
@@ -6651,7 +6627,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
@@ -6694,7 +6670,7 @@ msgstr  ""
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490 cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489 cmd/incus/info.go:495
 #, c-format
 msgid   "Used: %v"
 msgstr  ""
@@ -6732,17 +6708,17 @@ msgstr  ""
 msgid   "VLAN:"
 msgstr  ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, c-format
 msgid   "Vendor ID: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, c-format
 msgid   "Vendor: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, c-format
 msgid   "Vendor: %v"
 msgstr  ""
@@ -6757,12 +6733,12 @@ msgstr  ""
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, c-format
 msgid   "Version: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, c-format
 msgid   "Version: %v"
 msgstr  ""
@@ -6920,7 +6896,7 @@ msgstr  ""
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 msgid   "You must specify a source instance name"
 msgstr  ""
 
@@ -7116,7 +7092,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <template>"
 msgstr  ""
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 msgid   "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr  ""
 
@@ -7687,7 +7663,7 @@ msgid   "incus monitor --type=logging\n"
         "    Only show lifecycle events."
 msgstr  ""
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 msgid   "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] [--instance-only]\n"
         "    Move an instance between two hosts, renaming it if destination name differs.\n"
         "\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-01 22:06-0400\n"
+"POT-Creation-Date: 2024-04-03 13:39-0400\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid "  Motherboard:"
 msgstr ""
 
@@ -687,8 +687,12 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: cmd/incus/move.go:265
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/config.go:822 cmd/incus/info.go:566
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -982,7 +986,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -1101,7 +1105,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1118,7 +1122,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1152,16 +1156,16 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1181,7 +1185,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Utilizzo CPU:"
@@ -1190,15 +1194,15 @@ msgstr "Utilizzo CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1232,7 +1236,7 @@ msgstr ""
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1323,7 +1327,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1431,7 +1435,7 @@ msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65
+#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
@@ -1514,7 +1518,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1567,7 +1571,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1627,7 +1631,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
 #: cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1833,7 +1837,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1898,7 +1902,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -2068,7 +2072,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
 #: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85
-#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236
 #: cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466
 #: cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796
@@ -2197,7 +2201,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Utilizzo disco:"
@@ -2217,7 +2221,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "La periferica esiste già: %s"
@@ -2279,21 +2283,21 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 #, fuzzy
 msgid "Disk:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 #, fuzzy
 msgid "Disks:"
 msgstr "Utilizzo disco:"
@@ -2637,7 +2641,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2872,7 +2876,7 @@ msgstr "Accetta certificato"
 msgid "Failed to configure cluster: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
@@ -2917,7 +2921,7 @@ msgstr "Accetta certificato"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Accetta certificato"
@@ -3055,7 +3059,7 @@ msgstr "Accetta certificato"
 msgid "Failed validation request: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3171,8 +3175,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
+#: cmd/incus/info.go:494
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3191,11 +3195,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid "GPUs:"
 msgstr ""
 
@@ -3378,12 +3382,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3429,7 +3433,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 msgid "IP addresses"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3603,7 +3607,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
@@ -3828,7 +3832,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -4231,7 +4235,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4240,7 +4244,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid "Log:"
 msgstr ""
 
@@ -4279,7 +4283,7 @@ msgstr "Creazione del container in corso"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 msgid "MAC address"
 msgstr ""
 
@@ -4322,7 +4326,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid "MTU"
 msgstr ""
 
@@ -4579,28 +4583,28 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4853,11 +4857,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -4877,7 +4881,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4935,11 +4939,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid "NICs:"
 msgstr ""
 
@@ -4955,7 +4959,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4968,7 +4972,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5030,7 +5034,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929
+#: cmd/incus/info.go:575 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5150,7 +5154,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5172,7 +5176,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5236,7 +5240,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5293,7 +5297,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5318,7 +5322,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5352,11 +5356,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5469,7 +5473,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5479,17 +5483,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -5538,7 +5542,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -6017,7 +6021,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid "Resources:"
 msgstr ""
 
@@ -6118,7 +6122,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6193,17 +6197,17 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6767,11 +6771,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6805,7 +6809,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
@@ -6815,11 +6819,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6895,7 +6899,7 @@ msgid "Storage pool %s pending on member %s"
 msgstr ""
 
 #: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
-#: cmd/incus/move.go:64
+#: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
 
@@ -6946,11 +6950,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6966,7 +6970,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid "System:"
 msgstr ""
 
@@ -6987,7 +6991,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 #, fuzzy
 msgid "Taken at"
@@ -7021,28 +7025,8 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "La periferica esiste già"
 
-#: cmd/incus/move.go:158
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: cmd/incus/move.go:170
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: cmd/incus/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: cmd/incus/move.go:162
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -7075,10 +7059,6 @@ msgstr ""
 #: cmd/incus/console.go:378
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
-msgstr ""
-
-#: cmd/incus/move.go:182
-msgid "The destination server is not clustered"
 msgstr ""
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
@@ -7259,12 +7239,8 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid "The server doesn't implement the newer v2 resources API"
-msgstr ""
-
-#: cmd/incus/move.go:286
-msgid "The source server is not clustered"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
@@ -7338,7 +7314,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7352,8 +7328,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7379,7 +7355,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -7388,7 +7364,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -7407,7 +7383,7 @@ msgstr "Password amministratore per %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 msgid "Type"
 msgstr ""
 
@@ -7426,14 +7402,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
-#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
+#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7454,12 +7430,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 #, fuzzy
 msgid "USB device:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 #, fuzzy
 msgid "USB devices:"
 msgstr "Creazione del container in corso"
@@ -7476,7 +7452,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7537,7 +7513,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -7690,7 +7666,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7738,8 +7714,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7779,17 +7755,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7804,12 +7780,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -7981,7 +7957,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -8240,7 +8216,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <template>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
@@ -8970,7 +8946,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-01 22:06-0400\n"
+"POT-Creation-Date: 2024-04-03 13:39-0400\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -18,16 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 #, fuzzy
 msgid "  Chassis:"
 msgstr "Chassis"
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid "  Motherboard:"
 msgstr ""
 
@@ -677,8 +677,13 @@ msgstr "--project は query コマンドでは使えません"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
+#: cmd/incus/move.go:265
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--target はインスタンスでは使えません"
+
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/config.go:822 cmd/incus/info.go:566
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
 
@@ -979,7 +984,7 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -1102,7 +1107,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1121,7 +1126,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1155,16 +1160,16 @@ msgstr "ブランド: %v"
 msgid "Bridge:"
 msgstr "ブリッジ:"
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1184,7 +1189,7 @@ msgstr "CONTENT-TYPE"
 msgid "COUNT"
 msgstr "COUNT"
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
@@ -1193,15 +1198,15 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs (%s):"
@@ -1234,7 +1239,7 @@ msgstr "キャッシュ:"
 msgid "Can't bind address %q: %w"
 msgstr "アドレス %q をバインドできません: %w"
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
@@ -1331,7 +1336,7 @@ msgstr "スナップショットをコピーするときに --volume-only は指
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid "Card %d:"
 msgstr "カード %d:"
@@ -1441,7 +1446,7 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65
+#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
@@ -1531,7 +1536,7 @@ msgstr "新しいインスタンスに適用するキー/値の設定"
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
@@ -1584,7 +1589,7 @@ msgstr "コンテンツタイプ: %s"
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
@@ -1660,7 +1665,7 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
 #: cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
@@ -1860,7 +1865,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1925,7 +1930,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr "%d 秒のタイムアウトが経過しましたが、デーモンがまだ実行中です"
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "状態: %s"
@@ -2088,7 +2093,7 @@ msgstr "警告を削除します"
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
 #: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85
-#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236
 #: cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466
 #: cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796
@@ -2216,7 +2221,7 @@ msgstr "インスタンスからストレージボリュームを取り外しま
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "デバイス: %s"
@@ -2236,7 +2241,7 @@ msgstr "デバイス %s が %s で上書きされました"
 msgid "Device %s removed from %s"
 msgstr "デバイス %s が %s から削除されました"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "アドレス: %s"
@@ -2303,20 +2308,20 @@ msgstr "擬似端末の割り当てを無効にします"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, c-format
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 msgid "Disk:"
 msgstr "ディスク:"
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 msgid "Disks:"
 msgstr "ディスク:"
 
@@ -2701,7 +2706,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2936,7 +2941,7 @@ msgstr "サーバー証明書ファイル %q のクローズに失敗しまし�
 msgid "Failed to configure cluster: %w"
 msgstr "クラスターの設定に失敗しました: %w"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスターメンバへの接続に失敗しました: %w"
@@ -2981,7 +2986,7 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed to create storage volume backup: %w"
 msgstr "ストレージボリュームのバックアップ作成に失敗しました: %w"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "移動元のインスタンスをコピーしたあとの削除に失敗しました: %w"
@@ -3119,7 +3124,7 @@ msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 msgid "Failed validation request: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, fuzzy, c-format
 msgid "Family: %v"
 msgstr "名前: %v"
@@ -3248,8 +3253,8 @@ msgstr "Forward delay"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "エイリアス %q が指定した番号以外の引数を参照しているのが見つかりました"
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
+#: cmd/incus/info.go:494
 #, c-format
 msgid "Free: %v"
 msgstr "空き: %v"
@@ -3268,11 +3273,11 @@ msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid "GPU:"
 msgstr "GPU:"
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid "GPUs:"
 msgstr "GPUs:"
 
@@ -3455,11 +3460,11 @@ msgstr "MAC ADDRESS"
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
@@ -3505,7 +3510,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 msgid "IP addresses"
 msgstr "IP アドレス"
 
@@ -3557,7 +3562,7 @@ msgstr "設定されている自動でのインスタンスの有効期限設定
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr "コピー中にファイルが更新された場合のエラーを無視します"
 
@@ -3693,7 +3698,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
@@ -3920,7 +3925,7 @@ msgstr "LISTEN ADDRESS"
 msgid "LOCATION"
 msgstr "LOCATION"
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, c-format
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
@@ -4485,7 +4490,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4494,7 +4499,7 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid "Log:"
 msgstr "ログ:"
 
@@ -4531,7 +4536,7 @@ msgstr "Lower devices"
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 msgid "MAC address"
 msgstr "MAC アドレス"
 
@@ -4574,7 +4579,7 @@ msgstr "MII 監視頻度"
 msgid "MII state"
 msgstr "MII 状態"
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid "MTU"
 msgstr "MTU"
 
@@ -4834,28 +4839,28 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -5101,12 +5106,12 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "Move instances within or in between servers"
 msgstr "LXD サーバ内もしくはサーバ間でインスタンスを移動します"
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 #, fuzzy
 msgid ""
 "Move instances within or in between servers\n"
@@ -5138,7 +5143,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
@@ -5198,11 +5203,11 @@ msgstr "NETWORKS"
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr "新規: %q (バックエンド=%q, ソース=%q)"
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid "NIC:"
 msgstr "NIC:"
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid "NICs:"
 msgstr "NICs:"
 
@@ -5218,7 +5223,7 @@ msgstr "NO"
 msgid "NUMA node: %v"
 msgstr "NUMA ノード: %v"
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid "NUMA nodes:\n"
 msgstr "NUMA ノード:\n"
 
@@ -5231,7 +5236,7 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5297,7 +5302,7 @@ msgstr "使用するストレージバックエンド名 (%s)"
 msgid "Name of the storage pool:"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929
+#: cmd/incus/info.go:575 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5419,7 +5424,7 @@ msgstr ""
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -5441,7 +5446,7 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
@@ -5508,7 +5513,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
@@ -5569,7 +5574,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -5594,7 +5599,7 @@ msgstr "PEER"
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, c-format
 msgid "PID: %d"
 msgstr "PID: %d"
@@ -5629,11 +5634,11 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -5747,7 +5752,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -5757,17 +5762,17 @@ msgstr "プロセス数: %d"
 msgid "Processing aliases failed: %s"
 msgstr "エイリアスの処理が失敗しました: %s"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "製品名: %v (%v)"
@@ -5815,7 +5820,7 @@ msgstr "新しいイメージに適用するプロファイル"
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
@@ -6324,7 +6329,7 @@ msgstr "クラスターメンバーに join するためのトークンを要求
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -6425,7 +6430,7 @@ msgstr "SEVERITY"
 msgid "SIZE"
 msgstr "SIZE"
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, fuzzy, c-format
 msgid "SKU: %v"
 msgstr "UUID: %v"
@@ -6501,17 +6506,17 @@ msgstr "秘密鍵: %s"
 msgid "Send a raw query to the server"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "合計: %v"
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "合計: %v"
@@ -7147,11 +7152,11 @@ msgstr "ストレージボリュームのスナップショットを取得しま
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid "Socket %d:"
 msgstr "ソケット %d:"
@@ -7186,7 +7191,7 @@ msgstr "%s を起動中"
 msgid "Starting recovery..."
 msgstr "リカバリーを開始します..."
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 msgid "State"
 msgstr "状態"
 
@@ -7195,11 +7200,11 @@ msgstr "状態"
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr "ステートフル"
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
@@ -7275,7 +7280,7 @@ msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
 #: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
-#: cmd/incus/move.go:64
+#: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
@@ -7326,11 +7331,11 @@ msgstr "サポートするモード: %s"
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -7346,7 +7351,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr "シンボリックリンクのターゲットパスは \"symlink\" タイプにのみ使えます"
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid "System:"
 msgstr ""
 
@@ -7367,7 +7372,7 @@ msgstr "TOKEN"
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr "取得日時"
@@ -7409,30 +7414,9 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "デバイスはすでに存在します"
 
-#: cmd/incus/move.go:158
-msgid "The --instance-only flag can't be used with --target"
-msgstr "--instance-only と --target は同時に指定できません"
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-#, fuzzy
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr "--mode と --target-project は同時に指定できません"
-
-#: cmd/incus/move.go:170
-msgid "The --mode flag can't be used with --target"
-msgstr "--mode と --target は同時に指定できません"
-
 #: cmd/incus/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
-
-#: cmd/incus/move.go:162
-msgid "The --storage flag can't be used with --target"
-msgstr "--storage と --target は同時に指定できません"
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
-msgstr "--target-project と --target は同時に指定できません"
 
 #: cmd/incus/admin_init_interactive.go:742
 msgid "The LVM thin provisioning tools couldn't be found on the system"
@@ -7484,11 +7468,6 @@ msgid ""
 msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
-
-#: cmd/incus/move.go:182
-#, fuzzy
-msgid "The destination server is not clustered"
-msgstr "移動先の LXD サーバはクラスタに属していません"
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
 #: cmd/incus/config_device.go:444
@@ -7682,14 +7661,9 @@ msgstr ""
 "入力したストレージプール \"%s\" はすでに存在しています。他の名前を入力してく"
 "ださい。"
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
-
-#: cmd/incus/move.go:286
-#, fuzzy
-msgid "The source server is not clustered"
-msgstr "移動元の LXD サーバはクラスタに属していません"
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
 #: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
@@ -7784,7 +7758,7 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7800,8 +7774,8 @@ msgstr "リンクが多すぎます"
 msgid "Total: %s"
 msgstr "合計: %s"
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Total: %v"
 msgstr "合計: %v"
@@ -7827,7 +7801,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull, push or relay"
 msgstr "転送モード。pull, push, relay のいずれか"
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
@@ -7836,7 +7810,7 @@ msgstr "転送モード。pull, push, relay のいずれか。"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -7855,7 +7829,7 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 msgid "Type"
 msgstr "タイプ"
 
@@ -7875,14 +7849,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
-#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
+#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
@@ -7903,12 +7877,12 @@ msgstr "URL"
 msgid "USAGE"
 msgstr "USAGE"
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 #, fuzzy
 msgid "USB device:"
 msgstr "device"
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 #, fuzzy
 msgid "USB devices:"
 msgstr "上位デバイス"
@@ -7925,7 +7899,7 @@ msgstr "USED BY"
 msgid "UUID"
 msgstr "UUID"
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid "UUID: %v"
 msgstr "UUID: %v"
@@ -7984,7 +7958,7 @@ msgstr "未知の出力タイプ: %q"
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 msgid "Unset all profiles on the target instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
@@ -8135,7 +8109,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr "インスタンスプロパティの設定を削除します"
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
@@ -8185,8 +8159,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Used: %v"
 msgstr "使用済: %v"
@@ -8228,17 +8202,17 @@ msgstr "VLAN フィルタリング"
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, c-format
 msgid "Vendor: %v"
 msgstr "ベンダー: %v"
@@ -8253,12 +8227,12 @@ msgstr "ベンダ: %v (%v)"
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "CUDA バージョン: %v"
@@ -8450,7 +8424,7 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -8669,7 +8643,7 @@ msgstr "[<remote>:]<instance> <snapshot>"
 msgid "[<remote>:]<instance> <template>"
 msgstr "[<remote>:]<instance> <template>"
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr "[<remote>:]<instance> [[<remote>:]<instance>...]"
@@ -9434,7 +9408,7 @@ msgstr ""
 "lxc monitor --type=lifecycle\n"
 "    lifecycle イベントのみを表示します。"
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 #, fuzzy
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
@@ -9740,6 +9714,30 @@ msgstr "y"
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr "yes"
+
+#, fuzzy
+#~ msgid "The source server is not clustered"
+#~ msgstr "移動元の LXD サーバはクラスタに属していません"
+
+#~ msgid "The --instance-only flag can't be used with --target"
+#~ msgstr "--instance-only と --target は同時に指定できません"
+
+#, fuzzy
+#~ msgid "The --mode flag can't be used with --storage or --target-project"
+#~ msgstr "--mode と --target-project は同時に指定できません"
+
+#~ msgid "The --mode flag can't be used with --target"
+#~ msgstr "--mode と --target は同時に指定できません"
+
+#~ msgid "The --storage flag can't be used with --target"
+#~ msgstr "--storage と --target は同時に指定できません"
+
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr "--target-project と --target は同時に指定できません"
+
+#, fuzzy
+#~ msgid "The destination server is not clustered"
+#~ msgstr "移動先の LXD サーバはクラスタに属していません"
 
 #, fuzzy, c-format
 #~ msgid "Usb %d:"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-01 22:06-0400\n"
+"POT-Creation-Date: 2024-04-03 13:39-0400\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid "  Motherboard:"
 msgstr ""
 
@@ -698,8 +698,13 @@ msgstr "--project kan niet gebruikt worden met de query command"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kan alleen worden gebruikt bij geïnstantieerden (instances)"
 
+#: cmd/incus/move.go:265
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--target kan niet gebruikt worden met: instances"
+
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/config.go:822 cmd/incus/info.go:566
 msgid "--target cannot be used with instances"
 msgstr "--target kan niet gebruikt worden met: instances"
 
@@ -997,7 +1002,7 @@ msgstr "Alle server adressen zijn onbeschikbaar"
 msgid "Alternative certificate name"
 msgstr "Alternatieve certificaat naam"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architectuur: %s"
@@ -1121,7 +1126,7 @@ msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1138,7 +1143,7 @@ msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1172,16 +1177,16 @@ msgstr "Merk (Brand): %v"
 msgid "Bridge:"
 msgstr "Brug (Bridge):"
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, fuzzy, c-format
 msgid "Bus Address: %v"
 msgstr "Adres: %s"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes ontvangen (received)"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes verzonden"
 
@@ -1201,7 +1206,7 @@ msgstr "INHOUDSTYPE"
 msgid "COUNT"
 msgstr "SOM"
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
@@ -1210,15 +1215,15 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU GEBRUIK"
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid "CPU usage (in seconds)"
 msgstr "CPU gebruik (in seconde)"
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 msgid "CPU usage:"
 msgstr "CPU gebruik:"
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, c-format
 msgid "CPUs (%s):"
 msgstr "CPU's (%s):"
@@ -1251,7 +1256,7 @@ msgstr "Caches:"
 msgid "Can't bind address %q: %w"
 msgstr "Kan niet binden (bind) aan adres (address) %q: %w"
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 "Niet mogelijk om geforceerd (override) de configuratie of de profielen in "
@@ -1344,7 +1349,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1451,7 +1456,7 @@ msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65
+#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
@@ -1533,7 +1538,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1586,7 +1591,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1646,7 +1651,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
 #: cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1842,7 +1847,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1906,7 +1911,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Cached: %s"
@@ -2069,7 +2074,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
 #: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85
-#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236
 #: cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466
 #: cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796
@@ -2197,7 +2202,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Adres: %s"
@@ -2217,7 +2222,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "Adres: %s"
@@ -2278,20 +2283,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 msgid "Disks:"
 msgstr ""
 
@@ -2624,7 +2629,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2855,7 +2860,7 @@ msgstr ""
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2900,7 +2905,7 @@ msgstr ""
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -3038,7 +3043,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3152,8 +3157,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
+#: cmd/incus/info.go:494
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3172,11 +3177,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid "GPUs:"
 msgstr ""
 
@@ -3348,11 +3353,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3398,7 +3403,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 msgid "IP addresses"
 msgstr ""
 
@@ -3444,7 +3449,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3568,7 +3573,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 msgid "Instance Only"
 msgstr ""
 
@@ -3787,7 +3792,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4175,7 +4180,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4184,7 +4189,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid "Log:"
 msgstr ""
 
@@ -4221,7 +4226,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 msgid "MAC address"
 msgstr ""
 
@@ -4264,7 +4269,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid "MTU"
 msgstr ""
 
@@ -4503,28 +4508,28 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4761,11 +4766,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -4785,7 +4790,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4843,11 +4848,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid "NICs:"
 msgstr ""
 
@@ -4863,7 +4868,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4876,7 +4881,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4938,7 +4943,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929
+#: cmd/incus/info.go:575 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5058,7 +5063,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5080,7 +5085,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5144,7 +5149,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5201,7 +5206,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5226,7 +5231,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5260,11 +5265,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5375,7 +5380,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5385,17 +5390,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Merk (Brand): %v"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Merk (Brand): %v"
@@ -5443,7 +5448,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5908,7 +5913,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid "Resources:"
 msgstr ""
 
@@ -6002,7 +6007,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6077,17 +6082,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Merk (Brand): %v"
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Alias: %s"
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Merk (Brand): %v"
@@ -6631,11 +6636,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6668,7 +6673,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 msgid "State"
 msgstr ""
 
@@ -6677,11 +6682,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6757,7 +6762,7 @@ msgid "Storage pool %s pending on member %s"
 msgstr ""
 
 #: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
-#: cmd/incus/move.go:64
+#: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
 
@@ -6807,11 +6812,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6827,7 +6832,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid "System:"
 msgstr ""
 
@@ -6848,7 +6853,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -6881,28 +6886,8 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/move.go:158
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: cmd/incus/move.go:170
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: cmd/incus/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: cmd/incus/move.go:162
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -6935,10 +6920,6 @@ msgstr ""
 #: cmd/incus/console.go:378
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
-msgstr ""
-
-#: cmd/incus/move.go:182
-msgid "The destination server is not clustered"
 msgstr ""
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
@@ -7118,12 +7099,8 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid "The server doesn't implement the newer v2 resources API"
-msgstr ""
-
-#: cmd/incus/move.go:286
-msgid "The source server is not clustered"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
@@ -7196,7 +7173,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7210,8 +7187,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7237,7 +7214,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -7246,7 +7223,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -7265,7 +7242,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 msgid "Type"
 msgstr ""
 
@@ -7283,14 +7260,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
-#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
+#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7311,11 +7288,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 msgid "USB devices:"
 msgstr ""
 
@@ -7331,7 +7308,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7389,7 +7366,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -7529,7 +7506,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7575,8 +7552,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7615,17 +7592,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Cached: %s"
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Cached: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7640,12 +7617,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "CUDA Versie: %v"
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "CUDA Versie: %v"
@@ -7815,7 +7792,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8025,7 +8002,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
 
@@ -8655,7 +8632,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-01 22:06-0400\n"
+"POT-Creation-Date: 2024-04-03 13:39-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,15 +16,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid "  Motherboard:"
 msgstr ""
 
@@ -442,8 +442,12 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: cmd/incus/move.go:265
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/config.go:822 cmd/incus/info.go:566
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -726,7 +730,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -844,7 +848,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -861,7 +865,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -895,16 +899,16 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr ""
 
@@ -924,7 +928,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -933,15 +937,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1172,7 +1176,7 @@ msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65
+#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
@@ -1254,7 +1258,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1307,7 +1311,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1367,7 +1371,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
 #: cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1562,7 +1566,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1626,7 +1630,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -1788,7 +1792,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
 #: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85
-#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236
 #: cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466
 #: cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796
@@ -1916,7 +1920,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, c-format
 msgid "Device %d:"
 msgstr ""
@@ -1936,7 +1940,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
@@ -1997,20 +2001,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 msgid "Disks:"
 msgstr ""
 
@@ -2343,7 +2347,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2574,7 +2578,7 @@ msgstr ""
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2619,7 +2623,7 @@ msgstr ""
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -2757,7 +2761,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -2871,8 +2875,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
+#: cmd/incus/info.go:494
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -2891,11 +2895,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid "GPUs:"
 msgstr ""
 
@@ -3065,11 +3069,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3115,7 +3119,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 msgid "IP addresses"
 msgstr ""
 
@@ -3161,7 +3165,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3285,7 +3289,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 msgid "Instance Only"
 msgstr ""
 
@@ -3504,7 +3508,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3891,7 +3895,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3900,7 +3904,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid "Log:"
 msgstr ""
 
@@ -3937,7 +3941,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 msgid "MAC address"
 msgstr ""
 
@@ -3980,7 +3984,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid "MTU"
 msgstr ""
 
@@ -4218,28 +4222,28 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4475,11 +4479,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -4499,7 +4503,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4557,11 +4561,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid "NICs:"
 msgstr ""
 
@@ -4577,7 +4581,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4590,7 +4594,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4652,7 +4656,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929
+#: cmd/incus/info.go:575 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -4772,7 +4776,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -4794,7 +4798,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4858,7 +4862,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4915,7 +4919,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4940,7 +4944,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4974,11 +4978,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5089,7 +5093,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5099,17 +5103,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -5157,7 +5161,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5621,7 +5625,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid "Resources:"
 msgstr ""
 
@@ -5715,7 +5719,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -5790,17 +5794,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6341,11 +6345,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 msgid "State"
 msgstr ""
 
@@ -6387,11 +6391,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6467,7 +6471,7 @@ msgid "Storage pool %s pending on member %s"
 msgstr ""
 
 #: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
-#: cmd/incus/move.go:64
+#: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
 
@@ -6517,11 +6521,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6537,7 +6541,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid "System:"
 msgstr ""
 
@@ -6558,7 +6562,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -6591,28 +6595,8 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/move.go:158
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: cmd/incus/move.go:170
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: cmd/incus/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: cmd/incus/move.go:162
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -6645,10 +6629,6 @@ msgstr ""
 #: cmd/incus/console.go:378
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
-msgstr ""
-
-#: cmd/incus/move.go:182
-msgid "The destination server is not clustered"
 msgstr ""
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
@@ -6828,12 +6808,8 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid "The server doesn't implement the newer v2 resources API"
-msgstr ""
-
-#: cmd/incus/move.go:286
-msgid "The source server is not clustered"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
@@ -6906,7 +6882,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6920,8 +6896,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -6947,7 +6923,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6956,7 +6932,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6975,7 +6951,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 msgid "Type"
 msgstr ""
 
@@ -6993,14 +6969,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
-#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
+#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7021,11 +6997,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 msgid "USB devices:"
 msgstr ""
 
@@ -7041,7 +7017,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7099,7 +7075,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -7239,7 +7215,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7285,8 +7261,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7325,17 +7301,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7350,12 +7326,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -7525,7 +7501,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7735,7 +7711,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
 
@@ -8365,7 +8341,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-01 22:06-0400\n"
+"POT-Creation-Date: 2024-04-03 13:39-0400\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid "  Motherboard:"
 msgstr ""
 
@@ -686,8 +686,13 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
+#: cmd/incus/move.go:265
+#, fuzzy
+msgid "--target can only be used with clusters"
+msgstr "--refresh só pode ser usado com containers"
+
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/config.go:822 cmd/incus/info.go:566
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -986,7 +991,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
@@ -1111,7 +1116,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1128,7 +1133,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1162,16 +1167,16 @@ msgstr "Marca: %v"
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1191,7 +1196,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Utilização do CPU:"
@@ -1200,15 +1205,15 @@ msgstr "Utilização do CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, fuzzy, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs:"
@@ -1242,7 +1247,7 @@ msgstr "Em cache: %s"
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1334,7 +1339,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid "Card %d:"
 msgstr "Cartão %d:"
@@ -1442,7 +1447,7 @@ msgstr "Dispositivo %s removido de %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65
+#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
@@ -1535,7 +1540,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1589,7 +1594,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1650,7 +1655,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
 #: cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1928,7 +1933,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Criado: %s"
@@ -2105,7 +2110,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
 #: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85
-#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236
 #: cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466
 #: cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796
@@ -2236,7 +2241,7 @@ msgstr "Desconectar volumes de armazenamento dos containers"
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Em cache: %s"
@@ -2256,7 +2261,7 @@ msgstr "Dispositivo %s sobreposto em %s"
 msgid "Device %s removed from %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, fuzzy, c-format
 msgid "Device Address: %v"
 msgstr "O dispositivo já existe: %s"
@@ -2318,21 +2323,21 @@ msgstr "Desabilitar alocação de pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desabilitar stdin (ler de /dev/null)"
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 #, fuzzy
 msgid "Disk:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso de disco:"
@@ -2684,7 +2689,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2917,7 +2922,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to configure cluster: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
@@ -2962,7 +2967,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Aceitar certificado"
@@ -3100,7 +3105,7 @@ msgstr "Aceitar certificado"
 msgid "Failed validation request: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3215,8 +3220,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
+#: cmd/incus/info.go:494
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3235,11 +3240,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid "GPUs:"
 msgstr ""
 
@@ -3431,11 +3436,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3481,7 +3486,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 msgid "IP addresses"
 msgstr ""
 
@@ -3527,7 +3532,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3656,7 +3661,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 msgid "Instance Only"
 msgstr ""
 
@@ -3879,7 +3884,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Criado: %s"
@@ -4278,7 +4283,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4287,7 +4292,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid "Log:"
 msgstr ""
 
@@ -4326,7 +4331,7 @@ msgstr "Editar arquivos no container"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 msgid "MAC address"
 msgstr ""
 
@@ -4369,7 +4374,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid "MTU"
 msgstr ""
 
@@ -4632,28 +4637,28 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4905,12 +4910,12 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 #, fuzzy
 msgid "Move instances within or in between servers"
 msgstr "Copiar imagens entre servidores"
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -4930,7 +4935,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4988,11 +4993,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid "NICs:"
 msgstr ""
 
@@ -5008,7 +5013,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5021,7 +5026,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5083,7 +5088,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929
+#: cmd/incus/info.go:575 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5203,7 +5208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5225,7 +5230,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5289,7 +5294,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5346,7 +5351,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5371,7 +5376,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5405,11 +5410,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5531,17 +5536,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Marca: %v"
@@ -5591,7 +5596,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -6078,7 +6083,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid "Resources:"
 msgstr ""
 
@@ -6184,7 +6189,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6259,17 +6264,17 @@ msgstr "Criado: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Marca: %v"
@@ -6852,11 +6857,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6889,7 +6894,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 msgid "State"
 msgstr ""
 
@@ -6898,11 +6903,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6978,7 +6983,7 @@ msgid "Storage pool %s pending on member %s"
 msgstr ""
 
 #: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
-#: cmd/incus/move.go:64
+#: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
 
@@ -7030,11 +7035,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7050,7 +7055,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid "System:"
 msgstr ""
 
@@ -7071,7 +7076,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7105,32 +7110,9 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "Alias %s já existe"
 
-#: cmd/incus/move.go:158
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-#, fuzzy
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr "--refresh só pode ser usado com containers"
-
-#: cmd/incus/move.go:170
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: cmd/incus/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
-
-#: cmd/incus/move.go:162
-#, fuzzy
-msgid "The --storage flag can't be used with --target"
-msgstr "--refresh só pode ser usado com containers"
-
-#: cmd/incus/move.go:166
-#, fuzzy
-msgid "The --target-project flag can't be used with --target"
-msgstr "--refresh só pode ser usado com containers"
 
 #: cmd/incus/admin_init_interactive.go:742
 msgid "The LVM thin provisioning tools couldn't be found on the system"
@@ -7162,10 +7144,6 @@ msgstr ""
 #: cmd/incus/console.go:378
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
-msgstr ""
-
-#: cmd/incus/move.go:182
-msgid "The destination server is not clustered"
 msgstr ""
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
@@ -7345,12 +7323,8 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid "The server doesn't implement the newer v2 resources API"
-msgstr ""
-
-#: cmd/incus/move.go:286
-msgid "The source server is not clustered"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
@@ -7424,7 +7398,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7438,8 +7412,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7465,7 +7439,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -7474,7 +7448,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -7493,7 +7467,7 @@ msgstr "Senha de administrador para %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 msgid "Type"
 msgstr ""
 
@@ -7512,14 +7486,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
-#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
+#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7540,12 +7514,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 #, fuzzy
 msgid "USB device:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 #, fuzzy
 msgid "USB devices:"
 msgstr "Editar arquivos no container"
@@ -7562,7 +7536,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7623,7 +7597,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -7787,7 +7761,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7835,8 +7809,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7876,17 +7850,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7901,12 +7875,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Versão CUDA: %v"
@@ -8077,7 +8051,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8312,7 +8286,7 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "[<remote>:]<instance> <template>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr "Editar templates de arquivo do container"
@@ -8998,7 +8972,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"
@@ -9215,6 +9189,18 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:236
 msgid "yes"
 msgstr "sim"
+
+#, fuzzy
+#~ msgid "The --mode flag can't be used with --storage or --target-project"
+#~ msgstr "--refresh só pode ser usado com containers"
+
+#, fuzzy
+#~ msgid "The --storage flag can't be used with --target"
+#~ msgstr "--refresh só pode ser usado com containers"
+
+#, fuzzy
+#~ msgid "The --target-project flag can't be used with --target"
+#~ msgstr "--refresh só pode ser usado com containers"
 
 #, fuzzy, c-format
 #~ msgid "Usb %d:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-01 22:06-0400\n"
+"POT-Creation-Date: 2024-04-03 13:39-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,15 +20,15 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid "  Motherboard:"
 msgstr ""
 
@@ -702,8 +702,12 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: cmd/incus/move.go:265
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/config.go:822 cmd/incus/info.go:566
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -1006,7 +1010,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -1127,7 +1131,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1144,7 +1148,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1178,16 +1182,16 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1207,7 +1211,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr " Использование ЦП:"
@@ -1216,16 +1220,16 @@ msgstr " Использование ЦП:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1259,7 +1263,7 @@ msgstr ""
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1350,7 +1354,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1458,7 +1462,7 @@ msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65
+#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
@@ -1540,7 +1544,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1593,7 +1597,7 @@ msgstr "Авто-обновление: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1654,7 +1658,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
 #: cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1867,7 +1871,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1932,7 +1936,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Авто-обновление: %s"
@@ -2106,7 +2110,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
 #: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85
-#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236
 #: cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466
 #: cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796
@@ -2236,7 +2240,7 @@ msgstr "Копирование образа: %s"
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr " Использование диска:"
@@ -2256,7 +2260,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
@@ -2317,22 +2321,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 #, fuzzy
 msgid "Disk:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 #, fuzzy
 msgid "Disks:"
 msgstr " Использование диска:"
@@ -2680,7 +2684,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2918,7 +2922,7 @@ msgstr "Принять сертификат"
 msgid "Failed to configure cluster: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
@@ -2963,7 +2967,7 @@ msgstr "Принять сертификат"
 msgid "Failed to create storage volume backup: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, fuzzy, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Принять сертификат"
@@ -3101,7 +3105,7 @@ msgstr "Принять сертификат"
 msgid "Failed validation request: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3216,8 +3220,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
+#: cmd/incus/info.go:494
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3236,11 +3240,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid "GPUs:"
 msgstr ""
 
@@ -3428,12 +3432,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3479,7 +3483,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 msgid "IP addresses"
 msgstr ""
 
@@ -3525,7 +3529,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3655,7 +3659,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
@@ -3880,7 +3884,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
@@ -4286,7 +4290,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4295,7 +4299,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid "Log:"
 msgstr ""
 
@@ -4334,7 +4338,7 @@ msgstr "Копирование образа: %s"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 msgid "MAC address"
 msgstr ""
 
@@ -4377,7 +4381,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid "MTU"
 msgstr ""
 
@@ -4641,30 +4645,30 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 #, fuzzy
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4917,11 +4921,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -4942,7 +4946,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -5000,11 +5004,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid "NICs:"
 msgstr ""
 
@@ -5020,7 +5024,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5033,7 +5037,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5099,7 +5103,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929
+#: cmd/incus/info.go:575 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5220,7 +5224,7 @@ msgstr ""
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -5243,7 +5247,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5308,7 +5312,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5365,7 +5369,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5390,7 +5394,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5424,11 +5428,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5540,7 +5544,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5550,17 +5554,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -5608,7 +5612,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -6088,7 +6092,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid "Resources:"
 msgstr ""
 
@@ -6190,7 +6194,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6265,17 +6269,17 @@ msgstr "Авто-обновление: %s"
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, fuzzy, c-format
 msgid "Serial Number: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6851,11 +6855,11 @@ msgstr "Копирование образа: %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6888,7 +6892,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
@@ -6898,11 +6902,11 @@ msgstr "Авто-обновление: %s"
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6980,7 +6984,7 @@ msgid "Storage pool %s pending on member %s"
 msgstr ""
 
 #: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
-#: cmd/incus/move.go:64
+#: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
 
@@ -7032,11 +7036,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7052,7 +7056,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid "System:"
 msgstr ""
 
@@ -7073,7 +7077,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7106,28 +7110,8 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/move.go:158
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: cmd/incus/move.go:170
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: cmd/incus/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: cmd/incus/move.go:162
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -7160,10 +7144,6 @@ msgstr ""
 #: cmd/incus/console.go:378
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
-msgstr ""
-
-#: cmd/incus/move.go:182
-msgid "The destination server is not clustered"
 msgstr ""
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
@@ -7343,12 +7323,8 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid "The server doesn't implement the newer v2 resources API"
-msgstr ""
-
-#: cmd/incus/move.go:286
-msgid "The source server is not clustered"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
@@ -7422,7 +7398,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7436,8 +7412,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7463,7 +7439,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -7472,7 +7448,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -7491,7 +7467,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 msgid "Type"
 msgstr ""
 
@@ -7510,14 +7486,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
-#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
+#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7538,12 +7514,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 #, fuzzy
 msgid "USB device:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 #, fuzzy
 msgid "USB devices:"
 msgstr "Копирование образа: %s"
@@ -7560,7 +7536,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7620,7 +7596,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -7780,7 +7756,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7828,8 +7804,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7869,17 +7845,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7894,12 +7870,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -8070,7 +8046,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8468,7 +8444,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 #, fuzzy
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
@@ -9502,7 +9478,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-01 22:06-0400\n"
+"POT-Creation-Date: 2024-04-03 13:39-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: cmd/incus/info.go:408
+#: cmd/incus/info.go:407
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:444
+#: cmd/incus/info.go:443
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:426
+#: cmd/incus/info.go:425
 msgid "  Motherboard:"
 msgstr ""
 
@@ -654,8 +654,12 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
+#: cmd/incus/move.go:265
+msgid "--target can only be used with clusters"
+msgstr ""
+
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:567
+#: cmd/incus/config.go:822 cmd/incus/info.go:566
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -938,7 +942,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:590
+#: cmd/incus/image.go:999 cmd/incus/info.go:589
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1056,7 +1060,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1073,7 +1077,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:370
+#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:124 cmd/incus/project.go:138
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1107,16 +1111,16 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: cmd/incus/info.go:346
+#: cmd/incus/info.go:345
 #, c-format
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:947
+#: cmd/incus/info.go:680 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:948
+#: cmd/incus/info.go:681 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:459
+#: cmd/incus/info.go:458
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -1145,15 +1149,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:631
+#: cmd/incus/info.go:630
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:635
+#: cmd/incus/info.go:634
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:462
+#: cmd/incus/info.go:461
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1186,7 +1190,7 @@ msgstr ""
 msgid "Can't bind address %q: %w"
 msgstr ""
 
-#: cmd/incus/move.go:128
+#: cmd/incus/move.go:127
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1277,7 +1281,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:506 cmd/incus/info.go:518
+#: cmd/incus/info.go:505 cmd/incus/info.go:517
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1384,7 +1388,7 @@ msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:65
+#: cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
@@ -1466,7 +1470,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: cmd/incus/move.go:57
+#: cmd/incus/move.go:56
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1519,7 +1523,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:63
+#: cmd/incus/copy.go:58 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1579,7 +1583,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:66
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
 #: cmd/incus/profile.go:272 cmd/incus/storage_volume.go:367
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1774,7 +1778,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:601
+#: cmd/incus/image.go:1005 cmd/incus/info.go:600
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1838,7 +1842,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:454
+#: cmd/incus/info.go:453
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -2000,7 +2004,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
 #: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33
 #: cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85
-#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:36
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236
 #: cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466
 #: cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796
@@ -2128,7 +2132,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:542
+#: cmd/incus/info.go:541
 #, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2148,7 +2152,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: cmd/incus/info.go:347
+#: cmd/incus/info.go:346
 #, c-format
 msgid "Device Address: %v"
 msgstr ""
@@ -2209,20 +2213,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:530
+#: cmd/incus/info.go:529
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:624
+#: cmd/incus/info.go:623
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:525
+#: cmd/incus/info.go:524
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:528
+#: cmd/incus/info.go:527
 msgid "Disks:"
 msgstr ""
 
@@ -2555,7 +2559,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:346
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:346
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2786,7 +2790,7 @@ msgstr ""
 msgid "Failed to configure cluster: %w"
 msgstr ""
 
-#: cmd/incus/move.go:281 cmd/incus/move.go:357
+#: cmd/incus/move.go:261
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2831,7 +2835,7 @@ msgstr ""
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
 
-#: cmd/incus/move.go:248
+#: cmd/incus/move.go:226
 #, c-format
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
@@ -2969,7 +2973,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:388
+#: cmd/incus/info.go:387
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3083,8 +3087,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
+#: cmd/incus/info.go:494
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3103,11 +3107,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:501
+#: cmd/incus/info.go:500
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:503
 msgid "GPUs:"
 msgstr ""
 
@@ -3277,11 +3281,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:669
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483
+#: cmd/incus/info.go:471 cmd/incus/info.go:482
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3327,7 +3331,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:686
+#: cmd/incus/info.go:685
 msgid "IP addresses"
 msgstr ""
 
@@ -3373,7 +3377,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:67
+#: cmd/incus/copy.go:64 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3497,7 +3501,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:796
+#: cmd/incus/info.go:795
 msgid "Instance Only"
 msgstr ""
 
@@ -3716,7 +3720,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:604
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4103,7 +4107,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:593 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4112,7 +4116,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:824
+#: cmd/incus/info.go:823
 msgid "Log:"
 msgstr ""
 
@@ -4149,7 +4153,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:674
+#: cmd/incus/info.go:673
 msgid "MAC address"
 msgstr ""
 
@@ -4192,7 +4196,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:678
+#: cmd/incus/info.go:677
 msgid "MTU"
 msgstr ""
 
@@ -4430,28 +4434,28 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:642
+#: cmd/incus/info.go:641
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:646
+#: cmd/incus/info.go:645
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:657
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:470
+#: cmd/incus/info.go:469
 msgid "Memory:"
 msgstr ""
 
-#: cmd/incus/move.go:299 cmd/incus/move.go:412
+#: cmd/incus/move.go:338
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: cmd/incus/move.go:324 cmd/incus/move.go:417
+#: cmd/incus/move.go:357
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4687,11 +4691,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/move.go:35
+#: cmd/incus/move.go:34
 msgid "Move instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/move.go:36
+#: cmd/incus/move.go:35
 msgid ""
 "Move instances within or in between servers\n"
 "\n"
@@ -4711,7 +4715,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: cmd/incus/move.go:61
+#: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4769,11 +4773,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:513
+#: cmd/incus/info.go:512
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:516
+#: cmd/incus/info.go:515
 msgid "NICs:"
 msgstr ""
 
@@ -4789,7 +4793,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:479
+#: cmd/incus/info.go:478
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4802,7 +4806,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:344
+#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:344
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4864,7 +4868,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:576 cmd/incus/network.go:929
+#: cmd/incus/info.go:575 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -4984,7 +4988,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:699 cmd/incus/network.go:946
+#: cmd/incus/info.go:698 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5006,7 +5010,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:58
+#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5070,7 +5074,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:481
+#: cmd/incus/info.go:480
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5127,7 +5131,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5152,7 +5156,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:597
+#: cmd/incus/info.go:596
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5186,11 +5190,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:949
+#: cmd/incus/info.go:682 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:950
+#: cmd/incus/info.go:683 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5301,7 +5305,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:611
+#: cmd/incus/info.go:610
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5311,17 +5315,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:345
+#: cmd/incus/info.go:344
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:432
+#: cmd/incus/info.go:431
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:344 cmd/incus/info.go:384
+#: cmd/incus/info.go:343 cmd/incus/info.go:383
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -5369,7 +5373,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: cmd/incus/move.go:59
+#: cmd/incus/move.go:58
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5833,7 +5837,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:609
+#: cmd/incus/info.go:608
 msgid "Resources:"
 msgstr ""
 
@@ -5927,7 +5931,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:396
+#: cmd/incus/info.go:395
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6002,17 +6006,17 @@ msgstr ""
 msgid "Send a raw query to the server"
 msgstr ""
 
-#: cmd/incus/info.go:349
+#: cmd/incus/info.go:348
 #, c-format
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:422 cmd/incus/info.go:436
+#: cmd/incus/info.go:421 cmd/incus/info.go:435
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:400
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6553,11 +6557,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:711 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:464
+#: cmd/incus/info.go:463
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6590,7 +6594,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:667
 msgid "State"
 msgstr ""
 
@@ -6599,11 +6603,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/snapshot.go:347
+#: cmd/incus/info.go:744 cmd/incus/snapshot.go:347
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:578
+#: cmd/incus/info.go:577
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6679,7 +6683,7 @@ msgid "Storage pool %s pending on member %s"
 msgstr ""
 
 #: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
-#: cmd/incus/move.go:64
+#: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
 
@@ -6729,11 +6733,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:650
+#: cmd/incus/info.go:649
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:653
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6749,7 +6753,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:374
+#: cmd/incus/info.go:373
 msgid "System:"
 msgstr ""
 
@@ -6770,7 +6774,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:345
+#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:345
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -6803,28 +6807,8 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/move.go:158
-msgid "The --instance-only flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:196 cmd/incus/move.go:217
-msgid "The --mode flag can't be used with --storage or --target-project"
-msgstr ""
-
-#: cmd/incus/move.go:170
-msgid "The --mode flag can't be used with --target"
-msgstr ""
-
 #: cmd/incus/console.go:126
 msgid "The --show-log flag is only supported for by 'console' output type"
-msgstr ""
-
-#: cmd/incus/move.go:162
-msgid "The --storage flag can't be used with --target"
-msgstr ""
-
-#: cmd/incus/move.go:166
-msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:742
@@ -6857,10 +6841,6 @@ msgstr ""
 #: cmd/incus/console.go:378
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
-msgstr ""
-
-#: cmd/incus/move.go:182
-msgid "The destination server is not clustered"
 msgstr ""
 
 #: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
@@ -7040,12 +7020,8 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:365
+#: cmd/incus/info.go:364
 msgid "The server doesn't implement the newer v2 resources API"
-msgstr ""
-
-#: cmd/incus/move.go:286
-msgid "The source server is not clustered"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
@@ -7118,7 +7094,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:357
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
 #: cmd/incus/network.go:917 cmd/incus/storage.go:489
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7132,8 +7108,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
-#: cmd/incus/info.go:497
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7159,7 +7135,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: cmd/incus/move.go:62
+#: cmd/incus/move.go:61
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -7168,7 +7144,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:304
+#: cmd/incus/copy.go:350 cmd/incus/move.go:343
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -7187,7 +7163,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:666
 msgid "Type"
 msgstr ""
 
@@ -7205,14 +7181,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:404
-#: cmd/incus/info.go:414 cmd/incus/info.go:587 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
+#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:585
+#: cmd/incus/info.go:584
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7233,11 +7209,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:537
+#: cmd/incus/info.go:536
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:540
+#: cmd/incus/info.go:539
 msgid "USB devices:"
 msgstr ""
 
@@ -7253,7 +7229,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:376
+#: cmd/incus/info.go:140 cmd/incus/info.go:375
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7311,7 +7287,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/move.go:60
+#: cmd/incus/move.go:59
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -7451,7 +7427,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:816
+#: cmd/incus/info.go:815
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7497,8 +7473,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
+#: cmd/incus/info.go:495
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7537,17 +7513,17 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:343
+#: cmd/incus/info.go:342
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:410 cmd/incus/info.go:428 cmd/incus/info.go:446
+#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:342 cmd/incus/info.go:380
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7562,12 +7538,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:418 cmd/incus/info.go:440 cmd/incus/info.go:450
+#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:392
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Version: %v"
 msgstr ""
@@ -7737,7 +7713,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:270 cmd/incus/move.go:346
+#: cmd/incus/copy.go:96 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7947,7 +7923,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
-#: cmd/incus/move.go:33
+#: cmd/incus/move.go:32
 msgid "[<remote>:]<instance> [<remote>:][<instance>]"
 msgstr ""
 
@@ -8577,7 +8553,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: cmd/incus/move.go:46
+#: cmd/incus/move.go:45
 msgid ""
 "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
 "[--instance-only]\n"


### PR DESCRIPTION
This very seriously reworks the server-side instance move logic.
It had been slowly grown over the years meaning that each addition didn't necessarily fit well with the previous ones.

The new logic is basically split into two main stage:
 - Request validation (access control, target selection, ...) and non-migration process (simple renames)
 - Instance migration

The instance migration part then got a major overhaul too and now will basically do:
 - Handle basic instance rename first
 - Handle project and storage pool changes
 - Handle cluster server re-location

This should basically allow handling requests that can change one or more of:
 - Name
 - Location
 - Project
 - Storage pool

As well as supporting the additional properties controlling live migration, whether to retain snapshots and whether to override some specific parts of the instance configuration.

Closes #589 
Closes #695 
Closes #590
Closes #566