### PR TITLE
incus/network_acl: Add cmd.Example for network acl create

### DIFF
--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -360,6 +360,10 @@ func (c *cmdNetworkACLCreate) Command() *cobra.Command {
 	cmd.Use = usage("create", i18n.G("[<remote>:]<ACL> [key=value...]"))
 	cmd.Short = i18n.G("Create new network ACLs")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network ACLs"))
+	cmd.Example = cli.FormatSection("", i18n.G(`incus network acl create a1
+
+incus network acl create a1 < config.yaml
+    Create network acl with configuration from config.yaml`))
 
 	cmd.RunE = c.Run
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-22 09:14+0200\n"
+"POT-Creation-Date: 2024-04-23 12:51+0200\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -235,7 +235,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -940,7 +940,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Add roles to a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1148,7 +1148,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
@@ -1204,11 +1204,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1372,7 +1372,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1586,7 +1586,7 @@ msgstr ""
 #: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
+#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
@@ -2031,7 +2031,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Delete key from a storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2158,10 +2158,10 @@ msgstr ""
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
 #: cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233
 #: cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362
-#: cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543
-#: cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725
-#: cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839
-#: cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547
+#: cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729
+#: cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843
+#: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
 #: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
@@ -2504,7 +2504,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2632,7 +2632,7 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
-#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
+#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
@@ -2654,7 +2654,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2752,7 +2752,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3507,7 +3507,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3558,7 +3558,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
@@ -3736,7 +3736,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 msgid "Instance Only"
 msgstr ""
 
@@ -4396,7 +4396,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid "Log:"
 msgstr ""
 
@@ -4435,7 +4435,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
@@ -4483,7 +4483,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid "MTU"
 msgstr ""
 
@@ -4590,7 +4590,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Manage instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4866,10 +4866,10 @@ msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
 
 #: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262
-#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393
-#: cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644
-#: cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812
-#: cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648
+#: cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5079,7 +5079,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5251,17 +5251,17 @@ msgstr "Profil %s erstellt\n"
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Profil %s erstellt\n"
@@ -5341,7 +5341,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5488,7 +5488,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5547,11 +5547,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5639,7 +5639,7 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
-#: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
+#: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
@@ -6078,7 +6078,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -6131,7 +6131,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6168,7 +6168,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Rename instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6512,12 +6512,12 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6720,7 +6720,7 @@ msgstr "Setzt die uid der Datei beim Übertragen"
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7017,7 +7017,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
@@ -7055,7 +7055,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
@@ -7065,7 +7065,7 @@ msgstr "Erstellt: %s"
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
@@ -7243,7 +7243,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7319,7 +7319,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7640,7 +7640,7 @@ msgstr "Administrator Passwort für %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 msgid "Type"
 msgstr ""
 
@@ -7755,7 +7755,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, fuzzy, c-format
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -7789,7 +7789,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -7870,7 +7870,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -7936,7 +7936,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8329,7 +8329,7 @@ msgstr ""
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231
-#: cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -8337,7 +8337,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -8345,7 +8345,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -8353,7 +8353,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -8361,7 +8361,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -9745,6 +9745,14 @@ msgstr ""
 "Verschiebt Container innerhalb einer oder zwischen lxd Instanzen\n"
 "\n"
 "lxc move <Quelle> <Ziel>\n"
+
+#: cmd/incus/network_acl.go:363
+msgid ""
+"incus network acl create a1\n"
+"\n"
+"incus network acl create a1 < config.yaml\n"
+"    Create network acl with configuration from config.yaml"
+msgstr ""
 
 #: cmd/incus/network.go:322
 msgid ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-22 09:14+0200\n"
+"POT-Creation-Date: 2024-04-23 12:51+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -241,7 +241,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -1107,7 +1107,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1116,7 +1116,7 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
@@ -1164,11 +1164,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 #: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
+#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
@@ -1963,7 +1963,7 @@ msgstr "Eliminar imágenes"
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2088,10 +2088,10 @@ msgstr ""
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
 #: cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233
 #: cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362
-#: cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543
-#: cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725
-#: cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839
-#: cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547
+#: cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729
+#: cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843
+#: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
 #: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
@@ -2415,7 +2415,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2539,7 +2539,7 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
-#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
+#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
@@ -2561,7 +2561,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2651,7 +2651,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 #, fuzzy
@@ -3395,7 +3395,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
@@ -3622,7 +3622,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
@@ -4258,7 +4258,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid "Log:"
 msgstr "Registro:"
 
@@ -4295,7 +4295,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
@@ -4339,7 +4339,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid "MTU"
 msgstr ""
 
@@ -4436,7 +4436,7 @@ msgstr ""
 msgid "Manage instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -4701,10 +4701,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262
-#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393
-#: cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644
-#: cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812
-#: cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648
+#: cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nombre del contenedor es: %s"
@@ -4908,7 +4908,7 @@ msgstr ""
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4982,7 +4982,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5075,17 +5075,17 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -5164,7 +5164,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5221,7 +5221,7 @@ msgstr ""
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5307,7 +5307,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5366,11 +5366,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5456,7 +5456,7 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
-#: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
+#: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
@@ -5888,7 +5888,7 @@ msgstr ""
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -5937,7 +5937,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5973,7 +5973,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Rename instances"
 msgstr "Aliases:"
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6300,11 +6300,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6501,7 +6501,7 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -6784,7 +6784,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
@@ -6821,7 +6821,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
@@ -6831,7 +6831,7 @@ msgstr "Auto actualización: %s"
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
@@ -7003,7 +7003,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7077,7 +7077,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7393,7 +7393,7 @@ msgstr "Contraseña admin para %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
@@ -7506,7 +7506,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7537,7 +7537,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -7615,7 +7615,7 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -7679,7 +7679,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8028,27 +8028,27 @@ msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231
-#: cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8984,6 +8984,14 @@ msgid ""
 "\n"
 "incus move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    Rename a snapshot."
+msgstr ""
+
+#: cmd/incus/network_acl.go:363
+msgid ""
+"incus network acl create a1\n"
+"\n"
+"incus network acl create a1 < config.yaml\n"
+"    Create network acl with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/network.go:322

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-22 09:14+0200\n"
+"POT-Creation-Date: 2024-04-23 12:51+0200\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -231,7 +231,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -928,7 +928,7 @@ msgstr "Ajouter des profils aux instances"
 msgid "Add roles to a cluster member"
 msgstr "Ajoutez des roles à un membre d'un cluster"
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 msgid "Add rules to an ACL"
 msgstr "Ajoutez des règles à une liste de contrôle d'accès (ACL)"
 
@@ -1137,7 +1137,7 @@ msgstr "Sauvegarder le volume de stockage : %s"
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1148,7 +1148,7 @@ msgstr ""
 "Mauvais appareil remplacez la syntaxe, syntaxe attendue <appareil>,"
 "<clé>=<valeur>: %s"
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
@@ -1195,11 +1195,11 @@ msgstr "Pont:"
 msgid "Bus Address: %v"
 msgstr "Addresse : %s"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1366,7 +1366,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "Impossible d'assigner les clés: %s"
@@ -1585,7 +1585,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
+#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
@@ -2067,7 +2067,7 @@ msgstr "Création du conteneur"
 msgid "Delete key from a storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 msgid "Delete network ACLs"
 msgstr "Supprimer les ACLs réseau"
 
@@ -2196,10 +2196,10 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
 #: cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233
 #: cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362
-#: cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543
-#: cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725
-#: cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839
-#: cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547
+#: cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729
+#: cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843
+#: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
 #: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
@@ -2539,7 +2539,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2681,7 +2681,7 @@ msgid "Error retrieving aliases: %w"
 msgstr "Erreur lors de la récupération des alias : %w"
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
-#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
+#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
@@ -2703,7 +2703,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Erreur lors du déparamétrage des propriétés: %v"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2847,7 +2847,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 #, fuzzy
@@ -3653,7 +3653,7 @@ msgstr "ADRESSE MATÉRIEL"
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3705,7 +3705,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "ADRESSE IP"
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
@@ -3903,7 +3903,7 @@ msgstr "Infiniband :"
 msgid "Input data"
 msgstr "Données d'entrée"
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
@@ -4615,7 +4615,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid "Log:"
 msgstr "Journal :"
 
@@ -4654,7 +4654,7 @@ msgstr "Création du conteneur"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
@@ -4698,7 +4698,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid "MTU"
 msgstr ""
 
@@ -4803,7 +4803,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Manage instance snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Copie de l'image : %s"
@@ -5079,10 +5079,10 @@ msgid "Missing name"
 msgstr "Résumé manquant."
 
 #: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262
-#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393
-#: cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644
-#: cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812
-#: cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648
+#: cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nom du réseau"
@@ -5296,7 +5296,7 @@ msgstr "Copie de l'image : %s"
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5371,7 +5371,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 #, fuzzy
@@ -5469,17 +5469,17 @@ msgstr "Le réseau %s a été créé"
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, fuzzy, c-format
 msgid "Network ACL %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, fuzzy, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "Le réseau %s a été créé"
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
@@ -5619,7 +5619,7 @@ msgstr ""
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5715,7 +5715,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5775,11 +5775,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -5867,7 +5867,7 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
-#: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
+#: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
@@ -6310,7 +6310,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -6363,7 +6363,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Création du conteneur"
@@ -6401,7 +6401,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Rename instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6755,12 +6755,12 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6965,7 +6965,7 @@ msgstr "Définir l'uid du fichier lors de l'envoi"
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -7268,7 +7268,7 @@ msgstr "Copie de l'image : %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -7306,7 +7306,7 @@ msgstr "Démarrage de %s"
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
@@ -7316,7 +7316,7 @@ msgstr "État : %s"
 msgid "State: %s"
 msgstr "État : %s"
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
@@ -7496,7 +7496,7 @@ msgstr ""
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 #, fuzzy
 msgid "Taken at"
@@ -7572,7 +7572,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7904,7 +7904,7 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
@@ -8020,7 +8020,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -8054,7 +8054,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Clé de configuration invalide"
@@ -8138,7 +8138,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -8204,7 +8204,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8570,23 +8570,23 @@ msgid "[<remote>:] [<filters>...]"
 msgstr "[<serveur distant>:] [<filtres>...]"
 
 #: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231
-#: cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 msgid "[<remote>:]<ACL>"
 msgstr "[<serveur distant>:]<ACL>"
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<serveur distant>:]<ACL> <direction> <clé=valeur>..."
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<serveur distant>:] <ACL> <clé>"
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<serveur distant>:]<ACL> <clé>=<valeur>"
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -10097,6 +10097,14 @@ msgstr ""
 "\n"
 "lxc move <container>/<old snapshot name> <container>/<new snapshot name>\n"
 "    Renomme un instantané."
