### PR TITLE
incus/doc/installing.md: Add Docker information

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -199,6 +199,7 @@ pre
 preseed
 proxied
 proxying
+Podman
 PTS
 qdisc
 QEMU

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -83,6 +83,10 @@ There are three options currently available to Debian users.
     Up to date installation instructions may be found here: [`https://github.com/zabbly/incus`](https://github.com/zabbly/incus)
 ```
 
+```{group-tab} Docker
+Docker/Podman images of Incus, based on the Zabbly package repository, are available with instructions here: [`ghcr.io/cmspam/incus-docker`](https://ghcr.io/cmspam/incus-docker)
+```
+
 ```{group-tab} Fedora
 RPM packages of Incus and its dependencies are not yet available via official Fedora repositories but via the [`ganto/lxc4`](https://copr.fedorainfracloud.org/coprs/ganto/lxc4/) Community Project (COPR) repository.
 


### PR DESCRIPTION
As discussed here:
https://github.com/zabbly/incus/issues/41

As I maintain a Dockerfile and docker images for incus, I would like to add that information to make it more accessible to people who don't have better installation options on their distributions.