### PR TITLE
Add all-projects support for network zones #712

### DIFF
--- a/client/incus_network_zones.go
+++ b/client/incus_network_zones.go
@@ -42,6 +42,23 @@ func (r *ProtocolIncus) GetNetworkZones() ([]api.NetworkZone, error) {
 	return zones, nil
 }
 
+// GetNetworkZonesAllProjects returns a list of network zones across all projects as NetworkZone structs.
+func (r *ProtocolIncus) GetNetworkZonesAllProjects() ([]api.NetworkZone, error) {
+	err := r.CheckExtension("network_zones_all_projects")
+	if err != nil {
+		return nil, fmt.Errorf(`The server is missing the required "network_zones_all_projects" API extension`)
+	}
+
+	zones := []api.NetworkZone{}
+	uri := "/network-zones?all-projects=true&recursion=1"
+	_, err = r.queryStruct("GET", uri, nil, "", &zones)
+	if err != nil {
+		return nil, err
+	}
+
+	return zones, nil
+}
+
 // GetNetworkZone returns a Network zone entry for the provided name.
 func (r *ProtocolIncus) GetNetworkZone(name string) (*api.NetworkZone, string, error) {
 	if !r.HasExtension("network_dns") {

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -235,6 +235,7 @@ type InstanceServer interface {
 	GetNetworkAllocations(allProjects bool) (allocations []api.NetworkAllocations, err error)
 
 	// Network zone functions ("network_dns" API extension)
+	GetNetworkZonesAllProjects() (zones []api.NetworkZone, err error)
 	GetNetworkZoneNames() (names []string, err error)
 	GetNetworkZones() (zones []api.NetworkZone, err error)
 	GetNetworkZone(name string) (zone *api.NetworkZone, ETag string, err error)

--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -73,7 +73,8 @@ type cmdNetworkZoneList struct {
 	global      *cmdGlobal
 	networkZone *cmdNetworkZone
 
-	flagFormat string
+	flagFormat      string
+	flagAllProjects bool
 }
 
 func (c *cmdNetworkZoneList) Command() *cobra.Command {
@@ -85,6 +86,7 @@ func (c *cmdNetworkZoneList) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
+	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display network zones from all projects"))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -122,9 +124,17 @@ func (c *cmdNetworkZoneList) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(i18n.G("Filtering isn't supported yet"))
 	}
 
-	zones, err := resource.server.GetNetworkZones()
-	if err != nil {
-		return err
+	var zones []api.NetworkZone
+	if c.flagAllProjects {
+		zones, err = resource.server.GetNetworkZonesAllProjects()
+		if err != nil {
+			return err
+		}
+	} else {
+		zones, err = resource.server.GetNetworkZones()
+		if err != nil {
+			return err
+		}
 	}
 
 	data := [][]string{}
@@ -136,6 +146,10 @@ func (c *cmdNetworkZoneList) Run(cmd *cobra.Command, args []string) error {
 			strUsedBy,
 		}
 
+		if c.flagAllProjects {
+			details = append([]string{zone.Project}, details...)
+		}
+
 		data = append(data, details)
 	}
 
@@ -145,6 +159,10 @@ func (c *cmdNetworkZoneList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("NAME"),
 		i18n.G("DESCRIPTION"),
 		i18n.G("USED BY"),
+	}
+
+	if c.flagAllProjects {
+		header = append([]string{i18n.G("PROJECT")}, header...)
 	}
 
 	return cli.RenderTable(c.flagFormat, header, data, zones)

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1846,6 +1846,10 @@ This adds:
 * `PATCH /1.0/network-zones/ZONE/records/RECORD`
 * `DELETE /1.0/network-zones/ZONE/records/RECORD`
 
+## `network_zones_all_projects`
+
+This adds support for listing network zones across all projects through the `all-projects` parameter on the `GET /1.0/network-zones`API.
+
 ## `storage_zfs_reserve_space`
 
 Adds ability to set the `reservation`/`refreservation` ZFS property along with `quota`/`refquota`.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -3569,6 +3569,11 @@ definitions:
                 example: example.net
                 type: string
                 x-go-name: Name
+            project:
+                description: Project name
+                example: project1
+                type: string
+                x-go-name: Project
             used_by:
                 description: List of URLs of objects using this network zone
                 example:
@@ -10959,6 +10964,11 @@ paths:
                   in: query
                   name: project
                   type: string
+                - description: Retrieve network zones from all projects
+                  example: true
+                  in: query
+                  name: all-projects
+                  type: boolean
             produces:
                 - application/json
             responses:
@@ -11418,6 +11428,11 @@ paths:
                   in: query
                   name: project
                   type: string
+                - description: Retrieve network zones from all projects
+                  example: true
+                  in: query
+                  name: all-projects
+                  type: boolean
             produces:
                 - application/json
             responses:

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -408,6 +408,7 @@ var APIExtensions = []string{
 	"network_integrations",
 	"instance_memory_swap_bytes",
 	"network_bridge_external_create",
+	"network_zones_all_projects",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-18 10:59+0200\n"
+"POT-Creation-Date: 2024-04-18 17:10-0400\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -415,7 +415,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -441,7 +441,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -848,7 +848,7 @@ msgstr "Aktion (Standard: GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Profil %s erstellt\n"
@@ -861,7 +861,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1158,8 +1158,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360
-#: cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379
+#: cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1590,7 +1590,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1761,7 +1761,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1875,12 +1875,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new network peering"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1944,8 +1944,8 @@ msgstr ""
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156
-#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146
-#: cmd/incus/network_zone.go:822 cmd/incus/operation.go:173
+#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161
+#: cmd/incus/network_zone.go:841 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -2055,12 +2055,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2192,17 +2192,17 @@ msgstr ""
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
-#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84
-#: cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226
-#: cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390
-#: cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704
-#: cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162
-#: cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339
-#: cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415
-#: cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
+#: cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245
+#: cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409
+#: cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540
+#: cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723
+#: cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858
+#: cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181
+#: cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358
+#: cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434
+#: cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2402,6 +2402,11 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display instances from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
+#: cmd/incus/network_zone.go:89
+#, fuzzy
+msgid "Display network zones from all projects"
+msgstr "Herunterfahren des Containers erzwingen."
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
@@ -2439,7 +2444,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid "ENTRIES"
 msgstr ""
 
@@ -2530,12 +2535,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network peer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2594,7 +2599,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid "Entry TTL"
 msgstr ""
 
@@ -2631,7 +2636,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137
+#: cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2652,8 +2657,8 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447
-#: cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466
+#: cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980
 #: cmd/incus/project.go:713 cmd/incus/storage.go:780
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3183,7 +3188,7 @@ msgid "Fetch instance backup file: %w"
 msgstr "Herunterfahren des Containers erzwingen."
 
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131
-#: cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3260,7 +3265,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473
 #: cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467
@@ -3372,12 +3377,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
@@ -3454,12 +3459,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network peer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -4051,16 +4056,16 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
@@ -4632,12 +4637,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network peerings"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4904,18 +4909,18 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262
-#: cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426
-#: cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678
-#: cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110
-#: cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449
-#: cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281
+#: cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445
+#: cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697
+#: cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891
+#: cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129
+#: cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468
+#: cmd/incus/network_zone.go:1525
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5093,7 +5098,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821
+#: cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840
 #: cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5262,12 +5267,12 @@ msgstr "Profil %s gelöscht\n"
 msgid "Network ACL %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -5342,12 +5347,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -5526,7 +5531,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166
 #: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5638,7 +5643,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307
+#: cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -6060,7 +6065,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Profil %s erstellt\n"
@@ -6088,7 +6093,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove backends from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6592,12 +6597,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6606,7 +6611,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -6744,12 +6749,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
@@ -6895,17 +6900,17 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network peer configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
@@ -7410,12 +7415,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7695,7 +7700,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
-#: cmd/incus/network_zone.go:147 cmd/incus/profile.go:756
+#: cmd/incus/network_zone.go:162 cmd/incus/profile.go:756
 #: cmd/incus/project.go:574 cmd/incus/storage.go:698
 #: cmd/incus/storage_volume.go:1638
 msgid "USED BY"
@@ -7829,12 +7834,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -7895,12 +7900,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as a network property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
@@ -8263,7 +8268,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1008 cmd/incus/network_acl.go:90
-#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81
+#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468
 #: cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 #, fuzzy
@@ -8382,8 +8387,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519
-#: cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538
+#: cmd/incus/network_zone.go:664
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -8391,7 +8396,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -8399,7 +8404,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -8407,7 +8412,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -9416,7 +9421,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -9424,8 +9429,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207
-#: cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226
+#: cmd/incus/network_zone.go:1355
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -9433,7 +9438,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -9441,7 +9446,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -9449,7 +9454,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -9457,7 +9462,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-18 10:59+0200\n"
+"POT-Creation-Date: 2024-04-18 17:10-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -407,7 +407,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -436,7 +436,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -819,7 +819,7 @@ msgstr "Accion (predeterminados a GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Perfil %s creado"
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1117,8 +1117,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360
-#: cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379
+#: cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1540,7 +1540,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1708,7 +1708,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1815,12 +1815,12 @@ msgstr "Perfil %s creado"
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 msgid "Create new network zones"
 msgstr ""
 
@@ -1879,8 +1879,8 @@ msgstr ""
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156
-#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146
-#: cmd/incus/network_zone.go:822 cmd/incus/operation.go:173
+#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161
+#: cmd/incus/network_zone.go:841 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -1987,12 +1987,12 @@ msgstr "Perfil %s creado"
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Perfil %s creado"
@@ -2122,17 +2122,17 @@ msgstr ""
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
-#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84
-#: cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226
-#: cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390
-#: cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704
-#: cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162
-#: cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339
-#: cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415
-#: cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
+#: cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245
+#: cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409
+#: cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540
+#: cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723
+#: cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858
+#: cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181
+#: cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358
+#: cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434
+#: cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2318,6 +2318,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display instances from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
+#: cmd/incus/network_zone.go:89
+#, fuzzy
+msgid "Display network zones from all projects"
+msgstr "No se puede proveer el nombre del container a la lista"
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
@@ -2355,7 +2360,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid "ENTRIES"
 msgstr ""
 
@@ -2439,12 +2444,12 @@ msgstr "Perfil %s creado"
 msgid "Edit network peer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
@@ -2502,7 +2507,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid "Entry TTL"
 msgstr ""
 
@@ -2538,7 +2543,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137
+#: cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2559,8 +2564,8 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447
-#: cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466
+#: cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980
 #: cmd/incus/project.go:713 cmd/incus/storage.go:780
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3081,7 +3086,7 @@ msgid "Fetch instance backup file: %w"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131
-#: cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
@@ -3155,7 +3160,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473
 #: cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467
@@ -3266,12 +3271,12 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Perfil %s creado"
@@ -3343,12 +3348,12 @@ msgstr "Perfil %s creado"
 msgid "Get values for network peer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
@@ -3931,16 +3936,16 @@ msgstr "Nombre del contenedor es: %s"
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
@@ -4474,12 +4479,12 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nombre del contenedor es: %s"
@@ -4739,18 +4744,18 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262
-#: cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426
-#: cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678
-#: cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110
-#: cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449
-#: cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281
+#: cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445
+#: cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697
+#: cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891
+#: cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129
+#: cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468
+#: cmd/incus/network_zone.go:1525
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nombre del contenedor es: %s"
@@ -4921,7 +4926,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821
+#: cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840
 #: cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5086,12 +5091,12 @@ msgstr "Perfil %s eliminado"
 msgid "Network ACL %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
@@ -5164,12 +5169,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Perfil %s eliminado"
@@ -5345,7 +5350,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166
 #: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5455,7 +5460,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307
+#: cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5871,7 +5876,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Perfil %s creado"
@@ -5898,7 +5903,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove backends from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6379,12 +6384,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6393,7 +6398,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
@@ -6525,12 +6530,12 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Perfil %s creado"
@@ -6667,17 +6672,17 @@ msgstr "Perfil %s creado"
 msgid "Show network peer configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
@@ -7167,12 +7172,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -7447,7 +7452,7 @@ msgstr ""
 
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
-#: cmd/incus/network_zone.go:147 cmd/incus/profile.go:756
+#: cmd/incus/network_zone.go:162 cmd/incus/profile.go:756
 #: cmd/incus/project.go:574 cmd/incus/storage.go:698
 #: cmd/incus/storage_volume.go:1638
 msgid "USED BY"
@@ -7576,12 +7581,12 @@ msgstr "Perfil %s creado"
 msgid "Unset network peer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
@@ -7640,12 +7645,12 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Perfil %s creado"
@@ -7986,7 +7991,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1008 cmd/incus/network_acl.go:90
-#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81
+#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468
 #: cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 #, fuzzy
@@ -8059,23 +8064,23 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<API path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519
-#: cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538
+#: cmd/incus/network_zone.go:664
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8699,33 +8704,33 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<warning-uuid>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207
-#: cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226
+#: cmd/incus/network_zone.go:1355
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-18 10:59+0200\n"
+"POT-Creation-Date: 2024-04-18 17:10-0400\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -419,7 +419,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié."
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -443,7 +443,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -824,7 +824,7 @@ msgstr "Action (GET par défaut)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Ajoutez un membre d'un cluster à un groupe de cluster"
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 msgid "Add a network zone record entry"
 msgstr "Ajoutez un enregistrement d'une zone réseau"
 
@@ -836,7 +836,7 @@ msgstr "Ajoutez un backend à un équilibreur de charge"
 msgid "Add backends to a load balancer"
 msgstr "Ajoutez des backends à un équilibreur de charge"
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid "Add entries to a network zone record"
 msgstr "Ajoutez des entrées à la zone d'enregistrement réseau"
 
@@ -1149,8 +1149,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360
-#: cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379
+#: cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
@@ -1588,7 +1588,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1774,7 +1774,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible d'écrire le fichier de certificat serveur %q: %w"
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid "Couldn't find a matching entry"
 msgstr "Impossible de trouver une entrée correspondante"
 
@@ -1905,12 +1905,12 @@ msgstr "Copie de l'image : %s"
 msgid "Create new network peering"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Copie de l'image : %s"
@@ -1975,8 +1975,8 @@ msgstr "ADRESSE CIBLE PAR DÉFAUT"
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156
-#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146
-#: cmd/incus/network_zone.go:822 cmd/incus/operation.go:173
+#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161
+#: cmd/incus/network_zone.go:841 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -2091,12 +2091,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete network peerings"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Récupération de l'image : %s"
@@ -2229,17 +2229,17 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
-#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84
-#: cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226
-#: cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390
-#: cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704
-#: cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162
-#: cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339
-#: cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415
-#: cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
+#: cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245
+#: cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409
+#: cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540
+#: cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723
+#: cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858
+#: cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181
+#: cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358
+#: cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434
+#: cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2432,6 +2432,11 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display instances from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
+#: cmd/incus/network_zone.go:89
+#, fuzzy
+msgid "Display network zones from all projects"
+msgstr "Forcer le conteneur à s'arrêter"
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid "Do you want to configure a new local storage pool?"
 msgstr "Voulez-vous configurer un nouveau pool de stockage locale?"
@@ -2470,7 +2475,7 @@ msgstr "Pilote: %v (%v)"
 msgid "Dump YAML config to stdout"
 msgstr "Copié de la configuration YAML vers stdout"
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid "ENTRIES"
 msgstr "ENTRÉES"
 
@@ -2564,12 +2569,12 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network peer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2642,7 +2647,7 @@ msgstr ""
 "définir une valeur\n"
 "  pour l'adresse si elle n'est pas encore paramétrée."
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid "Entry TTL"
 msgstr "Entrée TTL"
 
@@ -2679,7 +2684,7 @@ msgstr "Erreur lors de la récupération des alias : %w"
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137
+#: cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2700,8 +2705,8 @@ msgstr "Erreur lors du déparamétrage des propriétés: %v"
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447
-#: cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466
+#: cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980
 #: cmd/incus/project.go:713 cmd/incus/storage.go:780
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3298,7 +3303,7 @@ msgid "Fetch instance backup file: %w"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131
-#: cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "Le filtrage n'est pas encore pris en charge"
 
@@ -3395,7 +3400,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473
 #: cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467
@@ -3511,12 +3516,12 @@ msgstr "Nom du réseau"
 msgid "Get the key as a network property"
 msgstr "Obtenir la clé en tant que propriété du réseau"
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Clé de configuration invalide"
@@ -3594,12 +3599,12 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network peer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4223,16 +4228,16 @@ msgstr "Nom du réseau"
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
@@ -4845,12 +4850,12 @@ msgstr "Nom du réseau"
 msgid "Manage network peerings"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nom du réseau"
@@ -5117,18 +5122,18 @@ msgstr "Nom du réseau"
 msgid "Missing network name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262
-#: cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426
-#: cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678
-#: cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110
-#: cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449
-#: cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281
+#: cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445
+#: cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697
+#: cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891
+#: cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129
+#: cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468
+#: cmd/incus/network_zone.go:1525
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nom du réseau"
@@ -5309,7 +5314,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821
+#: cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840
 #: cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5479,12 +5484,12 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Network ACL %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -5558,12 +5563,12 @@ msgstr "Nom du réseau"
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -5753,7 +5758,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166
 #: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5865,7 +5870,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307
+#: cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -6291,7 +6296,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Clé de configuration invalide"
@@ -6319,7 +6324,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove backends from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
@@ -6835,12 +6840,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6849,7 +6854,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
@@ -6988,12 +6993,12 @@ msgstr "Nom du réseau"
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Clé de configuration invalide"
@@ -7142,17 +7147,17 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network peer configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
@@ -7669,12 +7674,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -7959,7 +7964,7 @@ msgstr "Création du conteneur"
 
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
-#: cmd/incus/network_zone.go:147 cmd/incus/profile.go:756
+#: cmd/incus/network_zone.go:162 cmd/incus/profile.go:756
 #: cmd/incus/project.go:574 cmd/incus/storage.go:698
 #: cmd/incus/storage_volume.go:1638
 msgid "USED BY"
@@ -8094,12 +8099,12 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network peer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
@@ -8162,12 +8167,12 @@ msgstr "Nom du réseau"
 msgid "Unset the key as a network property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Clé de configuration invalide"
@@ -8526,7 +8531,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1008 cmd/incus/network_acl.go:90
-#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81
+#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468
 #: cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 msgid "[<remote>:]"
@@ -8609,8 +8614,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519
-#: cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538
+#: cmd/incus/network_zone.go:664
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -8618,7 +8623,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -8626,7 +8631,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -8634,7 +8639,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -9739,7 +9744,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -9747,8 +9752,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207
-#: cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226
+#: cmd/incus/network_zone.go:1355
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -9756,7 +9761,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -9764,7 +9769,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -9772,7 +9777,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -9780,7 +9785,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-04-18 10:59+0200\n"
+        "POT-Creation-Date: 2024-04-18 17:10-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -225,7 +225,7 @@ msgid   "### This is a YAML representation of the network peer.\n"
         "### Note that the name, target_project, target_network and status fields cannot be changed."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 msgid   "### This is a YAML representation of the network zone record.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -238,7 +238,7 @@ msgid   "### This is a YAML representation of the network zone record.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 msgid   "### This is a YAML representation of the network zone.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -542,7 +542,7 @@ msgstr  ""
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 msgid   "Add a network zone record entry"
 msgstr  ""
 
@@ -554,7 +554,7 @@ msgstr  ""
 msgid   "Add backends to a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid   "Add entries to a network zone record"
 msgstr  ""
 
@@ -821,7 +821,7 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425 cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360 cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425 cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379 cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -1180,7 +1180,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:375 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692 cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288 cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306 cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:375 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692 cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288 cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325 cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1336,7 +1336,7 @@ msgstr  ""
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid   "Couldn't find a matching entry"
 msgstr  ""
 
@@ -1434,11 +1434,11 @@ msgstr  ""
 msgid   "Create new network peering"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 msgid   "Create new network zone record"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 msgid   "Create new network zones"
 msgstr  ""
 
@@ -1490,7 +1490,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:197 cmd/incus/cluster_group.go:482 cmd/incus/config_trust.go:435 cmd/incus/image.go:1121 cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092 cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152 cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146 cmd/incus/network_zone.go:822 cmd/incus/operation.go:173 cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697 cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840 cmd/incus/storage_volume.go:1636
+#: cmd/incus/cluster.go:197 cmd/incus/cluster_group.go:482 cmd/incus/config_trust.go:435 cmd/incus/image.go:1121 cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092 cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152 cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:841 cmd/incus/operation.go:173 cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697 cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840 cmd/incus/storage_volume.go:1636
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1589,11 +1589,11 @@ msgstr  ""
 msgid   "Delete network peerings"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 msgid   "Delete network zone record"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 msgid   "Delete network zones"
 msgstr  ""
 
@@ -1629,7 +1629,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:30 cmd/incus/cluster.go:123 cmd/incus/cluster.go:215 cmd/incus/cluster.go:272 cmd/incus/cluster.go:331 cmd/incus/cluster.go:404 cmd/incus/cluster.go:484 cmd/incus/cluster.go:528 cmd/incus/cluster.go:586 cmd/incus/cluster.go:677 cmd/incus/cluster.go:770 cmd/incus/cluster.go:891 cmd/incus/cluster.go:963 cmd/incus/cluster.go:1073 cmd/incus/cluster.go:1161 cmd/incus/cluster.go:1285 cmd/incus/cluster.go:1314 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:234 cmd/incus/cluster_group.go:294 cmd/incus/cluster_group.go:418 cmd/incus/cluster_group.go:500 cmd/incus/cluster_group.go:585 cmd/incus/cluster_group.go:641 cmd/incus/cluster_group.go:703 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:117 cmd/incus/config_template.go:171 cmd/incus/config_template.go:271 cmd/incus/config_template.go:339 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543 cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725 cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839 cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348 cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543 cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154 cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323 cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454 cmd/incus/network_integration.go:508 cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:622 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:351 cmd/incus/network_load_balancer.go:419 cmd/incus/network_load_balancer.go:529 cmd/incus/network_load_balancer.go:559 cmd/incus/network_load_balancer.go:714 cmd/incus/network_load_balancer.go:787 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:878 cmd/incus/network_load_balancer.go:976 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84 cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226 cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521 cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704 cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839 cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979 cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162 cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339 cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415 cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:434 cmd/incus/profile.go:492 cmd/incus/profile.go:628 cmd/incus/profile.go:702 cmd/incus/profile.go:771 cmd/incus/profile.go:859 cmd/incus/profile.go:919 cmd/incus/profile.go:1008 cmd/incus/profile.go:1072 cmd/incus/project.go:30 cmd/incus/project.go:94 cmd/incus/project.go:190 cmd/incus/project.go:261 cmd/incus/project.go:397 cmd/incus/project.go:471 cmd/incus/project.go:591 cmd/incus/project.go:656 cmd/incus/project.go:744 cmd/incus/project.go:788 cmd/incus/project.go:849 cmd/incus/project.go:916 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:177 cmd/incus/storage.go:235 cmd/incus/storage.go:367 cmd/incus/storage.go:449 cmd/incus/storage.go:629 cmd/incus/storage.go:716 cmd/incus/storage.go:820 cmd/incus/storage.go:914 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:30 cmd/incus/cluster.go:123 cmd/incus/cluster.go:215 cmd/incus/cluster.go:272 cmd/incus/cluster.go:331 cmd/incus/cluster.go:404 cmd/incus/cluster.go:484 cmd/incus/cluster.go:528 cmd/incus/cluster.go:586 cmd/incus/cluster.go:677 cmd/incus/cluster.go:770 cmd/incus/cluster.go:891 cmd/incus/cluster.go:963 cmd/incus/cluster.go:1073 cmd/incus/cluster.go:1161 cmd/incus/cluster.go:1285 cmd/incus/cluster.go:1314 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:234 cmd/incus/cluster_group.go:294 cmd/incus/cluster_group.go:418 cmd/incus/cluster_group.go:500 cmd/incus/cluster_group.go:585 cmd/incus/cluster_group.go:641 cmd/incus/cluster_group.go:703 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:117 cmd/incus/config_template.go:171 cmd/incus/config_template.go:271 cmd/incus/config_template.go:339 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543 cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725 cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839 cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348 cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543 cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154 cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323 cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454 cmd/incus/network_integration.go:508 cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:622 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:351 cmd/incus/network_load_balancer.go:419 cmd/incus/network_load_balancer.go:529 cmd/incus/network_load_balancer.go:559 cmd/incus/network_load_balancer.go:714 cmd/incus/network_load_balancer.go:787 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:878 cmd/incus/network_load_balancer.go:976 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245 cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409 cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540 cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723 cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858 cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181 cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358 cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434 cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:434 cmd/incus/profile.go:492 cmd/incus/profile.go:628 cmd/incus/profile.go:702 cmd/incus/profile.go:771 cmd/incus/profile.go:859 cmd/incus/profile.go:919 cmd/incus/profile.go:1008 cmd/incus/profile.go:1072 cmd/incus/project.go:30 cmd/incus/project.go:94 cmd/incus/project.go:190 cmd/incus/project.go:261 cmd/incus/project.go:397 cmd/incus/project.go:471 cmd/incus/project.go:591 cmd/incus/project.go:656 cmd/incus/project.go:744 cmd/incus/project.go:788 cmd/incus/project.go:849 cmd/incus/project.go:916 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:177 cmd/incus/storage.go:235 cmd/incus/storage.go:367 cmd/incus/storage.go:449 cmd/incus/storage.go:629 cmd/incus/storage.go:716 cmd/incus/storage.go:820 cmd/incus/storage.go:914 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1758,6 +1758,10 @@ msgstr  ""
 msgid   "Display instances from all projects"
 msgstr  ""
 
+#: cmd/incus/network_zone.go:89
+msgid   "Display network zones from all projects"
+msgstr  ""
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid   "Do you want to configure a new local storage pool?"
 msgstr  ""
@@ -1795,7 +1799,7 @@ msgstr  ""
 msgid   "Dump YAML config to stdout"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid   "ENTRIES"
 msgstr  ""
 
@@ -1872,11 +1876,11 @@ msgstr  ""
 msgid   "Edit network peer configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 msgid   "Edit network zone configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
@@ -1928,7 +1932,7 @@ msgid   "Enable clustering on a single non-clustered server\n"
         "  for the address if not yet set."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid   "Entry TTL"
 msgstr  ""
 
@@ -1960,7 +1964,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:518 cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563 cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137 cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
+#: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:518 cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563 cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156 cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1975,7 +1979,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:453 cmd/incus/network.go:1319 cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510 cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447 cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980 cmd/incus/project.go:713 cmd/incus/storage.go:780 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
+#: cmd/incus/cluster.go:453 cmd/incus/network.go:1319 cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510 cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466 cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980 cmd/incus/project.go:713 cmd/incus/storage.go:780 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2475,7 +2479,7 @@ msgstr  ""
 msgid   "Fetch instance backup file: %w"
 msgstr  ""
 
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131 cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131 cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -2535,7 +2539,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/alias.go:113 cmd/incus/cluster.go:125 cmd/incus/cluster.go:964 cmd/incus/cluster_group.go:420 cmd/incus/config_template.go:273 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586 cmd/incus/image.go:1100 cmd/incus/image_alias.go:157 cmd/incus/list.go:133 cmd/incus/network.go:1015 cmd/incus/network.go:1114 cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84 cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764 cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473 cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291 cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467 cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539 cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/alias.go:113 cmd/incus/cluster.go:125 cmd/incus/cluster.go:964 cmd/incus/cluster_group.go:420 cmd/incus/config_template.go:273 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586 cmd/incus/image.go:1100 cmd/incus/image_alias.go:157 cmd/incus/list.go:133 cmd/incus/network.go:1015 cmd/incus/network.go:1114 cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84 cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783 cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473 cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291 cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467 cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539 cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2635,11 +2639,11 @@ msgstr  ""
 msgid   "Get the key as a network property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 msgid   "Get the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 msgid   "Get the key as a network zone record property"
 msgstr  ""
 
@@ -2703,11 +2707,11 @@ msgstr  ""
 msgid   "Get values for network peer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 msgid   "Get values for network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
@@ -3257,15 +3261,15 @@ msgstr  ""
 msgid   "List available network peers"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid   "List available network zone"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 msgid   "List available network zone records"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid   "List available network zoneS"
 msgstr  ""
 
@@ -3764,11 +3768,11 @@ msgstr  ""
 msgid   "Manage network peerings"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 msgid   "Manage network zone record entries"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 msgid   "Manage network zone records"
 msgstr  ""
 
@@ -3950,11 +3954,11 @@ msgstr  ""
 msgid   "Missing network name"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262 cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426 cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678 cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872 cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110 cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449 cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281 cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445 cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697 cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891 cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129 cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468 cmd/incus/network_zone.go:1525
 msgid   "Missing network zone name"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 msgid   "Missing network zone record name"
 msgstr  ""
 
@@ -4082,7 +4086,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:192 cmd/incus/cluster.go:1055 cmd/incus/cluster_group.go:481 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:666 cmd/incus/list.go:581 cmd/incus/network.go:1087 cmd/incus/network_acl.go:154 cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154 cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821 cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519 cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/cluster.go:192 cmd/incus/cluster.go:1055 cmd/incus/cluster_group.go:481 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:666 cmd/incus/list.go:581 cmd/incus/network.go:1087 cmd/incus/network_acl.go:154 cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154 cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840 cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519 cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
 msgid   "NAME"
 msgstr  ""
 
@@ -4237,12 +4241,12 @@ msgstr  ""
 msgid   "Network ACL %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, c-format
 msgid   "Network Zone %s created"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, c-format
 msgid   "Network Zone %s deleted"
 msgstr  ""
@@ -4314,12 +4318,12 @@ msgstr  ""
 msgid   "Network usage:"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, c-format
 msgid   "Network zone record %s created"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, c-format
 msgid   "Network zone record %s deleted"
 msgstr  ""
@@ -4492,7 +4496,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166 cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4593,7 +4597,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:860 cmd/incus/cluster_group.go:376 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:693 cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289 cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307 cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/cluster.go:860 cmd/incus/cluster_group.go:376 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:693 cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289 cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326 cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4974,7 +4978,7 @@ msgstr  ""
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 msgid   "Remove a network zone record entry"
 msgstr  ""
 
@@ -4998,7 +5002,7 @@ msgstr  ""
 msgid   "Remove backends from a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
@@ -5436,18 +5440,18 @@ msgid   "Set network peer keys\n"
         "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 msgid   "Set network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 msgid   "Set network zone configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
@@ -5562,11 +5566,11 @@ msgstr  ""
 msgid   "Set the key as a network property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 msgid   "Set the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 msgid   "Set the key as a network zone record property"
 msgstr  ""
 
@@ -5694,15 +5698,15 @@ msgstr  ""
 msgid   "Show network peer configurations"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 msgid   "Show network zone configurations"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 msgid   "Show network zone record configuration"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 msgid   "Show network zone record configurations"
 msgstr  ""
 
@@ -6164,12 +6168,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the network peer %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, c-format
 msgid   "The property %q does not exist on the network zone %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, c-format
 msgid   "The property %q does not exist on the network zone record %q: %v"
 msgstr  ""
@@ -6422,7 +6426,7 @@ msgstr  ""
 msgid   "USB devices:"
 msgstr  ""
 
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156 cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436 cmd/incus/network_zone.go:147 cmd/incus/profile.go:756 cmd/incus/project.go:574 cmd/incus/storage.go:698 cmd/incus/storage_volume.go:1638
+#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156 cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436 cmd/incus/network_zone.go:162 cmd/incus/profile.go:756 cmd/incus/project.go:574 cmd/incus/storage.go:698 cmd/incus/storage_volume.go:1638
 msgid   "USED BY"
 msgstr  ""
 
@@ -6539,11 +6543,11 @@ msgstr  ""
 msgid   "Unset network peer keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 msgid   "Unset network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
@@ -6595,11 +6599,11 @@ msgstr  ""
 msgid   "Unset the key as a network property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 msgid   "Unset the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 msgid   "Unset the key as a network zone record property"
 msgstr  ""
 
@@ -6912,7 +6916,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:120 cmd/incus/cluster.go:961 cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31 cmd/incus/network.go:1008 cmd/incus/network_acl.go:90 cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81 cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468 cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/cluster.go:120 cmd/incus/cluster.go:961 cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31 cmd/incus/network.go:1008 cmd/incus/network_acl.go:90 cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82 cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468 cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6968,19 +6972,19 @@ msgstr  ""
 msgid   "[<remote>:]<API path>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519 cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:664
 msgid   "[<remote>:]<Zone>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 msgid   "[<remote>:]<Zone> <key>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 msgid   "[<remote>:]<Zone> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 msgid   "[<remote>:]<Zone> [key=value...]"
 msgstr  ""
 
@@ -7452,27 +7456,27 @@ msgstr  ""
 msgid   "[<remote>:]<warning-uuid>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 msgid   "[<remote>:]<zone>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207 cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1355
 msgid   "[<remote>:]<zone> <record>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 msgid   "[<remote>:]<zone> <record> <key>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 msgid   "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 msgid   "[<remote>:]<zone> <record> <type> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-18 10:59+0200\n"
+"POT-Creation-Date: 2024-04-18 17:10-0400\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -411,7 +411,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -440,7 +440,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -818,7 +818,7 @@ msgstr "Azione (default a GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Il nome del container è: %s"
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1116,8 +1116,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360
-#: cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379
+#: cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1532,7 +1532,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1698,7 +1698,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1808,12 +1808,12 @@ msgstr "Creazione del container in corso"
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 msgid "Create new network zones"
 msgstr ""
 
@@ -1872,8 +1872,8 @@ msgstr ""
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156
-#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146
-#: cmd/incus/network_zone.go:822 cmd/incus/operation.go:173
+#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161
+#: cmd/incus/network_zone.go:841 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -1981,12 +1981,12 @@ msgstr "Il nome del container è: %s"
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 msgid "Delete network zones"
 msgstr ""
 
@@ -2115,17 +2115,17 @@ msgstr ""
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
-#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84
-#: cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226
-#: cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390
-#: cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704
-#: cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162
-#: cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339
-#: cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415
-#: cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
+#: cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245
+#: cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409
+#: cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540
+#: cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723
+#: cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858
+#: cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181
+#: cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358
+#: cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434
+#: cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2312,6 +2312,11 @@ msgstr "Creazione del container in corso"
 msgid "Display instances from all projects"
 msgstr "Creazione del container in corso"
 
+#: cmd/incus/network_zone.go:89
+#, fuzzy
+msgid "Display network zones from all projects"
+msgstr "Creazione del container in corso"
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
@@ -2349,7 +2354,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid "ENTRIES"
 msgstr ""
 
@@ -2433,12 +2438,12 @@ msgstr "Il nome del container è: %s"
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
@@ -2496,7 +2501,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid "Entry TTL"
 msgstr ""
 
@@ -2532,7 +2537,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137
+#: cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2553,8 +2558,8 @@ msgstr ""
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447
-#: cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466
+#: cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980
 #: cmd/incus/project.go:713 cmd/incus/storage.go:780
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3074,7 +3079,7 @@ msgid "Fetch instance backup file: %w"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131
-#: cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
@@ -3149,7 +3154,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473
 #: cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467
@@ -3258,12 +3263,12 @@ msgstr ""
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Il nome del container è: %s"
@@ -3334,12 +3339,12 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network peer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
@@ -3920,16 +3925,16 @@ msgstr "Creazione del container in corso"
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
@@ -4469,12 +4474,12 @@ msgstr "Creazione del container in corso"
 msgid "Manage network peerings"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Creazione del container in corso"
@@ -4733,18 +4738,18 @@ msgstr "Il nome del container è: %s"
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262
-#: cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426
-#: cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678
-#: cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110
-#: cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449
-#: cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281
+#: cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445
+#: cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697
+#: cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891
+#: cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129
+#: cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468
+#: cmd/incus/network_zone.go:1525
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Il nome del container è: %s"
@@ -4915,7 +4920,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821
+#: cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840
 #: cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5080,12 +5085,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5158,12 +5163,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5339,7 +5344,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166
 #: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5450,7 +5455,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307
+#: cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5865,7 +5870,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Il nome del container è: %s"
@@ -5892,7 +5897,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove backends from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6372,12 +6377,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6386,7 +6391,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
@@ -6516,12 +6521,12 @@ msgstr ""
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Il nome del container è: %s"
@@ -6658,17 +6663,17 @@ msgstr "Il nome del container è: %s"
 msgid "Show network peer configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
@@ -7161,12 +7166,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Il nome del container è: %s"
@@ -7442,7 +7447,7 @@ msgstr "Creazione del container in corso"
 
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
-#: cmd/incus/network_zone.go:147 cmd/incus/profile.go:756
+#: cmd/incus/network_zone.go:162 cmd/incus/profile.go:756
 #: cmd/incus/project.go:574 cmd/incus/storage.go:698
 #: cmd/incus/storage_volume.go:1638
 msgid "USED BY"
@@ -7570,12 +7575,12 @@ msgstr "Il nome del container è: %s"
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
@@ -7631,12 +7636,12 @@ msgstr ""
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Il nome del container è: %s"
@@ -7981,7 +7986,7 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1008 cmd/incus/network_acl.go:90
-#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81
+#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468
 #: cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 #, fuzzy
@@ -8054,23 +8059,23 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<API path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519
-#: cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538
+#: cmd/incus/network_zone.go:664
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -8694,33 +8699,33 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207
-#: cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226
+#: cmd/incus/network_zone.go:1355
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-18 10:59+0200\n"
+"POT-Creation-Date: 2024-04-18 17:10-0400\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -408,7 +408,7 @@ msgstr ""
 "### Note that the name, target_project, target_network and status fields "
 "cannot be changed."
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -432,7 +432,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -805,7 +805,7 @@ msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスターメンバーをクラスターグループに追加します"
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 msgid "Add a network zone record entry"
 msgstr "ネットワークゾーンレコードのエントリを追加します"
 
@@ -817,7 +817,7 @@ msgstr "ロードバランサーにバックエンドを追加します"
 msgid "Add backends to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid "Add entries to a network zone record"
 msgstr "ネットワークゾーンレコードにエントリを追加します"
 
@@ -1120,8 +1120,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360
-#: cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379
+#: cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
@@ -1550,7 +1550,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1732,7 +1732,7 @@ msgstr "リモート '%s' に対する新しいリモート証明書がエラー
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid "Couldn't find a matching entry"
 msgstr "一致するエントリを見つけられませんでした"
 
@@ -1837,11 +1837,11 @@ msgstr "新たにネットワークロードバランサーを作成します"
 msgid "Create new network peering"
 msgstr "新たにネットワークピアリングを作成します"
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 msgid "Create new network zone record"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 msgid "Create new network zones"
 msgstr "新たにネットワークゾーンを作成します"
 
@@ -1899,8 +1899,8 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156
-#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146
-#: cmd/incus/network_zone.go:822 cmd/incus/operation.go:173
+#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161
+#: cmd/incus/network_zone.go:841 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -2005,11 +2005,11 @@ msgstr "ネットワークロードバランサーを削除します"
 msgid "Delete network peerings"
 msgstr "ネットワークピアリングを削除します"
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 msgid "Delete network zone record"
 msgstr "ネットワークゾーンレコードを削除します"
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 msgid "Delete network zones"
 msgstr "ネットワークゾーンを削除します"
 
@@ -2136,17 +2136,17 @@ msgstr "警告を削除します"
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
-#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84
-#: cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226
-#: cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390
-#: cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704
-#: cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162
-#: cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339
-#: cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415
-#: cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
+#: cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245
+#: cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409
+#: cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540
+#: cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723
+#: cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858
+#: cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181
+#: cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358
+#: cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434
+#: cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2334,6 +2334,11 @@ msgstr "すべてのプロジェクトのイメージを表示します"
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
+#: cmd/incus/network_zone.go:89
+#, fuzzy
+msgid "Display network zones from all projects"
+msgstr "すべてのプロジェクトのインスタンスを表示します"
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid "Do you want to configure a new local storage pool?"
 msgstr "新しいローカルストレージプールを設定しますか?"
@@ -2371,7 +2376,7 @@ msgstr "ドライバ: %v (%v)"
 msgid "Dump YAML config to stdout"
 msgstr "YAML 形式で設定を stdout に出力します"
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid "ENTRIES"
 msgstr "ENTRIES"
 
@@ -2454,11 +2459,11 @@ msgstr "ネットワークロードバランサー設定をYAMLで編集しま�
 msgid "Edit network peer configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 msgid "Edit network zone configurations as YAML"
 msgstr "ネットワークゾーン設定をYAMLで編集します"
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
@@ -2524,7 +2529,7 @@ msgstr ""
 "  これは 'incus config get core.https_address' コマンドでチェックできます。\n"
 "  まだ使用可能でない場合は、アドレスを設定することもできます。"
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid "Entry TTL"
 msgstr "TTLを指定します"
 
@@ -2560,7 +2565,7 @@ msgstr "エイリアスの取得に失敗しました: %w"
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137
+#: cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2581,8 +2586,8 @@ msgstr "プロパティの削除でエラーが発生しました: %v"
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447
-#: cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466
+#: cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980
 #: cmd/incus/project.go:713 cmd/incus/storage.go:780
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3140,7 +3145,7 @@ msgid "Fetch instance backup file: %w"
 msgstr "インスタンスのバックアップをエクスポートします"
 
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131
-#: cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
@@ -3228,7 +3233,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473
 #: cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467
@@ -3340,12 +3345,12 @@ msgstr "ネットワークピアの設定を行います"
 msgid "Get the key as a network property"
 msgstr "key をネットワークプロパティとして取得します"
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
@@ -3415,11 +3420,11 @@ msgstr "ネットワークロードバランサーの設定値を取得します
 msgid "Get values for network peer configuration keys"
 msgstr "ネットワークピアの設定値を取得します"
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 msgid "Get values for network zone configuration keys"
 msgstr "ネットワークゾーンの設定値を取得します"
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
@@ -4008,15 +4013,15 @@ msgstr "利用可能なネットワークロードバランサーを一覧表示
 msgid "List available network peers"
 msgstr "利用可能なネットワークピアを一覧表示します"
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid "List available network zone"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 msgid "List available network zone records"
 msgstr "利用可能なネットワークゾーンレコードを一覧表示します"
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid "List available network zoneS"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
@@ -4729,11 +4734,11 @@ msgstr "ネットワークロードバランサーを管理します"
 msgid "Manage network peerings"
 msgstr "ネットワークピアリングを管理します"
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 msgid "Manage network zone record entries"
 msgstr "ネットワークゾーンレコードのエントリを管理します"
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 msgid "Manage network zone records"
 msgstr "ネットワークゾーンレコードを管理します"
 
@@ -4983,17 +4988,17 @@ msgstr "ネットワークゾーン名を指定する必要があります"
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262
-#: cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426
-#: cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678
-#: cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110
-#: cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449
-#: cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281
+#: cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445
+#: cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697
+#: cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891
+#: cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129
+#: cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468
+#: cmd/incus/network_zone.go:1525
 msgid "Missing network zone name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 msgid "Missing network zone record name"
 msgstr "ネットワークゾーンレコード名を指定する必要があります"
 
@@ -5180,7 +5185,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821
+#: cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840
 #: cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5349,12 +5354,12 @@ msgstr "ネットワーク ACL %s を削除しました"
 msgid "Network ACL %s renamed to %s"
 msgstr "ネットワーク ACL 名 %s を %s に変更しました"
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, c-format
 msgid "Network Zone %s created"
 msgstr "ネットワークゾーン %s を作成しました"
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
@@ -5429,12 +5434,12 @@ msgstr "ネットワークタイプ:"
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, c-format
 msgid "Network zone record %s created"
 msgstr "ネットワークゾーンレコード %s を作成しました"
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr "ネットワークゾーンレコード %s を削除しました"
@@ -5617,7 +5622,7 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166
 #: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
@@ -5728,7 +5733,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307
+#: cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -6180,7 +6185,7 @@ msgstr "クラスターグループからメンバを削除します"
 msgid "Remove a member from the cluster"
 msgstr "クラスターからメンバを削除します"
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 msgid "Remove a network zone record entry"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
@@ -6204,7 +6209,7 @@ msgstr "ロードバランサーからバックエンドを削除します"
 msgid "Remove backends from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
@@ -6728,11 +6733,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 msgid "Set network zone configuration keys"
 msgstr "ネットワークゾーンの設定を行います"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 #, fuzzy
 msgid ""
 "Set network zone configuration keys\n"
@@ -6746,7 +6751,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
@@ -6905,12 +6910,12 @@ msgstr "ネットワークピアの設定を行います"
 msgid "Set the key as a network property"
 msgstr "ネットワークプロパティとして設定します"
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
@@ -7046,15 +7051,15 @@ msgstr "ネットワークロードバランサーの設定を表示します"
 msgid "Show network peer configurations"
 msgstr "ネットワークピアの設定を表示します"
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 msgid "Show network zone configurations"
 msgstr "ネットワークゾーンの設定を表示します"
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 msgid "Show network zone record configuration"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
@@ -7574,12 +7579,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -7890,7 +7895,7 @@ msgstr "上位デバイス"
 
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
-#: cmd/incus/network_zone.go:147 cmd/incus/profile.go:756
+#: cmd/incus/network_zone.go:162 cmd/incus/profile.go:756
 #: cmd/incus/project.go:574 cmd/incus/storage.go:698
 #: cmd/incus/storage_volume.go:1638
 msgid "USED BY"
@@ -8012,11 +8017,11 @@ msgstr "ネットワークピアの設定を削除します"
 msgid "Unset network peer keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 msgid "Unset network zone configuration keys"
 msgstr "ネットワークゾーンの設定を削除します"
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
@@ -8073,12 +8078,12 @@ msgstr "ネットワークピアの設定を削除します"
 msgid "Unset the key as a network property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
@@ -8447,7 +8452,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 #: cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1008 cmd/incus/network_acl.go:90
-#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81
+#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468
 #: cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 msgid "[<remote>:]"
@@ -8507,20 +8512,20 @@ msgstr "[<remote>:]<ACL> [key=value...]"
 msgid "[<remote>:]<API path>"
 msgstr "[<remote>:]<API path>"
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519
-#: cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538
+#: cmd/incus/network_zone.go:664
 msgid "[<remote>:]<Zone>"
 msgstr "[<remote>:]<Zone>"
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 msgid "[<remote>:]<Zone> <key>"
 msgstr "[<remote>:]<Zone> <key>"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <key>=<value>..."
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zone> [key=value...]"
 
@@ -9062,28 +9067,28 @@ msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgid "[<remote>:]<warning-uuid>"
 msgstr "[<remote>:]<warning-uuid>"
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 msgid "[<remote>:]<zone>"
 msgstr "[<remote>:]<zone>"
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207
-#: cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226
+#: cmd/incus/network_zone.go:1355
 msgid "[<remote>:]<zone> <record>"
 msgstr "[<remote>:]<zone> <record>"
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "[<remote>:]<zone> <record> <key>"
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "[<remote>:]<zone> <record> <key>=<value>..."
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "[<remote>:]<zone> <record> <type> <value>"
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-18 10:59+0200\n"
+"POT-Creation-Date: 2024-04-18 17:10-0400\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -416,7 +416,7 @@ msgstr ""
 "(target_project), bestemming netwerk (target_network) en de status velden "
 "(status fielsds) niet kunnen worden aangepast."
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -442,7 +442,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -825,7 +825,7 @@ msgid "Add a cluster member to a cluster group"
 msgstr ""
 "Voeg een clusterlid (cluster member) toe aan de clustergroep (cluster group)"
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 msgid "Add a network zone record entry"
 msgstr "Voeg een netwerk (network) zone record toe"
 
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid "Add entries to a network zone record"
 msgstr "Voeg een items toe aan een netwerk (network) zone record"
 
@@ -1137,8 +1137,8 @@ msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360
-#: cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379
+#: cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
@@ -1552,7 +1552,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1718,7 +1718,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1819,11 +1819,11 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 msgid "Create new network zones"
 msgstr ""
 
@@ -1881,8 +1881,8 @@ msgstr ""
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156
-#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146
-#: cmd/incus/network_zone.go:822 cmd/incus/operation.go:173
+#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161
+#: cmd/incus/network_zone.go:841 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -1986,11 +1986,11 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 msgid "Delete network zones"
 msgstr ""
 
@@ -2117,17 +2117,17 @@ msgstr ""
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
-#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84
-#: cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226
-#: cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390
-#: cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704
-#: cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162
-#: cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339
-#: cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415
-#: cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
+#: cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245
+#: cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409
+#: cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540
+#: cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723
+#: cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858
+#: cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181
+#: cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358
+#: cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434
+#: cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2308,6 +2308,10 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
+#: cmd/incus/network_zone.go:89
+msgid "Display network zones from all projects"
+msgstr ""
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
@@ -2345,7 +2349,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid "ENTRIES"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
@@ -2485,7 +2489,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid "Entry TTL"
 msgstr ""
 
@@ -2521,7 +2525,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137
+#: cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2542,8 +2546,8 @@ msgstr ""
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447
-#: cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466
+#: cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980
 #: cmd/incus/project.go:713 cmd/incus/storage.go:780
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3058,7 +3062,7 @@ msgid "Fetch instance backup file: %w"
 msgstr ""
 
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131
-#: cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -3131,7 +3135,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473
 #: cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467
@@ -3239,11 +3243,11 @@ msgstr ""
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 msgid "Get the key as a network zone record property"
 msgstr ""
 
@@ -3308,11 +3312,11 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
@@ -3873,15 +3877,15 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 msgid "List available network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
@@ -4402,11 +4406,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 msgid "Manage network zone records"
 msgstr ""
 
@@ -4651,17 +4655,17 @@ msgstr "Toekennen van netwerk interfaces aan instanties (instances)"
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262
-#: cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426
-#: cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678
-#: cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110
-#: cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449
-#: cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281
+#: cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445
+#: cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697
+#: cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891
+#: cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129
+#: cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468
+#: cmd/incus/network_zone.go:1525
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4824,7 +4828,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821
+#: cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840
 #: cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -4989,12 +4993,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5067,12 +5071,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5248,7 +5252,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166
 #: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5357,7 +5361,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307
+#: cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5766,7 +5770,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5790,7 +5794,7 @@ msgstr ""
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6255,11 +6259,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6268,7 +6272,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 msgid "Set network zone record configuration keys"
 msgstr ""
 
@@ -6395,11 +6399,11 @@ msgstr ""
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 msgid "Set the key as a network zone record property"
 msgstr ""
 
@@ -6529,15 +6533,15 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 msgid "Show network zone record configurations"
 msgstr ""
 
@@ -7021,12 +7025,12 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
@@ -7298,7 +7302,7 @@ msgstr ""
 
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
-#: cmd/incus/network_zone.go:147 cmd/incus/profile.go:756
+#: cmd/incus/network_zone.go:162 cmd/incus/profile.go:756
 #: cmd/incus/project.go:574 cmd/incus/storage.go:698
 #: cmd/incus/storage_volume.go:1638
 msgid "USED BY"
@@ -7418,11 +7422,11 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -7474,11 +7478,11 @@ msgstr ""
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -7812,7 +7816,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1008 cmd/incus/network_acl.go:90
-#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81
+#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468
 #: cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 msgid "[<remote>:]"
@@ -7871,20 +7875,20 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519
-#: cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538
+#: cmd/incus/network_zone.go:664
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -8392,28 +8396,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207
-#: cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226
+#: cmd/incus/network_zone.go:1355
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-18 10:59+0200\n"
+"POT-Creation-Date: 2024-04-18 17:10-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -242,7 +242,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -256,7 +256,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 msgid "Add a network zone record entry"
 msgstr ""
 
@@ -579,7 +579,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -859,8 +859,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360
-#: cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379
+#: cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1272,7 +1272,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1438,7 +1438,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1538,11 +1538,11 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 msgid "Create new network zones"
 msgstr ""
 
@@ -1600,8 +1600,8 @@ msgstr ""
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156
-#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146
-#: cmd/incus/network_zone.go:822 cmd/incus/operation.go:173
+#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161
+#: cmd/incus/network_zone.go:841 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -1704,11 +1704,11 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 msgid "Delete network zones"
 msgstr ""
 
@@ -1835,17 +1835,17 @@ msgstr ""
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
-#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84
-#: cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226
-#: cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390
-#: cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704
-#: cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162
-#: cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339
-#: cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415
-#: cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
+#: cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245
+#: cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409
+#: cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540
+#: cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723
+#: cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858
+#: cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181
+#: cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358
+#: cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434
+#: cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2026,6 +2026,10 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
+#: cmd/incus/network_zone.go:89
+msgid "Display network zones from all projects"
+msgstr ""
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
@@ -2063,7 +2067,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid "ENTRIES"
 msgstr ""
 
@@ -2143,11 +2147,11 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
@@ -2203,7 +2207,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid "Entry TTL"
 msgstr ""
 
@@ -2239,7 +2243,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137
+#: cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2260,8 +2264,8 @@ msgstr ""
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447
-#: cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466
+#: cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980
 #: cmd/incus/project.go:713 cmd/incus/storage.go:780
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -2776,7 +2780,7 @@ msgid "Fetch instance backup file: %w"
 msgstr ""
 
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131
-#: cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2849,7 +2853,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473
 #: cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467
@@ -2955,11 +2959,11 @@ msgstr ""
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 msgid "Get the key as a network zone record property"
 msgstr ""
 
@@ -3024,11 +3028,11 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
@@ -3589,15 +3593,15 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 msgid "List available network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
@@ -4116,11 +4120,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 msgid "Manage network zone records"
 msgstr ""
 
@@ -4364,17 +4368,17 @@ msgstr ""
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262
-#: cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426
-#: cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678
-#: cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110
-#: cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449
-#: cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281
+#: cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445
+#: cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697
+#: cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891
+#: cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129
+#: cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468
+#: cmd/incus/network_zone.go:1525
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4537,7 +4541,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821
+#: cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840
 #: cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -4702,12 +4706,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -4780,12 +4784,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -4961,7 +4965,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166
 #: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5070,7 +5074,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307
+#: cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5479,7 +5483,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5503,7 +5507,7 @@ msgstr ""
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -5966,11 +5970,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -5979,7 +5983,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 msgid "Set network zone record configuration keys"
 msgstr ""
 
@@ -6105,11 +6109,11 @@ msgstr ""
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 msgid "Set the key as a network zone record property"
 msgstr ""
 
@@ -6238,15 +6242,15 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 msgid "Show network zone record configurations"
 msgstr ""
 
@@ -6730,12 +6734,12 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
@@ -7007,7 +7011,7 @@ msgstr ""
 
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
-#: cmd/incus/network_zone.go:147 cmd/incus/profile.go:756
+#: cmd/incus/network_zone.go:162 cmd/incus/profile.go:756
 #: cmd/incus/project.go:574 cmd/incus/storage.go:698
 #: cmd/incus/storage_volume.go:1638
 msgid "USED BY"
@@ -7127,11 +7131,11 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -7183,11 +7187,11 @@ msgstr ""
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -7521,7 +7525,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1008 cmd/incus/network_acl.go:90
-#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81
+#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468
 #: cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 msgid "[<remote>:]"
@@ -7580,20 +7584,20 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519
-#: cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538
+#: cmd/incus/network_zone.go:664
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -8101,28 +8105,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207
-#: cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226
+#: cmd/incus/network_zone.go:1355
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-18 10:59+0200\n"
+"POT-Creation-Date: 2024-04-18 17:10-0400\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -400,7 +400,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -426,7 +426,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -819,7 +819,7 @@ msgstr "Ação (padrão para o GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1127,8 +1127,8 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360
-#: cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379
+#: cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
@@ -1555,7 +1555,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1723,7 +1723,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1838,12 +1838,12 @@ msgstr "Criar novas redes"
 msgid "Create new network peering"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Criar novas redes"
@@ -1903,8 +1903,8 @@ msgstr ""
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156
-#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146
-#: cmd/incus/network_zone.go:822 cmd/incus/operation.go:173
+#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161
+#: cmd/incus/network_zone.go:841 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -2018,12 +2018,12 @@ msgstr "Criar novas redes"
 msgid "Delete network peerings"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Criar novas redes"
@@ -2153,17 +2153,17 @@ msgstr ""
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
-#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84
-#: cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226
-#: cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390
-#: cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704
-#: cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162
-#: cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339
-#: cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415
-#: cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
+#: cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245
+#: cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409
+#: cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540
+#: cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723
+#: cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858
+#: cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181
+#: cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358
+#: cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434
+#: cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2351,6 +2351,11 @@ msgstr "Criar projetos"
 msgid "Display instances from all projects"
 msgstr ""
 
+#: cmd/incus/network_zone.go:89
+#, fuzzy
+msgid "Display network zones from all projects"
+msgstr "Criar projetos"
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
@@ -2388,7 +2393,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid "ENTRIES"
 msgstr ""
 
@@ -2479,12 +2484,12 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network peer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2544,7 +2549,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid "Entry TTL"
 msgstr ""
 
@@ -2580,7 +2585,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137
+#: cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2601,8 +2606,8 @@ msgstr "Editar propriedades da imagem"
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447
-#: cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466
+#: cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980
 #: cmd/incus/project.go:713 cmd/incus/storage.go:780
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3120,7 +3125,7 @@ msgid "Fetch instance backup file: %w"
 msgstr "Copiar a imagem: %s"
 
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131
-#: cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -3194,7 +3199,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473
 #: cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467
@@ -3306,12 +3311,12 @@ msgstr "Criar novas redes"
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
@@ -3387,12 +3392,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3970,16 +3975,16 @@ msgstr "Criar novas redes"
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
@@ -4522,12 +4527,12 @@ msgstr "Criar novas redes"
 msgid "Manage network peerings"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Criar novas redes"
@@ -4787,18 +4792,18 @@ msgstr "Nome de membro do cluster"
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262
-#: cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426
-#: cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678
-#: cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110
-#: cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449
-#: cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281
+#: cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445
+#: cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697
+#: cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891
+#: cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129
+#: cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468
+#: cmd/incus/network_zone.go:1525
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nome de membro do cluster"
@@ -4969,7 +4974,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821
+#: cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840
 #: cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5134,12 +5139,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5212,12 +5217,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5393,7 +5398,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166
 #: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5503,7 +5508,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307
+#: cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5922,7 +5927,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
@@ -5949,7 +5954,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove backends from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
@@ -6445,12 +6450,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6459,7 +6464,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -6592,12 +6597,12 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
@@ -6742,17 +6747,17 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network peer configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -7245,12 +7250,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nome de membro do cluster"
@@ -7526,7 +7531,7 @@ msgstr "Editar arquivos no container"
 
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
-#: cmd/incus/network_zone.go:147 cmd/incus/profile.go:756
+#: cmd/incus/network_zone.go:162 cmd/incus/profile.go:756
 #: cmd/incus/project.go:574 cmd/incus/storage.go:698
 #: cmd/incus/storage_volume.go:1638
 msgid "USED BY"
@@ -7661,12 +7666,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network peer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -7726,12 +7731,12 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
@@ -8072,7 +8077,7 @@ msgstr "Criar perfis"
 #: cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1008 cmd/incus/network_acl.go:90
-#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81
+#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468
 #: cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 msgid "[<remote>:]"
@@ -8140,23 +8145,23 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519
-#: cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538
+#: cmd/incus/network_zone.go:664
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -8724,33 +8729,33 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207
-#: cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226
+#: cmd/incus/network_zone.go:1355
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-18 10:59+0200\n"
+"POT-Creation-Date: 2024-04-18 17:10-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -421,7 +421,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -449,7 +449,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -840,7 +840,7 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Копирование образа: %s"
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1142,8 +1142,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360
-#: cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379
+#: cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1558,7 +1558,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1726,7 +1726,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1839,12 +1839,12 @@ msgstr "Копирование образа: %s"
 msgid "Create new network peering"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 #, fuzzy
 msgid "Create new network zones"
 msgstr "Копирование образа: %s"
@@ -1906,8 +1906,8 @@ msgstr ""
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156
-#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146
-#: cmd/incus/network_zone.go:822 cmd/incus/operation.go:173
+#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161
+#: cmd/incus/network_zone.go:841 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -2017,12 +2017,12 @@ msgstr "Копирование образа: %s"
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Копирование образа: %s"
@@ -2153,17 +2153,17 @@ msgstr ""
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
-#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84
-#: cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226
-#: cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390
-#: cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704
-#: cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162
-#: cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339
-#: cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415
-#: cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
+#: cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245
+#: cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409
+#: cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540
+#: cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723
+#: cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858
+#: cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181
+#: cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358
+#: cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434
+#: cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2351,6 +2351,11 @@ msgstr "Копирование образа: %s"
 msgid "Display instances from all projects"
 msgstr "Копирование образа: %s"
 
+#: cmd/incus/network_zone.go:89
+#, fuzzy
+msgid "Display network zones from all projects"
+msgstr "Копирование образа: %s"
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
@@ -2388,7 +2393,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid "ENTRIES"
 msgstr ""
 
@@ -2473,12 +2478,12 @@ msgstr "Копирование образа: %s"
 msgid "Edit network peer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
@@ -2536,7 +2541,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid "Entry TTL"
 msgstr ""
 
@@ -2572,7 +2577,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137
+#: cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2593,8 +2598,8 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447
-#: cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466
+#: cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980
 #: cmd/incus/project.go:713 cmd/incus/storage.go:780
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3120,7 +3125,7 @@ msgid "Fetch instance backup file: %w"
 msgstr "Невозможно добавить имя контейнера в список"
 
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131
-#: cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -3194,7 +3199,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473
 #: cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467
@@ -3305,12 +3310,12 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 #, fuzzy
 msgid "Get the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Копирование образа: %s"
@@ -3384,12 +3389,12 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network peer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 #, fuzzy
 msgid "Get values for network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
@@ -3972,16 +3977,16 @@ msgstr "Копирование образа: %s"
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
@@ -4528,12 +4533,12 @@ msgstr "Копирование образа: %s"
 msgid "Manage network peerings"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Копирование образа: %s"
@@ -4797,18 +4802,18 @@ msgstr "Имя контейнера: %s"
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262
-#: cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426
-#: cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678
-#: cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110
-#: cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449
-#: cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281
+#: cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445
+#: cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697
+#: cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891
+#: cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129
+#: cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468
+#: cmd/incus/network_zone.go:1525
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Имя контейнера: %s"
@@ -4980,7 +4985,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821
+#: cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840
 #: cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5149,12 +5154,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
@@ -5229,12 +5234,12 @@ msgstr " Использование сети:"
 msgid "Network usage:"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr " Использование сети:"
@@ -5411,7 +5416,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166
 #: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5521,7 +5526,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307
+#: cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5935,7 +5940,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Копирование образа: %s"
@@ -5962,7 +5967,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove backends from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6446,12 +6451,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6460,7 +6465,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
@@ -6592,12 +6597,12 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Копирование образа: %s"
@@ -6739,17 +6744,17 @@ msgstr "Копирование образа: %s"
 msgid "Show network peer configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 #, fuzzy
 msgid "Show network zone configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
@@ -7245,12 +7250,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Копирование образа: %s"
@@ -7526,7 +7531,7 @@ msgstr "Копирование образа: %s"
 
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
-#: cmd/incus/network_zone.go:147 cmd/incus/profile.go:756
+#: cmd/incus/network_zone.go:162 cmd/incus/profile.go:756
 #: cmd/incus/project.go:574 cmd/incus/storage.go:698
 #: cmd/incus/storage_volume.go:1638
 msgid "USED BY"
@@ -7655,12 +7660,12 @@ msgstr "Копирование образа: %s"
 msgid "Unset network peer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
@@ -7719,12 +7724,12 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Копирование образа: %s"
@@ -8074,7 +8079,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1008 cmd/incus/network_acl.go:90
-#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81
+#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468
 #: cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 #, fuzzy
@@ -8189,8 +8194,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519
-#: cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538
+#: cmd/incus/network_zone.go:664
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -8198,7 +8203,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -8206,7 +8211,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -8214,7 +8219,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 #, fuzzy
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
@@ -9190,7 +9195,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -9198,8 +9203,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207
-#: cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226
+#: cmd/incus/network_zone.go:1355
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -9207,7 +9212,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -9215,7 +9220,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -9223,7 +9228,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -9231,7 +9236,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-18 10:59+0200\n"
+"POT-Creation-Date: 2024-04-18 17:10-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -385,7 +385,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1248
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -410,7 +410,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_zone.go:537
+#: cmd/incus/network_zone.go:556
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -779,7 +779,7 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1414
+#: cmd/incus/network_zone.go:1433
 msgid "Add a network zone record entry"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1415
+#: cmd/incus/network_zone.go:1434
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1071,8 +1071,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:360
-#: cmd/incus/network_zone.go:1043 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:379
+#: cmd/incus/network_zone.go:1062 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1484,7 +1484,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:615 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:333
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1650,7 +1650,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1526
+#: cmd/incus/network_zone.go:1545
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1750,11 +1750,11 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:978 cmd/incus/network_zone.go:979
+#: cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:998
 msgid "Create new network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:298 cmd/incus/network_zone.go:299
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:318
 msgid "Create new network zones"
 msgstr ""
 
@@ -1812,8 +1812,8 @@ msgstr ""
 #: cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:434 cmd/incus/network_load_balancer.go:156
-#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:146
-#: cmd/incus/network_zone.go:822 cmd/incus/operation.go:173
+#: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:161
+#: cmd/incus/network_zone.go:841 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:573 cmd/incus/storage.go:697
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -1916,11 +1916,11 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1338 cmd/incus/network_zone.go:1339
+#: cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1358
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:647 cmd/incus/network_zone.go:648
+#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:667
 msgid "Delete network zones"
 msgstr ""
 
@@ -2047,17 +2047,17 @@ msgstr ""
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
-#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:84
-#: cmd/incus/network_zone.go:163 cmd/incus/network_zone.go:226
-#: cmd/incus/network_zone.go:299 cmd/incus/network_zone.go:390
-#: cmd/incus/network_zone.go:478 cmd/incus/network_zone.go:521
-#: cmd/incus/network_zone.go:648 cmd/incus/network_zone.go:704
-#: cmd/incus/network_zone.go:761 cmd/incus/network_zone.go:839
-#: cmd/incus/network_zone.go:903 cmd/incus/network_zone.go:979
-#: cmd/incus/network_zone.go:1073 cmd/incus/network_zone.go:1162
-#: cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1339
-#: cmd/incus/network_zone.go:1400 cmd/incus/network_zone.go:1415
-#: cmd/incus/network_zone.go:1473 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
+#: cmd/incus/network_zone.go:182 cmd/incus/network_zone.go:245
+#: cmd/incus/network_zone.go:318 cmd/incus/network_zone.go:409
+#: cmd/incus/network_zone.go:497 cmd/incus/network_zone.go:540
+#: cmd/incus/network_zone.go:667 cmd/incus/network_zone.go:723
+#: cmd/incus/network_zone.go:780 cmd/incus/network_zone.go:858
+#: cmd/incus/network_zone.go:922 cmd/incus/network_zone.go:998
+#: cmd/incus/network_zone.go:1092 cmd/incus/network_zone.go:1181
+#: cmd/incus/network_zone.go:1228 cmd/incus/network_zone.go:1358
+#: cmd/incus/network_zone.go:1419 cmd/incus/network_zone.go:1434
+#: cmd/incus/network_zone.go:1492 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2238,6 +2238,10 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
+#: cmd/incus/network_zone.go:89
+msgid "Display network zones from all projects"
+msgstr ""
+
 #: cmd/incus/admin_init_interactive.go:416
 msgid "Do you want to configure a new local storage pool?"
 msgstr ""
@@ -2275,7 +2279,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:823
+#: cmd/incus/network_zone.go:842
 msgid "ENTRIES"
 msgstr ""
 
@@ -2355,11 +2359,11 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:520 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:540
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1208 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1228
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
@@ -2415,7 +2419,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417
+#: cmd/incus/network_zone.go:1436
 msgid "Entry TTL"
 msgstr ""
 
@@ -2451,7 +2455,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:453 cmd/incus/network_zone.go:1137
+#: cmd/incus/network_zone.go:472 cmd/incus/network_zone.go:1156
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:786
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2472,8 +2476,8 @@ msgstr ""
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:447
-#: cmd/incus/network_zone.go:1131 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:466
+#: cmd/incus/network_zone.go:1150 cmd/incus/profile.go:980
 #: cmd/incus/project.go:713 cmd/incus/storage.go:780
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -2988,7 +2992,7 @@ msgid "Fetch instance backup file: %w"
 msgstr ""
 
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:131
-#: cmd/incus/network_zone.go:122 cmd/incus/operation.go:137
+#: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -3061,7 +3065,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:388
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:87 cmd/incus/network_zone.go:764
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:783
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:473
 #: cmd/incus/project.go:918 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:631 cmd/incus/storage_bucket.go:467
@@ -3167,11 +3171,11 @@ msgstr ""
 msgid "Get the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:229
+#: cmd/incus/network_zone.go:248
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:906
+#: cmd/incus/network_zone.go:925
 msgid "Get the key as a network zone record property"
 msgstr ""
 
@@ -3236,11 +3240,11 @@ msgstr ""
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:225 cmd/incus/network_zone.go:226
+#: cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:245
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:902 cmd/incus/network_zone.go:903
+#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:922
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
@@ -3801,15 +3805,15 @@ msgstr ""
 msgid "List available network peers"
 msgstr ""
 
-#: cmd/incus/network_zone.go:84
+#: cmd/incus/network_zone.go:85
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:760 cmd/incus/network_zone.go:761
+#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:780
 msgid "List available network zone records"
 msgstr ""
 
-#: cmd/incus/network_zone.go:83
+#: cmd/incus/network_zone.go:84
 msgid "List available network zoneS"
 msgstr ""
 
@@ -4328,11 +4332,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1399 cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1419
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:703 cmd/incus/network_zone.go:704
+#: cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:723
 msgid "Manage network zone records"
 msgstr ""
 
@@ -4576,17 +4580,17 @@ msgstr ""
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:193 cmd/incus/network_zone.go:262
-#: cmd/incus/network_zone.go:330 cmd/incus/network_zone.go:426
-#: cmd/incus/network_zone.go:567 cmd/incus/network_zone.go:678
-#: cmd/incus/network_zone.go:792 cmd/incus/network_zone.go:872
-#: cmd/incus/network_zone.go:1013 cmd/incus/network_zone.go:1110
-#: cmd/incus/network_zone.go:1372 cmd/incus/network_zone.go:1449
-#: cmd/incus/network_zone.go:1506
+#: cmd/incus/network_zone.go:212 cmd/incus/network_zone.go:281
+#: cmd/incus/network_zone.go:349 cmd/incus/network_zone.go:445
+#: cmd/incus/network_zone.go:586 cmd/incus/network_zone.go:697
+#: cmd/incus/network_zone.go:811 cmd/incus/network_zone.go:891
+#: cmd/incus/network_zone.go:1032 cmd/incus/network_zone.go:1129
+#: cmd/incus/network_zone.go:1391 cmd/incus/network_zone.go:1468
+#: cmd/incus/network_zone.go:1525
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:942 cmd/incus/network_zone.go:1258
+#: cmd/incus/network_zone.go:961 cmd/incus/network_zone.go:1277
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4749,7 +4753,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:433 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:145 cmd/incus/network_zone.go:821
+#: cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840
 #: cmd/incus/profile.go:754 cmd/incus/project.go:566 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -4914,12 +4918,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:372
+#: cmd/incus/network_zone.go:391
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:688
+#: cmd/incus/network_zone.go:707
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -4992,12 +4996,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1055
+#: cmd/incus/network_zone.go:1074
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1382
+#: cmd/incus/network_zone.go:1401
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5173,7 +5177,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:166
 #: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5282,7 +5286,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:1307
+#: cmd/incus/network_zone.go:635 cmd/incus/network_zone.go:1326
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:334
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5691,7 +5695,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1472
+#: cmd/incus/network_zone.go:1491
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5715,7 +5719,7 @@ msgstr ""
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1473
+#: cmd/incus/network_zone.go:1492
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6178,11 +6182,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:389
+#: cmd/incus/network_zone.go:408
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:409
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6191,7 +6195,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1072 cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1092
 msgid "Set network zone record configuration keys"
 msgstr ""
 
@@ -6317,11 +6321,11 @@ msgstr ""
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:397
+#: cmd/incus/network_zone.go:416
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1078
+#: cmd/incus/network_zone.go:1097
 msgid "Set the key as a network zone record property"
 msgstr ""
 
@@ -6450,15 +6454,15 @@ msgstr ""
 msgid "Show network peer configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:162 cmd/incus/network_zone.go:163
+#: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:182
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:838
+#: cmd/incus/network_zone.go:857
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:858
 msgid "Show network zone record configurations"
 msgstr ""
 
@@ -6942,12 +6946,12 @@ msgstr ""
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:274
+#: cmd/incus/network_zone.go:293
 #, c-format
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:954
+#: cmd/incus/network_zone.go:973
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
@@ -7219,7 +7223,7 @@ msgstr ""
 
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:436
-#: cmd/incus/network_zone.go:147 cmd/incus/profile.go:756
+#: cmd/incus/network_zone.go:162 cmd/incus/profile.go:756
 #: cmd/incus/project.go:574 cmd/incus/storage.go:698
 #: cmd/incus/storage_volume.go:1638
 msgid "USED BY"
@@ -7339,11 +7343,11 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:477 cmd/incus/network_zone.go:478
+#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:497
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1161 cmd/incus/network_zone.go:1162
+#: cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1181
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -7395,11 +7399,11 @@ msgstr ""
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:481
+#: cmd/incus/network_zone.go:500
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1165
+#: cmd/incus/network_zone.go:1184
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -7733,7 +7737,7 @@ msgstr ""
 #: cmd/incus/cluster_group.go:415 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1008 cmd/incus/network_acl.go:90
-#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:81
+#: cmd/incus/network_integration.go:383 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:699 cmd/incus/project.go:468
 #: cmd/incus/storage.go:626 cmd/incus/version.go:20 cmd/incus/warning.go:69
 msgid "[<remote>:]"
@@ -7792,20 +7796,20 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:161 cmd/incus/network_zone.go:519
-#: cmd/incus/network_zone.go:645
+#: cmd/incus/network_zone.go:180 cmd/incus/network_zone.go:538
+#: cmd/incus/network_zone.go:664
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:224 cmd/incus/network_zone.go:476
+#: cmd/incus/network_zone.go:243 cmd/incus/network_zone.go:495
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:388
+#: cmd/incus/network_zone.go:407
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:297
+#: cmd/incus/network_zone.go:316
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
@@ -8313,28 +8317,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:758
+#: cmd/incus/network_zone.go:777
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:837 cmd/incus/network_zone.go:1207
-#: cmd/incus/network_zone.go:1336
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:1226
+#: cmd/incus/network_zone.go:1355
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:901 cmd/incus/network_zone.go:1160
+#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:1179
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1071
+#: cmd/incus/network_zone.go:1090
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1413 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1432 cmd/incus/network_zone.go:1490
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:977
+#: cmd/incus/network_zone.go:996
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 

--- a/shared/api/network_zone.go
+++ b/shared/api/network_zone.go
@@ -44,6 +44,12 @@ type NetworkZone struct {
 	// Read only: true
 	// Example: ["/1.0/networks/foo", "/1.0/networks/bar"]
 	UsedBy []string `json:"used_by" yaml:"used_by"` // Resources that use the zone.
+
+	// Project name
+	// Example: project1
+	//
+	// API extension: network_zones_all_projects
+	Project string `json:"project" yaml:"project"`
 }
 
 // Writable converts a full NetworkZone struct into a NetworkZonePut struct (filters read-only fields).

--- a/test/suites/network_zone.sh
+++ b/test/suites/network_zone.sh
@@ -42,6 +42,10 @@ test_network_zone() {
   # Create zone in project.
   incus network zone create incus-foo.example.net --project foo
 
+  # Check all-projects column
+  incus network zone list --all-projects -fcsv | grep -q default,incus.example.net || false
+  incus network zone list --all-projects -fcsv | grep -q foo,incus-foo.example.net || false
+
   # Check associating a network to a missing zone isn't allowed.
   ! incus network set "${netName}" dns.zone.forward missing || false
   ! incus network set "${netName}" dns.zone.reverse.ipv4 missing || false


### PR DESCRIPTION
![image](https://github.com/lxc/incus/assets/122630595/9168b435-fcef-44b5-ba2f-bce83d19c4eb)

![image](https://github.com/lxc/incus/assets/122630595/ce6ca5b2-1a56-4ede-a7dc-b58487be50c7)

### What Changed

1. api: network_zones_all_projects

-  Added `network_zones_all_projects` to `internal/version/api.go`

2. incusd/network_zones: Add support for all-projects

- Added support to all-projects by getting all network zones when allProjects field is added to the uri in `networkZonesGet` function.
- Included all-projects to the comments for `networkZonesGet` functon
- Added Project field in the `NetworkZone` struct in `shared/api/network_zone.go`

3. client: Add GetNetworkZonesAllProjects
- Added `GetNetworkZonesAllProjects` that makes a GET request with all-projects field. Added it to `client/interfaces.go`

4. incus/network_zone: Add --all-projects flag to list
- Added flagAllProjects boolean field to cmdNetworkZoneList
- Calls GetNetworkZonesAllProjects when set to true, GetNetworkZones on false
- Changed output to include Project in the table when set