+
+#: cmd/incus/network_acl.go:363
+msgid ""
+"incus network acl create a1\n"
+"\n"
+"incus network acl create a1 < config.yaml\n"
+"    Create network acl with configuration from config.yaml"
+msgstr ""
 
 #: cmd/incus/network.go:322
 msgid ""

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-04-22 09:14+0200\n"
+        "POT-Creation-Date: 2024-04-23 12:51+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -133,7 +133,7 @@ msgid   "### This is a YAML representation of the instance metadata.\n"
         "###     properties: {}"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 msgid   "### This is a YAML representation of the network ACL.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -621,7 +621,7 @@ msgstr  ""
 msgid   "Add roles to a cluster member"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 msgid   "Add rules to an ACL"
 msgstr  ""
 
@@ -812,7 +812,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid   "Backups:"
 msgstr  ""
 
@@ -821,7 +821,7 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425 cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378 cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378 cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -863,11 +863,11 @@ msgstr  ""
 msgid   "Bus Address: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid   "Bytes received"
 msgstr  ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -1017,7 +1017,7 @@ msgstr  ""
 msgid   "Cannot set --volume-only when copying a snapshot"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid   "Cannot set key: %s"
 msgstr  ""
@@ -1178,7 +1178,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692 cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288 cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324 cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288 cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324 cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1567,7 +1567,7 @@ msgstr  ""
 msgid   "Delete key from a storage bucket"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 msgid   "Delete network ACLs"
 msgstr  ""
 
