### PR TITLE
incus/info displays cpu arch when using resources flag

### DIFF
--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -455,10 +455,12 @@ func (c *cmdInfo) remoteInfo(d incus.InstanceServer) error {
 
 		// CPU
 		if len(resources.CPU.Sockets) == 1 {
-			fmt.Printf("\n"+i18n.G("CPU (%s):")+"\n", resources.CPU.Architecture)
+			fmt.Printf("\n" + i18n.G("CPU:") + "\n")
+			fmt.Printf("  "+i18n.G("Architecture: %s")+"\n", resources.CPU.Architecture)
 			c.renderCPU(resources.CPU.Sockets[0], "  ")
 		} else if len(resources.CPU.Sockets) > 1 {
-			fmt.Printf(i18n.G("CPUs (%s):")+"\n", resources.CPU.Architecture)
+			fmt.Printf(i18n.G("CPUs:") + "\n")
+			fmt.Printf("  "+i18n.G("Architecture: %s")+"\n", resources.CPU.Architecture)
 			for _, cpu := range resources.CPU.Sockets {
 				fmt.Printf("  "+i18n.G("Socket %d:")+"\n", cpu.Socket)
 				c.renderCPU(cpu, "    ")

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-20 14:44-0400\n"
+"POT-Creation-Date: 2024-04-21 11:19+0100\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -709,7 +709,7 @@ msgid "--target can only be used with clusters"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:822 cmd/incus/info.go:568
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -1021,7 +1021,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463
+#: cmd/incus/info.go:591
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -1147,7 +1148,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1203,11 +1204,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1227,26 +1228,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:458
-#, c-format
-msgid "CPU (%s):"
-msgstr "Prozessorauslastung (%s):"
-
 #: cmd/incus/list.go:588
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 msgid "CPU usage:"
 msgstr "Prozessorauslastung:"
 
-#: cmd/incus/info.go:461
-#, c-format
-msgid "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid "CPU:"
+msgstr ""
+
+#: cmd/incus/info.go:462
+msgid "CPUs:"
 msgstr ""
 
 #: cmd/incus/operation.go:176
@@ -1378,7 +1377,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1909,7 +1908,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -2280,7 +2279,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2372,22 +2371,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 #, fuzzy
 msgid "Disk:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 #, fuzzy
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
@@ -2753,7 +2752,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3291,8 +3290,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3311,11 +3310,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid "GPUs:"
 msgstr ""
 
@@ -3508,12 +3507,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3559,7 +3558,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
@@ -3737,7 +3736,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 msgid "Instance Only"
 msgstr ""
 
@@ -3968,7 +3967,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
@@ -4388,7 +4387,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4397,7 +4396,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid "Log:"
 msgstr ""
 
@@ -4436,7 +4435,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
@@ -4484,7 +4483,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid "MTU"
 msgstr ""
 
@@ -4757,19 +4756,19 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 msgid "Memory:"
 msgstr ""
 
@@ -5122,11 +5121,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "NICs:"
 msgstr ""
 
@@ -5142,7 +5141,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5155,7 +5154,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5221,7 +5220,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929
+#: cmd/incus/info.go:577 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5342,7 +5341,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -5432,7 +5431,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5489,7 +5488,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5514,7 +5513,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5548,11 +5547,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5666,7 +5665,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -6229,7 +6228,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid "Resources:"
 msgstr ""
 
@@ -7018,11 +7017,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7056,7 +7055,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
@@ -7066,11 +7065,11 @@ msgstr "Erstellt: %s"
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7203,11 +7202,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7244,7 +7243,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7586,8 +7585,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492
+#: cmd/incus/info.go:498
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7641,7 +7640,7 @@ msgstr "Administrator Passwort für %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 msgid "Type"
 msgstr ""
 
@@ -7661,13 +7660,13 @@ msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
+#: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7688,12 +7687,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 #, fuzzy
 msgid "USB device:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 #, fuzzy
 msgid "USB devices:"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -7937,7 +7936,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7985,8 +7984,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -9962,6 +9961,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""
+
+#, c-format
+#~ msgid "CPU (%s):"
+#~ msgstr "Prozessorauslastung (%s):"
 
 #, fuzzy
 #~ msgid "The --mode flag can't be used with --storage or --target-project"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-20 14:44-0400\n"
+"POT-Creation-Date: 2024-04-21 11:19+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -693,7 +693,7 @@ msgid "--target can only be used with clusters"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:822 cmd/incus/info.go:568
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -987,7 +987,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463
+#: cmd/incus/info.go:591
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -1106,7 +1107,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1163,11 +1164,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1187,26 +1188,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:458
-#, c-format
-msgid "CPU (%s):"
-msgstr "CPU (%s):"
-
 #: cmd/incus/list.go:588
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
-#: cmd/incus/info.go:461
-#, c-format
-msgid "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid "CPU:"
+msgstr ""
+
+#: cmd/incus/info.go:462
+msgid "CPUs:"
 msgstr ""
 
 #: cmd/incus/operation.go:176
@@ -1332,7 +1331,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1844,7 +1843,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -2208,7 +2207,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Dispositivo: %s"
@@ -2291,20 +2290,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, c-format
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "Disk:"
 msgstr "Disco:"
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 msgid "Disks:"
 msgstr "Discos:"
 
@@ -2652,7 +2651,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 #, fuzzy
@@ -3186,8 +3185,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3206,11 +3205,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid "GPUs:"
 msgstr ""
 
@@ -3396,12 +3395,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3447,7 +3446,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
@@ -3623,7 +3622,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
@@ -3848,7 +3847,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Creado: %s"
@@ -4250,7 +4249,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4259,7 +4258,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid "Log:"
 msgstr "Registro:"
 
@@ -4296,7 +4295,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
@@ -4340,7 +4339,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid "MTU"
 msgstr ""
 
@@ -4593,19 +4592,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 msgid "Memory:"
 msgstr ""
 
@@ -4950,11 +4949,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "NICs:"
 msgstr ""
 
@@ -4970,7 +4969,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4983,7 +4982,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5045,7 +5044,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929
+#: cmd/incus/info.go:577 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5165,7 +5164,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5251,7 +5250,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5308,7 +5307,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5333,7 +5332,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5367,11 +5366,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5483,7 +5482,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -6031,7 +6030,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid "Resources:"
 msgstr ""
 
@@ -6785,11 +6784,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6822,7 +6821,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
@@ -6832,11 +6831,11 @@ msgstr "Auto actualización: %s"
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6963,11 +6962,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7004,7 +7003,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7339,8 +7338,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492
+#: cmd/incus/info.go:498
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7394,7 +7393,7 @@ msgstr "Contraseña admin para %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
@@ -7415,13 +7414,13 @@ msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
+#: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7442,11 +7441,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 msgid "USB devices:"
 msgstr ""
 
@@ -7680,7 +7679,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7727,8 +7726,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -9202,6 +9201,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""
+
+#, c-format
+#~ msgid "CPU (%s):"
+#~ msgstr "CPU (%s):"
 
 #, fuzzy
 #~ msgid "The --mode flag can't be used with --storage or --target-project"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-20 14:44-0400\n"
+"POT-Creation-Date: 2024-04-21 11:19+0100\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -701,7 +701,7 @@ msgid "--target can only be used with clusters"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:822 cmd/incus/info.go:568
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
@@ -1009,7 +1009,8 @@ msgstr "Toutes les adresses serveurs sont indisponibles"
 msgid "Alternative certificate name"
 msgstr "Nom alternatif du certificat"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463
+#: cmd/incus/info.go:591
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -1136,7 +1137,7 @@ msgstr "Sauvegarder le volume de stockage : %s"
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1194,11 +1195,11 @@ msgstr "Pont:"
 msgid "Bus Address: %v"
 msgstr "Addresse : %s"
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1218,27 +1219,26 @@ msgstr "Type de contenu"
 msgid "COUNT"
 msgstr "NOMBRE"
 
-#: cmd/incus/info.go:458
-#, c-format
-msgid "CPU (%s):"
-msgstr "CPU (%s) :"
-
 #: cmd/incus/list.go:588
 msgid "CPU USAGE"
 msgstr "UTILISATION CPU"
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
-#: cmd/incus/info.go:461
-#, c-format
-msgid "CPUs (%s):"
-msgstr "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid "CPU:"
+msgstr ""
+
+#: cmd/incus/info.go:462
+#, fuzzy
+msgid "CPUs:"
+msgstr "GPUs :"
 
 #: cmd/incus/operation.go:176
 msgid "CREATED"
@@ -1371,7 +1371,7 @@ msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 msgid "Cannot set key: %s"
 msgstr "Impossible d'assigner les clés: %s"
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid "Card %d:"
 msgstr "Cartes %d:"
@@ -1940,7 +1940,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -2316,7 +2316,7 @@ msgstr "Clé de configuration invalide"
 msgid "Detach storage volumes from profiles"
 msgstr "Détacher les volumes de stockage des profils"
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Serveur distant : %s"
@@ -2405,20 +2405,20 @@ msgstr "Désactiver l'allocation pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Disque %d:"
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 msgid "Disk usage:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "Disk:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 msgid "Disks:"
 msgstr "Disque utilisé :"
 
@@ -2847,7 +2847,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 #, fuzzy
@@ -3430,8 +3430,8 @@ msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 "L'alias trouvé %q fait référence à un argument en dehors du nombre donné"
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, fuzzy, c-format
 msgid "Free: %v"
 msgstr "Libre : %v"
@@ -3450,11 +3450,11 @@ msgstr "Fréquence : %vMhz (min : %vMhz, max : %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid "GPU:"
 msgstr "GPU :"
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid "GPUs:"
 msgstr "GPUs :"
 
@@ -3653,12 +3653,12 @@ msgstr "ADRESSE MATÉRIEL"
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3705,7 +3705,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "ADRESSE IP"
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
@@ -3903,7 +3903,7 @@ msgstr "Infiniband :"
 msgid "Input data"
 msgstr "Données d'entrée"
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
@@ -4140,7 +4140,7 @@ msgstr "ADRESSE D’ÉCOUTE"
 msgid "LOCATION"
 msgstr "LOCALISATION"
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
@@ -4606,7 +4606,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4615,7 +4615,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid "Log:"
 msgstr "Journal :"
 
@@ -4654,7 +4654,7 @@ msgstr "Création du conteneur"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
@@ -4698,7 +4698,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid "MTU"
 msgstr ""
 
@@ -4969,19 +4969,19 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 msgid "Memory usage:"
 msgstr "Mémoire utilisée :"
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 msgid "Memory:"
 msgstr "Mémoire utilisée :"
 
@@ -5338,11 +5338,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "NICs:"
 msgstr ""
 
@@ -5358,7 +5358,7 @@ msgstr "NON"
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5371,7 +5371,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 #, fuzzy
@@ -5438,7 +5438,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929
+#: cmd/incus/info.go:577 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
@@ -5648,7 +5648,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5715,7 +5715,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5741,7 +5741,7 @@ msgstr ""
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, fuzzy, c-format
 msgid "PID: %d"
 msgstr "Pid : %d"
@@ -5775,11 +5775,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -5894,7 +5894,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -6460,7 +6460,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -7268,11 +7268,11 @@ msgstr "Copie de l'image : %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7306,7 +7306,7 @@ msgstr "Démarrage de %s"
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
@@ -7316,12 +7316,12 @@ msgstr "État : %s"
 msgid "State: %s"
 msgstr "État : %s"
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
@@ -7453,11 +7453,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -7496,7 +7496,7 @@ msgstr ""
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 #, fuzzy
 msgid "Taken at"
@@ -7849,8 +7849,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Publié : %s"
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492
+#: cmd/incus/info.go:498
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7904,7 +7904,7 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
@@ -7925,13 +7925,13 @@ msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
+#: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, fuzzy, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
@@ -7952,12 +7952,12 @@ msgstr "URL"
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 #, fuzzy
 msgid "USB device:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 #, fuzzy
 msgid "USB devices:"
 msgstr "Création du conteneur"
@@ -8204,7 +8204,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8252,8 +8252,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, fuzzy, c-format
 msgid "Used: %v"
 msgstr "Publié : %s"
@@ -10315,6 +10315,14 @@ msgstr "o"
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "oui"
+
+#, c-format
+#~ msgid "CPU (%s):"
+#~ msgstr "CPU (%s) :"
+
+#, c-format
+#~ msgid "CPUs (%s):"
+#~ msgstr "CPUs (%s):"
 
 #, fuzzy, c-format
 #~ msgid "Usb %d:"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-04-20 14:44-0400\n"
+        "POT-Creation-Date: 2024-04-21 11:19+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -423,7 +423,7 @@ msgstr  ""
 msgid   "--target can only be used with clusters"
 msgstr  ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615 cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615 cmd/incus/config.go:822 cmd/incus/info.go:568
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -696,7 +696,7 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463 cmd/incus/info.go:591
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -812,7 +812,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid   "Backups:"
 msgstr  ""
 
@@ -863,11 +863,11 @@ msgstr  ""
 msgid   "Bus Address: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid   "Bytes received"
 msgstr  ""
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -887,26 +887,24 @@ msgstr  ""
 msgid   "COUNT"
 msgstr  ""
 
-#: cmd/incus/info.go:458
-#, c-format
-msgid   "CPU (%s):"
-msgstr  ""
-
 #: cmd/incus/list.go:588
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 msgid   "CPU usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:461
-#, c-format
-msgid   "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid   "CPU:"
+msgstr  ""
+
+#: cmd/incus/info.go:462
+msgid   "CPUs:"
 msgstr  ""
 
 #: cmd/incus/operation.go:176
@@ -1024,7 +1022,7 @@ msgstr  ""
 msgid   "Cannot set key: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid   "Card %d:"
 msgstr  ""
@@ -1462,7 +1460,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600 cmd/incus/storage_volume.go:1407
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1658,7 +1656,7 @@ msgstr  ""
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, c-format
 msgid   "Device %d:"
 msgstr  ""
@@ -1733,20 +1731,20 @@ msgstr  ""
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, c-format
 msgid   "Disk %d:"
 msgstr  ""
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 msgid   "Disk usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid   "Disk:"
 msgstr  ""
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 msgid   "Disks:"
 msgstr  ""
 
@@ -2058,7 +2056,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366 cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490 cmd/incus/storage_volume.go:2575
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366 cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490 cmd/incus/storage_volume.go:2575
 msgid   "Expires at"
 msgstr  ""
 
@@ -2560,7 +2558,7 @@ msgstr  ""
 msgid   "Found alias %q references an argument outside the given number"
 msgstr  ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488 cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490 cmd/incus/info.go:496
 #, c-format
 msgid   "Free: %v"
 msgstr  ""
@@ -2579,11 +2577,11 @@ msgstr  ""
 msgid   "GLOBAL"
 msgstr  ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid   "GPU:"
 msgstr  ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid   "GPUs:"
 msgstr  ""
 
@@ -2752,11 +2750,11 @@ msgstr  ""
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 msgid   "Host interface"
 msgstr  ""
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid   "Hugepages:\n"
 msgstr  ""
 
@@ -2802,7 +2800,7 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 msgid   "IP addresses"
 msgstr  ""
 
@@ -2969,7 +2967,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 msgid   "Instance Only"
 msgstr  ""
 
@@ -3180,7 +3178,7 @@ msgstr  ""
 msgid   "LOCATION"
 msgstr  ""
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, c-format
 msgid   "Last Used: %s"
 msgstr  ""
@@ -3552,7 +3550,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3561,7 +3559,7 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid   "Log:"
 msgstr  ""
 
@@ -3598,7 +3596,7 @@ msgstr  ""
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 msgid   "MAC address"
 msgstr  ""
 
@@ -3641,7 +3639,7 @@ msgstr  ""
 msgid   "MII state"
 msgstr  ""
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid   "MTU"
 msgstr  ""
 
@@ -3872,19 +3870,19 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid   "Memory (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 msgid   "Memory usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 msgid   "Memory:"
 msgstr  ""
 
@@ -4107,11 +4105,11 @@ msgstr  ""
 msgid   "NEW: %q (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid   "NIC:"
 msgstr  ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid   "NICs:"
 msgstr  ""
 
@@ -4124,7 +4122,7 @@ msgstr  ""
 msgid   "NUMA node: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid   "NUMA nodes:\n"
 msgstr  ""
 
@@ -4137,7 +4135,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364 cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488 cmd/incus/storage_volume.go:2573
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364 cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488 cmd/incus/storage_volume.go:2573
 msgid   "Name"
 msgstr  ""
 
@@ -4196,7 +4194,7 @@ msgstr  ""
 msgid   "Name of the storage pool:"
 msgstr  ""
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1378
+#: cmd/incus/info.go:577 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1378
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -4314,7 +4312,7 @@ msgstr  ""
 msgid   "Network type"
 msgstr  ""
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 msgid   "Network usage:"
 msgstr  ""
 
@@ -4400,7 +4398,7 @@ msgstr  ""
 msgid   "No value found in %q"
 msgstr  ""
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid   "Node %d:\n"
 msgstr  ""
@@ -4454,7 +4452,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4479,7 +4477,7 @@ msgstr  ""
 msgid   "PID"
 msgstr  ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, c-format
 msgid   "PID: %d"
 msgstr  ""
@@ -4512,11 +4510,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid   "Packets received"
 msgstr  ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid   "Packets sent"
 msgstr  ""
 
@@ -4617,7 +4615,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -5122,7 +5120,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid   "Resources:"
 msgstr  ""
 
@@ -5804,11 +5802,11 @@ msgstr  ""
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid   "Snapshots:"
 msgstr  ""
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid   "Socket %d:"
 msgstr  ""
@@ -5839,7 +5837,7 @@ msgstr  ""
 msgid   "Starting recovery..."
 msgstr  ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 msgid   "State"
 msgstr  ""
 
@@ -5848,11 +5846,11 @@ msgstr  ""
 msgid   "State: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 msgid   "Stateful"
 msgstr  ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
@@ -5977,11 +5975,11 @@ msgstr  ""
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid   "Swap (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -6013,7 +6011,7 @@ msgstr  ""
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365 cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365 cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid   "Taken at"
 msgstr  ""
 
@@ -6322,7 +6320,7 @@ msgstr  ""
 msgid   "Total: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490 cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492 cmd/incus/info.go:498
 #, c-format
 msgid   "Total: %v"
 msgstr  ""
@@ -6376,7 +6374,7 @@ msgstr  ""
 msgid   "Try `incus info --show-log %s` for more info"
 msgstr  ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 msgid   "Type"
 msgstr  ""
 
@@ -6392,12 +6390,12 @@ msgstr  ""
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403 cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933 cmd/incus/storage_volume.go:1387
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403 cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933 cmd/incus/storage_volume.go:1387
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, c-format
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
@@ -6418,11 +6416,11 @@ msgstr  ""
 msgid   "USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 msgid   "USB device:"
 msgstr  ""
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 msgid   "USB devices:"
 msgstr  ""
 
@@ -6631,7 +6629,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
@@ -6674,7 +6672,7 @@ msgstr  ""
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489 cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491 cmd/incus/info.go:497
 #, c-format
 msgid   "Used: %v"
 msgstr  ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-20 14:44-0400\n"
+"POT-Creation-Date: 2024-04-21 11:19+0100\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -692,7 +692,7 @@ msgid "--target can only be used with clusters"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:822 cmd/incus/info.go:568
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -986,7 +986,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463
+#: cmd/incus/info.go:591
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -1105,7 +1106,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1161,11 +1162,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1185,26 +1186,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:458
-#, fuzzy, c-format
-msgid "CPU (%s):"
-msgstr "Utilizzo CPU:"
-
 #: cmd/incus/list.go:588
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
-#: cmd/incus/info.go:461
-#, c-format
-msgid "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid "CPU:"
+msgstr ""
+
+#: cmd/incus/info.go:462
+msgid "CPUs:"
 msgstr ""
 
 #: cmd/incus/operation.go:176
@@ -1327,7 +1326,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1837,7 +1836,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -2201,7 +2200,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Utilizzo disco:"
@@ -2283,21 +2282,21 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 #, fuzzy
 msgid "Disk:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 #, fuzzy
 msgid "Disks:"
 msgstr "Utilizzo disco:"
@@ -2646,7 +2645,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3180,8 +3179,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3200,11 +3199,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid "GPUs:"
 msgstr ""
 
@@ -3387,12 +3386,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3438,7 +3437,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 msgid "IP addresses"
 msgstr ""
 
@@ -3612,7 +3611,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
@@ -3837,7 +3836,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -4240,7 +4239,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4249,7 +4248,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid "Log:"
 msgstr ""
 
@@ -4288,7 +4287,7 @@ msgstr "Creazione del container in corso"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 msgid "MAC address"
 msgstr ""
 
@@ -4331,7 +4330,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid "MTU"
 msgstr ""
 
@@ -4588,19 +4587,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 msgid "Memory:"
 msgstr ""
 
@@ -4944,11 +4943,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "NICs:"
 msgstr ""
 
@@ -4964,7 +4963,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4977,7 +4976,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5039,7 +5038,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929
+#: cmd/incus/info.go:577 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5159,7 +5158,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5245,7 +5244,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5302,7 +5301,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5327,7 +5326,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5361,11 +5360,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5478,7 +5477,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6026,7 +6025,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid "Resources:"
 msgstr ""
 
@@ -6776,11 +6775,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6814,7 +6813,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
@@ -6824,11 +6823,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6955,11 +6954,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6996,7 +6995,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 #, fuzzy
 msgid "Taken at"
@@ -7333,8 +7332,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492
+#: cmd/incus/info.go:498
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7388,7 +7387,7 @@ msgstr "Password amministratore per %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 msgid "Type"
 msgstr ""
 
@@ -7408,13 +7407,13 @@ msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
+#: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7435,12 +7434,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 #, fuzzy
 msgid "USB device:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 #, fuzzy
 msgid "USB devices:"
 msgstr "Creazione del container in corso"
@@ -7671,7 +7670,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7719,8 +7718,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -9198,6 +9197,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "si"
+
+#, fuzzy, c-format
+#~ msgid "CPU (%s):"
+#~ msgstr "Utilizzo CPU:"
 
 #, fuzzy, c-format
 #~ msgid "Usb %d:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-20 14:44-0400\n"
+"POT-Creation-Date: 2024-04-21 11:19+0100\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -683,7 +683,7 @@ msgid "--target can only be used with clusters"
 msgstr "--target はインスタンスでは使えません"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:822 cmd/incus/info.go:568
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
 
@@ -984,7 +984,8 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463
+#: cmd/incus/info.go:591
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -1107,7 +1108,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1165,11 +1166,11 @@ msgstr "ブリッジ:"
 msgid "Bus Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1189,27 +1190,26 @@ msgstr "CONTENT-TYPE"
 msgid "COUNT"
 msgstr "COUNT"
 
-#: cmd/incus/info.go:458
-#, c-format
-msgid "CPU (%s):"
-msgstr "CPU (%s):"
-
 #: cmd/incus/list.go:588
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
-#: cmd/incus/info.go:461
-#, c-format
-msgid "CPUs (%s):"
-msgstr "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid "CPU:"
+msgstr ""
+
+#: cmd/incus/info.go:462
+#, fuzzy
+msgid "CPUs:"
+msgstr "GPUs:"
 
 #: cmd/incus/operation.go:176
 msgid "CREATED"
@@ -1336,7 +1336,7 @@ msgstr "スナップショットをコピーするときに --volume-only は指
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid "Card %d:"
 msgstr "カード %d:"
@@ -1865,7 +1865,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -2221,7 +2221,7 @@ msgstr "インスタンスからストレージボリュームを取り外しま
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "デバイス: %s"
@@ -2309,20 +2309,20 @@ msgstr "擬似端末の割り当てを無効にします"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, c-format
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "Disk:"
 msgstr "ディスク:"
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 msgid "Disks:"
 msgstr "ディスク:"
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3259,8 +3259,8 @@ msgstr "Forward delay"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "エイリアス %q が指定した番号以外の引数を参照しているのが見つかりました"
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Free: %v"
 msgstr "空き: %v"
@@ -3279,11 +3279,11 @@ msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid "GPU:"
 msgstr "GPU:"
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid "GPUs:"
 msgstr "GPUs:"
 
@@ -3466,11 +3466,11 @@ msgstr "MAC ADDRESS"
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
@@ -3516,7 +3516,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 msgid "IP addresses"
 msgstr "IP アドレス"
 
@@ -3704,7 +3704,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
@@ -3931,7 +3931,7 @@ msgstr "LISTEN ADDRESS"
 msgid "LOCATION"
 msgstr "LOCATION"
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, c-format
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
@@ -4496,7 +4496,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4505,7 +4505,7 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid "Log:"
 msgstr "ログ:"
 
@@ -4542,7 +4542,7 @@ msgstr "Lower devices"
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 msgid "MAC address"
 msgstr "MAC アドレス"
 
@@ -4585,7 +4585,7 @@ msgstr "MII 監視頻度"
 msgid "MII state"
 msgstr "MII 状態"
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid "MTU"
 msgstr "MTU"
 
@@ -4845,19 +4845,19 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 msgid "Memory:"
 msgstr "メモリ:"
 
@@ -5209,11 +5209,11 @@ msgstr "NETWORKS"
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr "新規: %q (バックエンド=%q, ソース=%q)"
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid "NIC:"
 msgstr "NIC:"
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "NICs:"
 msgstr "NICs:"
 
@@ -5229,7 +5229,7 @@ msgstr "NO"
 msgid "NUMA node: %v"
 msgstr "NUMA ノード: %v"
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid "NUMA nodes:\n"
 msgstr "NUMA ノード:\n"
 
@@ -5242,7 +5242,7 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5308,7 +5308,7 @@ msgstr "使用するストレージバックエンド名 (%s)"
 msgid "Name of the storage pool:"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929
+#: cmd/incus/info.go:577 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5430,7 +5430,7 @@ msgstr ""
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -5519,7 +5519,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
@@ -5580,7 +5580,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -5605,7 +5605,7 @@ msgstr "PEER"
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, c-format
 msgid "PID: %d"
 msgstr "PID: %d"
@@ -5640,11 +5640,11 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -5758,7 +5758,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -6335,7 +6335,7 @@ msgstr "クラスターメンバーに join するためのトークンを要求
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -7158,11 +7158,11 @@ msgstr "ストレージボリュームのスナップショットを取得しま
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Socket %d:"
 msgstr "ソケット %d:"
@@ -7197,7 +7197,7 @@ msgstr "%s を起動中"
 msgid "Starting recovery..."
 msgstr "リカバリーを開始します..."
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 msgid "State"
 msgstr "状態"
 
@@ -7206,11 +7206,11 @@ msgstr "状態"
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr "ステートフル"
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
@@ -7337,11 +7337,11 @@ msgstr "サポートするモード: %s"
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -7378,7 +7378,7 @@ msgstr "TOKEN"
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr "取得日時"
@@ -7780,8 +7780,8 @@ msgstr "リンクが多すぎます"
 msgid "Total: %s"
 msgstr "合計: %s"
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492
+#: cmd/incus/info.go:498
 #, c-format
 msgid "Total: %v"
 msgstr "合計: %v"
@@ -7835,7 +7835,7 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 msgid "Type"
 msgstr "タイプ"
 
@@ -7856,13 +7856,13 @@ msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
+#: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
@@ -7883,12 +7883,12 @@ msgstr "URL"
 msgid "USAGE"
 msgstr "USAGE"
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 #, fuzzy
 msgid "USB device:"
 msgstr "device"
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 #, fuzzy
 msgid "USB devices:"
 msgstr "上位デバイス"
@@ -8115,7 +8115,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr "インスタンスプロパティの設定を削除します"
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
@@ -8165,8 +8165,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Used: %v"
 msgstr "使用済: %v"
@@ -9764,6 +9764,14 @@ msgstr "y"
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "yes"
+
+#, c-format
+#~ msgid "CPU (%s):"
+#~ msgstr "CPU (%s):"
+
+#, c-format
+#~ msgid "CPUs (%s):"
+#~ msgstr "CPUs (%s):"
 
 #, fuzzy
 #~ msgid ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-20 14:44-0400\n"
+"POT-Creation-Date: 2024-04-21 11:19+0100\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -704,7 +704,7 @@ msgid "--target can only be used with clusters"
 msgstr "--target kan niet gebruikt worden met: instances"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:822 cmd/incus/info.go:568
 msgid "--target cannot be used with instances"
 msgstr "--target kan niet gebruikt worden met: instances"
 
@@ -1002,7 +1002,8 @@ msgstr "Alle server adressen zijn onbeschikbaar"
 msgid "Alternative certificate name"
 msgstr "Alternatieve certificaat naam"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463
+#: cmd/incus/info.go:591
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architectuur: %s"
@@ -1126,7 +1127,7 @@ msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1182,11 +1183,11 @@ msgstr "Brug (Bridge):"
 msgid "Bus Address: %v"
 msgstr "Adres: %s"
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes ontvangen (received)"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes verzonden"
 
@@ -1206,26 +1207,25 @@ msgstr "INHOUDSTYPE"
 msgid "COUNT"
 msgstr "SOM"
 
-#: cmd/incus/info.go:458
-#, c-format
-msgid "CPU (%s):"
-msgstr "CPU (%s):"
-
 #: cmd/incus/list.go:588
 msgid "CPU USAGE"
 msgstr "CPU GEBRUIK"
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid "CPU usage (in seconds)"
 msgstr "CPU gebruik (in seconde)"
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 msgid "CPU usage:"
 msgstr "CPU gebruik:"
 
-#: cmd/incus/info.go:461
-#, c-format
-msgid "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid "CPU:"
+msgstr ""
+
+#: cmd/incus/info.go:462
+#, fuzzy
+msgid "CPUs:"
 msgstr "CPU's (%s):"
 
 #: cmd/incus/operation.go:176
@@ -1349,7 +1349,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1847,7 +1847,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -2202,7 +2202,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Adres: %s"
@@ -2283,20 +2283,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 msgid "Disks:"
 msgstr ""
 
@@ -2633,7 +2633,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3161,8 +3161,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3181,11 +3181,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid "GPUs:"
 msgstr ""
 
@@ -3357,11 +3357,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3407,7 +3407,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 msgid "IP addresses"
 msgstr ""
 
@@ -3577,7 +3577,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 msgid "Instance Only"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4184,7 +4184,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4193,7 +4193,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid "Log:"
 msgstr ""
 
@@ -4230,7 +4230,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 msgid "MAC address"
 msgstr ""
 
@@ -4273,7 +4273,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid "MTU"
 msgstr ""
 
@@ -4512,19 +4512,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 msgid "Memory:"
 msgstr ""
 
@@ -4852,11 +4852,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "NICs:"
 msgstr ""
 
@@ -4872,7 +4872,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4885,7 +4885,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4947,7 +4947,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929
+#: cmd/incus/info.go:577 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5067,7 +5067,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5210,7 +5210,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5235,7 +5235,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5269,11 +5269,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5384,7 +5384,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5917,7 +5917,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid "Resources:"
 msgstr ""
 
@@ -6640,11 +6640,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6677,7 +6677,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 msgid "State"
 msgstr ""
 
@@ -6686,11 +6686,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6816,11 +6816,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6857,7 +6857,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7191,8 +7191,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492
+#: cmd/incus/info.go:498
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7246,7 +7246,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 msgid "Type"
 msgstr ""
 
@@ -7265,13 +7265,13 @@ msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
+#: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7292,11 +7292,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 msgid "USB devices:"
 msgstr ""
 
@@ -7510,7 +7510,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7556,8 +7556,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8882,6 +8882,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""
+
+#, c-format
+#~ msgid "CPU (%s):"
+#~ msgstr "CPU (%s):"
 
 #, fuzzy
 #~ msgid "Path to the shared block device:"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-20 14:44-0400\n"
+"POT-Creation-Date: 2024-04-21 11:19+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -447,7 +447,7 @@ msgid "--target can only be used with clusters"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:822 cmd/incus/info.go:568
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -730,7 +730,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463
+#: cmd/incus/info.go:591
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -848,7 +849,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -904,11 +905,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr ""
 
@@ -928,26 +929,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:458
-#, c-format
-msgid "CPU (%s):"
-msgstr ""
-
 #: cmd/incus/list.go:588
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:461
-#, c-format
-msgid "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid "CPU:"
+msgstr ""
+
+#: cmd/incus/info.go:462
+msgid "CPUs:"
 msgstr ""
 
 #: cmd/incus/operation.go:176
@@ -1069,7 +1068,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1566,7 +1565,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -1920,7 +1919,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2001,20 +2000,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 msgid "Disks:"
 msgstr ""
 
@@ -2351,7 +2350,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -2879,8 +2878,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -2899,11 +2898,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid "GPUs:"
 msgstr ""
 
@@ -3073,11 +3072,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3123,7 +3122,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 msgid "IP addresses"
 msgstr ""
 
@@ -3293,7 +3292,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 msgid "Instance Only"
 msgstr ""
 
@@ -3512,7 +3511,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3899,7 +3898,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3908,7 +3907,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid "Log:"
 msgstr ""
 
@@ -3945,7 +3944,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 msgid "MAC address"
 msgstr ""
 
@@ -3988,7 +3987,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid "MTU"
 msgstr ""
 
@@ -4226,19 +4225,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 msgid "Memory:"
 msgstr ""
 
@@ -4565,11 +4564,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "NICs:"
 msgstr ""
 
@@ -4585,7 +4584,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4598,7 +4597,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4660,7 +4659,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929
+#: cmd/incus/info.go:577 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -4780,7 +4779,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -4866,7 +4865,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4923,7 +4922,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4948,7 +4947,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4982,11 +4981,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5097,7 +5096,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5629,7 +5628,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid "Resources:"
 msgstr ""
 
@@ -6349,11 +6348,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6386,7 +6385,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 msgid "State"
 msgstr ""
 
@@ -6395,11 +6394,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6525,11 +6524,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6566,7 +6565,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -6900,8 +6899,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492
+#: cmd/incus/info.go:498
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -6955,7 +6954,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 msgid "Type"
 msgstr ""
 
@@ -6974,13 +6973,13 @@ msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
+#: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7001,11 +7000,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 msgid "USB devices:"
 msgstr ""
 
@@ -7219,7 +7218,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7265,8 +7264,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Used: %v"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-20 14:44-0400\n"
+"POT-Creation-Date: 2024-04-21 11:19+0100\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -692,7 +692,7 @@ msgid "--target can only be used with clusters"
 msgstr "--refresh só pode ser usado com containers"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:822 cmd/incus/info.go:568
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -991,7 +991,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463
+#: cmd/incus/info.go:591
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
@@ -1116,7 +1117,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1172,11 +1173,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1196,26 +1197,25 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:458
-#, fuzzy, c-format
-msgid "CPU (%s):"
-msgstr "Utilização do CPU:"
-
 #: cmd/incus/list.go:588
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
-#: cmd/incus/info.go:461
-#, fuzzy, c-format
-msgid "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid "CPU:"
+msgstr "CPU:"
+
+#: cmd/incus/info.go:462
+#, fuzzy
+msgid "CPUs:"
 msgstr "CPUs:"
 
 #: cmd/incus/operation.go:176
@@ -1339,7 +1339,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid "Card %d:"
 msgstr "Cartão %d:"
@@ -1868,7 +1868,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -2241,7 +2241,7 @@ msgstr "Desconectar volumes de armazenamento dos containers"
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Em cache: %s"
@@ -2323,21 +2323,21 @@ msgstr "Desabilitar alocação de pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desabilitar stdin (ler de /dev/null)"
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 #, fuzzy
 msgid "Disk:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso de disco:"
@@ -2694,7 +2694,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3225,8 +3225,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3245,11 +3245,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid "GPUs:"
 msgstr ""
 
@@ -3441,11 +3441,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3491,7 +3491,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 msgid "IP addresses"
 msgstr ""
 
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 msgid "Instance Only"
 msgstr ""
 
@@ -3889,7 +3889,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Criado: %s"
@@ -4288,7 +4288,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4297,7 +4297,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid "Log:"
 msgstr ""
 
@@ -4336,7 +4336,7 @@ msgstr "Editar arquivos no container"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 msgid "MAC address"
 msgstr ""
 
@@ -4379,7 +4379,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid "MTU"
 msgstr ""
 
@@ -4642,19 +4642,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 msgid "Memory:"
 msgstr ""
 
@@ -4998,11 +4998,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "NICs:"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5031,7 +5031,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5093,7 +5093,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929
+#: cmd/incus/info.go:577 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5213,7 +5213,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5299,7 +5299,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5381,7 +5381,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5415,11 +5415,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5531,7 +5531,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6088,7 +6088,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid "Resources:"
 msgstr ""
 
@@ -6862,11 +6862,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6899,7 +6899,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 msgid "State"
 msgstr ""
 
@@ -6908,11 +6908,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7040,11 +7040,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7081,7 +7081,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7417,8 +7417,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492
+#: cmd/incus/info.go:498
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7472,7 +7472,7 @@ msgstr "Senha de administrador para %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 msgid "Type"
 msgstr ""
 
@@ -7492,13 +7492,13 @@ msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
+#: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7519,12 +7519,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 #, fuzzy
 msgid "USB device:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 #, fuzzy
 msgid "USB devices:"
 msgstr "Editar arquivos no container"
@@ -7766,7 +7766,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7814,8 +7814,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -9224,6 +9224,10 @@ msgstr ""
 msgid "yes"
 msgstr "sim"
 
+#, fuzzy, c-format
+#~ msgid "CPU (%s):"
+#~ msgstr "Utilização do CPU:"
+
 #, fuzzy
 #~ msgid "The --mode flag can't be used with --storage or --target-project"
 #~ msgstr "--refresh só pode ser usado com containers"
@@ -9303,9 +9307,6 @@ msgstr "sim"
 
 #~ msgid "ARCH"
 #~ msgstr "ARQUITETURA"
-
-#~ msgid "CPU:"
-#~ msgstr "CPU:"
 
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "Não é possível ler stdin: %s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-20 14:44-0400\n"
+"POT-Creation-Date: 2024-04-21 11:19+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -707,7 +707,7 @@ msgid "--target can only be used with clusters"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:822 cmd/incus/info.go:568
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -1010,7 +1010,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463
+#: cmd/incus/info.go:591
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -1131,7 +1132,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1187,11 +1188,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1211,27 +1212,25 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:458
-#, fuzzy, c-format
-msgid "CPU (%s):"
-msgstr " Использование ЦП:"
-
 #: cmd/incus/list.go:588
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
 
-#: cmd/incus/info.go:461
-#, c-format
-msgid "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid "CPU:"
+msgstr ""
+
+#: cmd/incus/info.go:462
+msgid "CPUs:"
 msgstr ""
 
 #: cmd/incus/operation.go:176
@@ -1354,7 +1353,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1871,7 +1870,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -2240,7 +2239,7 @@ msgstr "Копирование образа: %s"
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr " Использование диска:"
@@ -2321,22 +2320,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 #, fuzzy
 msgid "Disk:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 #, fuzzy
 msgid "Disks:"
 msgstr " Использование диска:"
@@ -2689,7 +2688,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3225,8 +3224,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3245,11 +3244,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid "GPUs:"
 msgstr ""
 
@@ -3437,12 +3436,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3488,7 +3487,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 msgid "IP addresses"
 msgstr ""
 
@@ -3664,7 +3663,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
@@ -3889,7 +3888,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
@@ -4295,7 +4294,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4304,7 +4303,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid "Log:"
 msgstr ""
 
@@ -4343,7 +4342,7 @@ msgstr "Копирование образа: %s"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 msgid "MAC address"
 msgstr ""
 
@@ -4386,7 +4385,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid "MTU"
 msgstr ""
 
@@ -4650,20 +4649,20 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 #, fuzzy
 msgid "Memory:"
 msgstr " Использование памяти:"
@@ -5009,11 +5008,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "NICs:"
 msgstr ""
 
@@ -5029,7 +5028,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5042,7 +5041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5108,7 +5107,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929
+#: cmd/incus/info.go:577 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -5229,7 +5228,7 @@ msgstr ""
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -5317,7 +5316,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5374,7 +5373,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5399,7 +5398,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5433,11 +5432,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5549,7 +5548,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6097,7 +6096,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid "Resources:"
 msgstr ""
 
@@ -6860,11 +6859,11 @@ msgstr "Копирование образа: %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6897,7 +6896,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
@@ -6907,11 +6906,11 @@ msgstr "Авто-обновление: %s"
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7041,11 +7040,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7082,7 +7081,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7417,8 +7416,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492
+#: cmd/incus/info.go:498
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7472,7 +7471,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 msgid "Type"
 msgstr ""
 
@@ -7492,13 +7491,13 @@ msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
+#: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7519,12 +7518,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 #, fuzzy
 msgid "USB device:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 #, fuzzy
 msgid "USB devices:"
 msgstr "Копирование образа: %s"
@@ -7761,7 +7760,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7809,8 +7808,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -9729,6 +9728,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "да"
+
+#, fuzzy, c-format
+#~ msgid "CPU (%s):"
+#~ msgstr " Использование ЦП:"
 
 #, fuzzy, c-format
 #~ msgid "Usb %d:"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-20 14:44-0400\n"
+"POT-Creation-Date: 2024-04-21 11:19+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -659,7 +659,7 @@ msgid "--target can only be used with clusters"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:566
+#: cmd/incus/config.go:822 cmd/incus/info.go:568
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -942,7 +942,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:589
+#: cmd/incus/image.go:999 cmd/incus/info.go:459 cmd/incus/info.go:463
+#: cmd/incus/info.go:591
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1060,7 +1061,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1116,11 +1117,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:680 cmd/incus/network.go:947
+#: cmd/incus/info.go:682 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:681 cmd/incus/network.go:948
+#: cmd/incus/info.go:683 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr ""
 
@@ -1140,26 +1141,24 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/info.go:458
-#, c-format
-msgid "CPU (%s):"
-msgstr ""
-
 #: cmd/incus/list.go:588
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:630
+#: cmd/incus/info.go:632
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:634
+#: cmd/incus/info.go:636
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:461
-#, c-format
-msgid "CPUs (%s):"
+#: cmd/incus/info.go:458
+msgid "CPU:"
+msgstr ""
+
+#: cmd/incus/info.go:462
+msgid "CPUs:"
 msgstr ""
 
 #: cmd/incus/operation.go:176
@@ -1281,7 +1280,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:505 cmd/incus/info.go:517
+#: cmd/incus/info.go:507 cmd/incus/info.go:519
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1778,7 +1777,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:600
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602
 #: cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Created: %s"
@@ -2132,7 +2131,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:541
+#: cmd/incus/info.go:543
 #, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2213,20 +2212,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:529
+#: cmd/incus/info.go:531
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:623
+#: cmd/incus/info.go:625
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:526
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:527
+#: cmd/incus/info.go:529
 msgid "Disks:"
 msgstr ""
 
@@ -2563,7 +2562,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3091,8 +3090,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:472 cmd/incus/info.go:483 cmd/incus/info.go:488
-#: cmd/incus/info.go:494
+#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
+#: cmd/incus/info.go:496
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3111,11 +3110,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:500
+#: cmd/incus/info.go:502
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:505
 msgid "GPUs:"
 msgstr ""
 
@@ -3285,11 +3284,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:671
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:471 cmd/incus/info.go:482
+#: cmd/incus/info.go:473 cmd/incus/info.go:484
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3335,7 +3334,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:685
+#: cmd/incus/info.go:687
 msgid "IP addresses"
 msgstr ""
 
@@ -3505,7 +3504,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:795
+#: cmd/incus/info.go:797
 msgid "Instance Only"
 msgstr ""
 
@@ -3724,7 +3723,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:604
+#: cmd/incus/info.go:606
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4111,7 +4110,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:592 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4120,7 +4119,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:823
+#: cmd/incus/info.go:825
 msgid "Log:"
 msgstr ""
 
@@ -4157,7 +4156,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:673
+#: cmd/incus/info.go:675
 msgid "MAC address"
 msgstr ""
 
@@ -4200,7 +4199,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:677
+#: cmd/incus/info.go:679
 msgid "MTU"
 msgstr ""
 
@@ -4438,19 +4437,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:641
+#: cmd/incus/info.go:643
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:645
+#: cmd/incus/info.go:647
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:657
+#: cmd/incus/info.go:659
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:471
 msgid "Memory:"
 msgstr ""
 
@@ -4777,11 +4776,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:514
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:515
+#: cmd/incus/info.go:517
 msgid "NICs:"
 msgstr ""
 
@@ -4797,7 +4796,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:480
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4810,7 +4809,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:741 cmd/incus/info.go:792 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4872,7 +4871,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:575 cmd/incus/network.go:929
+#: cmd/incus/info.go:577 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1378
 #, c-format
 msgid "Name: %s"
@@ -4992,7 +4991,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:698 cmd/incus/network.go:946
+#: cmd/incus/info.go:700 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5078,7 +5077,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:480
+#: cmd/incus/info.go:482
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5135,7 +5134,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:796 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5160,7 +5159,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:596
+#: cmd/incus/info.go:598
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5194,11 +5193,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:949
+#: cmd/incus/info.go:684 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:950
+#: cmd/incus/info.go:685 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5309,7 +5308,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:610
+#: cmd/incus/info.go:612
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5841,7 +5840,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:608
+#: cmd/incus/info.go:610
 msgid "Resources:"
 msgstr ""
 
@@ -6561,11 +6560,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:710 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:463
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6598,7 +6597,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:667
+#: cmd/incus/info.go:669
 msgid "State"
 msgstr ""
 
@@ -6607,11 +6606,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:577
+#: cmd/incus/info.go:579
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6737,11 +6736,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:649
+#: cmd/incus/info.go:651
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:653
+#: cmd/incus/info.go:655
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6778,7 +6777,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:742 cmd/incus/info.go:793 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7112,8 +7111,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:474 cmd/incus/info.go:485 cmd/incus/info.go:490
-#: cmd/incus/info.go:496
+#: cmd/incus/info.go:476 cmd/incus/info.go:487 cmd/incus/info.go:492
+#: cmd/incus/info.go:498
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7167,7 +7166,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:668
 msgid "Type"
 msgstr ""
 
@@ -7186,13 +7185,13 @@ msgid "Type of peer (local or remote)"
 msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:586 cmd/incus/network.go:933
+#: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1387
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:584
+#: cmd/incus/info.go:586
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7213,11 +7212,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:538
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:539
+#: cmd/incus/info.go:541
 msgid "USB devices:"
 msgstr ""
 
@@ -7431,7 +7430,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:815
+#: cmd/incus/info.go:817
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7477,8 +7476,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:473 cmd/incus/info.go:484 cmd/incus/info.go:489
-#: cmd/incus/info.go:495
+#: cmd/incus/info.go:475 cmd/incus/info.go:486 cmd/incus/info.go:491
+#: cmd/incus/info.go:497
 #, c-format
 msgid "Used: %v"
 msgstr ""


### PR DESCRIPTION
Added a new line for CPU architecture when the client runs incus info --resources

the previous version of this file already has the architecture flag displayed in the terminal, but we just moved it to a separate line for readability

Closes: #703 