### PR TITLE
 incus/network_load_balancer: add Example to create 

### DIFF
--- a/cmd/incus/network_load_balancer.go
+++ b/cmd/incus/network_load_balancer.go
@@ -251,6 +251,11 @@ func (c *cmdNetworkLoadBalancerCreate) Command() *cobra.Command {
 	cmd.Use = usage("create", i18n.G("[<remote>:]<network> <listen_address> [key=value...]"))
 	cmd.Short = i18n.G("Create new network load balancers")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network load balancers"))
+	cmd.Example = cli.FormatSection("", i18n.G(`incus network load-balancer create n1 127.0.0.1
+
+incus network load-balancer create n1 127.0.0.1 < config.yaml
+    Create network load-balancer for network n1 with configuration from config.yaml`))
+
 	cmd.RunE = c.Run
 
 	cmd.Flags().StringVar(&c.networkLoadBalancer.flagTarget, "target", "", i18n.G("Cluster member name")+"``")

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-25 07:03+0100\n"
+"POT-Creation-Date: 2024-04-26 10:40+0200\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -338,7 +338,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -853,11 +853,11 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Add a network zone record entry"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -925,8 +925,8 @@ msgstr ""
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:990
-#: cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995
+#: cmd/incus/network_load_balancer.go:996
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1497,14 +1497,14 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
 #: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:427
-#: cmd/incus/network_load_balancer.go:562
-#: cmd/incus/network_load_balancer.go:717
-#: cmd/incus/network_load_balancer.go:805
-#: cmd/incus/network_load_balancer.go:881
-#: cmd/incus/network_load_balancer.go:994
-#: cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:432
+#: cmd/incus/network_load_balancer.go:567
+#: cmd/incus/network_load_balancer.go:722
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:886
+#: cmd/incus/network_load_balancer.go:999
+#: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746
 #: cmd/incus/storage.go:848 cmd/incus/storage.go:941
 #: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
@@ -1589,7 +1589,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
@@ -2045,8 +2045,8 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:713
-#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:719
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2178,17 +2178,17 @@ msgstr ""
 #: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
-#: cmd/incus/network_load_balancer.go:351
-#: cmd/incus/network_load_balancer.go:419
-#: cmd/incus/network_load_balancer.go:529
-#: cmd/incus/network_load_balancer.go:559
-#: cmd/incus/network_load_balancer.go:714
-#: cmd/incus/network_load_balancer.go:787
-#: cmd/incus/network_load_balancer.go:802
-#: cmd/incus/network_load_balancer.go:878
-#: cmd/incus/network_load_balancer.go:976
-#: cmd/incus/network_load_balancer.go:991
-#: cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:356
+#: cmd/incus/network_load_balancer.go:424
+#: cmd/incus/network_load_balancer.go:534
+#: cmd/incus/network_load_balancer.go:564
+#: cmd/incus/network_load_balancer.go:719
+#: cmd/incus/network_load_balancer.go:792
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:996
+#: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
@@ -2530,8 +2530,8 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network integration configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_load_balancer.go:558
-#: cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563
+#: cmd/incus/network_load_balancer.go:564
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2642,7 +2642,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
@@ -2663,7 +2663,7 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
-#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496
+#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
@@ -3370,7 +3370,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Get the key as a network integration property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3455,8 +3455,8 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network integration configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:350
-#: cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355
+#: cmd/incus/network_load_balancer.go:356
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -4665,14 +4665,14 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network integrations"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:786
-#: cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791
+#: cmd/incus/network_load_balancer.go:792
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:975
-#: cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:981
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4895,15 +4895,15 @@ msgstr "Fehlende Zusammenfassung."
 #: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
 #: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
-#: cmd/incus/network_load_balancer.go:281
-#: cmd/incus/network_load_balancer.go:379
-#: cmd/incus/network_load_balancer.go:464
-#: cmd/incus/network_load_balancer.go:622
-#: cmd/incus/network_load_balancer.go:754
-#: cmd/incus/network_load_balancer.go:842
-#: cmd/incus/network_load_balancer.go:918
-#: cmd/incus/network_load_balancer.go:1031
-#: cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_load_balancer.go:286
+#: cmd/incus/network_load_balancer.go:384
+#: cmd/incus/network_load_balancer.go:469
+#: cmd/incus/network_load_balancer.go:627
+#: cmd/incus/network_load_balancer.go:759
+#: cmd/incus/network_load_balancer.go:847
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1036
+#: cmd/incus/network_load_balancer.go:1110
 #, fuzzy
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4944,15 +4944,15 @@ msgstr "Profilname kann nicht geändert werden"
 #: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
-#: cmd/incus/network_load_balancer.go:277
-#: cmd/incus/network_load_balancer.go:375
-#: cmd/incus/network_load_balancer.go:460
-#: cmd/incus/network_load_balancer.go:618
-#: cmd/incus/network_load_balancer.go:750
-#: cmd/incus/network_load_balancer.go:838
-#: cmd/incus/network_load_balancer.go:914
-#: cmd/incus/network_load_balancer.go:1027
-#: cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118
+#: cmd/incus/network_load_balancer.go:282
+#: cmd/incus/network_load_balancer.go:380
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:623
+#: cmd/incus/network_load_balancer.go:755
+#: cmd/incus/network_load_balancer.go:843
+#: cmd/incus/network_load_balancer.go:919
+#: cmd/incus/network_load_balancer.go:1032
+#: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
 #: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
 #: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
 #: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
@@ -5126,7 +5126,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5352,12 +5352,12 @@ msgstr "Profil %s gelöscht\n"
 msgid "Network integration %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -5445,11 +5445,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5692,7 +5692,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
@@ -6125,7 +6125,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -6133,12 +6133,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6162,8 +6162,8 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_load_balancer.go:1063
-#: cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068
+#: cmd/incus/network_load_balancer.go:1069
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6623,12 +6623,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6789,7 +6789,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Set the key as a network integration property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7439,7 +7439,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7869,12 +7869,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset network integration configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7940,7 +7940,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as a network integration property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -8956,8 +8956,8 @@ msgstr ""
 
 #: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
 #: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
-#: cmd/incus/network_load_balancer.go:557
-#: cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:716
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -8965,7 +8965,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -8973,7 +8973,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8984,8 +8984,8 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
-#: cmd/incus/network_load_balancer.go:349
-#: cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:532
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -8993,7 +8993,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -9001,7 +9001,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -9017,7 +9017,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -9850,6 +9850,15 @@ msgid ""
 "yaml\n"
 "    Update a network integration using the content of network-integration."
 "yaml"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:254
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
+"\n"
+"incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
 msgstr ""
 
 #: cmd/incus/network_peer.go:246

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-25 07:03+0100\n"
+"POT-Creation-Date: 2024-04-26 10:40+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,7 +336,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -824,11 +824,11 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Add a network zone record entry"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -895,8 +895,8 @@ msgstr ""
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:990
-#: cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995
+#: cmd/incus/network_load_balancer.go:996
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1117,7 +1117,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1447,14 +1447,14 @@ msgstr "Perfil %s eliminado de %s"
 #: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
 #: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:427
-#: cmd/incus/network_load_balancer.go:562
-#: cmd/incus/network_load_balancer.go:717
-#: cmd/incus/network_load_balancer.go:805
-#: cmd/incus/network_load_balancer.go:881
-#: cmd/incus/network_load_balancer.go:994
-#: cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:432
+#: cmd/incus/network_load_balancer.go:567
+#: cmd/incus/network_load_balancer.go:722
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:886
+#: cmd/incus/network_load_balancer.go:999
+#: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746
 #: cmd/incus/storage.go:848 cmd/incus/storage.go:941
 #: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
@@ -1539,7 +1539,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
@@ -1977,8 +1977,8 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:713
-#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:719
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Perfil %s creado"
@@ -2108,17 +2108,17 @@ msgstr ""
 #: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
-#: cmd/incus/network_load_balancer.go:351
-#: cmd/incus/network_load_balancer.go:419
-#: cmd/incus/network_load_balancer.go:529
-#: cmd/incus/network_load_balancer.go:559
-#: cmd/incus/network_load_balancer.go:714
-#: cmd/incus/network_load_balancer.go:787
-#: cmd/incus/network_load_balancer.go:802
-#: cmd/incus/network_load_balancer.go:878
-#: cmd/incus/network_load_balancer.go:976
-#: cmd/incus/network_load_balancer.go:991
-#: cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:356
+#: cmd/incus/network_load_balancer.go:424
+#: cmd/incus/network_load_balancer.go:534
+#: cmd/incus/network_load_balancer.go:564
+#: cmd/incus/network_load_balancer.go:719
+#: cmd/incus/network_load_balancer.go:792
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:996
+#: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
@@ -2439,8 +2439,8 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:558
-#: cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563
+#: cmd/incus/network_load_balancer.go:564
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Perfil %s creado"
@@ -2549,7 +2549,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
@@ -2570,7 +2570,7 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
-#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496
+#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
@@ -3264,7 +3264,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a network integration property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Nombre del contenedor es: %s"
@@ -3344,8 +3344,8 @@ msgstr "Perfil %s creado"
 msgid "Get values for network integration configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:350
-#: cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355
+#: cmd/incus/network_load_balancer.go:356
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Perfil %s creado"
@@ -4508,14 +4508,14 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_load_balancer.go:786
-#: cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791
+#: cmd/incus/network_load_balancer.go:792
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_load_balancer.go:975
-#: cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:981
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Nombre del contenedor es: %s"
@@ -4731,15 +4731,15 @@ msgstr "Nombre del contenedor es: %s"
 #: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
 #: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
-#: cmd/incus/network_load_balancer.go:281
-#: cmd/incus/network_load_balancer.go:379
-#: cmd/incus/network_load_balancer.go:464
-#: cmd/incus/network_load_balancer.go:622
-#: cmd/incus/network_load_balancer.go:754
-#: cmd/incus/network_load_balancer.go:842
-#: cmd/incus/network_load_balancer.go:918
-#: cmd/incus/network_load_balancer.go:1031
-#: cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_load_balancer.go:286
+#: cmd/incus/network_load_balancer.go:384
+#: cmd/incus/network_load_balancer.go:469
+#: cmd/incus/network_load_balancer.go:627
+#: cmd/incus/network_load_balancer.go:759
+#: cmd/incus/network_load_balancer.go:847
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1036
+#: cmd/incus/network_load_balancer.go:1110
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
@@ -4779,15 +4779,15 @@ msgstr "Nombre del contenedor es: %s"
 #: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
-#: cmd/incus/network_load_balancer.go:277
-#: cmd/incus/network_load_balancer.go:375
-#: cmd/incus/network_load_balancer.go:460
-#: cmd/incus/network_load_balancer.go:618
-#: cmd/incus/network_load_balancer.go:750
-#: cmd/incus/network_load_balancer.go:838
-#: cmd/incus/network_load_balancer.go:914
-#: cmd/incus/network_load_balancer.go:1027
-#: cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118
+#: cmd/incus/network_load_balancer.go:282
+#: cmd/incus/network_load_balancer.go:380
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:623
+#: cmd/incus/network_load_balancer.go:755
+#: cmd/incus/network_load_balancer.go:843
+#: cmd/incus/network_load_balancer.go:919
+#: cmd/incus/network_load_balancer.go:1032
+#: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
 #: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
 #: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
 #: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
@@ -4955,7 +4955,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5176,12 +5176,12 @@ msgstr "Perfil %s eliminado"
 msgid "Network integration %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Perfil %s eliminado"
@@ -5264,11 +5264,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5509,7 +5509,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
@@ -5935,7 +5935,7 @@ msgstr "Perfil %s creado"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5943,12 +5943,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
@@ -5969,8 +5969,8 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1063
-#: cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068
+#: cmd/incus/network_load_balancer.go:1069
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
@@ -6410,12 +6410,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6570,7 +6570,7 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network integration property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Perfil %s creado"
@@ -7196,7 +7196,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -7616,12 +7616,12 @@ msgstr "Perfil %s creado"
 msgid "Unset network integration configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Perfil %s creado"
@@ -7685,7 +7685,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network integration property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Perfil %s creado"
@@ -8431,18 +8431,18 @@ msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
 #: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
-#: cmd/incus/network_load_balancer.go:557
-#: cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:716
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8450,18 +8450,18 @@ msgid ""
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
-#: cmd/incus/network_load_balancer.go:349
-#: cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:532
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8474,7 +8474,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9090,6 +9090,15 @@ msgid ""
 "yaml\n"
 "    Update a network integration using the content of network-integration."
 "yaml"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:254
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
+"\n"
+"incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
 msgstr ""
 
 #: cmd/incus/network_peer.go:246

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-25 07:03+0100\n"
+"POT-Creation-Date: 2024-04-26 10:40+0200\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -346,7 +346,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -828,11 +828,11 @@ msgstr "Ajoutez un membre d'un cluster à un groupe de cluster"
 msgid "Add a network zone record entry"
 msgstr "Ajoutez un enregistrement d'une zone réseau"
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid "Add backend to a load balancer"
 msgstr "Ajoutez un backend à un équilibreur de charge"
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid "Add backends to a load balancer"
 msgstr "Ajoutez des backends à un équilibreur de charge"
 
@@ -915,8 +915,8 @@ msgstr ""
 msgid "Add ports to a forward"
 msgstr "Ajoutez des ports à la redirection"
 
-#: cmd/incus/network_load_balancer.go:990
-#: cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995
+#: cmd/incus/network_load_balancer.go:996
 msgid "Add ports to a load balancer"
 msgstr "Ajoutez des ports à l'équilibreur de charge"
 
@@ -1149,7 +1149,7 @@ msgstr ""
 "<clé>=<valeur>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1489,14 +1489,14 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 #: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
 #: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:427
-#: cmd/incus/network_load_balancer.go:562
-#: cmd/incus/network_load_balancer.go:717
-#: cmd/incus/network_load_balancer.go:805
-#: cmd/incus/network_load_balancer.go:881
-#: cmd/incus/network_load_balancer.go:994
-#: cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:432
+#: cmd/incus/network_load_balancer.go:567
+#: cmd/incus/network_load_balancer.go:722
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:886
+#: cmd/incus/network_load_balancer.go:999
+#: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746
 #: cmd/incus/storage.go:848 cmd/incus/storage.go:941
 #: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
@@ -1588,7 +1588,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
@@ -2081,8 +2081,8 @@ msgstr "Supprime les redirections réseaux"
 msgid "Delete network integrations"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_load_balancer.go:713
-#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:719
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Récupération de l'image : %s"
@@ -2216,17 +2216,17 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
-#: cmd/incus/network_load_balancer.go:351
-#: cmd/incus/network_load_balancer.go:419
-#: cmd/incus/network_load_balancer.go:529
-#: cmd/incus/network_load_balancer.go:559
-#: cmd/incus/network_load_balancer.go:714
-#: cmd/incus/network_load_balancer.go:787
-#: cmd/incus/network_load_balancer.go:802
-#: cmd/incus/network_load_balancer.go:878
-#: cmd/incus/network_load_balancer.go:976
-#: cmd/incus/network_load_balancer.go:991
-#: cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:356
+#: cmd/incus/network_load_balancer.go:424
+#: cmd/incus/network_load_balancer.go:534
+#: cmd/incus/network_load_balancer.go:564
+#: cmd/incus/network_load_balancer.go:719
+#: cmd/incus/network_load_balancer.go:792
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:996
+#: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
@@ -2565,8 +2565,8 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network integration configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:558
-#: cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563
+#: cmd/incus/network_load_balancer.go:564
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2691,7 +2691,7 @@ msgstr "Erreur lors de la récupération des alias : %w"
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
@@ -2712,7 +2712,7 @@ msgstr "Erreur lors du déparamétrage des propriétés: %v"
 
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
-#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496
+#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
@@ -3510,7 +3510,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a network integration property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Copie de l'image : %s"
@@ -3596,8 +3596,8 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network integration configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:350
-#: cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355
+#: cmd/incus/network_load_balancer.go:356
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4879,14 +4879,14 @@ msgstr "Nom du réseau"
 msgid "Manage network integrations"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:786
-#: cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791
+#: cmd/incus/network_load_balancer.go:792
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:975
-#: cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:981
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Copie de l'image : %s"
@@ -5108,15 +5108,15 @@ msgstr "Résumé manquant."
 #: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
 #: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
-#: cmd/incus/network_load_balancer.go:281
-#: cmd/incus/network_load_balancer.go:379
-#: cmd/incus/network_load_balancer.go:464
-#: cmd/incus/network_load_balancer.go:622
-#: cmd/incus/network_load_balancer.go:754
-#: cmd/incus/network_load_balancer.go:842
-#: cmd/incus/network_load_balancer.go:918
-#: cmd/incus/network_load_balancer.go:1031
-#: cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_load_balancer.go:286
+#: cmd/incus/network_load_balancer.go:384
+#: cmd/incus/network_load_balancer.go:469
+#: cmd/incus/network_load_balancer.go:627
+#: cmd/incus/network_load_balancer.go:759
+#: cmd/incus/network_load_balancer.go:847
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1036
+#: cmd/incus/network_load_balancer.go:1110
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5157,15 +5157,15 @@ msgstr "Nom du réseau"
 #: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
-#: cmd/incus/network_load_balancer.go:277
-#: cmd/incus/network_load_balancer.go:375
-#: cmd/incus/network_load_balancer.go:460
-#: cmd/incus/network_load_balancer.go:618
-#: cmd/incus/network_load_balancer.go:750
-#: cmd/incus/network_load_balancer.go:838
-#: cmd/incus/network_load_balancer.go:914
-#: cmd/incus/network_load_balancer.go:1027
-#: cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118
+#: cmd/incus/network_load_balancer.go:282
+#: cmd/incus/network_load_balancer.go:380
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:623
+#: cmd/incus/network_load_balancer.go:755
+#: cmd/incus/network_load_balancer.go:843
+#: cmd/incus/network_load_balancer.go:919
+#: cmd/incus/network_load_balancer.go:1032
+#: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
 #: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
 #: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
 #: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
@@ -5343,7 +5343,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5570,12 +5570,12 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Network integration %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -5662,11 +5662,11 @@ msgstr "Aucun périphérique existant pour ce réseau"
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5920,7 +5920,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
@@ -6357,7 +6357,7 @@ msgstr "Clé de configuration invalide"
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -6365,12 +6365,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6394,8 +6394,8 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network_load_balancer.go:1063
-#: cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068
+#: cmd/incus/network_load_balancer.go:1069
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
@@ -6868,12 +6868,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -7035,7 +7035,7 @@ msgstr "Nom du réseau"
 msgid "Set the key as a network integration property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Nom du réseau"
@@ -7700,7 +7700,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -8136,12 +8136,12 @@ msgstr "Nom du réseau"
 msgid "Unset network integration configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Nom du réseau"
@@ -8209,7 +8209,7 @@ msgstr "Nom du réseau"
 msgid "Unset the key as a network integration property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Nom du réseau"
@@ -9254,8 +9254,8 @@ msgstr ""
 
 #: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
 #: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
-#: cmd/incus/network_load_balancer.go:557
-#: cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:716
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -9263,7 +9263,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -9271,7 +9271,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -9282,8 +9282,8 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
-#: cmd/incus/network_load_balancer.go:349
-#: cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:532
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -9291,7 +9291,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -9299,7 +9299,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -9315,7 +9315,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -10203,6 +10203,15 @@ msgid ""
 "yaml\n"
 "    Update a network integration using the content of network-integration."
 "yaml"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:254
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
+"\n"
+"incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
 msgstr ""
 
 #: cmd/incus/network_peer.go:246

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-04-25 07:03+0100\n"
+        "POT-Creation-Date: 2024-04-26 10:40+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -188,7 +188,7 @@ msgid   "### This is a YAML representation of the network integration.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -546,11 +546,11 @@ msgstr  ""
 msgid   "Add a network zone record entry"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid   "Add backend to a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid   "Add backends to a load balancer"
 msgstr  ""
 
@@ -609,7 +609,7 @@ msgstr  ""
 msgid   "Add ports to a forward"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:990 cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995 cmd/incus/network_load_balancer.go:996
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
@@ -821,7 +821,7 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378 cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378 cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -1125,7 +1125,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64 cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880 cmd/incus/network.go:1257 cmd/incus/network.go:1350 cmd/incus/network.go:1422 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:256 cmd/incus/network_load_balancer.go:427 cmd/incus/network_load_balancer.go:562 cmd/incus/network_load_balancer.go:717 cmd/incus/network_load_balancer.go:805 cmd/incus/network_load_balancer.go:881 cmd/incus/network_load_balancer.go:994 cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103 cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746 cmd/incus/storage.go:848 cmd/incus/storage.go:941 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392 cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642 cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941 cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939 cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294 cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834 cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083 cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598 cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773 cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64 cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880 cmd/incus/network.go:1257 cmd/incus/network.go:1350 cmd/incus/network.go:1422 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:432 cmd/incus/network_load_balancer.go:567 cmd/incus/network_load_balancer.go:722 cmd/incus/network_load_balancer.go:810 cmd/incus/network_load_balancer.go:886 cmd/incus/network_load_balancer.go:999 cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103 cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746 cmd/incus/storage.go:848 cmd/incus/storage.go:941 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392 cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642 cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941 cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939 cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294 cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834 cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083 cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598 cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773 cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1178,7 +1178,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324 cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324 cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1579,7 +1579,7 @@ msgstr  ""
 msgid   "Delete network integrations"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:713 cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718 cmd/incus/network_load_balancer.go:719
 msgid   "Delete network load balancers"
 msgstr  ""
 
@@ -1627,7 +1627,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:351 cmd/incus/network_load_balancer.go:419 cmd/incus/network_load_balancer.go:529 cmd/incus/network_load_balancer.go:559 cmd/incus/network_load_balancer.go:714 cmd/incus/network_load_balancer.go:787 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:878 cmd/incus/network_load_balancer.go:976 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408 cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857 cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433 cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:434 cmd/incus/profile.go:492 cmd/incus/profile.go:628 cmd/incus/profile.go:702 cmd/incus/profile.go:771 cmd/incus/profile.go:859 cmd/incus/profile.go:919 cmd/incus/profile.go:1008 cmd/incus/profile.go:1072 cmd/incus/project.go:35 cmd/incus/project.go:99 cmd/incus/project.go:195 cmd/incus/project.go:266 cmd/incus/project.go:402 cmd/incus/project.go:477 cmd/incus/project.go:692 cmd/incus/project.go:757 cmd/incus/project.go:845 cmd/incus/project.go:889 cmd/incus/project.go:950 cmd/incus/project.go:1017 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:201 cmd/incus/storage.go:259 cmd/incus/storage.go:391 cmd/incus/storage.go:473 cmd/incus/storage.go:653 cmd/incus/storage.go:740 cmd/incus/storage.go:844 cmd/incus/storage.go:938 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:719 cmd/incus/network_load_balancer.go:792 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:883 cmd/incus/network_load_balancer.go:981 cmd/incus/network_load_balancer.go:996 cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408 cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857 cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433 cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:434 cmd/incus/profile.go:492 cmd/incus/profile.go:628 cmd/incus/profile.go:702 cmd/incus/profile.go:771 cmd/incus/profile.go:859 cmd/incus/profile.go:919 cmd/incus/profile.go:1008 cmd/incus/profile.go:1072 cmd/incus/project.go:35 cmd/incus/project.go:99 cmd/incus/project.go:195 cmd/incus/project.go:266 cmd/incus/project.go:402 cmd/incus/project.go:477 cmd/incus/project.go:692 cmd/incus/project.go:757 cmd/incus/project.go:845 cmd/incus/project.go:889 cmd/incus/project.go:950 cmd/incus/project.go:1017 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:201 cmd/incus/storage.go:259 cmd/incus/storage.go:391 cmd/incus/storage.go:473 cmd/incus/storage.go:653 cmd/incus/storage.go:740 cmd/incus/storage.go:844 cmd/incus/storage.go:938 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1870,7 +1870,7 @@ msgstr  ""
 msgid   "Edit network integration configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:558 cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563 cmd/incus/network_load_balancer.go:564
 msgid   "Edit network load balancer configurations as YAML"
 msgstr  ""
 
@@ -1966,7 +1966,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155 cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
+#: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155 cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1981,7 +1981,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465 cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980 cmd/incus/project.go:814 cmd/incus/storage.go:804 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
+#: cmd/incus/cluster.go:556 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465 cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980 cmd/incus/project.go:814 cmd/incus/storage.go:804 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2629,7 +2629,7 @@ msgstr  ""
 msgid   "Get the key as a network integration property"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 msgid   "Get the key as a network load balancer property"
 msgstr  ""
 
@@ -2701,7 +2701,7 @@ msgstr  ""
 msgid   "Get values for network integration configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:350 cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355 cmd/incus/network_load_balancer.go:356
 msgid   "Get values for network load balancer configuration keys"
 msgstr  ""
 
@@ -3795,11 +3795,11 @@ msgstr  ""
 msgid   "Manage network integrations"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:786 cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791 cmd/incus/network_load_balancer.go:792
 msgid   "Manage network load balancer backends"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:975 cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980 cmd/incus/network_load_balancer.go:981
 msgid   "Manage network load balancer ports"
 msgstr  ""
 
@@ -3977,7 +3977,7 @@ msgstr  ""
 msgid   "Missing key name"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283 cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789 cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964 cmd/incus/network_load_balancer.go:217 cmd/incus/network_load_balancer.go:281 cmd/incus/network_load_balancer.go:379 cmd/incus/network_load_balancer.go:464 cmd/incus/network_load_balancer.go:622 cmd/incus/network_load_balancer.go:754 cmd/incus/network_load_balancer.go:842 cmd/incus/network_load_balancer.go:918 cmd/incus/network_load_balancer.go:1031 cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_forward.go:214 cmd/incus/network_forward.go:283 cmd/incus/network_forward.go:398 cmd/incus/network_forward.go:483 cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789 cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964 cmd/incus/network_load_balancer.go:217 cmd/incus/network_load_balancer.go:286 cmd/incus/network_load_balancer.go:384 cmd/incus/network_load_balancer.go:469 cmd/incus/network_load_balancer.go:627 cmd/incus/network_load_balancer.go:759 cmd/incus/network_load_balancer.go:847 cmd/incus/network_load_balancer.go:923 cmd/incus/network_load_balancer.go:1036 cmd/incus/network_load_balancer.go:1110
 msgid   "Missing listen address"
 msgstr  ""
 
@@ -3993,7 +3993,7 @@ msgstr  ""
 msgid   "Missing network integration name"
 msgstr  ""
 
-#: cmd/incus/network.go:175 cmd/incus/network.go:272 cmd/incus/network.go:440 cmd/incus/network.go:502 cmd/incus/network.go:599 cmd/incus/network.go:712 cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145 cmd/incus/network.go:1223 cmd/incus/network.go:1289 cmd/incus/network.go:1381 cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960 cmd/incus/network_load_balancer.go:127 cmd/incus/network_load_balancer.go:213 cmd/incus/network_load_balancer.go:277 cmd/incus/network_load_balancer.go:375 cmd/incus/network_load_balancer.go:460 cmd/incus/network_load_balancer.go:618 cmd/incus/network_load_balancer.go:750 cmd/incus/network_load_balancer.go:838 cmd/incus/network_load_balancer.go:914 cmd/incus/network_load_balancer.go:1027 cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118 cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288 cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network.go:175 cmd/incus/network.go:272 cmd/incus/network.go:440 cmd/incus/network.go:502 cmd/incus/network.go:599 cmd/incus/network.go:712 cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145 cmd/incus/network.go:1223 cmd/incus/network.go:1289 cmd/incus/network.go:1381 cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960 cmd/incus/network_load_balancer.go:127 cmd/incus/network_load_balancer.go:213 cmd/incus/network_load_balancer.go:282 cmd/incus/network_load_balancer.go:380 cmd/incus/network_load_balancer.go:465 cmd/incus/network_load_balancer.go:623 cmd/incus/network_load_balancer.go:755 cmd/incus/network_load_balancer.go:843 cmd/incus/network_load_balancer.go:919 cmd/incus/network_load_balancer.go:1032 cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118 cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288 cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
 msgid   "Missing network name"
 msgstr  ""
 
@@ -4113,7 +4113,7 @@ msgstr  ""
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
@@ -4319,12 +4319,12 @@ msgstr  ""
 msgid   "Network integration %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, c-format
 msgid   "Network load balancer %s created"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, c-format
 msgid   "Network load balancer %s deleted"
 msgstr  ""
@@ -4406,11 +4406,11 @@ msgstr  ""
 msgid   "No device found for this storage volume"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid   "No matching backend found"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid   "No matching port(s) found"
 msgstr  ""
 
@@ -4640,7 +4640,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325 cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325 cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -5029,7 +5029,7 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid   "Remove all ports that match"
 msgstr  ""
 
@@ -5037,11 +5037,11 @@ msgstr  ""
 msgid   "Remove all rules that match"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 msgid   "Remove backend from a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 msgid   "Remove backends from a load balancer"
 msgstr  ""
 
@@ -5061,7 +5061,7 @@ msgstr  ""
 msgid   "Remove ports from a forward"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:1063 cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068 cmd/incus/network_load_balancer.go:1069
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
@@ -5465,11 +5465,11 @@ msgid   "Set network integration configuration keys\n"
         "    incus network integration set [<remote>:]<network integration> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 msgid   "Set network load balancer keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 msgid   "Set network load balancer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5601,7 +5601,7 @@ msgstr  ""
 msgid   "Set the key as a network integration property"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 msgid   "Set the key as a network load balancer property"
 msgstr  ""
 
@@ -6185,7 +6185,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, c-format
 msgid   "The property %q does not exist on the load balancer %q: %v"
 msgstr  ""
@@ -6574,11 +6574,11 @@ msgstr  ""
 msgid   "Unset network integration configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 msgid   "Unset network load balancer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 msgid   "Unset network load balancer keys"
 msgstr  ""
 
@@ -6634,7 +6634,7 @@ msgstr  ""
 msgid   "Unset the key as a network integration property"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 msgid   "Unset the key as a network load balancer property"
 msgstr  ""
 
@@ -7255,27 +7255,27 @@ msgstr  ""
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175 cmd/incus/network_load_balancer.go:557 cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593 cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175 cmd/incus/network_load_balancer.go:562 cmd/incus/network_load_balancer.go:716
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 msgid   "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 msgid   "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546 cmd/incus/network_load_balancer.go:349 cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546 cmd/incus/network_load_balancer.go:354 cmd/incus/network_load_balancer.go:532
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
 msgstr  ""
 
@@ -7283,7 +7283,7 @@ msgstr  ""
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
@@ -7779,6 +7779,13 @@ msgstr  ""
 #: cmd/incus/network_integration.go:232
 msgid   "incus network integration edit <network integration> < network-integration.yaml\n"
         "    Update a network integration using the content of network-integration.yaml"
+msgstr  ""
+
+#: cmd/incus/network_load_balancer.go:254
+msgid   "incus network load-balancer create n1 127.0.0.1\n"
+        "\n"
+        "incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+        "    Create network load-balancer for network n1 with configuration from config.yaml"
 msgstr  ""
 
 #: cmd/incus/network_peer.go:246

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-25 07:03+0100\n"
+"POT-Creation-Date: 2024-04-26 10:40+0200\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -340,7 +340,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -823,11 +823,11 @@ msgstr "Il nome del container è: %s"
 msgid "Add a network zone record entry"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -894,8 +894,8 @@ msgstr ""
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:990
-#: cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995
+#: cmd/incus/network_load_balancer.go:996
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1116,7 +1116,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1442,14 +1442,14 @@ msgstr ""
 #: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
 #: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:427
-#: cmd/incus/network_load_balancer.go:562
-#: cmd/incus/network_load_balancer.go:717
-#: cmd/incus/network_load_balancer.go:805
-#: cmd/incus/network_load_balancer.go:881
-#: cmd/incus/network_load_balancer.go:994
-#: cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:432
+#: cmd/incus/network_load_balancer.go:567
+#: cmd/incus/network_load_balancer.go:722
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:886
+#: cmd/incus/network_load_balancer.go:999
+#: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746
 #: cmd/incus/storage.go:848 cmd/incus/storage.go:941
 #: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
@@ -1531,7 +1531,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
@@ -1971,8 +1971,8 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:713
-#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:719
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Il nome del container è: %s"
@@ -2101,17 +2101,17 @@ msgstr ""
 #: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
-#: cmd/incus/network_load_balancer.go:351
-#: cmd/incus/network_load_balancer.go:419
-#: cmd/incus/network_load_balancer.go:529
-#: cmd/incus/network_load_balancer.go:559
-#: cmd/incus/network_load_balancer.go:714
-#: cmd/incus/network_load_balancer.go:787
-#: cmd/incus/network_load_balancer.go:802
-#: cmd/incus/network_load_balancer.go:878
-#: cmd/incus/network_load_balancer.go:976
-#: cmd/incus/network_load_balancer.go:991
-#: cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:356
+#: cmd/incus/network_load_balancer.go:424
+#: cmd/incus/network_load_balancer.go:534
+#: cmd/incus/network_load_balancer.go:564
+#: cmd/incus/network_load_balancer.go:719
+#: cmd/incus/network_load_balancer.go:792
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:996
+#: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
@@ -2434,8 +2434,8 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:558
-#: cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563
+#: cmd/incus/network_load_balancer.go:564
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Il nome del container è: %s"
@@ -2543,7 +2543,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
@@ -2564,7 +2564,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
-#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496
+#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
@@ -3257,7 +3257,7 @@ msgstr ""
 msgid "Get the key as a network integration property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Creazione del container in corso"
@@ -3335,8 +3335,8 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:350
-#: cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355
+#: cmd/incus/network_load_balancer.go:356
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
@@ -4502,14 +4502,14 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:786
-#: cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791
+#: cmd/incus/network_load_balancer.go:792
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:975
-#: cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:981
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Creazione del container in corso"
@@ -4725,15 +4725,15 @@ msgstr "Il nome del container è: %s"
 #: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
 #: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
-#: cmd/incus/network_load_balancer.go:281
-#: cmd/incus/network_load_balancer.go:379
-#: cmd/incus/network_load_balancer.go:464
-#: cmd/incus/network_load_balancer.go:622
-#: cmd/incus/network_load_balancer.go:754
-#: cmd/incus/network_load_balancer.go:842
-#: cmd/incus/network_load_balancer.go:918
-#: cmd/incus/network_load_balancer.go:1031
-#: cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_load_balancer.go:286
+#: cmd/incus/network_load_balancer.go:384
+#: cmd/incus/network_load_balancer.go:469
+#: cmd/incus/network_load_balancer.go:627
+#: cmd/incus/network_load_balancer.go:759
+#: cmd/incus/network_load_balancer.go:847
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1036
+#: cmd/incus/network_load_balancer.go:1110
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
@@ -4773,15 +4773,15 @@ msgstr "Il nome del container è: %s"
 #: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
-#: cmd/incus/network_load_balancer.go:277
-#: cmd/incus/network_load_balancer.go:375
-#: cmd/incus/network_load_balancer.go:460
-#: cmd/incus/network_load_balancer.go:618
-#: cmd/incus/network_load_balancer.go:750
-#: cmd/incus/network_load_balancer.go:838
-#: cmd/incus/network_load_balancer.go:914
-#: cmd/incus/network_load_balancer.go:1027
-#: cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118
+#: cmd/incus/network_load_balancer.go:282
+#: cmd/incus/network_load_balancer.go:380
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:623
+#: cmd/incus/network_load_balancer.go:755
+#: cmd/incus/network_load_balancer.go:843
+#: cmd/incus/network_load_balancer.go:919
+#: cmd/incus/network_load_balancer.go:1032
+#: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
 #: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
 #: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
 #: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
@@ -4949,7 +4949,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5170,12 +5170,12 @@ msgstr "Il nome del container è: %s"
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -5258,11 +5258,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5504,7 +5504,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
@@ -5929,7 +5929,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5937,12 +5937,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Il nome del container è: %s"
@@ -5964,8 +5964,8 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1063
-#: cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068
+#: cmd/incus/network_load_balancer.go:1069
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
@@ -6404,12 +6404,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6562,7 +6562,7 @@ msgstr ""
 msgid "Set the key as a network integration property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
@@ -7190,7 +7190,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Il nome del container è: %s"
@@ -7611,12 +7611,12 @@ msgstr ""
 msgid "Unset network integration configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Il nome del container è: %s"
@@ -7678,7 +7678,7 @@ msgstr ""
 msgid "Unset the key as a network integration property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
@@ -8426,18 +8426,18 @@ msgstr "Creazione del container in corso"
 
 #: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
 #: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
-#: cmd/incus/network_load_balancer.go:557
-#: cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:716
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8445,18 +8445,18 @@ msgid ""
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
-#: cmd/incus/network_load_balancer.go:349
-#: cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:532
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8469,7 +8469,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
@@ -9085,6 +9085,15 @@ msgid ""
 "yaml\n"
 "    Update a network integration using the content of network-integration."
 "yaml"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:254
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
+"\n"
+"incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
 msgstr ""
 
 #: cmd/incus/network_peer.go:246

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-25 07:03+0100\n"
+"POT-Creation-Date: 2024-04-26 10:40+0200\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -334,7 +334,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -809,11 +809,11 @@ msgstr "クラスターメンバーをクラスターグループに追加しま
 msgid "Add a network zone record entry"
 msgstr "ネットワークゾーンレコードのエントリを追加します"
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid "Add backend to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid "Add backends to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
@@ -894,8 +894,8 @@ msgstr ""
 msgid "Add ports to a forward"
 msgstr "フォワードにポートを追加します"
 
-#: cmd/incus/network_load_balancer.go:990
-#: cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995
+#: cmd/incus/network_load_balancer.go:996
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
@@ -1120,7 +1120,7 @@ msgstr ""
 "<device>,<key>=<value>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1454,14 +1454,14 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
 #: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:427
-#: cmd/incus/network_load_balancer.go:562
-#: cmd/incus/network_load_balancer.go:717
-#: cmd/incus/network_load_balancer.go:805
-#: cmd/incus/network_load_balancer.go:881
-#: cmd/incus/network_load_balancer.go:994
-#: cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:432
+#: cmd/incus/network_load_balancer.go:567
+#: cmd/incus/network_load_balancer.go:722
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:886
+#: cmd/incus/network_load_balancer.go:999
+#: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746
 #: cmd/incus/storage.go:848 cmd/incus/storage.go:941
 #: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
@@ -1550,7 +1550,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
@@ -1997,8 +1997,8 @@ msgstr "ネットワークフォワードを削除します"
 msgid "Delete network integrations"
 msgstr "ネットワークピアリングを削除します"
 
-#: cmd/incus/network_load_balancer.go:713
-#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:719
 msgid "Delete network load balancers"
 msgstr "ネットワークロードバランサーを削除します"
 
@@ -2123,17 +2123,17 @@ msgstr "警告を削除します"
 #: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
-#: cmd/incus/network_load_balancer.go:351
-#: cmd/incus/network_load_balancer.go:419
-#: cmd/incus/network_load_balancer.go:529
-#: cmd/incus/network_load_balancer.go:559
-#: cmd/incus/network_load_balancer.go:714
-#: cmd/incus/network_load_balancer.go:787
-#: cmd/incus/network_load_balancer.go:802
-#: cmd/incus/network_load_balancer.go:878
-#: cmd/incus/network_load_balancer.go:976
-#: cmd/incus/network_load_balancer.go:991
-#: cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:356
+#: cmd/incus/network_load_balancer.go:424
+#: cmd/incus/network_load_balancer.go:534
+#: cmd/incus/network_load_balancer.go:564
+#: cmd/incus/network_load_balancer.go:719
+#: cmd/incus/network_load_balancer.go:792
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:996
+#: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
@@ -2457,8 +2457,8 @@ msgstr "ネットワークフォワード設定をYAMLで編集します"
 msgid "Edit network integration configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
-#: cmd/incus/network_load_balancer.go:558
-#: cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563
+#: cmd/incus/network_load_balancer.go:564
 msgid "Edit network load balancer configurations as YAML"
 msgstr "ネットワークロードバランサー設定をYAMLで編集します"
 
@@ -2572,7 +2572,7 @@ msgstr "エイリアスの取得に失敗しました: %w"
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
@@ -2593,7 +2593,7 @@ msgstr "プロパティの削除でエラーが発生しました: %v"
 
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
-#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496
+#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
@@ -3339,7 +3339,7 @@ msgstr "ネットワークフォワードのポートを管理します"
 msgid "Get the key as a network integration property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "ネットワークロードバランサーのポートを管理します"
@@ -3419,8 +3419,8 @@ msgstr "ネットワークフォワードの設定値を取得します"
 msgid "Get values for network integration configuration keys"
 msgstr "ネットワークピアの設定値を取得します"
 
-#: cmd/incus/network_load_balancer.go:350
-#: cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355
+#: cmd/incus/network_load_balancer.go:356
 msgid "Get values for network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定値を取得します"
 
@@ -4817,13 +4817,13 @@ msgstr "ネットワークフォワードを管理します"
 msgid "Manage network integrations"
 msgstr "ネットワークピアリングを管理します"
 
-#: cmd/incus/network_load_balancer.go:786
-#: cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791
+#: cmd/incus/network_load_balancer.go:792
 msgid "Manage network load balancer backends"
 msgstr "ネットワークロードバランサーのバックエンドを管理します"
 
-#: cmd/incus/network_load_balancer.go:975
-#: cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:981
 msgid "Manage network load balancer ports"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
@@ -5028,15 +5028,15 @@ msgstr "鍵の名前を指定する必要があります"
 #: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
 #: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
-#: cmd/incus/network_load_balancer.go:281
-#: cmd/incus/network_load_balancer.go:379
-#: cmd/incus/network_load_balancer.go:464
-#: cmd/incus/network_load_balancer.go:622
-#: cmd/incus/network_load_balancer.go:754
-#: cmd/incus/network_load_balancer.go:842
-#: cmd/incus/network_load_balancer.go:918
-#: cmd/incus/network_load_balancer.go:1031
-#: cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_load_balancer.go:286
+#: cmd/incus/network_load_balancer.go:384
+#: cmd/incus/network_load_balancer.go:469
+#: cmd/incus/network_load_balancer.go:627
+#: cmd/incus/network_load_balancer.go:759
+#: cmd/incus/network_load_balancer.go:847
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1036
+#: cmd/incus/network_load_balancer.go:1110
 msgid "Missing listen address"
 msgstr "リッスンアドレスを指定する必要があります"
 
@@ -5074,15 +5074,15 @@ msgstr "ネットワークゾーン名を指定する必要があります"
 #: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
-#: cmd/incus/network_load_balancer.go:277
-#: cmd/incus/network_load_balancer.go:375
-#: cmd/incus/network_load_balancer.go:460
-#: cmd/incus/network_load_balancer.go:618
-#: cmd/incus/network_load_balancer.go:750
-#: cmd/incus/network_load_balancer.go:838
-#: cmd/incus/network_load_balancer.go:914
-#: cmd/incus/network_load_balancer.go:1027
-#: cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118
+#: cmd/incus/network_load_balancer.go:282
+#: cmd/incus/network_load_balancer.go:380
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:623
+#: cmd/incus/network_load_balancer.go:755
+#: cmd/incus/network_load_balancer.go:843
+#: cmd/incus/network_load_balancer.go:919
+#: cmd/incus/network_load_balancer.go:1032
+#: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
 #: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
 #: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
 #: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
@@ -5263,7 +5263,7 @@ msgstr "コピー／移動元とは異なるプロジェクトに移動します
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
@@ -5490,12 +5490,12 @@ msgstr "ネットワークゾーン %s を削除しました"
 msgid "Network integration %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, c-format
 msgid "Network load balancer %s created"
 msgstr "ネットワークロードバランサー %s を作成しました"
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr "ネットワークロードバランサー %s を削除しました"
@@ -5581,11 +5581,11 @@ msgstr "このネットワークに対するデバイスがありません"
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid "No matching backend found"
 msgstr "マッチするバックエンドが見つかりません"
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
@@ -5833,7 +5833,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
@@ -6294,7 +6294,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
@@ -6302,11 +6302,11 @@ msgstr "マッチするポートをすべて削除します"
 msgid "Remove all rules that match"
 msgstr "マッチするルールをすべて削除します"
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 msgid "Remove backend from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 msgid "Remove backends from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
@@ -6326,8 +6326,8 @@ msgstr "グループからメンバーを削除します"
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
-#: cmd/incus/network_load_balancer.go:1063
-#: cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068
+#: cmd/incus/network_load_balancer.go:1069
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
@@ -6802,11 +6802,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 msgid "Set network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 #, fuzzy
 msgid ""
 "Set network load balancer keys\n"
@@ -7001,7 +7001,7 @@ msgstr "ネットワークフォワードの設定値を設定します"
 msgid "Set the key as a network integration property"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を行います"
@@ -7654,7 +7654,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -8107,11 +8107,11 @@ msgstr "ネットワークフォワードの設定を削除します"
 msgid "Unset network integration configuration keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 msgid "Unset network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 msgid "Unset network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
@@ -8169,7 +8169,7 @@ msgstr "ネットワークフォワードの設定を削除します"
 msgid "Unset the key as a network integration property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を削除します"
@@ -8887,16 +8887,16 @@ msgstr "[<remote>:]<network> <key>=<value>..."
 
 #: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
 #: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
-#: cmd/incus/network_load_balancer.go:557
-#: cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:716
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "[<remote>:]<network> <listen_address>"
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "[<remote>:]<network> <listen_address> <backend_name>"
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
@@ -8905,16 +8905,16 @@ msgstr ""
 "[<target_port(s)>]"
 
 #: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
-#: cmd/incus/network_load_balancer.go:349
-#: cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:532
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <listen_address> <key>"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <listen_address> <key>=<value>..."
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -8930,7 +8930,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
@@ -9649,6 +9649,20 @@ msgid ""
 msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
+
+#: cmd/incus/network_load_balancer.go:254
+#, fuzzy
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
+"\n"
+"incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
+msgstr ""
+"lxc init ubuntu:22.04 u1\n"
+"\n"
+"lxc init ubuntu:22.04 u1 < config.yaml\n"
+"    config.yaml の設定を使ってインスタンスを作成します"
 
 #: cmd/incus/network_peer.go:246
 msgid ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-25 07:03+0100\n"
+"POT-Creation-Date: 2024-04-26 10:40+0200\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -338,7 +338,7 @@ msgstr ""
 "###\n"
 "### Merk op dat de getoonde fingerprint niet kan worden aangepast"
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr "Voeg een netwerk (network) zone record toe"
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -906,8 +906,8 @@ msgstr ""
 msgid "Add ports to a forward"
 msgstr "Voeg poorten (ports) toe aan een doorstuurregel (forward)"
 
-#: cmd/incus/network_load_balancer.go:990
-#: cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995
+#: cmd/incus/network_load_balancer.go:996
 msgid "Add ports to a load balancer"
 msgstr "Voeg poorten (ports) toe aan een werkverdeler (load balancer)"
 
@@ -1137,7 +1137,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1464,14 +1464,14 @@ msgstr ""
 #: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
 #: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:427
-#: cmd/incus/network_load_balancer.go:562
-#: cmd/incus/network_load_balancer.go:717
-#: cmd/incus/network_load_balancer.go:805
-#: cmd/incus/network_load_balancer.go:881
-#: cmd/incus/network_load_balancer.go:994
-#: cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:432
+#: cmd/incus/network_load_balancer.go:567
+#: cmd/incus/network_load_balancer.go:722
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:886
+#: cmd/incus/network_load_balancer.go:999
+#: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746
 #: cmd/incus/storage.go:848 cmd/incus/storage.go:941
 #: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
@@ -1552,7 +1552,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
@@ -1978,8 +1978,8 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr "Toekennen van netwerk interfaces aan instanties (instances)"
 
-#: cmd/incus/network_load_balancer.go:713
-#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:719
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -2104,17 +2104,17 @@ msgstr ""
 #: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
-#: cmd/incus/network_load_balancer.go:351
-#: cmd/incus/network_load_balancer.go:419
-#: cmd/incus/network_load_balancer.go:529
-#: cmd/incus/network_load_balancer.go:559
-#: cmd/incus/network_load_balancer.go:714
-#: cmd/incus/network_load_balancer.go:787
-#: cmd/incus/network_load_balancer.go:802
-#: cmd/incus/network_load_balancer.go:878
-#: cmd/incus/network_load_balancer.go:976
-#: cmd/incus/network_load_balancer.go:991
-#: cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:356
+#: cmd/incus/network_load_balancer.go:424
+#: cmd/incus/network_load_balancer.go:534
+#: cmd/incus/network_load_balancer.go:564
+#: cmd/incus/network_load_balancer.go:719
+#: cmd/incus/network_load_balancer.go:792
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:996
+#: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
@@ -2426,8 +2426,8 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:558
-#: cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563
+#: cmd/incus/network_load_balancer.go:564
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2531,7 +2531,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
@@ -2552,7 +2552,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
-#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496
+#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
@@ -3238,7 +3238,7 @@ msgstr ""
 msgid "Get the key as a network integration property"
 msgstr "Toekennen van netwerk (network) interfaces aan profielen (profiles)"
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -3310,8 +3310,8 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:350
-#: cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355
+#: cmd/incus/network_load_balancer.go:356
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -4438,13 +4438,13 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr "Toekennen van nieuwe netwerk interfaces aan instanties (instances)"
 
-#: cmd/incus/network_load_balancer.go:786
-#: cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791
+#: cmd/incus/network_load_balancer.go:792
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:975
-#: cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:981
 msgid "Manage network load balancer ports"
 msgstr ""
 
@@ -4644,15 +4644,15 @@ msgstr ""
 #: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
 #: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
-#: cmd/incus/network_load_balancer.go:281
-#: cmd/incus/network_load_balancer.go:379
-#: cmd/incus/network_load_balancer.go:464
-#: cmd/incus/network_load_balancer.go:622
-#: cmd/incus/network_load_balancer.go:754
-#: cmd/incus/network_load_balancer.go:842
-#: cmd/incus/network_load_balancer.go:918
-#: cmd/incus/network_load_balancer.go:1031
-#: cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_load_balancer.go:286
+#: cmd/incus/network_load_balancer.go:384
+#: cmd/incus/network_load_balancer.go:469
+#: cmd/incus/network_load_balancer.go:627
+#: cmd/incus/network_load_balancer.go:759
+#: cmd/incus/network_load_balancer.go:847
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1036
+#: cmd/incus/network_load_balancer.go:1110
 msgid "Missing listen address"
 msgstr ""
 
@@ -4690,15 +4690,15 @@ msgstr "Toekennen van netwerk interfaces aan instanties (instances)"
 #: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
-#: cmd/incus/network_load_balancer.go:277
-#: cmd/incus/network_load_balancer.go:375
-#: cmd/incus/network_load_balancer.go:460
-#: cmd/incus/network_load_balancer.go:618
-#: cmd/incus/network_load_balancer.go:750
-#: cmd/incus/network_load_balancer.go:838
-#: cmd/incus/network_load_balancer.go:914
-#: cmd/incus/network_load_balancer.go:1027
-#: cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118
+#: cmd/incus/network_load_balancer.go:282
+#: cmd/incus/network_load_balancer.go:380
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:623
+#: cmd/incus/network_load_balancer.go:755
+#: cmd/incus/network_load_balancer.go:843
+#: cmd/incus/network_load_balancer.go:919
+#: cmd/incus/network_load_balancer.go:1032
+#: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
 #: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
 #: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
 #: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
@@ -4857,7 +4857,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5078,12 +5078,12 @@ msgstr ""
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -5166,11 +5166,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5410,7 +5410,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
@@ -5828,7 +5828,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5836,11 +5836,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -5860,8 +5860,8 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1063
-#: cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068
+#: cmd/incus/network_load_balancer.go:1069
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -6287,11 +6287,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6441,7 +6441,7 @@ msgstr ""
 msgid "Set the key as a network integration property"
 msgstr "Toekennen van netwerk (network) interfaces aan profielen (profiles)"
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -7049,7 +7049,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -7461,11 +7461,11 @@ msgstr ""
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -7521,7 +7521,7 @@ msgstr ""
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -8184,32 +8184,32 @@ msgstr ""
 
 #: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
 #: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
-#: cmd/incus/network_load_balancer.go:557
-#: cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:716
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
 #: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
-#: cmd/incus/network_load_balancer.go:349
-#: cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:532
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -8221,7 +8221,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -8770,6 +8770,15 @@ msgid ""
 "yaml\n"
 "    Update a network integration using the content of network-integration."
 "yaml"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:254
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
+"\n"
+"incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
 msgstr ""
 
 #: cmd/incus/network_peer.go:246

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-25 07:03+0100\n"
+"POT-Creation-Date: 2024-04-26 10:40+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -201,7 +201,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -571,11 +571,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -640,8 +640,8 @@ msgstr ""
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:990
-#: cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995
+#: cmd/incus/network_load_balancer.go:996
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1183,14 +1183,14 @@ msgstr ""
 #: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
 #: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:427
-#: cmd/incus/network_load_balancer.go:562
-#: cmd/incus/network_load_balancer.go:717
-#: cmd/incus/network_load_balancer.go:805
-#: cmd/incus/network_load_balancer.go:881
-#: cmd/incus/network_load_balancer.go:994
-#: cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:432
+#: cmd/incus/network_load_balancer.go:567
+#: cmd/incus/network_load_balancer.go:722
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:886
+#: cmd/incus/network_load_balancer.go:999
+#: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746
 #: cmd/incus/storage.go:848 cmd/incus/storage.go:941
 #: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
@@ -1271,7 +1271,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
@@ -1695,8 +1695,8 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:713
-#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:719
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1821,17 +1821,17 @@ msgstr ""
 #: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
-#: cmd/incus/network_load_balancer.go:351
-#: cmd/incus/network_load_balancer.go:419
-#: cmd/incus/network_load_balancer.go:529
-#: cmd/incus/network_load_balancer.go:559
-#: cmd/incus/network_load_balancer.go:714
-#: cmd/incus/network_load_balancer.go:787
-#: cmd/incus/network_load_balancer.go:802
-#: cmd/incus/network_load_balancer.go:878
-#: cmd/incus/network_load_balancer.go:976
-#: cmd/incus/network_load_balancer.go:991
-#: cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:356
+#: cmd/incus/network_load_balancer.go:424
+#: cmd/incus/network_load_balancer.go:534
+#: cmd/incus/network_load_balancer.go:564
+#: cmd/incus/network_load_balancer.go:719
+#: cmd/incus/network_load_balancer.go:792
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:996
+#: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
@@ -2143,8 +2143,8 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:558
-#: cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563
+#: cmd/incus/network_load_balancer.go:564
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2248,7 +2248,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
@@ -2269,7 +2269,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
-#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496
+#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
@@ -2953,7 +2953,7 @@ msgstr ""
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -3025,8 +3025,8 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:350
-#: cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355
+#: cmd/incus/network_load_balancer.go:356
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -4151,13 +4151,13 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:786
-#: cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791
+#: cmd/incus/network_load_balancer.go:792
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:975
-#: cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:981
 msgid "Manage network load balancer ports"
 msgstr ""
 
@@ -4357,15 +4357,15 @@ msgstr ""
 #: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
 #: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
-#: cmd/incus/network_load_balancer.go:281
-#: cmd/incus/network_load_balancer.go:379
-#: cmd/incus/network_load_balancer.go:464
-#: cmd/incus/network_load_balancer.go:622
-#: cmd/incus/network_load_balancer.go:754
-#: cmd/incus/network_load_balancer.go:842
-#: cmd/incus/network_load_balancer.go:918
-#: cmd/incus/network_load_balancer.go:1031
-#: cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_load_balancer.go:286
+#: cmd/incus/network_load_balancer.go:384
+#: cmd/incus/network_load_balancer.go:469
+#: cmd/incus/network_load_balancer.go:627
+#: cmd/incus/network_load_balancer.go:759
+#: cmd/incus/network_load_balancer.go:847
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1036
+#: cmd/incus/network_load_balancer.go:1110
 msgid "Missing listen address"
 msgstr ""
 
@@ -4402,15 +4402,15 @@ msgstr ""
 #: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
-#: cmd/incus/network_load_balancer.go:277
-#: cmd/incus/network_load_balancer.go:375
-#: cmd/incus/network_load_balancer.go:460
-#: cmd/incus/network_load_balancer.go:618
-#: cmd/incus/network_load_balancer.go:750
-#: cmd/incus/network_load_balancer.go:838
-#: cmd/incus/network_load_balancer.go:914
-#: cmd/incus/network_load_balancer.go:1027
-#: cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118
+#: cmd/incus/network_load_balancer.go:282
+#: cmd/incus/network_load_balancer.go:380
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:623
+#: cmd/incus/network_load_balancer.go:755
+#: cmd/incus/network_load_balancer.go:843
+#: cmd/incus/network_load_balancer.go:919
+#: cmd/incus/network_load_balancer.go:1032
+#: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
 #: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
 #: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
 #: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
@@ -4569,7 +4569,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4790,12 +4790,12 @@ msgstr ""
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -4878,11 +4878,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5122,7 +5122,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
@@ -5540,7 +5540,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5548,11 +5548,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -5572,8 +5572,8 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1063
-#: cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068
+#: cmd/incus/network_load_balancer.go:1069
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5997,11 +5997,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6150,7 +6150,7 @@ msgstr ""
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -6757,7 +6757,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -7169,11 +7169,11 @@ msgstr ""
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -7229,7 +7229,7 @@ msgstr ""
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -7892,32 +7892,32 @@ msgstr ""
 
 #: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
 #: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
-#: cmd/incus/network_load_balancer.go:557
-#: cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:716
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
 #: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
-#: cmd/incus/network_load_balancer.go:349
-#: cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:532
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -7929,7 +7929,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -8478,6 +8478,15 @@ msgid ""
 "yaml\n"
 "    Update a network integration using the content of network-integration."
 "yaml"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:254
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
+"\n"
+"incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
 msgstr ""
 
 #: cmd/incus/network_peer.go:246

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-25 07:03+0100\n"
+"POT-Creation-Date: 2024-04-26 10:40+0200\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -327,7 +327,7 @@ msgstr ""
 "###\n"
 "### Observe que a impressão digital é exibida, mas não pode ser alterada"
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -824,11 +824,11 @@ msgstr "Nome de membro do cluster"
 msgid "Add a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -896,8 +896,8 @@ msgstr ""
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:990
-#: cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995
+#: cmd/incus/network_load_balancer.go:996
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1455,14 +1455,14 @@ msgstr "Dispositivo %s removido de %s"
 #: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
 #: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:427
-#: cmd/incus/network_load_balancer.go:562
-#: cmd/incus/network_load_balancer.go:717
-#: cmd/incus/network_load_balancer.go:805
-#: cmd/incus/network_load_balancer.go:881
-#: cmd/incus/network_load_balancer.go:994
-#: cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:432
+#: cmd/incus/network_load_balancer.go:567
+#: cmd/incus/network_load_balancer.go:722
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:886
+#: cmd/incus/network_load_balancer.go:999
+#: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746
 #: cmd/incus/storage.go:848 cmd/incus/storage.go:941
 #: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
@@ -1555,7 +1555,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
@@ -2008,8 +2008,8 @@ msgstr "Criar novas redes"
 msgid "Delete network integrations"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:713
-#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:719
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Criar novas redes"
@@ -2140,17 +2140,17 @@ msgstr ""
 #: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
-#: cmd/incus/network_load_balancer.go:351
-#: cmd/incus/network_load_balancer.go:419
-#: cmd/incus/network_load_balancer.go:529
-#: cmd/incus/network_load_balancer.go:559
-#: cmd/incus/network_load_balancer.go:714
-#: cmd/incus/network_load_balancer.go:787
-#: cmd/incus/network_load_balancer.go:802
-#: cmd/incus/network_load_balancer.go:878
-#: cmd/incus/network_load_balancer.go:976
-#: cmd/incus/network_load_balancer.go:991
-#: cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:356
+#: cmd/incus/network_load_balancer.go:424
+#: cmd/incus/network_load_balancer.go:534
+#: cmd/incus/network_load_balancer.go:564
+#: cmd/incus/network_load_balancer.go:719
+#: cmd/incus/network_load_balancer.go:792
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:996
+#: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
@@ -2480,8 +2480,8 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network integration configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_load_balancer.go:558
-#: cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563
+#: cmd/incus/network_load_balancer.go:564
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2592,7 +2592,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
@@ -2613,7 +2613,7 @@ msgstr "Editar propriedades da imagem"
 
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
-#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496
+#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
@@ -3305,7 +3305,7 @@ msgstr "Criar novas redes"
 msgid "Get the key as a network integration property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -3389,8 +3389,8 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network integration configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:350
-#: cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355
+#: cmd/incus/network_load_balancer.go:356
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -4556,14 +4556,14 @@ msgstr "Criar novas redes"
 msgid "Manage network integrations"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:786
-#: cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791
+#: cmd/incus/network_load_balancer.go:792
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:975
-#: cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:981
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Criar novas redes"
@@ -4780,15 +4780,15 @@ msgstr "Nome de membro do cluster"
 #: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
 #: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
-#: cmd/incus/network_load_balancer.go:281
-#: cmd/incus/network_load_balancer.go:379
-#: cmd/incus/network_load_balancer.go:464
-#: cmd/incus/network_load_balancer.go:622
-#: cmd/incus/network_load_balancer.go:754
-#: cmd/incus/network_load_balancer.go:842
-#: cmd/incus/network_load_balancer.go:918
-#: cmd/incus/network_load_balancer.go:1031
-#: cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_load_balancer.go:286
+#: cmd/incus/network_load_balancer.go:384
+#: cmd/incus/network_load_balancer.go:469
+#: cmd/incus/network_load_balancer.go:627
+#: cmd/incus/network_load_balancer.go:759
+#: cmd/incus/network_load_balancer.go:847
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1036
+#: cmd/incus/network_load_balancer.go:1110
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
@@ -4828,15 +4828,15 @@ msgstr "Nome de membro do cluster"
 #: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
-#: cmd/incus/network_load_balancer.go:277
-#: cmd/incus/network_load_balancer.go:375
-#: cmd/incus/network_load_balancer.go:460
-#: cmd/incus/network_load_balancer.go:618
-#: cmd/incus/network_load_balancer.go:750
-#: cmd/incus/network_load_balancer.go:838
-#: cmd/incus/network_load_balancer.go:914
-#: cmd/incus/network_load_balancer.go:1027
-#: cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118
+#: cmd/incus/network_load_balancer.go:282
+#: cmd/incus/network_load_balancer.go:380
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:623
+#: cmd/incus/network_load_balancer.go:755
+#: cmd/incus/network_load_balancer.go:843
+#: cmd/incus/network_load_balancer.go:919
+#: cmd/incus/network_load_balancer.go:1032
+#: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
 #: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
 #: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
 #: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
@@ -5004,7 +5004,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5225,12 +5225,12 @@ msgstr "Clustering ativado"
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -5313,11 +5313,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5558,7 +5558,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
@@ -5987,7 +5987,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5995,12 +5995,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Nome de membro do cluster"
@@ -6023,8 +6023,8 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/network_load_balancer.go:1063
-#: cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068
+#: cmd/incus/network_load_balancer.go:1069
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
@@ -6477,12 +6477,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6638,7 +6638,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network integration property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -7275,7 +7275,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Nome de membro do cluster"
@@ -7702,12 +7702,12 @@ msgstr "Criar novas redes"
 msgid "Unset network integration configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Criar novas redes"
@@ -7772,7 +7772,7 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network integration property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Criar novas redes"
@@ -8483,18 +8483,18 @@ msgstr ""
 
 #: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
 #: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
-#: cmd/incus/network_load_balancer.go:557
-#: cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:716
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8502,18 +8502,18 @@ msgid ""
 msgstr "Criar perfis"
 
 #: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
-#: cmd/incus/network_load_balancer.go:349
-#: cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:532
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8526,7 +8526,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -9112,6 +9112,15 @@ msgid ""
 "yaml\n"
 "    Update a network integration using the content of network-integration."
 "yaml"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:254
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
+"\n"
+"incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
 msgstr ""
 
 #: cmd/incus/network_peer.go:246

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-25 07:03+0100\n"
+"POT-Creation-Date: 2024-04-26 10:40+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -345,7 +345,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -845,11 +845,11 @@ msgstr "Копирование образа: %s"
 msgid "Add a network zone record entry"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -917,8 +917,8 @@ msgstr ""
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:990
-#: cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995
+#: cmd/incus/network_load_balancer.go:996
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1142,7 +1142,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1469,14 +1469,14 @@ msgstr ""
 #: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
 #: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:427
-#: cmd/incus/network_load_balancer.go:562
-#: cmd/incus/network_load_balancer.go:717
-#: cmd/incus/network_load_balancer.go:805
-#: cmd/incus/network_load_balancer.go:881
-#: cmd/incus/network_load_balancer.go:994
-#: cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:432
+#: cmd/incus/network_load_balancer.go:567
+#: cmd/incus/network_load_balancer.go:722
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:886
+#: cmd/incus/network_load_balancer.go:999
+#: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746
 #: cmd/incus/storage.go:848 cmd/incus/storage.go:941
 #: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
@@ -1557,7 +1557,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
@@ -2007,8 +2007,8 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:713
-#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:719
 #, fuzzy
 msgid "Delete network load balancers"
 msgstr "Копирование образа: %s"
@@ -2139,17 +2139,17 @@ msgstr ""
 #: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
-#: cmd/incus/network_load_balancer.go:351
-#: cmd/incus/network_load_balancer.go:419
-#: cmd/incus/network_load_balancer.go:529
-#: cmd/incus/network_load_balancer.go:559
-#: cmd/incus/network_load_balancer.go:714
-#: cmd/incus/network_load_balancer.go:787
-#: cmd/incus/network_load_balancer.go:802
-#: cmd/incus/network_load_balancer.go:878
-#: cmd/incus/network_load_balancer.go:976
-#: cmd/incus/network_load_balancer.go:991
-#: cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:356
+#: cmd/incus/network_load_balancer.go:424
+#: cmd/incus/network_load_balancer.go:534
+#: cmd/incus/network_load_balancer.go:564
+#: cmd/incus/network_load_balancer.go:719
+#: cmd/incus/network_load_balancer.go:792
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:996
+#: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
@@ -2473,8 +2473,8 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:558
-#: cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563
+#: cmd/incus/network_load_balancer.go:564
 #, fuzzy
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Копирование образа: %s"
@@ -2583,7 +2583,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
@@ -2604,7 +2604,7 @@ msgstr "Копирование образа: %s"
 
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
-#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496
+#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
@@ -3303,7 +3303,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a network integration property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 #, fuzzy
 msgid "Get the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -3385,8 +3385,8 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network integration configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:350
-#: cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355
+#: cmd/incus/network_load_balancer.go:356
 #, fuzzy
 msgid "Get values for network load balancer configuration keys"
 msgstr "Копирование образа: %s"
@@ -4561,14 +4561,14 @@ msgstr "Копирование образа: %s"
 msgid "Manage network integrations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:786
-#: cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791
+#: cmd/incus/network_load_balancer.go:792
 #, fuzzy
 msgid "Manage network load balancer backends"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:975
-#: cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:981
 #, fuzzy
 msgid "Manage network load balancer ports"
 msgstr "Копирование образа: %s"
@@ -4789,15 +4789,15 @@ msgstr "Имя контейнера: %s"
 #: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
 #: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
-#: cmd/incus/network_load_balancer.go:281
-#: cmd/incus/network_load_balancer.go:379
-#: cmd/incus/network_load_balancer.go:464
-#: cmd/incus/network_load_balancer.go:622
-#: cmd/incus/network_load_balancer.go:754
-#: cmd/incus/network_load_balancer.go:842
-#: cmd/incus/network_load_balancer.go:918
-#: cmd/incus/network_load_balancer.go:1031
-#: cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_load_balancer.go:286
+#: cmd/incus/network_load_balancer.go:384
+#: cmd/incus/network_load_balancer.go:469
+#: cmd/incus/network_load_balancer.go:627
+#: cmd/incus/network_load_balancer.go:759
+#: cmd/incus/network_load_balancer.go:847
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1036
+#: cmd/incus/network_load_balancer.go:1110
 #, fuzzy
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
@@ -4837,15 +4837,15 @@ msgstr "Имя контейнера: %s"
 #: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
-#: cmd/incus/network_load_balancer.go:277
-#: cmd/incus/network_load_balancer.go:375
-#: cmd/incus/network_load_balancer.go:460
-#: cmd/incus/network_load_balancer.go:618
-#: cmd/incus/network_load_balancer.go:750
-#: cmd/incus/network_load_balancer.go:838
-#: cmd/incus/network_load_balancer.go:914
-#: cmd/incus/network_load_balancer.go:1027
-#: cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118
+#: cmd/incus/network_load_balancer.go:282
+#: cmd/incus/network_load_balancer.go:380
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:623
+#: cmd/incus/network_load_balancer.go:755
+#: cmd/incus/network_load_balancer.go:843
+#: cmd/incus/network_load_balancer.go:919
+#: cmd/incus/network_load_balancer.go:1032
+#: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
 #: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
 #: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
 #: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
@@ -5014,7 +5014,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5239,12 +5239,12 @@ msgstr " Использование сети:"
 msgid "Network integration %s renamed to %s"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, fuzzy, c-format
 msgid "Network load balancer %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, fuzzy, c-format
 msgid "Network load balancer %s deleted"
 msgstr " Использование сети:"
@@ -5330,11 +5330,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5575,7 +5575,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
@@ -5999,7 +5999,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -6007,12 +6007,12 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 #, fuzzy
 msgid "Remove backend from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 #, fuzzy
 msgid "Remove backends from a load balancer"
 msgstr "Копирование образа: %s"
@@ -6034,8 +6034,8 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1063
-#: cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068
+#: cmd/incus/network_load_balancer.go:1069
 #, fuzzy
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
@@ -6477,12 +6477,12 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 #, fuzzy
 msgid "Set network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6637,7 +6637,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network integration property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 #, fuzzy
 msgid "Set the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -7274,7 +7274,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, fuzzy, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr "Копирование образа: %s"
@@ -7695,12 +7695,12 @@ msgstr "Копирование образа: %s"
 msgid "Unset network integration configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 #, fuzzy
 msgid "Unset network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 #, fuzzy
 msgid "Unset network load balancer keys"
 msgstr "Копирование образа: %s"
@@ -7764,7 +7764,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network integration property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 #, fuzzy
 msgid "Unset the key as a network load balancer property"
 msgstr "Копирование образа: %s"
@@ -8739,8 +8739,8 @@ msgstr ""
 
 #: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
 #: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
-#: cmd/incus/network_load_balancer.go:557
-#: cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:716
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -8748,7 +8748,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
@@ -8756,7 +8756,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
@@ -8767,8 +8767,8 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
-#: cmd/incus/network_load_balancer.go:349
-#: cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:532
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
@@ -8776,7 +8776,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8784,7 +8784,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 #, fuzzy
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
@@ -8800,7 +8800,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -9617,6 +9617,15 @@ msgid ""
 "yaml\n"
 "    Update a network integration using the content of network-integration."
 "yaml"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:254
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
+"\n"
+"incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
 msgstr ""
 
 #: cmd/incus/network_peer.go:246

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-25 07:03+0100\n"
+"POT-Creation-Date: 2024-04-26 10:40+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -308,7 +308,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_load_balancer.go:580
+#: cmd/incus/network_load_balancer.go:585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network load balancer.\n"
@@ -783,11 +783,11 @@ msgstr ""
 msgid "Add a network zone record entry"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:802
+#: cmd/incus/network_load_balancer.go:807
 msgid "Add backend to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:801
+#: cmd/incus/network_load_balancer.go:806
 msgid "Add backends to a load balancer"
 msgstr ""
 
@@ -852,8 +852,8 @@ msgstr ""
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:990
-#: cmd/incus/network_load_balancer.go:991
+#: cmd/incus/network_load_balancer.go:995
+#: cmd/incus/network_load_balancer.go:996
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -1071,7 +1071,7 @@ msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:306
+#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
 #: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
 #, c-format
@@ -1395,14 +1395,14 @@ msgstr ""
 #: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
 #: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
 #: cmd/incus/network_load_balancer.go:180
-#: cmd/incus/network_load_balancer.go:256
-#: cmd/incus/network_load_balancer.go:427
-#: cmd/incus/network_load_balancer.go:562
-#: cmd/incus/network_load_balancer.go:717
-#: cmd/incus/network_load_balancer.go:805
-#: cmd/incus/network_load_balancer.go:881
-#: cmd/incus/network_load_balancer.go:994
-#: cmd/incus/network_load_balancer.go:1068 cmd/incus/storage.go:103
+#: cmd/incus/network_load_balancer.go:261
+#: cmd/incus/network_load_balancer.go:432
+#: cmd/incus/network_load_balancer.go:567
+#: cmd/incus/network_load_balancer.go:722
+#: cmd/incus/network_load_balancer.go:810
+#: cmd/incus/network_load_balancer.go:886
+#: cmd/incus/network_load_balancer.go:999
+#: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:394 cmd/incus/storage.go:477 cmd/incus/storage.go:746
 #: cmd/incus/storage.go:848 cmd/incus/storage.go:941
 #: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
@@ -1483,7 +1483,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:681 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
@@ -1907,8 +1907,8 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:713
-#: cmd/incus/network_load_balancer.go:714
+#: cmd/incus/network_load_balancer.go:718
+#: cmd/incus/network_load_balancer.go:719
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -2033,17 +2033,17 @@ msgstr ""
 #: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
 #: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
-#: cmd/incus/network_load_balancer.go:351
-#: cmd/incus/network_load_balancer.go:419
-#: cmd/incus/network_load_balancer.go:529
-#: cmd/incus/network_load_balancer.go:559
-#: cmd/incus/network_load_balancer.go:714
-#: cmd/incus/network_load_balancer.go:787
-#: cmd/incus/network_load_balancer.go:802
-#: cmd/incus/network_load_balancer.go:878
-#: cmd/incus/network_load_balancer.go:976
-#: cmd/incus/network_load_balancer.go:991
-#: cmd/incus/network_load_balancer.go:1064 cmd/incus/network_peer.go:28
+#: cmd/incus/network_load_balancer.go:356
+#: cmd/incus/network_load_balancer.go:424
+#: cmd/incus/network_load_balancer.go:534
+#: cmd/incus/network_load_balancer.go:564
+#: cmd/incus/network_load_balancer.go:719
+#: cmd/incus/network_load_balancer.go:792
+#: cmd/incus/network_load_balancer.go:807
+#: cmd/incus/network_load_balancer.go:883
+#: cmd/incus/network_load_balancer.go:981
+#: cmd/incus/network_load_balancer.go:996
+#: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
 #: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
 #: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
@@ -2355,8 +2355,8 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:558
-#: cmd/incus/network_load_balancer.go:559
+#: cmd/incus/network_load_balancer.go:563
+#: cmd/incus/network_load_balancer.go:564
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:502 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
@@ -2481,7 +2481,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
-#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:496
+#: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
 #: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
@@ -3165,7 +3165,7 @@ msgstr ""
 msgid "Get the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:359
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
@@ -3237,8 +3237,8 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:350
-#: cmd/incus/network_load_balancer.go:351
+#: cmd/incus/network_load_balancer.go:355
+#: cmd/incus/network_load_balancer.go:356
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -4363,13 +4363,13 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:786
-#: cmd/incus/network_load_balancer.go:787
+#: cmd/incus/network_load_balancer.go:791
+#: cmd/incus/network_load_balancer.go:792
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:975
-#: cmd/incus/network_load_balancer.go:976
+#: cmd/incus/network_load_balancer.go:980
+#: cmd/incus/network_load_balancer.go:981
 msgid "Manage network load balancer ports"
 msgstr ""
 
@@ -4569,15 +4569,15 @@ msgstr ""
 #: cmd/incus/network_forward.go:658 cmd/incus/network_forward.go:789
 #: cmd/incus/network_forward.go:882 cmd/incus/network_forward.go:964
 #: cmd/incus/network_load_balancer.go:217
-#: cmd/incus/network_load_balancer.go:281
-#: cmd/incus/network_load_balancer.go:379
-#: cmd/incus/network_load_balancer.go:464
-#: cmd/incus/network_load_balancer.go:622
-#: cmd/incus/network_load_balancer.go:754
-#: cmd/incus/network_load_balancer.go:842
-#: cmd/incus/network_load_balancer.go:918
-#: cmd/incus/network_load_balancer.go:1031
-#: cmd/incus/network_load_balancer.go:1105
+#: cmd/incus/network_load_balancer.go:286
+#: cmd/incus/network_load_balancer.go:384
+#: cmd/incus/network_load_balancer.go:469
+#: cmd/incus/network_load_balancer.go:627
+#: cmd/incus/network_load_balancer.go:759
+#: cmd/incus/network_load_balancer.go:847
+#: cmd/incus/network_load_balancer.go:923
+#: cmd/incus/network_load_balancer.go:1036
+#: cmd/incus/network_load_balancer.go:1110
 msgid "Missing listen address"
 msgstr ""
 
@@ -4614,15 +4614,15 @@ msgstr ""
 #: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
-#: cmd/incus/network_load_balancer.go:277
-#: cmd/incus/network_load_balancer.go:375
-#: cmd/incus/network_load_balancer.go:460
-#: cmd/incus/network_load_balancer.go:618
-#: cmd/incus/network_load_balancer.go:750
-#: cmd/incus/network_load_balancer.go:838
-#: cmd/incus/network_load_balancer.go:914
-#: cmd/incus/network_load_balancer.go:1027
-#: cmd/incus/network_load_balancer.go:1101 cmd/incus/network_peer.go:118
+#: cmd/incus/network_load_balancer.go:282
+#: cmd/incus/network_load_balancer.go:380
+#: cmd/incus/network_load_balancer.go:465
+#: cmd/incus/network_load_balancer.go:623
+#: cmd/incus/network_load_balancer.go:755
+#: cmd/incus/network_load_balancer.go:843
+#: cmd/incus/network_load_balancer.go:919
+#: cmd/incus/network_load_balancer.go:1032
+#: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
 #: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
 #: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
 #: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
@@ -4781,7 +4781,7 @@ msgstr ""
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_forward.go:1008 cmd/incus/network_load_balancer.go:1154
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -5002,12 +5002,12 @@ msgstr ""
 msgid "Network integration %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:333
+#: cmd/incus/network_load_balancer.go:338
 #, c-format
 msgid "Network load balancer %s created"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:771
+#: cmd/incus/network_load_balancer.go:776
 #, c-format
 msgid "Network load balancer %s deleted"
 msgstr ""
@@ -5090,11 +5090,11 @@ msgstr ""
 msgid "No device found for this storage volume"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:949
+#: cmd/incus/network_load_balancer.go:954
 msgid "No matching backend found"
 msgstr ""
 
-#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1160
+#: cmd/incus/network_forward.go:1019 cmd/incus/network_load_balancer.go:1165
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -5334,7 +5334,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:682 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
@@ -5752,7 +5752,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1065
+#: cmd/incus/network_forward.go:920 cmd/incus/network_load_balancer.go:1070
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5760,11 +5760,11 @@ msgstr ""
 msgid "Remove all rules that match"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:878
+#: cmd/incus/network_load_balancer.go:883
 msgid "Remove backend from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:877
+#: cmd/incus/network_load_balancer.go:882
 msgid "Remove backends from a load balancer"
 msgstr ""
 
@@ -5784,8 +5784,8 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1063
-#: cmd/incus/network_load_balancer.go:1064
+#: cmd/incus/network_load_balancer.go:1068
+#: cmd/incus/network_load_balancer.go:1069
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -6209,11 +6209,11 @@ msgid ""
 "<value>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:418
+#: cmd/incus/network_load_balancer.go:423
 msgid "Set network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:419
+#: cmd/incus/network_load_balancer.go:424
 msgid ""
 "Set network load balancer keys\n"
 "\n"
@@ -6362,7 +6362,7 @@ msgstr ""
 msgid "Set the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:431
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
@@ -6969,7 +6969,7 @@ msgstr ""
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:392
+#: cmd/incus/network_load_balancer.go:397
 #, c-format
 msgid "The property %q does not exist on the load balancer %q: %v"
 msgstr ""
@@ -7381,11 +7381,11 @@ msgstr ""
 msgid "Unset network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:528
+#: cmd/incus/network_load_balancer.go:533
 msgid "Unset network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:529
+#: cmd/incus/network_load_balancer.go:534
 msgid "Unset network load balancer keys"
 msgstr ""
 
@@ -7441,7 +7441,7 @@ msgstr ""
 msgid "Unset the key as a network integration property"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:532
+#: cmd/incus/network_load_balancer.go:537
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
@@ -8104,32 +8104,32 @@ msgstr ""
 
 #: cmd/incus/network_forward.go:172 cmd/incus/network_forward.go:593
 #: cmd/incus/network_forward.go:746 cmd/incus/network_load_balancer.go:175
-#: cmd/incus/network_load_balancer.go:557
-#: cmd/incus/network_load_balancer.go:711
+#: cmd/incus/network_load_balancer.go:562
+#: cmd/incus/network_load_balancer.go:716
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:876
+#: cmd/incus/network_load_balancer.go:881
 msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:805
 msgid ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 msgstr ""
 
 #: cmd/incus/network_forward.go:351 cmd/incus/network_forward.go:546
-#: cmd/incus/network_load_balancer.go:349
-#: cmd/incus/network_load_balancer.go:527
+#: cmd/incus/network_load_balancer.go:354
+#: cmd/incus/network_load_balancer.go:532
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:417
+#: cmd/incus/network_forward.go:436 cmd/incus/network_load_balancer.go:422
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:989
+#: cmd/incus/network_load_balancer.go:994
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
@@ -8141,7 +8141,7 @@ msgid ""
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_forward.go:917 cmd/incus/network_load_balancer.go:1067
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -8690,6 +8690,15 @@ msgid ""
 "yaml\n"
 "    Update a network integration using the content of network-integration."
 "yaml"
+msgstr ""
+
+#: cmd/incus/network_load_balancer.go:254
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
+"\n"
+"incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
 msgstr ""
 
 #: cmd/incus/network_peer.go:246


### PR DESCRIPTION
incus network load-balancer create` already has support for creation from a yaml configuration file, but the same wasn't printed in the usage information of the command.

This commit updates `incus network load-balancer create` to include an example

Part of https://github.com/lxc/incus/issues/741