@@ -1627,7 +1627,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:30 cmd/incus/cluster.go:123 cmd/incus/cluster.go:215 cmd/incus/cluster.go:272 cmd/incus/cluster.go:331 cmd/incus/cluster.go:404 cmd/incus/cluster.go:484 cmd/incus/cluster.go:528 cmd/incus/cluster.go:586 cmd/incus/cluster.go:677 cmd/incus/cluster.go:770 cmd/incus/cluster.go:891 cmd/incus/cluster.go:963 cmd/incus/cluster.go:1073 cmd/incus/cluster.go:1161 cmd/incus/cluster.go:1285 cmd/incus/cluster.go:1314 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:117 cmd/incus/config_template.go:171 cmd/incus/config_template.go:271 cmd/incus/config_template.go:339 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543 cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725 cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839 cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348 cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543 cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154 cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323 cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454 cmd/incus/network_integration.go:508 cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:622 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:351 cmd/incus/network_load_balancer.go:419 cmd/incus/network_load_balancer.go:529 cmd/incus/network_load_balancer.go:559 cmd/incus/network_load_balancer.go:714 cmd/incus/network_load_balancer.go:787 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:878 cmd/incus/network_load_balancer.go:976 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408 cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857 cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433 cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:434 cmd/incus/profile.go:492 cmd/incus/profile.go:628 cmd/incus/profile.go:702 cmd/incus/profile.go:771 cmd/incus/profile.go:859 cmd/incus/profile.go:919 cmd/incus/profile.go:1008 cmd/incus/profile.go:1072 cmd/incus/project.go:30 cmd/incus/project.go:94 cmd/incus/project.go:190 cmd/incus/project.go:261 cmd/incus/project.go:397 cmd/incus/project.go:471 cmd/incus/project.go:591 cmd/incus/project.go:656 cmd/incus/project.go:744 cmd/incus/project.go:788 cmd/incus/project.go:849 cmd/incus/project.go:916 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:201 cmd/incus/storage.go:259 cmd/incus/storage.go:391 cmd/incus/storage.go:473 cmd/incus/storage.go:653 cmd/incus/storage.go:740 cmd/incus/storage.go:844 cmd/incus/storage.go:938 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:30 cmd/incus/cluster.go:123 cmd/incus/cluster.go:215 cmd/incus/cluster.go:272 cmd/incus/cluster.go:331 cmd/incus/cluster.go:404 cmd/incus/cluster.go:484 cmd/incus/cluster.go:528 cmd/incus/cluster.go:586 cmd/incus/cluster.go:677 cmd/incus/cluster.go:770 cmd/incus/cluster.go:891 cmd/incus/cluster.go:963 cmd/incus/cluster.go:1073 cmd/incus/cluster.go:1161 cmd/incus/cluster.go:1285 cmd/incus/cluster.go:1314 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:117 cmd/incus/config_template.go:171 cmd/incus/config_template.go:271 cmd/incus/config_template.go:339 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348 cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543 cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154 cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323 cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454 cmd/incus/network_integration.go:508 cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:622 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:351 cmd/incus/network_load_balancer.go:419 cmd/incus/network_load_balancer.go:529 cmd/incus/network_load_balancer.go:559 cmd/incus/network_load_balancer.go:714 cmd/incus/network_load_balancer.go:787 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:878 cmd/incus/network_load_balancer.go:976 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408 cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857 cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433 cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:434 cmd/incus/profile.go:492 cmd/incus/profile.go:628 cmd/incus/profile.go:702 cmd/incus/profile.go:771 cmd/incus/profile.go:859 cmd/incus/profile.go:919 cmd/incus/profile.go:1008 cmd/incus/profile.go:1072 cmd/incus/project.go:30 cmd/incus/project.go:94 cmd/incus/project.go:190 cmd/incus/project.go:261 cmd/incus/project.go:397 cmd/incus/project.go:471 cmd/incus/project.go:591 cmd/incus/project.go:656 cmd/incus/project.go:744 cmd/incus/project.go:788 cmd/incus/project.go:849 cmd/incus/project.go:916 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:201 cmd/incus/storage.go:259 cmd/incus/storage.go:391 cmd/incus/storage.go:473 cmd/incus/storage.go:653 cmd/incus/storage.go:740 cmd/incus/storage.go:844 cmd/incus/storage.go:938 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1850,7 +1850,7 @@ msgstr  ""
 msgid   "Edit instance or server configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 msgid   "Edit network ACL configurations as YAML"
 msgstr  ""
 
@@ -1962,7 +1962,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:518 cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563 cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155 cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
+#: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563 cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155 cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1977,7 +1977,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:453 cmd/incus/network.go:1319 cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510 cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465 cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980 cmd/incus/project.go:713 cmd/incus/storage.go:804 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
+#: cmd/incus/cluster.go:453 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510 cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465 cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980 cmd/incus/project.go:713 cmd/incus/storage.go:804 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2056,7 +2056,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366 cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490 cmd/incus/storage_volume.go:2575
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366 cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490 cmd/incus/storage_volume.go:2575
 msgid   "Expires at"
 msgstr  ""
 
@@ -2750,7 +2750,7 @@ msgstr  ""
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 msgid   "Host interface"
 msgstr  ""
 
@@ -2800,7 +2800,7 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 msgid   "IP addresses"
 msgstr  ""
 
@@ -2967,7 +2967,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 msgid   "Instance Only"
 msgstr  ""
 
@@ -3559,7 +3559,7 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid   "Log:"
 msgstr  ""
 
@@ -3596,7 +3596,7 @@ msgstr  ""
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 msgid   "MAC address"
 msgstr  ""
 
@@ -3639,7 +3639,7 @@ msgstr  ""
 msgid   "MII state"
 msgstr  ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid   "MTU"
 msgstr  ""
 
@@ -3730,7 +3730,7 @@ msgstr  ""
 msgid   "Manage instance snapshots"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 msgid   "Manage network ACL rules"
 msgstr  ""
 
@@ -3940,7 +3940,7 @@ msgstr  ""
 msgid   "Missing name"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262 cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393 cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644 cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812 cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262 cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397 cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648 cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816 cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 msgid   "Missing network ACL name"
 msgstr  ""
 
@@ -4072,7 +4072,7 @@ msgstr  ""
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
@@ -4135,7 +4135,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364 cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488 cmd/incus/storage_volume.go:2573
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364 cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488 cmd/incus/storage_volume.go:2573
 msgid   "Name"
 msgstr  ""
 
@@ -4224,17 +4224,17 @@ msgstr  ""
 msgid   "Network %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, c-format
 msgid   "Network ACL %s created"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, c-format
 msgid   "Network ACL %s deleted"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, c-format
 msgid   "Network ACL %s renamed to %s"
 msgstr  ""
@@ -4312,7 +4312,7 @@ msgstr  ""
 msgid   "Network type"
 msgstr  ""
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 msgid   "Network usage:"
 msgstr  ""
 
@@ -4369,7 +4369,7 @@ msgstr  ""
 msgid   "No matching port(s) found"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid   "No matching rule(s) found"
 msgstr  ""
 
@@ -4452,7 +4452,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4510,11 +4510,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid   "Packets received"
 msgstr  ""
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid   "Packets sent"
 msgstr  ""
 
@@ -4595,7 +4595,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:860 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:693 cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289 cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325 cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/cluster.go:860 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289 cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325 cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4988,7 +4988,7 @@ msgstr  ""
 msgid   "Remove all ports that match"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid   "Remove all rules that match"
 msgstr  ""
 
@@ -5032,7 +5032,7 @@ msgstr  ""
 msgid   "Remove roles from a cluster member"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 msgid   "Remove rules from an ACL"
 msgstr  ""
 
@@ -5065,7 +5065,7 @@ msgstr  ""
 msgid   "Rename instances"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 msgid   "Rename network ACLs"
 msgstr  ""
 
@@ -5372,11 +5372,11 @@ msgid   "Set instance or server configuration keys\n"
         "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 msgid   "Set network ACL configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 msgid   "Set network ACL configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5540,7 +5540,7 @@ msgstr  ""
 msgid   "Set the key as a cluster property"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid   "Set the key as a network ACL property"
 msgstr  ""
 
@@ -5802,7 +5802,7 @@ msgstr  ""
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -5837,7 +5837,7 @@ msgstr  ""
 msgid   "Starting recovery..."
 msgstr  ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 msgid   "State"
 msgstr  ""
 
@@ -5846,7 +5846,7 @@ msgstr  ""
 msgid   "State: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 msgid   "Stateful"
 msgstr  ""
 
@@ -6011,7 +6011,7 @@ msgstr  ""
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365 cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365 cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid   "Taken at"
 msgstr  ""
 
@@ -6074,7 +6074,7 @@ msgstr  ""
 msgid   "The device already exists"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid   "The direction argument must be one of: ingress, egress"
 msgstr  ""
 
@@ -6374,7 +6374,7 @@ msgstr  ""
 msgid   "Try `incus info --show-log %s` for more info"
 msgstr  ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 msgid   "Type"
 msgstr  ""
 
