### PR TITLE
incus/network_forward: Add yaml example for create

### DIFF
--- a/cmd/incus/network_forward.go
+++ b/cmd/incus/network_forward.go
@@ -248,6 +248,11 @@ func (c *cmdNetworkForwardCreate) Command() *cobra.Command {
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> <listen_address> [key=value...]"))
 	cmd.Short = i18n.G("Create new network forwards")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network forwards"))
+	cmd.Example = cli.FormatSection("", i18n.G(`incus network forward create n1 127.0.0.1
+
+incus network forward create n1 127.0.0.1 < config.yaml
+    Create a new network forward for network n1 from config.yaml`))
+
 	cmd.RunE = c.Run
 
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-23 12:51+0200\n"
+"POT-Creation-Date: 2024-04-24 13:37+0200\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -281,7 +281,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -921,7 +921,7 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1493,9 +1493,9 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441
-#: cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747
-#: cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918
+#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
+#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
+#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:427
@@ -1587,7 +1587,7 @@ msgstr ""
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
-#: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
+#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357
@@ -2035,7 +2035,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2164,11 +2164,11 @@ msgstr ""
 #: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
-#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543
-#: cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744
-#: cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833
-#: cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
+#: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
+#: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
+#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154
 #: cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323
 #: cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454
@@ -2513,7 +2513,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2633,7 +2633,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
-#: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
+#: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810
@@ -2654,7 +2654,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -3352,7 +3352,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3437,7 +3437,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -4599,7 +4599,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4839,10 +4839,10 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278
-#: cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478
-#: cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784
-#: cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283
+#: cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483
+#: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
+#: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
 #: cmd/incus/network_load_balancer.go:281
 #: cmd/incus/network_load_balancer.go:379
@@ -4887,10 +4887,10 @@ msgstr "Profilname kann nicht geändert werden"
 #: cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145
 #: cmd/incus/network.go:1223 cmd/incus/network.go:1289
 #: cmd/incus/network.go:1381 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274
-#: cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474
-#: cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780
-#: cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955
+#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
+#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
+#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:277
@@ -5075,7 +5075,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5276,12 +5276,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -5398,7 +5398,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5640,7 +5640,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
-#: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
+#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358
@@ -6074,7 +6074,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -6106,7 +6106,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6539,12 +6539,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6724,7 +6724,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7399,7 +7399,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7798,12 +7798,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7874,7 +7874,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -8898,8 +8898,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588
-#: cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
+#: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
 #: cmd/incus/network_load_balancer.go:557
 #: cmd/incus/network_load_balancer.go:711
 #, fuzzy
@@ -8927,7 +8927,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
 #: cmd/incus/network_load_balancer.go:349
 #: cmd/incus/network_load_balancer.go:527
 #, fuzzy
@@ -8937,7 +8937,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8955,13 +8955,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -9761,6 +9761,14 @@ msgid ""
 "\n"
 "incus network create bar network=baz --type ovn\n"
 "    Create a new OVN network called bar using baz as its uplink network"
+msgstr ""
+
+#: cmd/incus/network_forward.go:251
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
+"\n"
+"incus network forward create n1 127.0.0.1 < config.yaml\n"
+"    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:208

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-23 12:51+0200\n"
+"POT-Creation-Date: 2024-04-24 13:37+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -284,7 +284,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -891,7 +891,7 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -1117,7 +1117,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1443,9 +1443,9 @@ msgstr "Perfil %s eliminado de %s"
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441
-#: cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747
-#: cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918
+#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
+#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
+#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:427
@@ -1537,7 +1537,7 @@ msgstr ""
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
-#: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
+#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357
@@ -1967,7 +1967,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2094,11 +2094,11 @@ msgstr ""
 #: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
-#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543
-#: cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744
-#: cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833
-#: cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
+#: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
+#: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
+#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154
 #: cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323
 #: cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454
@@ -2423,7 +2423,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2540,7 +2540,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
-#: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
+#: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810
@@ -2561,7 +2561,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -3246,7 +3246,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Perfil %s creado"
@@ -3326,7 +3326,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Perfil %s creado"
@@ -4444,7 +4444,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4675,10 +4675,10 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278
-#: cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478
-#: cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784
-#: cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283
+#: cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483
+#: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
+#: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
 #: cmd/incus/network_load_balancer.go:281
 #: cmd/incus/network_load_balancer.go:379
@@ -4722,10 +4722,10 @@ msgstr "Nombre del contenedor es: %s"
 #: cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145
 #: cmd/incus/network.go:1223 cmd/incus/network.go:1289
 #: cmd/incus/network.go:1381 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274
-#: cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474
-#: cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780
-#: cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955
+#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
+#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
+#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:277
@@ -4904,7 +4904,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5100,12 +5100,12 @@ msgstr "Perfil %s creado"
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Perfil %s eliminado"
@@ -5217,7 +5217,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5457,7 +5457,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
-#: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
+#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358
@@ -5884,7 +5884,7 @@ msgstr "Perfil %s creado"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5914,7 +5914,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -6326,12 +6326,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6505,7 +6505,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Perfil %s creado"
@@ -7156,7 +7156,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -7545,12 +7545,12 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Perfil %s creado"
@@ -7619,7 +7619,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Perfil %s creado"
@@ -8373,8 +8373,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588
-#: cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
+#: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
 #: cmd/incus/network_load_balancer.go:557
 #: cmd/incus/network_load_balancer.go:711
 #, fuzzy
@@ -8393,14 +8393,14 @@ msgid ""
 "[<target_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
 #: cmd/incus/network_load_balancer.go:349
 #: cmd/incus/network_load_balancer.go:527
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8412,13 +8412,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9001,6 +9001,14 @@ msgid ""
 "\n"
 "incus network create bar network=baz --type ovn\n"
 "    Create a new OVN network called bar using baz as its uplink network"
+msgstr ""
+
+#: cmd/incus/network_forward.go:251
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
+"\n"
+"incus network forward create n1 127.0.0.1 < config.yaml\n"
+"    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:208

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-23 12:51+0200\n"
+"POT-Creation-Date: 2024-04-24 13:37+0200\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -285,7 +285,7 @@ msgstr ""
 "### Notez que seules les règles d'entrée et de sortie, la description et les "
 "clés de configuration peuvent être modifiées ."
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -911,7 +911,7 @@ msgstr ""
 "Cela va générer un jeton de confiance a utiliser par le client pour "
 "s'ajouter au dépôt de confiance.\n"
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid "Add ports to a forward"
 msgstr "Ajoutez des ports à la redirection"
 
@@ -1149,7 +1149,7 @@ msgstr ""
 "<clé>=<valeur>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1485,9 +1485,9 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441
-#: cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747
-#: cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918
+#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
+#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
+#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:427
@@ -1586,7 +1586,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
-#: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
+#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357
@@ -2071,7 +2071,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete network ACLs"
 msgstr "Supprimer les ACLs réseau"
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 msgid "Delete network forwards"
 msgstr "Supprime les redirections réseaux"
 
@@ -2202,11 +2202,11 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
-#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543
-#: cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744
-#: cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833
-#: cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
+#: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
+#: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
+#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154
 #: cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323
 #: cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454
@@ -2548,7 +2548,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network configurations as YAML"
 msgstr "Modifier les configurations réseau au format YAML"
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2682,7 +2682,7 @@ msgstr "Erreur lors de la récupération des alias : %w"
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
-#: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
+#: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810
@@ -2703,7 +2703,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Erreur lors du déparamétrage des propriétés: %v"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -3492,7 +3492,7 @@ msgstr "Obtenir la clé en tant que propriété du cluster"
 msgid "Get the key as a network ACL property"
 msgstr "Obtenir la clé en tant que propriété ACL du réseau"
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Copie de l'image : %s"
@@ -3578,7 +3578,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4813,7 +4813,7 @@ msgstr "Copie de l'image : %s"
 msgid "Manage network ACLs"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Copie de l'image : %s"
@@ -5052,10 +5052,10 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing key name"
 msgstr "Résumé manquant."
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278
-#: cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478
-#: cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784
-#: cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283
+#: cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483
+#: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
+#: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
 #: cmd/incus/network_load_balancer.go:281
 #: cmd/incus/network_load_balancer.go:379
@@ -5100,10 +5100,10 @@ msgstr "Nom du réseau"
 #: cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145
 #: cmd/incus/network.go:1223 cmd/incus/network.go:1289
 #: cmd/incus/network.go:1381 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274
-#: cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474
-#: cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780
-#: cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955
+#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
+#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
+#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:277
@@ -5292,7 +5292,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5494,12 +5494,12 @@ msgstr "Le réseau %s a été créé"
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -5615,7 +5615,7 @@ msgstr "Aucun périphérique existant pour ce réseau"
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5868,7 +5868,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
-#: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
+#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358
@@ -6306,7 +6306,7 @@ msgstr "Clé de configuration invalide"
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -6338,7 +6338,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
@@ -6783,12 +6783,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6969,7 +6969,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Nom du réseau"
@@ -7659,7 +7659,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -8064,12 +8064,12 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Nom du réseau"
@@ -8142,7 +8142,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Nom du réseau"
@@ -9195,8 +9195,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588
-#: cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
+#: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
 #: cmd/incus/network_load_balancer.go:557
 #: cmd/incus/network_load_balancer.go:711
 #, fuzzy
@@ -9224,7 +9224,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
 #: cmd/incus/network_load_balancer.go:349
 #: cmd/incus/network_load_balancer.go:527
 #, fuzzy
@@ -9234,7 +9234,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -9252,13 +9252,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -10113,6 +10113,14 @@ msgid ""
 "\n"
 "incus network create bar network=baz --type ovn\n"
 "    Create a new OVN network called bar using baz as its uplink network"
+msgstr ""
+
+#: cmd/incus/network_forward.go:251
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
+"\n"
+"incus network forward create n1 127.0.0.1 < config.yaml\n"
+"    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:208

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-04-23 12:51+0200\n"
+        "POT-Creation-Date: 2024-04-24 13:37+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -159,7 +159,7 @@ msgid   "### This is a YAML representation of the network ACL.\n"
         "### Note that only the ingress and egress rules, description and configuration keys can be changed."
 msgstr  ""
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 msgid   "### This is a YAML representation of the network forward.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -605,7 +605,7 @@ msgid   "Add new trusted client\n"
         "This will issue a trust token to be used by the client to add itself to the trust store.\n"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid   "Add ports to a forward"
 msgstr  ""
 
@@ -821,7 +821,7 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378 cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378 cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -1125,7 +1125,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64 cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880 cmd/incus/network.go:1257 cmd/incus/network.go:1350 cmd/incus/network.go:1422 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441 cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747 cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:256 cmd/incus/network_load_balancer.go:427 cmd/incus/network_load_balancer.go:562 cmd/incus/network_load_balancer.go:717 cmd/incus/network_load_balancer.go:805 cmd/incus/network_load_balancer.go:881 cmd/incus/network_load_balancer.go:994 cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103 cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746 cmd/incus/storage.go:848 cmd/incus/storage.go:941 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392 cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642 cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941 cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939 cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294 cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834 cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083 cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598 cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773 cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64 cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880 cmd/incus/network.go:1257 cmd/incus/network.go:1350 cmd/incus/network.go:1422 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:256 cmd/incus/network_load_balancer.go:427 cmd/incus/network_load_balancer.go:562 cmd/incus/network_load_balancer.go:717 cmd/incus/network_load_balancer.go:805 cmd/incus/network_load_balancer.go:881 cmd/incus/network_load_balancer.go:994 cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103 cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746 cmd/incus/storage.go:848 cmd/incus/storage.go:941 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392 cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642 cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941 cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939 cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294 cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834 cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083 cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598 cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773 cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1178,7 +1178,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288 cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324 cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/cluster.go:859 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288 cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324 cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1571,7 +1571,7 @@ msgstr  ""
 msgid   "Delete network ACLs"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 msgid   "Delete network forwards"
 msgstr  ""
 
@@ -1627,7 +1627,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:30 cmd/incus/cluster.go:123 cmd/incus/cluster.go:215 cmd/incus/cluster.go:272 cmd/incus/cluster.go:331 cmd/incus/cluster.go:404 cmd/incus/cluster.go:484 cmd/incus/cluster.go:528 cmd/incus/cluster.go:586 cmd/incus/cluster.go:677 cmd/incus/cluster.go:770 cmd/incus/cluster.go:891 cmd/incus/cluster.go:963 cmd/incus/cluster.go:1073 cmd/incus/cluster.go:1161 cmd/incus/cluster.go:1285 cmd/incus/cluster.go:1314 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:117 cmd/incus/config_template.go:171 cmd/incus/config_template.go:271 cmd/incus/config_template.go:339 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348 cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543 cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744 cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833 cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154 cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323 cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454 cmd/incus/network_integration.go:508 cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:622 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:351 cmd/incus/network_load_balancer.go:419 cmd/incus/network_load_balancer.go:529 cmd/incus/network_load_balancer.go:559 cmd/incus/network_load_balancer.go:714 cmd/incus/network_load_balancer.go:787 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:878 cmd/incus/network_load_balancer.go:976 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408 cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857 cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433 cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:434 cmd/incus/profile.go:492 cmd/incus/profile.go:628 cmd/incus/profile.go:702 cmd/incus/profile.go:771 cmd/incus/profile.go:859 cmd/incus/profile.go:919 cmd/incus/profile.go:1008 cmd/incus/profile.go:1072 cmd/incus/project.go:30 cmd/incus/project.go:94 cmd/incus/project.go:190 cmd/incus/project.go:261 cmd/incus/project.go:397 cmd/incus/project.go:471 cmd/incus/project.go:591 cmd/incus/project.go:656 cmd/incus/project.go:744 cmd/incus/project.go:788 cmd/incus/project.go:849 cmd/incus/project.go:916 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:201 cmd/incus/storage.go:259 cmd/incus/storage.go:391 cmd/incus/storage.go:473 cmd/incus/storage.go:653 cmd/incus/storage.go:740 cmd/incus/storage.go:844 cmd/incus/storage.go:938 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:30 cmd/incus/cluster.go:123 cmd/incus/cluster.go:215 cmd/incus/cluster.go:272 cmd/incus/cluster.go:331 cmd/incus/cluster.go:404 cmd/incus/cluster.go:484 cmd/incus/cluster.go:528 cmd/incus/cluster.go:586 cmd/incus/cluster.go:677 cmd/incus/cluster.go:770 cmd/incus/cluster.go:891 cmd/incus/cluster.go:963 cmd/incus/cluster.go:1073 cmd/incus/cluster.go:1161 cmd/incus/cluster.go:1285 cmd/incus/cluster.go:1314 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:117 cmd/incus/config_template.go:171 cmd/incus/config_template.go:271 cmd/incus/config_template.go:339 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154 cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323 cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454 cmd/incus/network_integration.go:508 cmd/incus/network_integration.go:589 cmd/incus/network_integration.go:622 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:351 cmd/incus/network_load_balancer.go:419 cmd/incus/network_load_balancer.go:529 cmd/incus/network_load_balancer.go:559 cmd/incus/network_load_balancer.go:714 cmd/incus/network_load_balancer.go:787 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:878 cmd/incus/network_load_balancer.go:976 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408 cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857 cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433 cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:434 cmd/incus/profile.go:492 cmd/incus/profile.go:628 cmd/incus/profile.go:702 cmd/incus/profile.go:771 cmd/incus/profile.go:859 cmd/incus/profile.go:919 cmd/incus/profile.go:1008 cmd/incus/profile.go:1072 cmd/incus/project.go:30 cmd/incus/project.go:94 cmd/incus/project.go:190 cmd/incus/project.go:261 cmd/incus/project.go:397 cmd/incus/project.go:471 cmd/incus/project.go:591 cmd/incus/project.go:656 cmd/incus/project.go:744 cmd/incus/project.go:788 cmd/incus/project.go:849 cmd/incus/project.go:916 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:201 cmd/incus/storage.go:259 cmd/incus/storage.go:391 cmd/incus/storage.go:473 cmd/incus/storage.go:653 cmd/incus/storage.go:740 cmd/incus/storage.go:844 cmd/incus/storage.go:938 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1858,7 +1858,7 @@ msgstr  ""
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 msgid   "Edit network forward configurations as YAML"
 msgstr  ""
 
@@ -1962,7 +1962,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563 cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155 cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
+#: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563 cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155 cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1977,7 +1977,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:453 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510 cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465 cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980 cmd/incus/project.go:713 cmd/incus/storage.go:804 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
+#: cmd/incus/cluster.go:453 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465 cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980 cmd/incus/project.go:713 cmd/incus/storage.go:804 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2617,7 +2617,7 @@ msgstr  ""
 msgid   "Get the key as a network ACL property"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 msgid   "Get the key as a network forward property"
 msgstr  ""
 
@@ -2689,7 +2689,7 @@ msgstr  ""
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 msgid   "Get values for network forward configuration keys"
 msgstr  ""
 
@@ -3738,7 +3738,7 @@ msgstr  ""
 msgid   "Manage network ACLs"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 msgid   "Manage network forward ports"
 msgstr  ""
 
@@ -3932,7 +3932,7 @@ msgstr  ""
 msgid   "Missing key name"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278 cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478 cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784 cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959 cmd/incus/network_load_balancer.go:217 cmd/incus/network_load_balancer.go:281 cmd/incus/network_load_balancer.go:379 cmd/incus/network_load_balancer.go:464 cmd/incus/network_load_balancer.go:622 cmd/incus/network_load_balancer.go:754 cmd/incus/network_load_balancer.go:842 cmd/incus/network_load_balancer.go:918 cmd/incus/network_load_balancer.go:1031 cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283 cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789 cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964 cmd/incus/network_load_balancer.go:217 cmd/incus/network_load_balancer.go:281 cmd/incus/network_load_balancer.go:379 cmd/incus/network_load_balancer.go:464 cmd/incus/network_load_balancer.go:622 cmd/incus/network_load_balancer.go:754 cmd/incus/network_load_balancer.go:842 cmd/incus/network_load_balancer.go:918 cmd/incus/network_load_balancer.go:1031 cmd/incus/network_load_balancer.go:1105
 msgid   "Missing listen address"
 msgstr  ""
 
@@ -3948,7 +3948,7 @@ msgstr  ""
 msgid   "Missing network integration name"
 msgstr  ""
 
-#: cmd/incus/network.go:175 cmd/incus/network.go:272 cmd/incus/network.go:440 cmd/incus/network.go:502 cmd/incus/network.go:599 cmd/incus/network.go:712 cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145 cmd/incus/network.go:1223 cmd/incus/network.go:1289 cmd/incus/network.go:1381 cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274 cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474 cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780 cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955 cmd/incus/network_load_balancer.go:127 cmd/incus/network_load_balancer.go:213 cmd/incus/network_load_balancer.go:277 cmd/incus/network_load_balancer.go:375 cmd/incus/network_load_balancer.go:460 cmd/incus/network_load_balancer.go:618 cmd/incus/network_load_balancer.go:750 cmd/incus/network_load_balancer.go:838 cmd/incus/network_load_balancer.go:914 cmd/incus/network_load_balancer.go:1027 cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118 cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288 cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network.go:175 cmd/incus/network.go:272 cmd/incus/network.go:440 cmd/incus/network.go:502 cmd/incus/network.go:599 cmd/incus/network.go:712 cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145 cmd/incus/network.go:1223 cmd/incus/network.go:1289 cmd/incus/network.go:1381 cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960 cmd/incus/network_load_balancer.go:127 cmd/incus/network_load_balancer.go:213 cmd/incus/network_load_balancer.go:277 cmd/incus/network_load_balancer.go:375 cmd/incus/network_load_balancer.go:460 cmd/incus/network_load_balancer.go:618 cmd/incus/network_load_balancer.go:750 cmd/incus/network_load_balancer.go:838 cmd/incus/network_load_balancer.go:914 cmd/incus/network_load_balancer.go:1027 cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118 cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288 cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
 msgid   "Missing network name"
 msgstr  ""
 
@@ -4068,7 +4068,7 @@ msgstr  ""
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
@@ -4249,12 +4249,12 @@ msgstr  ""
 msgid   "Network Zone %s deleted"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, c-format
 msgid   "Network forward %s created"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, c-format
 msgid   "Network forward %s deleted"
 msgstr  ""
@@ -4365,7 +4365,7 @@ msgstr  ""
 msgid   "No matching backend found"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid   "No matching port(s) found"
 msgstr  ""
 
@@ -4595,7 +4595,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:860 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289 cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325 cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/cluster.go:860 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289 cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325 cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4984,7 +4984,7 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid   "Remove all ports that match"
 msgstr  ""
 
@@ -5012,7 +5012,7 @@ msgstr  ""
 msgid   "Remove member from group"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 msgid   "Remove ports from a forward"
 msgstr  ""
 
@@ -5394,11 +5394,11 @@ msgid   "Set network configuration keys\n"
         "    incus network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 msgid   "Set network forward keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 msgid   "Set network forward keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5544,7 +5544,7 @@ msgstr  ""
 msgid   "Set the key as a network ACL property"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 msgid   "Set the key as a network forward property"
 msgstr  ""
 
@@ -6151,7 +6151,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network ACL %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, c-format
 msgid   "The property %q does not exist on the network forward %q: %v"
 msgstr  ""
@@ -6513,11 +6513,11 @@ msgstr  ""
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 msgid   "Unset network forward configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 msgid   "Unset network forward keys"
 msgstr  ""
 
@@ -6577,7 +6577,7 @@ msgstr  ""
 msgid   "Unset the key as a network ACL property"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 msgid   "Unset the key as a network forward property"
 msgstr  ""
 
@@ -7206,7 +7206,7 @@ msgstr  ""
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588 cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175 cmd/incus/network_load_balancer.go:557 cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175 cmd/incus/network_load_balancer.go:557 cmd/incus/network_load_balancer.go:711
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
@@ -7218,11 +7218,11 @@ msgstr  ""
 msgid   "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541 cmd/incus/network_load_balancer.go:349 cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546 cmd/incus/network_load_balancer.go:349 cmd/incus/network_load_balancer.go:527
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
@@ -7230,11 +7230,11 @@ msgstr  ""
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
@@ -7704,6 +7704,13 @@ msgid   "incus network create foo\n"
         "\n"
         "incus network create bar network=baz --type ovn\n"
         "    Create a new OVN network called bar using baz as its uplink network"
+msgstr  ""
+
+#: cmd/incus/network_forward.go:251
+msgid   "incus network forward create n1 127.0.0.1\n"
+        "\n"
+        "incus network forward create n1 127.0.0.1 < config.yaml\n"
+        "    Create a new network forward for network n1 from config.yaml"
 msgstr  ""
 
 #: cmd/incus/network_integration.go:208

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-23 12:51+0200\n"
+"POT-Creation-Date: 2024-04-24 13:37+0200\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -285,7 +285,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -890,7 +890,7 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -1116,7 +1116,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1438,9 +1438,9 @@ msgstr ""
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441
-#: cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747
-#: cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918
+#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
+#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
+#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:427
@@ -1529,7 +1529,7 @@ msgstr ""
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
-#: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
+#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357
@@ -1961,7 +1961,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2087,11 +2087,11 @@ msgstr ""
 #: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
-#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543
-#: cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744
-#: cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833
-#: cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
+#: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
+#: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
+#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154
 #: cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323
 #: cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454
@@ -2418,7 +2418,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
-#: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
+#: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810
@@ -2555,7 +2555,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -3240,7 +3240,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -3318,7 +3318,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4669,10 +4669,10 @@ msgstr "Il nome del container è: %s"
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278
-#: cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478
-#: cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784
-#: cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283
+#: cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483
+#: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
+#: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
 #: cmd/incus/network_load_balancer.go:281
 #: cmd/incus/network_load_balancer.go:379
@@ -4716,10 +4716,10 @@ msgstr "Il nome del container è: %s"
 #: cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145
 #: cmd/incus/network.go:1223 cmd/incus/network.go:1289
 #: cmd/incus/network.go:1381 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274
-#: cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474
-#: cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780
-#: cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955
+#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
+#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
+#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:277
@@ -4898,7 +4898,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5094,12 +5094,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -5211,7 +5211,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5452,7 +5452,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
-#: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
+#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358
@@ -5878,7 +5878,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5909,7 +5909,7 @@ msgstr "Creazione del container in corso"
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -6321,11 +6321,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6498,7 +6498,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -7150,7 +7150,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Il nome del container è: %s"
@@ -7542,11 +7542,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -7613,7 +7613,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -8368,8 +8368,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588
-#: cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
+#: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
 #: cmd/incus/network_load_balancer.go:557
 #: cmd/incus/network_load_balancer.go:711
 #, fuzzy
@@ -8388,14 +8388,14 @@ msgid ""
 "[<target_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
 #: cmd/incus/network_load_balancer.go:349
 #: cmd/incus/network_load_balancer.go:527
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -8407,13 +8407,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
@@ -8996,6 +8996,14 @@ msgid ""
 "\n"
 "incus network create bar network=baz --type ovn\n"
 "    Create a new OVN network called bar using baz as its uplink network"
+msgstr ""
+
+#: cmd/incus/network_forward.go:251
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
+"\n"
+"incus network forward create n1 127.0.0.1 < config.yaml\n"
+"    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:208

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-23 12:51+0200\n"
+"POT-Creation-Date: 2024-04-24 13:37+0200\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -277,7 +277,7 @@ msgstr ""
 "### Note that only the ingress and egress rules, description and "
 "configuration keys can be changed."
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -890,7 +890,7 @@ msgstr ""
 "クライアントが自身をトラストストアに追加するために使うトラストトークンが発行"
 "されます。\n"
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid "Add ports to a forward"
 msgstr "フォワードにポートを追加します"
 
@@ -1120,7 +1120,7 @@ msgstr ""
 "<device>,<key>=<value>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1450,9 +1450,9 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441
-#: cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747
-#: cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918
+#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
+#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
+#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:427
@@ -1548,7 +1548,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
-#: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
+#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357
@@ -1987,7 +1987,7 @@ msgstr "ストレージバケットからキーを削除します"
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 msgid "Delete network forwards"
 msgstr "ネットワークフォワードを削除します"
 
@@ -2109,11 +2109,11 @@ msgstr "警告を削除します"
 #: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
-#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543
-#: cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744
-#: cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833
-#: cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
+#: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
+#: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
+#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154
 #: cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323
 #: cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454
@@ -2441,7 +2441,7 @@ msgstr "ネットワーク ACL をYAMLで編集します"
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 msgid "Edit network forward configurations as YAML"
 msgstr "ネットワークフォワード設定をYAMLで編集します"
 
@@ -2563,7 +2563,7 @@ msgstr "エイリアスの取得に失敗しました: %w"
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
-#: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
+#: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810
@@ -2584,7 +2584,7 @@ msgid "Error unsetting properties: %v"
 msgstr "プロパティの削除でエラーが発生しました: %v"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -3321,7 +3321,7 @@ msgstr "クラスターグループを作成します"
 msgid "Get the key as a network ACL property"
 msgstr "key をネットワーク ACL プロパティとして取得します"
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "ネットワークフォワードのポートを管理します"
@@ -3402,7 +3402,7 @@ msgstr "ネットワーク ACL の設定値を取得します"
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 msgid "Get values for network forward configuration keys"
 msgstr "ネットワークフォワードの設定値を取得します"
 
@@ -4703,7 +4703,7 @@ msgstr "ネットワーク ACL ルールを管理します"
 msgid "Manage network ACLs"
 msgstr "ネットワーク ACL を管理します"
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 msgid "Manage network forward ports"
 msgstr "ネットワークフォワードのポートを管理します"
 
@@ -4922,10 +4922,10 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278
-#: cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478
-#: cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784
-#: cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283
+#: cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483
+#: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
+#: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
 #: cmd/incus/network_load_balancer.go:281
 #: cmd/incus/network_load_balancer.go:379
@@ -4967,10 +4967,10 @@ msgstr "ネットワークゾーン名を指定する必要があります"
 #: cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145
 #: cmd/incus/network.go:1223 cmd/incus/network.go:1289
 #: cmd/incus/network.go:1381 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274
-#: cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474
-#: cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780
-#: cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955
+#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
+#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
+#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:277
@@ -5162,7 +5162,7 @@ msgstr "コピー／移動元とは異なるプロジェクトに移動します
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
@@ -5364,12 +5364,12 @@ msgstr "ネットワークゾーン %s を作成しました"
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, c-format
 msgid "Network forward %s created"
 msgstr "ネットワークフォワード %s を作成しました"
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, c-format
 msgid "Network forward %s deleted"
 msgstr "ネットワークフォワード %s を削除しました"
@@ -5484,7 +5484,7 @@ msgstr "このストレージボリュームに対するデバイスがありま
 msgid "No matching backend found"
 msgstr "マッチするバックエンドが見つかりません"
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
@@ -5731,7 +5731,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
-#: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
+#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358
@@ -6193,7 +6193,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
@@ -6221,7 +6221,7 @@ msgstr "インスタンスのデバイスを削除します"
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
@@ -6659,11 +6659,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 msgid "Set network forward keys"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 #, fuzzy
 msgid ""
 "Set network forward keys\n"
@@ -6886,7 +6886,7 @@ msgstr "クラスターグループを作成します"
 msgid "Set the key as a network ACL property"
 msgstr "ネットワーク ACL プロパティとして設定します"
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "ネットワークフォワードの設定値を設定します"
@@ -7564,7 +7564,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -7988,11 +7988,11 @@ msgstr "ネットワーク ACL の設定を削除します"
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 msgid "Unset network forward configuration keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 msgid "Unset network forward keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
@@ -8053,7 +8053,7 @@ msgstr "クラスタープロパティの設定を削除します"
 msgid "Unset the key as a network ACL property"
 msgstr "ネットワーク ACL プロパティの設定を削除します"
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "ネットワークフォワードの設定を削除します"
@@ -8779,8 +8779,8 @@ msgstr "[<remote>:]<network> <key>"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588
-#: cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
+#: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
 #: cmd/incus/network_load_balancer.go:557
 #: cmd/incus/network_load_balancer.go:711
 msgid "[<remote>:]<network> <listen_address>"
@@ -8798,13 +8798,13 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
 #: cmd/incus/network_load_balancer.go:349
 #: cmd/incus/network_load_balancer.go:527
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <listen_address> <key>"
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <listen_address> <key>=<value>..."
 
@@ -8816,7 +8816,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
@@ -8824,7 +8824,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
@@ -9492,6 +9492,19 @@ msgstr ""
 "incus network create bar network=baz --type ovn\n"
 "    上流ネットワークに baz を使用する、bar という名前の新しい OVN ネットワー"
 "クを作成します"
+
+#: cmd/incus/network_forward.go:251
+#, fuzzy
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
+"\n"
+"incus network forward create n1 127.0.0.1 < config.yaml\n"
+"    Create a new network forward for network n1 from config.yaml"
+msgstr ""
+"lxc init ubuntu:22.04 u1\n"
+"\n"
+"lxc init ubuntu:22.04 u1 < config.yaml\n"
+"    config.yaml の設定を使ってインスタンスを作成します"
 
 #: cmd/incus/network_integration.go:208
 #, fuzzy

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-23 12:51+0200\n"
+"POT-Creation-Date: 2024-04-24 13:37+0200\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -280,7 +280,7 @@ msgstr ""
 "### Merk op dat alleen de inkomende en uitgaande regels, beschrijving en "
 "configuratiesleutels kunnen worden aangepast."
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -902,7 +902,7 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid "Add ports to a forward"
 msgstr "Voeg poorten (ports) toe aan een doorstuurregel (forward)"
 
@@ -1137,7 +1137,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1460,9 +1460,9 @@ msgstr ""
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441
-#: cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747
-#: cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918
+#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
+#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
+#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:427
@@ -1550,7 +1550,7 @@ msgstr ""
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
-#: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
+#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357
@@ -1968,7 +1968,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2090,11 +2090,11 @@ msgstr ""
 #: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
-#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543
-#: cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744
-#: cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833
-#: cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
+#: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
+#: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
+#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154
 #: cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323
 #: cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454
@@ -2412,7 +2412,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2523,7 +2523,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
-#: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
+#: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810
@@ -2544,7 +2544,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -3222,7 +3222,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -3295,7 +3295,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4589,10 +4589,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278
-#: cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478
-#: cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784
-#: cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283
+#: cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483
+#: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
+#: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
 #: cmd/incus/network_load_balancer.go:281
 #: cmd/incus/network_load_balancer.go:379
@@ -4634,10 +4634,10 @@ msgstr "Toekennen van netwerk interfaces aan instanties (instances)"
 #: cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145
 #: cmd/incus/network.go:1223 cmd/incus/network.go:1289
 #: cmd/incus/network.go:1381 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274
-#: cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474
-#: cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780
-#: cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955
+#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
+#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
+#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:277
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5003,12 +5003,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -5120,7 +5120,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
-#: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
+#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358
@@ -5778,7 +5778,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5806,7 +5806,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -6205,11 +6205,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6378,7 +6378,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -7010,7 +7010,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -7394,11 +7394,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -7458,7 +7458,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -8127,8 +8127,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588
-#: cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
+#: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
 #: cmd/incus/network_load_balancer.go:557
 #: cmd/incus/network_load_balancer.go:711
 msgid "[<remote>:]<network> <listen_address>"
@@ -8144,13 +8144,13 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
 #: cmd/incus/network_load_balancer.go:349
 #: cmd/incus/network_load_balancer.go:527
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -8160,13 +8160,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -8682,6 +8682,14 @@ msgid ""
 "\n"
 "incus network create bar network=baz --type ovn\n"
 "    Create a new OVN network called bar using baz as its uplink network"
+msgstr ""
+
+#: cmd/incus/network_forward.go:251
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
+"\n"
+"incus network forward create n1 127.0.0.1 < config.yaml\n"
+"    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:208

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-23 12:51+0200\n"
+"POT-Creation-Date: 2024-04-24 13:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -169,7 +169,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -636,7 +636,7 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1179,9 +1179,9 @@ msgstr ""
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441
-#: cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747
-#: cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918
+#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
+#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
+#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:427
@@ -1269,7 +1269,7 @@ msgstr ""
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
-#: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
+#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357
@@ -1686,7 +1686,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1807,11 +1807,11 @@ msgstr ""
 #: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
-#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543
-#: cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744
-#: cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833
-#: cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
+#: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
+#: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
+#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154
 #: cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323
 #: cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454
@@ -2129,7 +2129,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2240,7 +2240,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
-#: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
+#: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810
@@ -2261,7 +2261,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -2938,7 +2938,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -3010,7 +3010,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -4089,7 +4089,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4302,10 +4302,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278
-#: cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478
-#: cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784
-#: cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283
+#: cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483
+#: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
+#: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
 #: cmd/incus/network_load_balancer.go:281
 #: cmd/incus/network_load_balancer.go:379
@@ -4346,10 +4346,10 @@ msgstr ""
 #: cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145
 #: cmd/incus/network.go:1223 cmd/incus/network.go:1289
 #: cmd/incus/network.go:1381 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274
-#: cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474
-#: cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780
-#: cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955
+#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
+#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
+#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:277
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4715,12 +4715,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4832,7 +4832,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5071,7 +5071,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
-#: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
+#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358
@@ -5490,7 +5490,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5518,7 +5518,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -5916,11 +5916,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6088,7 +6088,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -6718,7 +6718,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -7102,11 +7102,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -7166,7 +7166,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -7835,8 +7835,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588
-#: cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
+#: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
 #: cmd/incus/network_load_balancer.go:557
 #: cmd/incus/network_load_balancer.go:711
 msgid "[<remote>:]<network> <listen_address>"
@@ -7852,13 +7852,13 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
 #: cmd/incus/network_load_balancer.go:349
 #: cmd/incus/network_load_balancer.go:527
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -7868,13 +7868,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -8390,6 +8390,14 @@ msgid ""
 "\n"
 "incus network create bar network=baz --type ovn\n"
 "    Create a new OVN network called bar using baz as its uplink network"
+msgstr ""
+
+#: cmd/incus/network_forward.go:251
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
+"\n"
+"incus network forward create n1 127.0.0.1 < config.yaml\n"
+"    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:208

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-23 12:51+0200\n"
+"POT-Creation-Date: 2024-04-24 13:37+0200\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -273,7 +273,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -892,7 +892,7 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1451,9 +1451,9 @@ msgstr "Dispositivo %s removido de %s"
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441
-#: cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747
-#: cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918
+#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
+#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
+#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:427
@@ -1553,7 +1553,7 @@ msgstr ""
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
-#: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
+#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357
@@ -1997,7 +1997,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "Criar novas redes"
@@ -2126,11 +2126,11 @@ msgstr ""
 #: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
-#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543
-#: cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744
-#: cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833
-#: cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
+#: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
+#: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
+#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154
 #: cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323
 #: cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454
@@ -2463,7 +2463,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2583,7 +2583,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
-#: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
+#: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810
@@ -2604,7 +2604,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -3287,7 +3287,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Criar novas redes"
@@ -3371,7 +3371,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -4490,7 +4490,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Criar novas redes"
@@ -4724,10 +4724,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278
-#: cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478
-#: cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784
-#: cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283
+#: cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483
+#: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
+#: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
 #: cmd/incus/network_load_balancer.go:281
 #: cmd/incus/network_load_balancer.go:379
@@ -4771,10 +4771,10 @@ msgstr "Nome de membro do cluster"
 #: cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145
 #: cmd/incus/network.go:1223 cmd/incus/network.go:1289
 #: cmd/incus/network.go:1381 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274
-#: cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474
-#: cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780
-#: cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955
+#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
+#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
+#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:277
@@ -4953,7 +4953,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5149,12 +5149,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -5266,7 +5266,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5506,7 +5506,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
-#: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
+#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358
@@ -5936,7 +5936,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5967,7 +5967,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
@@ -6393,12 +6393,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6573,7 +6573,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Criar novas redes"
@@ -7235,7 +7235,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nome de membro do cluster"
@@ -7631,12 +7631,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Criar novas redes"
@@ -7706,7 +7706,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Criar novas redes"
@@ -8425,8 +8425,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588
-#: cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
+#: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
 #: cmd/incus/network_load_balancer.go:557
 #: cmd/incus/network_load_balancer.go:711
 #, fuzzy
@@ -8445,14 +8445,14 @@ msgid ""
 "[<target_port(s)>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
 #: cmd/incus/network_load_balancer.go:349
 #: cmd/incus/network_load_balancer.go:527
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
@@ -8464,13 +8464,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -9023,6 +9023,14 @@ msgid ""
 "\n"
 "incus network create bar network=baz --type ovn\n"
 "    Create a new OVN network called bar using baz as its uplink network"
+msgstr ""
+
+#: cmd/incus/network_forward.go:251
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
+"\n"
+"incus network forward create n1 127.0.0.1 < config.yaml\n"
+"    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:208

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-23 12:51+0200\n"
+"POT-Creation-Date: 2024-04-24 13:37+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -289,7 +289,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -913,7 +913,7 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -1142,7 +1142,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1465,9 +1465,9 @@ msgstr ""
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441
-#: cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747
-#: cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918
+#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
+#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
+#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:427
@@ -1555,7 +1555,7 @@ msgstr ""
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
-#: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
+#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357
@@ -1997,7 +1997,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2125,11 +2125,11 @@ msgstr ""
 #: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
-#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543
-#: cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744
-#: cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833
-#: cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
+#: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
+#: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
+#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154
 #: cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323
 #: cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2574,7 +2574,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
-#: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
+#: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810
@@ -2595,7 +2595,7 @@ msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -3285,7 +3285,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Копирование образа: %s"
@@ -3367,7 +3367,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Копирование образа: %s"
@@ -4495,7 +4495,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Копирование образа: %s"
@@ -4733,10 +4733,10 @@ msgstr "Имя контейнера: %s"
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278
-#: cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478
-#: cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784
-#: cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283
+#: cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483
+#: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
+#: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
 #: cmd/incus/network_load_balancer.go:281
 #: cmd/incus/network_load_balancer.go:379
@@ -4780,10 +4780,10 @@ msgstr "Имя контейнера: %s"
 #: cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145
 #: cmd/incus/network.go:1223 cmd/incus/network.go:1289
 #: cmd/incus/network.go:1381 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274
-#: cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474
-#: cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780
-#: cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955
+#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
+#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
+#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:277
@@ -4963,7 +4963,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5163,12 +5163,12 @@ msgstr " Использование сети:"
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr " Использование сети:"
@@ -5283,7 +5283,7 @@ msgstr "Копирование образа: %s"
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5523,7 +5523,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
-#: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
+#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358
@@ -5948,7 +5948,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5979,7 +5979,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -6393,12 +6393,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6572,7 +6572,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Копирование образа: %s"
@@ -7234,7 +7234,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Копирование образа: %s"
@@ -7624,12 +7624,12 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Копирование образа: %s"
@@ -7698,7 +7698,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Копирование образа: %s"
@@ -8681,8 +8681,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588
-#: cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
+#: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
 #: cmd/incus/network_load_balancer.go:557
 #: cmd/incus/network_load_balancer.go:711
 #, fuzzy
@@ -8710,7 +8710,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
 #: cmd/incus/network_load_balancer.go:349
 #: cmd/incus/network_load_balancer.go:527
 #, fuzzy
@@ -8720,7 +8720,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8738,13 +8738,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -9528,6 +9528,14 @@ msgid ""
 "\n"
 "incus network create bar network=baz --type ovn\n"
 "    Create a new OVN network called bar using baz as its uplink network"
+msgstr ""
+
+#: cmd/incus/network_forward.go:251
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
+"\n"
+"incus network forward create n1 127.0.0.1 < config.yaml\n"
+"    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:208

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-23 12:51+0200\n"
+"POT-Creation-Date: 2024-04-24 13:37+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -247,7 +247,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: cmd/incus/network_forward.go:611
+#: cmd/incus/network_forward.go:616
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -848,7 +848,7 @@ msgid ""
 "trust store.\n"
 msgstr ""
 
-#: cmd/incus/network_forward.go:832 cmd/incus/network_forward.go:833
+#: cmd/incus/network_forward.go:837 cmd/incus/network_forward.go:838
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:303 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1391,9 +1391,9 @@ msgstr ""
 #: cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880
 #: cmd/incus/network.go:1257 cmd/incus/network.go:1350
 #: cmd/incus/network.go:1422 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:253 cmd/incus/network_forward.go:441
-#: cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:747
-#: cmd/incus/network_forward.go:836 cmd/incus/network_forward.go:918
+#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
+#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
+#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:256
 #: cmd/incus/network_load_balancer.go:427
@@ -1481,7 +1481,7 @@ msgstr ""
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
-#: cmd/incus/network_forward.go:711 cmd/incus/network_integration.go:288
+#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:288
 #: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:363 cmd/incus/storage.go:357
@@ -1898,7 +1898,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:743 cmd/incus/network_forward.go:744
+#: cmd/incus/network_forward.go:748 cmd/incus/network_forward.go:749
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2019,11 +2019,11 @@ msgstr ""
 #: cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995
 #: cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28
 #: cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174
-#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:348
-#: cmd/incus/network_forward.go:433 cmd/incus/network_forward.go:543
-#: cmd/incus/network_forward.go:590 cmd/incus/network_forward.go:744
-#: cmd/incus/network_forward.go:818 cmd/incus/network_forward.go:833
-#: cmd/incus/network_forward.go:914 cmd/incus/network_integration.go:28
+#: cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
+#: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
+#: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
+#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
 #: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:154
 #: cmd/incus/network_integration.go:206 cmd/incus/network_integration.go:323
 #: cmd/incus/network_integration.go:386 cmd/incus/network_integration.go:454
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_forward.go:589 cmd/incus/network_forward.go:590
+#: cmd/incus/network_forward.go:594 cmd/incus/network_forward.go:595
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2452,7 +2452,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:459 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
-#: cmd/incus/network_forward.go:516 cmd/incus/network_integration.go:563
+#: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:563
 #: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:719 cmd/incus/storage.go:810
@@ -2473,7 +2473,7 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:453 cmd/incus/network.go:1319
-#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:510
+#: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:557 cmd/incus/network_load_balancer.go:496
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
@@ -3150,7 +3150,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:350
+#: cmd/incus/network_forward.go:355
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -3222,7 +3222,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:347 cmd/incus/network_forward.go:348
+#: cmd/incus/network_forward.go:352 cmd/incus/network_forward.go:353
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: cmd/incus/network_forward.go:817 cmd/incus/network_forward.go:818
+#: cmd/incus/network_forward.go:822 cmd/incus/network_forward.go:823
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4514,10 +4514,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:278
-#: cmd/incus/network_forward.go:393 cmd/incus/network_forward.go:478
-#: cmd/incus/network_forward.go:653 cmd/incus/network_forward.go:784
-#: cmd/incus/network_forward.go:877 cmd/incus/network_forward.go:959
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283
+#: cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483
+#: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
+#: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
 #: cmd/incus/network_load_balancer.go:281
 #: cmd/incus/network_load_balancer.go:379
@@ -4558,10 +4558,10 @@ msgstr ""
 #: cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145
 #: cmd/incus/network.go:1223 cmd/incus/network.go:1289
 #: cmd/incus/network.go:1381 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:274
-#: cmd/incus/network_forward.go:389 cmd/incus/network_forward.go:474
-#: cmd/incus/network_forward.go:649 cmd/incus/network_forward.go:780
-#: cmd/incus/network_forward.go:873 cmd/incus/network_forward.go:955
+#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
+#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
+#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
+#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:277
@@ -4731,7 +4731,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1003 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4927,12 +4927,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: cmd/incus/network_forward.go:330
+#: cmd/incus/network_forward.go:335
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: cmd/incus/network_forward.go:801
+#: cmd/incus/network_forward.go:806
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -5044,7 +5044,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1014 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:237
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
-#: cmd/incus/network_forward.go:712 cmd/incus/network_integration.go:289
+#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:289
 #: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:364 cmd/incus/storage.go:358
@@ -5702,7 +5702,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:915 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5730,7 +5730,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: cmd/incus/network_forward.go:913 cmd/incus/network_forward.go:914
+#: cmd/incus/network_forward.go:918 cmd/incus/network_forward.go:919
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -6128,11 +6128,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:432
+#: cmd/incus/network_forward.go:437
 msgid "Set network forward keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:433
+#: cmd/incus/network_forward.go:438
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6300,7 +6300,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:440
+#: cmd/incus/network_forward.go:445
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -6930,7 +6930,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: cmd/incus/network_forward.go:406
+#: cmd/incus/network_forward.go:411
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -7314,11 +7314,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:542
+#: cmd/incus/network_forward.go:547
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: cmd/incus/network_forward.go:543
+#: cmd/incus/network_forward.go:548
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -7378,7 +7378,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: cmd/incus/network_forward.go:546
+#: cmd/incus/network_forward.go:551
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -8047,8 +8047,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:588
-#: cmd/incus/network_forward.go:741 cmd/incus/network_load_balancer.go:175
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
+#: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
 #: cmd/incus/network_load_balancer.go:557
 #: cmd/incus/network_load_balancer.go:711
 msgid "[<remote>:]<network> <listen_address>"
@@ -8064,13 +8064,13 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:346 cmd/incus/network_forward.go:541
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
 #: cmd/incus/network_load_balancer.go:349
 #: cmd/incus/network_load_balancer.go:527
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:431 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -8080,13 +8080,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:831
+#: cmd/incus/network_forward.go:836
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:912 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -8602,6 +8602,14 @@ msgid ""
 "\n"
 "incus network create bar network=baz --type ovn\n"
 "    Create a new OVN network called bar using baz as its uplink network"
+msgstr ""
+
+#: cmd/incus/network_forward.go:251
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
+"\n"
+"incus network forward create n1 127.0.0.1 < config.yaml\n"
+"    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:208


### PR DESCRIPTION
incus network forward create` already has support for creation from a yaml configuration file, but the same wasn't printed in the usage information of the command.

This commit updates `incus network forward create` to include an example

Part of https://github.com/lxc/incus/issues/741