### PR TITLE
Fixed: Investigate sparse file support for VMs (#662)

### DIFF
--- a/internal/server/storage/drivers/driver_dir.go
+++ b/internal/server/storage/drivers/driver_dir.go
@@ -18,6 +18,10 @@ type dir struct {
 	common
 }
 
+type SparseFileWrapper struct {
+    W *os.File
+}
+
 // load is used to run one-time action per-driver rather than per-pool.
 func (d *dir) load() error {
 	// Register the patches.

--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -763,6 +763,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 
 					// Open block file (use O_CREATE to support drivers that use image files).
 					to, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+					customWrapper := &SparseFileWrapper{W: to}
 					if err != nil {
 						return fmt.Errorf("Error opening file for writing %q: %w", targetPath, err)
 					}
@@ -786,7 +787,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 					}
 
 					d.Logger().Debug(logMsg, logger.Ctx{"source": srcFile, "target": targetPath})
-					_, err = io.Copy(to, tr)
+					_, err = io.Copy(customWrapper, tr)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
## What Changed

1) `incusd/storage/drivers: Introduce SparseFileWrapper `

- Added `SparseFileWrapper `struct and `Write `function to `internal/server/storage/drivers/utils.go`

2) `incusd/storage/drivers/vfs`: Use `SpraseFileWrapper `on backup import

- Changed the `io.Copy` call in `genericVFSBackupUnpack `to use our wrapper struct.


### Examples

- On Creation
```
ubuntu@ubuntu:~/incus$ sudo du -sch /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
254M	/var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
254M	total
ubuntu@ubuntu:~/incus$ sudo  sha256sum /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
3621514d973e5e7f80f7c9302d1348bd2a9789454421ec3f458bac7c0feb9f0c  /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
```

- On Import
```
ubuntu@ubuntu:~/incus$ sudo du -sch /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
254M	/var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
254M	total
ubuntu@ubuntu:~/incus$ sudo  sha256sum /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
3621514d973e5e7f80f7c9302d1348bd2a9789454421ec3f458bac7c0feb9f0c  /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
```