@@ -6475,7 +6475,7 @@ msgstr  ""
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, c-format
 msgid   "Unknown key: %s"
 msgstr  ""
@@ -6505,7 +6505,7 @@ msgstr  ""
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 msgid   "Unset network ACL configuration keys"
 msgstr  ""
 
@@ -6573,7 +6573,7 @@ msgstr  ""
 msgid   "Unset the key as a cluster property"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid   "Unset the key as a network ACL property"
 msgstr  ""
 
@@ -6629,7 +6629,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
@@ -6942,23 +6942,23 @@ msgstr  ""
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231 cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231 cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 msgid   "[<remote>:]<ACL>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 msgid   "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 msgid   "[<remote>:]<ACL> <key>"
 msgstr  ""
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 msgid   "[<remote>:]<ACL> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 msgid   "[<remote>:]<ACL> <new-name>"
 msgstr  ""
 
@@ -7689,6 +7689,13 @@ msgid   "incus move [<remote>:]<source instance> [<remote>:][<destination instan
         "\n"
         "incus move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
         "    Rename a snapshot."
+msgstr  ""
+
+#: cmd/incus/network_acl.go:363
+msgid   "incus network acl create a1\n"
+        "\n"
+        "incus network acl create a1 < config.yaml\n"
+        "    Create network acl with configuration from config.yaml"
 msgstr  ""
 
 #: cmd/incus/network.go:322

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-22 09:14+0200\n"
+"POT-Creation-Date: 2024-04-23 12:51+0200\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -242,7 +242,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -908,7 +908,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -1106,7 +1106,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1115,7 +1115,7 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
@@ -1162,11 +1162,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgstr ""
 #: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
+#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
@@ -1957,7 +1957,7 @@ msgstr "Creazione del container in corso"
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2081,10 +2081,10 @@ msgstr ""
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
 #: cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233
 #: cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362
-#: cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543
-#: cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725
-#: cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839
-#: cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547
+#: cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729
+#: cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843
+#: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
 #: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2533,7 +2533,7 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
-#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
+#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
@@ -2555,7 +2555,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2645,7 +2645,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3386,7 +3386,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
@@ -3437,7 +3437,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 msgid "IP addresses"
 msgstr ""
 
@@ -3611,7 +3611,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
@@ -4248,7 +4248,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid "Log:"
 msgstr ""
 
@@ -4287,7 +4287,7 @@ msgstr "Creazione del container in corso"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 msgid "MAC address"
 msgstr ""
 
@@ -4330,7 +4330,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid "MTU"
 msgstr ""
 
@@ -4430,7 +4430,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -4695,10 +4695,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262
-#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393
-#: cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644
-#: cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812
-#: cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648
+#: cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Il nome del container è: %s"
@@ -4902,7 +4902,7 @@ msgstr ""
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4976,7 +4976,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5069,17 +5069,17 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5215,7 +5215,7 @@ msgstr ""
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5301,7 +5301,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5360,11 +5360,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5451,7 +5451,7 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
-#: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
+#: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
@@ -5882,7 +5882,7 @@ msgstr ""
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -5932,7 +5932,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5968,7 +5968,7 @@ msgstr "Creazione del container in corso"
 msgid "Rename instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6295,11 +6295,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6494,7 +6494,7 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -6775,7 +6775,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
@@ -6813,7 +6813,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
@@ -6823,7 +6823,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
@@ -6995,7 +6995,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 #, fuzzy
 msgid "Taken at"
@@ -7070,7 +7070,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "La periferica esiste già"
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7387,7 +7387,7 @@ msgstr "Password amministratore per %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 msgid "Type"
 msgstr ""
 
@@ -7502,7 +7502,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7534,7 +7534,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -7609,7 +7609,7 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -7670,7 +7670,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8023,27 +8023,27 @@ msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231
-#: cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Creazione del container in corso"
@@ -8979,6 +8979,14 @@ msgid ""
 "\n"
 "incus move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    Rename a snapshot."
+msgstr ""
+
+#: cmd/incus/network_acl.go:363
+msgid ""
+"incus network acl create a1\n"
+"\n"
+"incus network acl create a1 < config.yaml\n"
+"    Create network acl with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/network.go:322

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-22 09:14+0200\n"
+"POT-Creation-Date: 2024-04-23 12:51+0200\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -225,7 +225,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -907,7 +907,7 @@ msgstr "インスタンスにプロファイルを追加します"
 msgid "Add roles to a cluster member"
 msgstr "クラスターメンバーにロールを追加します"
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 msgid "Add rules to an ACL"
 msgstr "ACLにルールを追加します"
 
@@ -1108,7 +1108,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1119,7 +1119,7 @@ msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
@@ -1166,11 +1166,11 @@ msgstr "ブリッジ:"
 msgid "Bus Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "スナップショットをコピーするときに --volume-only は指定できません"
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
@@ -1547,7 +1547,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
+#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
@@ -1983,7 +1983,7 @@ msgstr "インスタンスを削除します"
 msgid "Delete key from a storage bucket"
 msgstr "ストレージバケットからキーを削除します"
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
@@ -2103,10 +2103,10 @@ msgstr "警告を削除します"
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
 #: cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233
 #: cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362
-#: cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543
-#: cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725
-#: cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839
-#: cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547
+#: cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729
+#: cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843
+#: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
 #: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
@@ -2433,7 +2433,7 @@ msgstr "インスタンスのメタデータファイルを編集します"
 msgid "Edit instance or server configurations as YAML"
 msgstr "インスタンスもしくはサーバの設定をYAMLファイルで編集します"
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 msgid "Edit network ACL configurations as YAML"
 msgstr "ネットワーク ACL をYAMLで編集します"
 
@@ -2562,7 +2562,7 @@ msgid "Error retrieving aliases: %w"
 msgstr "エイリアスの取得に失敗しました: %w"
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
-#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
+#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
@@ -2584,7 +2584,7 @@ msgid "Error unsetting properties: %v"
 msgstr "プロパティの削除でエラーが発生しました: %v"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3466,7 +3466,7 @@ msgstr "MAC ADDRESS"
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
@@ -3516,7 +3516,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 msgid "IP addresses"
 msgstr "IP アドレス"
 
@@ -3704,7 +3704,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
@@ -4505,7 +4505,7 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid "Log:"
 msgstr "ログ:"
 
@@ -4542,7 +4542,7 @@ msgstr "Lower devices"
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 msgid "MAC address"
 msgstr "MAC アドレス"
 
@@ -4585,7 +4585,7 @@ msgstr "MII 監視頻度"
 msgid "MII state"
 msgstr "MII 状態"
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid "MTU"
 msgstr "MTU"
 
@@ -4695,7 +4695,7 @@ msgstr "インスタンスのメタデータファイルを管理します"
 msgid "Manage instance snapshots"
 msgstr "インスタンスのスナップショットを作成します"
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 msgid "Manage network ACL rules"
 msgstr "ネットワーク ACL ルールを管理します"
 
@@ -4947,10 +4947,10 @@ msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
 #: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262
