### PR TITLE
Create sparse files on backup import and migration receive

### DIFF
--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -342,7 +342,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 		d.Logger().Debug("Receiving block volume started", logger.Ctx{"volName": volName, "path": path})
 		defer d.Logger().Debug("Receiving block volume stopped", logger.Ctx{"volName": volName, "path": path})
 
-		_, err = io.Copy(to, fromPipe)
+		_, err = io.Copy(NewSparseFileWrapper(to), fromPipe)
 		if err != nil {
 			return fmt.Errorf("Error copying from migration connection to %q: %w", path, err)
 		}

--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -786,7 +786,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 					}
 
 					d.Logger().Debug(logMsg, logger.Ctx{"source": srcFile, "target": targetPath})
-					_, err = io.Copy(to, tr)
+					_, err = io.Copy(NewSparseFileWrapper(to), tr)
 					if err != nil {
 						return err
 					}

--- a/internal/server/storage/drivers/utils.go
+++ b/internal/server/storage/drivers/utils.go
@@ -880,3 +880,49 @@ func wipeBlockHeaders(path string) error {
 func IsContentBlock(contentType ContentType) bool {
 	return contentType == ContentTypeBlock || contentType == ContentTypeISO
 }
+
+// NewSparseFileWrapper returns a SparseFileWrapper for the provided io.File.
+func NewSparseFileWrapper(w *os.File) *SparseFileWrapper {
+	return &SparseFileWrapper{w: w}
+}
+
+// SparseFileWrapper wraps os.File to create sparse Files.
+type SparseFileWrapper struct {
+	w *os.File
+}
+
+// Write performs the write but skips null bytes.
+func (sfw *SparseFileWrapper) Write(p []byte) (n int, err error) {
+	originalLength := len(p)
+	start := 0
+
+	for start < len(p) {
+		end := start
+		if p[start] == 0 {
+			for end < len(p) && p[end] == 0 {
+				end++
+			}
+
+			_, err := sfw.w.Seek(int64(end-start), io.SeekCurrent)
+			if err != nil {
+				return start, err
+			}
+
+			start = end
+		} else {
+			// Write non-zero bytes
+			for end < len(p) && p[end] != 0 {
+				end++
+			}
+
+			written, err := sfw.w.Write(p[start:end])
+			if err != nil {
+				return start + written, err
+			}
+
+			start = end
+		}
+	}
+
+	return originalLength, nil
+}


### PR DESCRIPTION
## What Changed

1. `incusd/storage/drivers: Introduce SparseFileWrapper `
- Added `SparseFileWrapper `struct and `Write `function to `internal/server/storage/drivers/utils.go`
2. `incusd/storage/drivers/vfs: Use SpraseFileWrapper on backup import`
- Changed the `io.Copy` call in `genericVFSBackupUnpack `to use our wrapper struct.

## Examples
- On Creation
```
ubuntu@ubuntu:~/incus$ sudo du -sch /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
254M	/var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
254M	total
ubuntu@ubuntu:~/incus$ sudo  sha256sum /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
3621514d973e5e7f80f7c9302d1348bd2a9789454421ec3f458bac7c0feb9f0c  /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
```

- On Import
```
ubuntu@ubuntu:~/incus$ sudo du -sch /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
254M	/var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
254M	total
ubuntu@ubuntu:~/incus$ sudo  sha256sum /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
3621514d973e5e7f80f7c9302d1348bd2a9789454421ec3f458bac7c0feb9f0c  /var/lib/incus/storage-pools/dir/virtual-machines/a1/root.img
```

Closes #662