### PR TITLE
incusd/instances: Don't start instances when evacuated

### DIFF
--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1611,9 +1611,7 @@ func (d *Daemon) init() error {
 	d.tasks.Start(d.shutdownCtx)
 
 	// Restore instances
-	if !d.db.Cluster.LocalNodeIsEvacuated() {
-		instancesStart(d.State(), instances)
-	}
+	instancesStart(d.State(), instances)
 
 	// Re-balance in case things changed while the daemon was down
 	deviceTaskBalance(d.State())

--- a/cmd/incusd/instances.go
+++ b/cmd/incusd/instances.go
@@ -192,11 +192,19 @@ func instanceShouldAutoStart(inst instance.Instance) bool {
 }
 
 func instancesStart(s *state.State, instances []instance.Instance) {
+	// Check if the cluster is currently evacuated.
+	if s.DB.Cluster.LocalNodeIsEvacuated() {
+		return
+	}
+
+	// Acquire startup lock.
 	instancesStartMu.Lock()
 	defer instancesStartMu.Unlock()
 
+	// Sort based on instance boot priority.
 	sort.Sort(instanceAutostartList(instances))
 
+	// Let's make up to 3 attempts to start instances.
 	maxAttempts := 3
 
 	// Start the instances


### PR DESCRIPTION
I noticed a few cases where an offline network or storage coming back online on an evacuated host would cause instances coming back online.

As all code paths to instancesStart come from locations attempting auto-start on daemon startup, lets just move the evacuation check to the function itself.