-#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393
-#: cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644
-#: cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812
-#: cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648
+#: cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 msgid "Missing network ACL name"
 msgstr "ネットワーク ACL 名を指定する必要があります"
 
@@ -5167,7 +5167,7 @@ msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
@@ -5242,7 +5242,7 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5339,17 +5339,17 @@ msgstr "ネットワーク %s はメンバ %s 上でペンディング状態で�
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, c-format
 msgid "Network ACL %s created"
 msgstr "ネットワーク ACL %s を作成しました"
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr "ネットワーク ACL %s を削除しました"
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr "ネットワーク ACL 名 %s を %s に変更しました"
@@ -5430,7 +5430,7 @@ msgstr ""
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -5488,7 +5488,7 @@ msgstr "マッチするバックエンドが見つかりません"
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid "No matching rule(s) found"
 msgstr "マッチするルールが見つかりません"
 
@@ -5580,7 +5580,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -5640,11 +5640,11 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -5730,7 +5730,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
-#: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
+#: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
@@ -6197,7 +6197,7 @@ msgstr "エイリアスを削除します"
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
@@ -6242,7 +6242,7 @@ msgstr "リモートサーバを削除します"
 msgid "Remove roles from a cluster member"
 msgstr "クラスターメンバからロールを削除します"
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 msgid "Remove rules from an ACL"
 msgstr "ACL からルールを削除します"
 
@@ -6278,7 +6278,7 @@ msgstr "インスタンスまたはインスタンスのスナップショット
 msgid "Rename instances"
 msgstr "インスタンスを再起動します"
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 msgid "Rename network ACLs"
 msgstr "ネットワーク ACL 名を変更します"
 
@@ -6623,11 +6623,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config set [<remote>:][<instance>] <key> <value>"
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 msgid "Set network ACL configuration keys"
 msgstr "ネットワーク ACL の設定項目を設定します"
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 #, fuzzy
 msgid ""
 "Set network ACL configuration keys\n"
@@ -6882,7 +6882,7 @@ msgstr "プッシュ時にファイルのuidを設定します"
 msgid "Set the key as a cluster property"
 msgstr "クラスターグループを作成します"
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid "Set the key as a network ACL property"
 msgstr "ネットワーク ACL プロパティとして設定します"
 
@@ -7158,7 +7158,7 @@ msgstr "ストレージボリュームのスナップショットを取得しま
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -7197,7 +7197,7 @@ msgstr "%s を起動中"
 msgid "Starting recovery..."
 msgstr "リカバリーを開始します..."
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 msgid "State"
 msgstr "状態"
 
@@ -7206,7 +7206,7 @@ msgstr "状態"
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr "ステートフル"
 
@@ -7378,7 +7378,7 @@ msgstr "TOKEN"
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr "取得日時"
@@ -7480,7 +7480,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr "デバイスはすでに存在します"
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid "The direction argument must be one of: ingress, egress"
 msgstr "direction 引数は次のいずれかでなければなりません: ingress, egress"
 
@@ -7835,7 +7835,7 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 msgid "Type"
 msgstr "タイプ"
 
@@ -7950,7 +7950,7 @@ msgstr "未知のコンソールタイプ %q"
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, c-format
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
@@ -7980,7 +7980,7 @@ msgstr "イメージのプロパティを削除します"
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 msgid "Unset network ACL configuration keys"
 msgstr "ネットワーク ACL の設定を削除します"
 
@@ -8049,7 +8049,7 @@ msgstr "ストレージボリュームの設定を削除します"
 msgid "Unset the key as a cluster property"
 msgstr "クラスタープロパティの設定を削除します"
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid "Unset the key as a network ACL property"
 msgstr "ネットワーク ACL プロパティの設定を削除します"
 
@@ -8115,7 +8115,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr "インスタンスプロパティの設定を削除します"
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
@@ -8484,23 +8484,23 @@ msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
 #: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231
-#: cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 msgid "[<remote>:]<ACL>"
 msgstr "[<remote>:]<ACL>"
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <direction> <key>=<value>..."
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 msgid "[<remote>:]<ACL> <key>"
 msgstr "[<remote>:]<ACL> <key>"
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "[<remote>:]<ACL> <key>=<value>..."
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "[<remote>:]<ACL> <new-name>"
 
@@ -9464,6 +9464,19 @@ msgstr ""
 "\n"
 "lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    スナップショットをリネームします。"
+
+#: cmd/incus/network_acl.go:363
+#, fuzzy
+msgid ""
+"incus network acl create a1\n"
+"\n"
+"incus network acl create a1 < config.yaml\n"
+"    Create network acl with configuration from config.yaml"
+msgstr ""
+"lxc init ubuntu:22.04 u1\n"
+"\n"
+"lxc init ubuntu:22.04 u1 < config.yaml\n"
+"    config.yaml の設定を使ってインスタンスを作成します"
 
 #: cmd/incus/network.go:322
 msgid ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-22 09:14+0200\n"
+"POT-Creation-Date: 2024-04-23 12:51+0200\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -227,7 +227,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -919,7 +919,7 @@ msgstr "Voeg profielen (profiles) toe aan instanties (instances)"
 msgid "Add roles to a cluster member"
 msgstr "Voeg rollen (roles) toe aan een clusterlid (cluster member)"
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 msgid "Add rules to an ACL"
 msgstr ""
 "Voeg regels (rules) toe aan een toegangscontrole lijst (Access Control List "
@@ -1127,7 +1127,7 @@ msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1136,7 +1136,7 @@ msgstr "Backups:"
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
@@ -1183,11 +1183,11 @@ msgstr "Brug (Bridge):"
 msgid "Bus Address: %v"
 msgstr "Adres: %s"
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes ontvangen (received)"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes verzonden"
 
@@ -1344,7 +1344,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1549,7 +1549,7 @@ msgstr ""
 #: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
+#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
@@ -1964,7 +1964,7 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2084,10 +2084,10 @@ msgstr ""
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
 #: cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233
 #: cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362
-#: cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543
-#: cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725
-#: cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839
-#: cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547
+#: cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729
+#: cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843
+#: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
 #: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
@@ -2404,7 +2404,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2522,7 +2522,7 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
-#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
+#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
@@ -2544,7 +2544,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2633,7 +2633,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3357,7 +3357,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 msgid "Host interface"
 msgstr ""
 
@@ -3407,7 +3407,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 msgid "IP addresses"
 msgstr ""
 
@@ -3577,7 +3577,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 msgid "Instance Only"
 msgstr ""
 
@@ -4193,7 +4193,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid "Log:"
 msgstr ""
 
@@ -4230,7 +4230,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 msgid "MAC address"
 msgstr ""
 
@@ -4273,7 +4273,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid "MTU"
 msgstr ""
 
@@ -4367,7 +4367,7 @@ msgstr ""
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -4614,10 +4614,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262
-#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393
-#: cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644
-#: cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812
-#: cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648
+#: cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -4811,7 +4811,7 @@ msgstr ""
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4885,7 +4885,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4978,17 +4978,17 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -5067,7 +5067,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5124,7 +5124,7 @@ msgstr ""
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5210,7 +5210,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5269,11 +5269,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5358,7 +5358,7 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
-#: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
+#: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
@@ -5782,7 +5782,7 @@ msgstr ""
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -5827,7 +5827,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5861,7 +5861,7 @@ msgstr ""
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6179,11 +6179,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6374,7 +6374,7 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -6640,7 +6640,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
@@ -6677,7 +6677,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 msgid "State"
 msgstr ""
 
@@ -6686,7 +6686,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
@@ -6857,7 +6857,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -6931,7 +6931,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7246,7 +7246,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 msgid "Type"
 msgstr ""
 
@@ -7356,7 +7356,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7386,7 +7386,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -7454,7 +7454,7 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -7510,7 +7510,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7847,23 +7847,23 @@ msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
 #: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231
-#: cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
@@ -8665,6 +8665,14 @@ msgid ""
 "\n"
 "incus move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    Rename a snapshot."
+msgstr ""
+
+#: cmd/incus/network_acl.go:363
+msgid ""
+"incus network acl create a1\n"
+"\n"
+"incus network acl create a1 < config.yaml\n"
+"    Create network acl with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/network.go:322

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-22 09:14+0200\n"
+"POT-Creation-Date: 2024-04-23 12:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -141,7 +141,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -653,7 +653,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -849,7 +849,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
@@ -905,11 +905,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr ""
 
@@ -1063,7 +1063,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1268,7 +1268,7 @@ msgstr ""
 #: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
+#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
@@ -1682,7 +1682,7 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -1801,10 +1801,10 @@ msgstr ""
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
 #: cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233
 #: cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362
-#: cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543
-#: cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725
-#: cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839
-#: cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547
+#: cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729
+#: cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843
+#: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
 #: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
@@ -2121,7 +2121,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2239,7 +2239,7 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
-#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
+#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
@@ -2261,7 +2261,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2350,7 +2350,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 msgid "Host interface"
 msgstr ""
 
@@ -3122,7 +3122,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 msgid "IP addresses"
 msgstr ""
 
@@ -3292,7 +3292,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 msgid "Instance Only"
 msgstr ""
 
@@ -3907,7 +3907,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid "Log:"
 msgstr ""
 
@@ -3944,7 +3944,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 msgid "MAC address"
 msgstr ""
 
@@ -3987,7 +3987,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid "MTU"
 msgstr ""
 
@@ -4081,7 +4081,7 @@ msgstr ""
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -4327,10 +4327,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262
-#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393
-#: cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644
-#: cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812
-#: cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648
+#: cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -4523,7 +4523,7 @@ msgstr ""
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4597,7 +4597,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4690,17 +4690,17 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -4779,7 +4779,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -4836,7 +4836,7 @@ msgstr ""
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -4922,7 +4922,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4981,11 +4981,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5070,7 +5070,7 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
-#: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
+#: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
@@ -5494,7 +5494,7 @@ msgstr ""
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -5539,7 +5539,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5573,7 +5573,7 @@ msgstr ""
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -5890,11 +5890,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6084,7 +6084,7 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -6348,7 +6348,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
@@ -6385,7 +6385,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 msgid "State"
 msgstr ""
 
@@ -6394,7 +6394,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
@@ -6565,7 +6565,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -6639,7 +6639,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -6954,7 +6954,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 msgid "Type"
 msgstr ""
 
@@ -7064,7 +7064,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7094,7 +7094,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -7162,7 +7162,7 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -7218,7 +7218,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7555,23 +7555,23 @@ msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
 #: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231
-#: cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
@@ -8373,6 +8373,14 @@ msgid ""
 "\n"
 "incus move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    Rename a snapshot."
+msgstr ""
+
+#: cmd/incus/network_acl.go:363
+msgid ""
+"incus network acl create a1\n"
+"\n"
+"incus network acl create a1 < config.yaml\n"
+"    Create network acl with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/network.go:322

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-22 09:14+0200\n"
+"POT-Creation-Date: 2024-04-23 12:51+0200\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -228,7 +228,7 @@ msgstr ""
 "###     template: template.tpl\n"
 "###     properties: {}"
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -911,7 +911,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Add roles to a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 #, fuzzy
 msgid "Add rules to an ACL"
 msgstr "Adicionar perfis aos containers"
@@ -1117,7 +1117,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1126,7 +1126,7 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
@@ -1173,11 +1173,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1552,7 +1552,7 @@ msgstr ""
 #: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
+#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
@@ -1992,7 +1992,7 @@ msgstr "Editar arquivos no container"
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 #, fuzzy
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
@@ -2120,10 +2120,10 @@ msgstr ""
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
 #: cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233
 #: cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362
-#: cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543
-#: cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725
-#: cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839
-#: cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547
+#: cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729
+#: cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843
+#: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
 #: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
@@ -2454,7 +2454,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Edit instance or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 #, fuzzy
 msgid "Edit network ACL configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2582,7 +2582,7 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
-#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
+#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
@@ -2604,7 +2604,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2694,7 +2694,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3441,7 +3441,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 msgid "Host interface"
 msgstr ""
 
@@ -3491,7 +3491,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 msgid "IP addresses"
 msgstr ""
 
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 msgid "Instance Only"
 msgstr ""
 
@@ -4297,7 +4297,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid "Log:"
 msgstr ""
 
@@ -4336,7 +4336,7 @@ msgstr "Editar arquivos no container"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 msgid "MAC address"
 msgstr ""
 
@@ -4379,7 +4379,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid "MTU"
 msgstr ""
 
@@ -4481,7 +4481,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Manage instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -4750,10 +4750,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262
-#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393
-#: cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644
-#: cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812
-#: cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648
+#: cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Nome de membro do cluster"
@@ -4957,7 +4957,7 @@ msgstr ""
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5031,7 +5031,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5124,17 +5124,17 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -5213,7 +5213,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5270,7 +5270,7 @@ msgstr ""
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5415,11 +5415,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5505,7 +5505,7 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
-#: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
+#: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
@@ -5940,7 +5940,7 @@ msgstr ""
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -5992,7 +5992,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 #, fuzzy
 msgid "Remove rules from an ACL"
 msgstr "Adicionar perfis aos containers"
@@ -6030,7 +6030,7 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "Rename instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 #, fuzzy
 msgid "Rename network ACLs"
 msgstr "Criar novas redes"
@@ -6366,12 +6366,12 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 #, fuzzy
 msgid "Set network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6569,7 +6569,7 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -6862,7 +6862,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
@@ -6899,7 +6899,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 msgid "State"
 msgstr ""
 
@@ -6908,7 +6908,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
@@ -7081,7 +7081,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7156,7 +7156,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7472,7 +7472,7 @@ msgstr "Senha de administrador para %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 msgid "Type"
 msgstr ""
 
@@ -7587,7 +7587,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7622,7 +7622,7 @@ msgstr "Editar propriedades da imagem"
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 #, fuzzy
 msgid "Unset network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -7702,7 +7702,7 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -7766,7 +7766,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8111,27 +8111,27 @@ msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
 #: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231
-#: cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr "Criar perfis"
@@ -9006,6 +9006,14 @@ msgid ""
 "\n"
 "incus move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    Rename a snapshot."
+msgstr ""
+
+#: cmd/incus/network_acl.go:363
+msgid ""
+"incus network acl create a1\n"
+"\n"
+"incus network acl create a1 < config.yaml\n"
+"    Create network acl with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/network.go:322

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-22 09:14+0200\n"
+"POT-Creation-Date: 2024-04-23 12:51+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -244,7 +244,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
@@ -931,7 +931,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -1132,7 +1132,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
@@ -1188,11 +1188,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1348,7 +1348,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1554,7 +1554,7 @@ msgstr ""
 #: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
+#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
@@ -1993,7 +1993,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete key from a storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2119,10 +2119,10 @@ msgstr ""
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
 #: cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233
 #: cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362
-#: cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543
-#: cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725
-#: cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839
-#: cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547
+#: cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729
+#: cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843
+#: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
 #: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
@@ -2449,7 +2449,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
-#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
+#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
@@ -2595,7 +2595,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2688,7 +2688,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3436,7 +3436,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
@@ -3487,7 +3487,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 msgid "IP addresses"
 msgstr ""
 
@@ -3663,7 +3663,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid "Log:"
 msgstr ""
 
@@ -4342,7 +4342,7 @@ msgstr "Копирование образа: %s"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 msgid "MAC address"
 msgstr ""
 
@@ -4385,7 +4385,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid "MTU"
 msgstr ""
 
@@ -4486,7 +4486,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Manage instance snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 #, fuzzy
 msgid "Manage network ACL rules"
 msgstr "Копирование образа: %s"
@@ -4759,10 +4759,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262
-#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393
-#: cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644
-#: cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812
-#: cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648
+#: cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 #, fuzzy
 msgid "Missing network ACL name"
 msgstr "Имя контейнера: %s"
@@ -4967,7 +4967,7 @@ msgstr "Копирование образа: %s"
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -5041,7 +5041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -5138,17 +5138,17 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, fuzzy, c-format
 msgid "Network ACL %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -5228,7 +5228,7 @@ msgstr ""
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -5287,7 +5287,7 @@ msgstr ""
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5373,7 +5373,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5432,11 +5432,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5522,7 +5522,7 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
-#: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
+#: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
@@ -5952,7 +5952,7 @@ msgstr ""
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -6002,7 +6002,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -6038,7 +6038,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rename instances"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6367,11 +6367,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6568,7 +6568,7 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -6859,7 +6859,7 @@ msgstr "Копирование образа: %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
@@ -6896,7 +6896,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
@@ -6906,7 +6906,7 @@ msgstr "Авто-обновление: %s"
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
@@ -7081,7 +7081,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -7155,7 +7155,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7471,7 +7471,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 msgid "Type"
 msgstr ""
 
@@ -7585,7 +7585,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7616,7 +7616,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -7694,7 +7694,7 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -7760,7 +7760,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8137,7 +8137,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231
-#: cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 #, fuzzy
 msgid "[<remote>:]<ACL>"
 msgstr ""
@@ -8145,7 +8145,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 #, fuzzy
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
@@ -8153,7 +8153,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
@@ -8161,7 +8161,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 #, fuzzy
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
@@ -8169,7 +8169,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 #, fuzzy
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
@@ -9511,6 +9511,14 @@ msgid ""
 "\n"
 "incus move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    Rename a snapshot."
+msgstr ""
+
+#: cmd/incus/network_acl.go:363
+msgid ""
+"incus network acl create a1\n"
+"\n"
+"incus network acl create a1 < config.yaml\n"
+"    Create network acl with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/network.go:322

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-22 09:14+0200\n"
+"POT-Creation-Date: 2024-04-23 12:51+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -219,7 +219,7 @@ msgid ""
 "###     properties: {}"
 msgstr ""
 
-#: cmd/incus/network_acl.go:602
+#: cmd/incus/network_acl.go:606
 msgid ""
 "### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Add roles to a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:853 cmd/incus/network_acl.go:854
+#: cmd/incus/network_acl.go:857 cmd/incus/network_acl.go:858
 msgid "Add rules to an ACL"
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
 msgid "Backups:"
 msgstr ""
 
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:425
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
@@ -1117,11 +1117,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:682 cmd/incus/network.go:947
+#: cmd/incus/info.go:691 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:683 cmd/incus/network.go:948
+#: cmd/incus/info.go:692 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr ""
 
@@ -1275,7 +1275,7 @@ msgstr ""
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
-#: cmd/incus/network_acl.go:923
+#: cmd/incus/network_acl.go:927
 #, c-format
 msgid "Cannot set key: %s"
 msgstr ""
@@ -1480,7 +1480,7 @@ msgstr ""
 #: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:692
+#: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
@@ -1894,7 +1894,7 @@ msgstr ""
 msgid "Delete key from a storage bucket"
 msgstr ""
 
-#: cmd/incus/network_acl.go:781 cmd/incus/network_acl.go:782
+#: cmd/incus/network_acl.go:785 cmd/incus/network_acl.go:786
 msgid "Delete network ACLs"
 msgstr ""
 
@@ -2013,10 +2013,10 @@ msgstr ""
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93
 #: cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233
 #: cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362
-#: cmd/incus/network_acl.go:455 cmd/incus/network_acl.go:543
-#: cmd/incus/network_acl.go:586 cmd/incus/network_acl.go:725
-#: cmd/incus/network_acl.go:782 cmd/incus/network_acl.go:839
-#: cmd/incus/network_acl.go:854 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547
+#: cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729
+#: cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843
+#: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
 #: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
@@ -2333,7 +2333,7 @@ msgstr ""
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_acl.go:585 cmd/incus/network_acl.go:586
+#: cmd/incus/network_acl.go:589 cmd/incus/network_acl.go:590
 msgid "Edit network ACL configurations as YAML"
 msgstr ""
 
@@ -2451,7 +2451,7 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
-#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:518
+#: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
@@ -2473,7 +2473,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:512 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2562,7 +2562,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:745 cmd/incus/info.go:796 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
 #: cmd/incus/storage_volume.go:2575
 msgid "Expires at"
@@ -3284,7 +3284,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:671
+#: cmd/incus/info.go:680
 msgid "Host interface"
 msgstr ""
 
@@ -3334,7 +3334,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:687
+#: cmd/incus/info.go:696
 msgid "IP addresses"
 msgstr ""
 
@@ -3504,7 +3504,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:797
+#: cmd/incus/info.go:806
 msgid "Instance Only"
 msgstr ""
 
@@ -4119,7 +4119,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:825
+#: cmd/incus/info.go:834
 msgid "Log:"
 msgstr ""
 
@@ -4156,7 +4156,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:684
 msgid "MAC address"
 msgstr ""
 
@@ -4199,7 +4199,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:679
+#: cmd/incus/info.go:688
 msgid "MTU"
 msgstr ""
 
@@ -4293,7 +4293,7 @@ msgstr ""
 msgid "Manage instance snapshots"
 msgstr ""
 
-#: cmd/incus/network_acl.go:838 cmd/incus/network_acl.go:839
+#: cmd/incus/network_acl.go:842 cmd/incus/network_acl.go:843
 msgid "Manage network ACL rules"
 msgstr ""
 
@@ -4539,10 +4539,10 @@ msgid "Missing name"
 msgstr ""
 
 #: cmd/incus/network_acl.go:202 cmd/incus/network_acl.go:262
-#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:393
-#: cmd/incus/network_acl.go:491 cmd/incus/network_acl.go:644
-#: cmd/incus/network_acl.go:755 cmd/incus/network_acl.go:812
-#: cmd/incus/network_acl.go:948 cmd/incus/network_acl.go:1031
+#: cmd/incus/network_acl.go:325 cmd/incus/network_acl.go:397
+#: cmd/incus/network_acl.go:495 cmd/incus/network_acl.go:648
+#: cmd/incus/network_acl.go:759 cmd/incus/network_acl.go:816
+#: cmd/incus/network_acl.go:952 cmd/incus/network_acl.go:1035
 msgid "Missing network ACL name"
 msgstr ""
 
@@ -4735,7 +4735,7 @@ msgstr ""
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1086
+#: cmd/incus/network_acl.go:1090
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:743 cmd/incus/info.go:794 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
 #: cmd/incus/storage_volume.go:2573
 msgid "Name"
@@ -4902,17 +4902,17 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_acl.go:437
+#: cmd/incus/network_acl.go:441
 #, c-format
 msgid "Network ACL %s created"
 msgstr ""
 
-#: cmd/incus/network_acl.go:822
+#: cmd/incus/network_acl.go:826
 #, c-format
 msgid "Network ACL %s deleted"
 msgstr ""
 
-#: cmd/incus/network_acl.go:765
+#: cmd/incus/network_acl.go:769
 #, c-format
 msgid "Network ACL %s renamed to %s"
 msgstr ""
@@ -4991,7 +4991,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:700 cmd/incus/network.go:946
+#: cmd/incus/info.go:709 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5048,7 +5048,7 @@ msgstr ""
 msgid "No matching port(s) found"
 msgstr ""
 
-#: cmd/incus/network_acl.go:1097
+#: cmd/incus/network_acl.go:1101
 msgid "No matching rule(s) found"
 msgstr ""
 
@@ -5134,7 +5134,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:798 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5193,11 +5193,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:684 cmd/incus/network.go:949
+#: cmd/incus/info.go:693 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:685 cmd/incus/network.go:950
+#: cmd/incus/info.go:694 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5282,7 +5282,7 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
-#: cmd/incus/network.go:763 cmd/incus/network_acl.go:693
+#: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
@@ -5706,7 +5706,7 @@ msgstr ""
 msgid "Remove all ports that match"
 msgstr ""
 
-#: cmd/incus/network_acl.go:992
+#: cmd/incus/network_acl.go:996
 msgid "Remove all rules that match"
 msgstr ""
 
@@ -5751,7 +5751,7 @@ msgstr ""
 msgid "Remove roles from a cluster member"
 msgstr ""
 
-#: cmd/incus/network_acl.go:990 cmd/incus/network_acl.go:991
+#: cmd/incus/network_acl.go:994 cmd/incus/network_acl.go:995
 msgid "Remove rules from an ACL"
 msgstr ""
 
@@ -5785,7 +5785,7 @@ msgstr ""
 msgid "Rename instances"
 msgstr ""
 
-#: cmd/incus/network_acl.go:724 cmd/incus/network_acl.go:725
+#: cmd/incus/network_acl.go:728 cmd/incus/network_acl.go:729
 msgid "Rename network ACLs"
 msgstr ""
 
@@ -6102,11 +6102,11 @@ msgid ""
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:454
+#: cmd/incus/network_acl.go:458
 msgid "Set network ACL configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:455
+#: cmd/incus/network_acl.go:459
 msgid ""
 "Set network ACL configuration keys\n"
 "\n"
@@ -6296,7 +6296,7 @@ msgstr ""
 msgid "Set the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:461
+#: cmd/incus/network_acl.go:465
 msgid "Set the key as a network ACL property"
 msgstr ""
 
@@ -6560,7 +6560,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:712 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
 msgid "Snapshots:"
 msgstr ""
 
@@ -6597,7 +6597,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:669
+#: cmd/incus/info.go:678
 msgid "State"
 msgstr ""
 
@@ -6606,7 +6606,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:746 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:755 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
@@ -6777,7 +6777,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:744 cmd/incus/info.go:795 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
 msgid "Taken at"
 msgstr ""
@@ -6851,7 +6851,7 @@ msgstr ""
 msgid "The device already exists"
 msgstr ""
 
-#: cmd/incus/network_acl.go:981 cmd/incus/network_acl.go:1119
+#: cmd/incus/network_acl.go:985 cmd/incus/network_acl.go:1123
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
@@ -7166,7 +7166,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:668
+#: cmd/incus/info.go:677
 msgid "Type"
 msgstr ""
 
@@ -7276,7 +7276,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: cmd/incus/network_acl.go:918 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:922 cmd/incus/network_acl.go:1057
 #, c-format
 msgid "Unknown key: %s"
 msgstr ""
@@ -7306,7 +7306,7 @@ msgstr ""
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
-#: cmd/incus/network_acl.go:542 cmd/incus/network_acl.go:543
+#: cmd/incus/network_acl.go:546 cmd/incus/network_acl.go:547
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
@@ -7374,7 +7374,7 @@ msgstr ""
 msgid "Unset the key as a cluster property"
 msgstr ""
 
-#: cmd/incus/network_acl.go:546
+#: cmd/incus/network_acl.go:550
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
@@ -7430,7 +7430,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:826
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7767,23 +7767,23 @@ msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
 #: cmd/incus/network_acl.go:170 cmd/incus/network_acl.go:231
-#: cmd/incus/network_acl.go:584 cmd/incus/network_acl.go:779
+#: cmd/incus/network_acl.go:588 cmd/incus/network_acl.go:783
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:852 cmd/incus/network_acl.go:989
+#: cmd/incus/network_acl.go:856 cmd/incus/network_acl.go:993
 msgid "[<remote>:]<ACL> <direction> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:541
+#: cmd/incus/network_acl.go:287 cmd/incus/network_acl.go:545
 msgid "[<remote>:]<ACL> <key>"
 msgstr ""
 
-#: cmd/incus/network_acl.go:453
+#: cmd/incus/network_acl.go:457
 msgid "[<remote>:]<ACL> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_acl.go:722
+#: cmd/incus/network_acl.go:726
 msgid "[<remote>:]<ACL> <new-name>"
 msgstr ""
 
@@ -8585,6 +8585,14 @@ msgid ""
 "\n"
 "incus move <instance>/<old snapshot name> <instance>/<new snapshot name>\n"
 "    Rename a snapshot."
+msgstr ""
+
+#: cmd/incus/network_acl.go:363
+msgid ""
+"incus network acl create a1\n"
+"\n"
+"incus network acl create a1 < config.yaml\n"
+"    Create network acl with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/network.go:322


### PR DESCRIPTION
`incus network acl create` already has support for creation from a yaml configuration file, but the same wasn't printed in the usage information of the command.

This commit updates `incus network acl create` to show example text for `incus network acl create`

Part of https://github.com/lxc/incus/issues/741