### PR TITLE
incus/network_zone: Add example for create command

### DIFF
--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -315,6 +315,10 @@ func (c *cmdNetworkZoneCreate) Command() *cobra.Command {
 	cmd.Use = usage("create", i18n.G("[<remote>:]<Zone> [key=value...]"))
 	cmd.Short = i18n.G("Create new network zones")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G("Create new network zones"))
+	cmd.Example = cli.FormatSection("", i18n.G(`incus network zone create z1
+
+incus network zone create z1 < config.yaml
+    Create network zone z1 with configuration from config.yaml`))
 
 	cmd.RunE = c.Run
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-26 10:40+0200\n"
+"POT-Creation-Date: 2024-04-26 12:30+0200\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -415,7 +415,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -441,7 +441,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -848,7 +848,7 @@ msgstr "Aktion (Standard: GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Profil %s erstellt\n"
@@ -861,7 +861,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1159,8 +1159,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
-#: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1590,7 +1590,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
+#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1761,7 +1761,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1875,7 +1875,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new network peering"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1945,7 +1945,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
-#: cmd/incus/network_zone.go:840 cmd/incus/operation.go:173
+#: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -2055,12 +2055,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2195,15 +2195,15 @@ msgstr ""
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
-#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408
-#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539
-#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857
-#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180
-#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357
-#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433
-#: cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
+#: cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726
+#: cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861
+#: cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184
+#: cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437
+#: cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid "ENTRIES"
 msgstr ""
 
@@ -2541,12 +2541,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network peer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2606,7 +2606,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid "Entry TTL"
 msgstr ""
 
@@ -2643,7 +2643,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
+#: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2664,8 +2664,8 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
-#: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3272,7 +3272,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
@@ -3471,7 +3471,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -4089,7 +4089,7 @@ msgstr ""
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4687,12 +4687,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network peerings"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4960,17 +4960,17 @@ msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280
-#: cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890
-#: cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128
-#: cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467
-#: cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448
+#: cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700
+#: cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132
+#: cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1528
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5148,7 +5148,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5317,12 +5317,12 @@ msgstr "Profil %s gelöscht\n"
 msgid "Network ACL %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -5397,12 +5397,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -5693,7 +5693,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
+#: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -6115,7 +6115,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Profil %s erstellt\n"
@@ -6143,7 +6143,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove backends from a load balancer"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6651,12 +6651,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6665,7 +6665,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -6803,12 +6803,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
@@ -6959,12 +6959,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network zone configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
@@ -7474,7 +7474,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7889,12 +7889,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -7955,12 +7955,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as a network property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Profil %s erstellt\n"
@@ -8442,8 +8442,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537
-#: cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541
+#: cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -8451,7 +8451,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -8459,7 +8459,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -9476,7 +9476,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -9484,8 +9484,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225
-#: cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -9493,7 +9493,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -9501,7 +9501,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -9509,7 +9509,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -9517,7 +9517,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -9870,6 +9870,14 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+msgstr ""
+
+#: cmd/incus/network_zone.go:318
+msgid ""
+"incus network zone create z1\n"
+"\n"
+"incus network zone create z1 < config.yaml\n"
+"    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/operation.go:196

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-26 10:40+0200\n"
+"POT-Creation-Date: 2024-04-26 12:30+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -407,7 +407,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -436,7 +436,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -819,7 +819,7 @@ msgstr "Accion (predeterminados a GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Perfil %s creado"
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1118,8 +1118,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
-#: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1540,7 +1540,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
+#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1708,7 +1708,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1815,7 +1815,7 @@ msgstr "Perfil %s creado"
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Perfil %s creado"
@@ -1880,7 +1880,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
-#: cmd/incus/network_zone.go:840 cmd/incus/operation.go:173
+#: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -1987,12 +1987,12 @@ msgstr "Perfil %s creado"
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Perfil %s creado"
@@ -2125,15 +2125,15 @@ msgstr ""
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
-#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408
-#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539
-#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857
-#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180
-#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357
-#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433
-#: cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
+#: cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726
+#: cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861
+#: cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184
+#: cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437
+#: cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2366,7 +2366,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid "ENTRIES"
 msgstr ""
 
@@ -2450,12 +2450,12 @@ msgstr "Perfil %s creado"
 msgid "Edit network peer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
@@ -2514,7 +2514,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid "Entry TTL"
 msgstr ""
 
@@ -2550,7 +2550,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
+#: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2571,8 +2571,8 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
-#: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3167,7 +3167,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467
@@ -3283,7 +3283,7 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Perfil %s creado"
@@ -3360,7 +3360,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
@@ -3969,7 +3969,7 @@ msgstr ""
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nombre del contenedor es: %s"
@@ -4529,12 +4529,12 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nombre del contenedor es: %s"
@@ -4795,17 +4795,17 @@ msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280
-#: cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890
-#: cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128
-#: cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467
-#: cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448
+#: cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700
+#: cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132
+#: cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1528
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nombre del contenedor es: %s"
@@ -4976,7 +4976,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5141,12 +5141,12 @@ msgstr "Perfil %s eliminado"
 msgid "Network ACL %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
@@ -5219,12 +5219,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Perfil %s eliminado"
@@ -5510,7 +5510,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
+#: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5926,7 +5926,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Perfil %s creado"
@@ -5953,7 +5953,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove backends from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6438,12 +6438,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6452,7 +6452,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
@@ -6584,12 +6584,12 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Perfil %s creado"
@@ -6731,12 +6731,12 @@ msgstr "Perfil %s creado"
 msgid "Show network zone configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
@@ -7231,7 +7231,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -7636,12 +7636,12 @@ msgstr "Perfil %s creado"
 msgid "Unset network peer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
@@ -7700,12 +7700,12 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Perfil %s creado"
@@ -8119,18 +8119,18 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<API path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537
-#: cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541
+#: cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8759,33 +8759,33 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<warning-uuid>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225
-#: cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9110,6 +9110,14 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+msgstr ""
+
+#: cmd/incus/network_zone.go:318
+msgid ""
+"incus network zone create z1\n"
+"\n"
+"incus network zone create z1 < config.yaml\n"
+"    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/operation.go:196

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-26 10:40+0200\n"
+"POT-Creation-Date: 2024-04-26 12:30+0200\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -419,7 +419,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié."
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -443,7 +443,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -824,7 +824,7 @@ msgstr "Action (GET par défaut)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Ajoutez un membre d'un cluster à un groupe de cluster"
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 msgid "Add a network zone record entry"
 msgstr "Ajoutez un enregistrement d'une zone réseau"
 
@@ -836,7 +836,7 @@ msgstr "Ajoutez un backend à un équilibreur de charge"
 msgid "Add backends to a load balancer"
 msgstr "Ajoutez des backends à un équilibreur de charge"
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid "Add entries to a network zone record"
 msgstr "Ajoutez des entrées à la zone d'enregistrement réseau"
 
@@ -1150,8 +1150,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
-#: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
@@ -1589,7 +1589,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
+#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1775,7 +1775,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible d'écrire le fichier de certificat serveur %q: %w"
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid "Couldn't find a matching entry"
 msgstr "Impossible de trouver une entrée correspondante"
 
@@ -1906,7 +1906,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new network peering"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Copie de l'image : %s"
@@ -1977,7 +1977,7 @@ msgstr "ADRESSE CIBLE PAR DÉFAUT"
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
-#: cmd/incus/network_zone.go:840 cmd/incus/operation.go:173
+#: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -2092,12 +2092,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete network peerings"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Récupération de l'image : %s"
@@ -2233,15 +2233,15 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
-#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408
-#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539
-#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857
-#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180
-#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357
-#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433
-#: cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
+#: cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726
+#: cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861
+#: cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184
+#: cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437
+#: cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2482,7 +2482,7 @@ msgstr "Pilote: %v (%v)"
 msgid "Dump YAML config to stdout"
 msgstr "Copié de la configuration YAML vers stdout"
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid "ENTRIES"
 msgstr "ENTRÉES"
 
@@ -2576,12 +2576,12 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network peer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2655,7 +2655,7 @@ msgstr ""
 "définir une valeur\n"
 "  pour l'adresse si elle n'est pas encore paramétrée."
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid "Entry TTL"
 msgstr "Entrée TTL"
 
@@ -2692,7 +2692,7 @@ msgstr "Erreur lors de la récupération des alias : %w"
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
+#: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2713,8 +2713,8 @@ msgstr "Erreur lors du déparamétrage des propriétés: %v"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
-#: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3408,7 +3408,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467
@@ -3529,7 +3529,7 @@ msgstr "Obtenir la clé en tant que propriété du réseau"
 msgid "Get the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Clé de configuration invalide"
@@ -3612,7 +3612,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4262,7 +4262,7 @@ msgstr ""
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Nom du réseau"
@@ -4901,12 +4901,12 @@ msgstr "Nom du réseau"
 msgid "Manage network peerings"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Nom du réseau"
@@ -5174,17 +5174,17 @@ msgid "Missing network name"
 msgstr "Nom du réseau"
 
 #: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280
-#: cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890
-#: cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128
-#: cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467
-#: cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448
+#: cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700
+#: cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132
+#: cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1528
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nom du réseau"
@@ -5365,7 +5365,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5535,12 +5535,12 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Network ACL %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -5614,12 +5614,12 @@ msgstr "Nom du réseau"
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -5921,7 +5921,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
+#: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -6347,7 +6347,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Clé de configuration invalide"
@@ -6375,7 +6375,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove backends from a load balancer"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
@@ -6896,12 +6896,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6910,7 +6910,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7049,12 +7049,12 @@ msgstr "Nom du réseau"
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Clé de configuration invalide"
@@ -7208,12 +7208,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network zone configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
@@ -7735,7 +7735,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -8156,12 +8156,12 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network peer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
@@ -8224,12 +8224,12 @@ msgstr "Nom du réseau"
 msgid "Unset the key as a network property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Clé de configuration invalide"
@@ -8671,8 +8671,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537
-#: cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541
+#: cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -8680,7 +8680,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -8688,7 +8688,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -9801,7 +9801,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -9809,8 +9809,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225
-#: cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -9818,7 +9818,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -9826,7 +9826,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -9834,7 +9834,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -9842,7 +9842,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -10223,6 +10223,14 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+msgstr ""
+
+#: cmd/incus/network_zone.go:318
+msgid ""
+"incus network zone create z1\n"
+"\n"
+"incus network zone create z1 < config.yaml\n"
+"    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/operation.go:196

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-04-26 10:40+0200\n"
+        "POT-Creation-Date: 2024-04-26 12:30+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -225,7 +225,7 @@ msgid   "### This is a YAML representation of the network peer.\n"
         "### Note that the name, target_project, target_network and status fields cannot be changed."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 msgid   "### This is a YAML representation of the network zone record.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -238,7 +238,7 @@ msgid   "### This is a YAML representation of the network zone record.\n"
         "###  user.foo: bah\n"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 msgid   "### This is a YAML representation of the network zone.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -542,7 +542,7 @@ msgstr  ""
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 msgid   "Add a network zone record entry"
 msgstr  ""
 
@@ -554,7 +554,7 @@ msgstr  ""
 msgid   "Add backends to a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid   "Add entries to a network zone record"
 msgstr  ""
 
@@ -821,7 +821,7 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378 cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382 cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -1178,7 +1178,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324 cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328 cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1334,7 +1334,7 @@ msgstr  ""
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid   "Couldn't find a matching entry"
 msgstr  ""
 
@@ -1432,7 +1432,7 @@ msgstr  ""
 msgid   "Create new network peering"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 msgid   "Create new network zone record"
 msgstr  ""
 
@@ -1488,7 +1488,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:503 cmd/incus/config_trust.go:435 cmd/incus/image.go:1121 cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092 cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152 cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:840 cmd/incus/operation.go:173 cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840 cmd/incus/storage_volume.go:1636
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:503 cmd/incus/config_trust.go:435 cmd/incus/image.go:1121 cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092 cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152 cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:844 cmd/incus/operation.go:173 cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721 cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840 cmd/incus/storage_volume.go:1636
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1587,11 +1587,11 @@ msgstr  ""
 msgid   "Delete network peerings"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 msgid   "Delete network zone record"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 msgid   "Delete network zones"
 msgstr  ""
 
@@ -1627,7 +1627,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:719 cmd/incus/network_load_balancer.go:792 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:883 cmd/incus/network_load_balancer.go:981 cmd/incus/network_load_balancer.go:996 cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408 cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539 cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722 cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857 cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997 cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180 cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357 cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433 cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:434 cmd/incus/profile.go:492 cmd/incus/profile.go:628 cmd/incus/profile.go:702 cmd/incus/profile.go:771 cmd/incus/profile.go:859 cmd/incus/profile.go:919 cmd/incus/profile.go:1008 cmd/incus/profile.go:1072 cmd/incus/project.go:35 cmd/incus/project.go:99 cmd/incus/project.go:195 cmd/incus/project.go:266 cmd/incus/project.go:402 cmd/incus/project.go:477 cmd/incus/project.go:692 cmd/incus/project.go:757 cmd/incus/project.go:845 cmd/incus/project.go:889 cmd/incus/project.go:950 cmd/incus/project.go:1017 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:201 cmd/incus/storage.go:259 cmd/incus/storage.go:391 cmd/incus/storage.go:473 cmd/incus/storage.go:653 cmd/incus/storage.go:740 cmd/incus/storage.go:844 cmd/incus/storage.go:938 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:719 cmd/incus/network_load_balancer.go:792 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:883 cmd/incus/network_load_balancer.go:981 cmd/incus/network_load_balancer.go:996 cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412 cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543 cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726 cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861 cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001 cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184 cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361 cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104 cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352 cmd/incus/profile.go:434 cmd/incus/profile.go:492 cmd/incus/profile.go:628 cmd/incus/profile.go:702 cmd/incus/profile.go:771 cmd/incus/profile.go:859 cmd/incus/profile.go:919 cmd/incus/profile.go:1008 cmd/incus/profile.go:1072 cmd/incus/project.go:35 cmd/incus/project.go:99 cmd/incus/project.go:195 cmd/incus/project.go:266 cmd/incus/project.go:402 cmd/incus/project.go:477 cmd/incus/project.go:692 cmd/incus/project.go:757 cmd/incus/project.go:845 cmd/incus/project.go:889 cmd/incus/project.go:950 cmd/incus/project.go:1017 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:201 cmd/incus/storage.go:259 cmd/incus/storage.go:391 cmd/incus/storage.go:473 cmd/incus/storage.go:653 cmd/incus/storage.go:740 cmd/incus/storage.go:844 cmd/incus/storage.go:938 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1801,7 +1801,7 @@ msgstr  ""
 msgid   "Dump YAML config to stdout"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid   "ENTRIES"
 msgstr  ""
 
@@ -1878,11 +1878,11 @@ msgstr  ""
 msgid   "Edit network peer configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 msgid   "Edit network zone configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
@@ -1934,7 +1934,7 @@ msgid   "Enable clustering on a single non-clustered server\n"
         "  for the address if not yet set."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid   "Entry TTL"
 msgstr  ""
 
@@ -1966,7 +1966,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155 cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
+#: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159 cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1981,7 +1981,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465 cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980 cmd/incus/project.go:814 cmd/incus/storage.go:804 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
+#: cmd/incus/cluster.go:556 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980 cmd/incus/project.go:814 cmd/incus/storage.go:804 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2541,7 +2541,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067 cmd/incus/cluster_group.go:441 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586 cmd/incus/image.go:1100 cmd/incus/image_alias.go:157 cmd/incus/list.go:133 cmd/incus/network.go:1015 cmd/incus/network.go:1114 cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84 cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782 cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498 cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291 cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467 cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539 cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067 cmd/incus/cluster_group.go:441 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586 cmd/incus/image.go:1100 cmd/incus/image_alias.go:157 cmd/incus/list.go:133 cmd/incus/network.go:1015 cmd/incus/network.go:1114 cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84 cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786 cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498 cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291 cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467 cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539 cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2645,7 +2645,7 @@ msgstr  ""
 msgid   "Get the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 msgid   "Get the key as a network zone record property"
 msgstr  ""
 
@@ -2713,7 +2713,7 @@ msgstr  ""
 msgid   "Get values for network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
@@ -3288,7 +3288,7 @@ msgstr  ""
 msgid   "List available network zone"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 msgid   "List available network zone records"
 msgstr  ""
 
@@ -3811,11 +3811,11 @@ msgstr  ""
 msgid   "Manage network peerings"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 msgid   "Manage network zone record entries"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 msgid   "Manage network zone records"
 msgstr  ""
 
@@ -3997,11 +3997,11 @@ msgstr  ""
 msgid   "Missing network name"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280 cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444 cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696 cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890 cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128 cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467 cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280 cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448 cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700 cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894 cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132 cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1528
 msgid   "Missing network zone name"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 msgid   "Missing network zone record name"
 msgstr  ""
 
@@ -4129,7 +4129,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158 cmd/incus/cluster_group.go:502 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:666 cmd/incus/list.go:581 cmd/incus/network.go:1087 cmd/incus/network_acl.go:154 cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154 cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839 cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773 cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519 cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158 cmd/incus/cluster_group.go:502 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:666 cmd/incus/list.go:581 cmd/incus/network.go:1087 cmd/incus/network_acl.go:154 cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154 cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843 cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773 cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519 cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
 msgid   "NAME"
 msgstr  ""
 
@@ -4284,12 +4284,12 @@ msgstr  ""
 msgid   "Network ACL %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, c-format
 msgid   "Network Zone %s created"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, c-format
 msgid   "Network Zone %s deleted"
 msgstr  ""
@@ -4361,12 +4361,12 @@ msgstr  ""
 msgid   "Network usage:"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, c-format
 msgid   "Network zone record %s created"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, c-format
 msgid   "Network zone record %s deleted"
 msgstr  ""
@@ -4640,7 +4640,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325 cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329 cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -5021,7 +5021,7 @@ msgstr  ""
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 msgid   "Remove a network zone record entry"
 msgstr  ""
 
@@ -5045,7 +5045,7 @@ msgstr  ""
 msgid   "Remove backends from a load balancer"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
@@ -5487,18 +5487,18 @@ msgid   "Set network peer keys\n"
         "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 msgid   "Set network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 msgid   "Set network zone configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
@@ -5613,11 +5613,11 @@ msgstr  ""
 msgid   "Set the key as a network property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 msgid   "Set the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 msgid   "Set the key as a network zone record property"
 msgstr  ""
 
@@ -5749,11 +5749,11 @@ msgstr  ""
 msgid   "Show network zone configurations"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 msgid   "Show network zone record configuration"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 msgid   "Show network zone record configurations"
 msgstr  ""
 
@@ -6220,7 +6220,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network zone %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, c-format
 msgid   "The property %q does not exist on the network zone record %q: %v"
 msgstr  ""
@@ -6590,11 +6590,11 @@ msgstr  ""
 msgid   "Unset network peer keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 msgid   "Unset network zone configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
@@ -6646,11 +6646,11 @@ msgstr  ""
 msgid   "Unset the key as a network property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 msgid   "Unset the key as a network zone property"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 msgid   "Unset the key as a network zone record property"
 msgstr  ""
 
@@ -7019,15 +7019,15 @@ msgstr  ""
 msgid   "[<remote>:]<API path>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537 cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541 cmd/incus/network_zone.go:667
 msgid   "[<remote>:]<Zone>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 msgid   "[<remote>:]<Zone> <key>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 msgid   "[<remote>:]<Zone> <key>=<value>..."
 msgstr  ""
 
@@ -7503,27 +7503,27 @@ msgstr  ""
 msgid   "[<remote>:]<warning-uuid>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 msgid   "[<remote>:]<zone>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225 cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229 cmd/incus/network_zone.go:1358
 msgid   "[<remote>:]<zone> <record>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 msgid   "[<remote>:]<zone> <record> <key>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 msgid   "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 msgid   "[<remote>:]<zone> <record> <type> <value>"
 msgstr  ""
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
@@ -7794,6 +7794,13 @@ msgid   "incus network peer create default peer1 web/default\n"
         "\n"
         "incus network peer create default peer2 ovn-ic --type=remote\n"
         "    Create a new peering between network \"default\" in the current project and other remote networks through the \"ovn-ic\" integration\n"
+msgstr  ""
+
+#: cmd/incus/network_zone.go:318
+msgid   "incus network zone create z1\n"
+        "\n"
+        "incus network zone create z1 < config.yaml\n"
+        "    Create network zone z1 with configuration from config.yaml"
 msgstr  ""
 
 #: cmd/incus/operation.go:196

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-26 10:40+0200\n"
+"POT-Creation-Date: 2024-04-26 12:30+0200\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -411,7 +411,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -440,7 +440,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -818,7 +818,7 @@ msgstr "Azione (default a GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Il nome del container è: %s"
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1117,8 +1117,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
-#: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1532,7 +1532,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
+#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1698,7 +1698,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1808,7 +1808,7 @@ msgstr "Creazione del container in corso"
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Creazione del container in corso"
@@ -1873,7 +1873,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
-#: cmd/incus/network_zone.go:840 cmd/incus/operation.go:173
+#: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -1981,12 +1981,12 @@ msgstr "Il nome del container è: %s"
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 msgid "Delete network zones"
 msgstr ""
 
@@ -2118,15 +2118,15 @@ msgstr ""
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
-#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408
-#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539
-#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857
-#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180
-#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357
-#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433
-#: cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
+#: cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726
+#: cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861
+#: cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184
+#: cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437
+#: cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2360,7 +2360,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid "ENTRIES"
 msgstr ""
 
@@ -2444,12 +2444,12 @@ msgstr "Il nome del container è: %s"
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
@@ -2508,7 +2508,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid "Entry TTL"
 msgstr ""
 
@@ -2544,7 +2544,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
+#: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2565,8 +2565,8 @@ msgstr ""
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
-#: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3161,7 +3161,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467
@@ -3275,7 +3275,7 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Il nome del container è: %s"
@@ -3351,7 +3351,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
@@ -3958,7 +3958,7 @@ msgstr ""
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Creazione del container in corso"
@@ -4524,12 +4524,12 @@ msgstr "Creazione del container in corso"
 msgid "Manage network peerings"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Creazione del container in corso"
@@ -4789,17 +4789,17 @@ msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280
-#: cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890
-#: cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128
-#: cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467
-#: cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448
+#: cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700
+#: cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132
+#: cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1528
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Il nome del container è: %s"
@@ -4970,7 +4970,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5135,12 +5135,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5213,12 +5213,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5505,7 +5505,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
+#: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5920,7 +5920,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Il nome del container è: %s"
@@ -5947,7 +5947,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove backends from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6431,12 +6431,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6445,7 +6445,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
@@ -6575,12 +6575,12 @@ msgstr ""
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Il nome del container è: %s"
@@ -6722,12 +6722,12 @@ msgstr "Il nome del container è: %s"
 msgid "Show network zone configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
@@ -7225,7 +7225,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Il nome del container è: %s"
@@ -7630,12 +7630,12 @@ msgstr "Il nome del container è: %s"
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
@@ -7691,12 +7691,12 @@ msgstr ""
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Il nome del container è: %s"
@@ -8114,18 +8114,18 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<API path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537
-#: cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541
+#: cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -8754,33 +8754,33 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225
-#: cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -9105,6 +9105,14 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+msgstr ""
+
+#: cmd/incus/network_zone.go:318
+msgid ""
+"incus network zone create z1\n"
+"\n"
+"incus network zone create z1 < config.yaml\n"
+"    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/operation.go:196

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-26 10:40+0200\n"
+"POT-Creation-Date: 2024-04-26 12:30+0200\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -408,7 +408,7 @@ msgstr ""
 "### Note that the name, target_project, target_network and status fields "
 "cannot be changed."
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -432,7 +432,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -805,7 +805,7 @@ msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスターメンバーをクラスターグループに追加します"
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 msgid "Add a network zone record entry"
 msgstr "ネットワークゾーンレコードのエントリを追加します"
 
@@ -817,7 +817,7 @@ msgstr "ロードバランサーにバックエンドを追加します"
 msgid "Add backends to a load balancer"
 msgstr "ロードバランサーにバックエンドを追加します"
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid "Add entries to a network zone record"
 msgstr "ネットワークゾーンレコードにエントリを追加します"
 
@@ -1121,8 +1121,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
-#: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
@@ -1551,7 +1551,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
+#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1733,7 +1733,7 @@ msgstr "リモート '%s' に対する新しいリモート証明書がエラー
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid "Couldn't find a matching entry"
 msgstr "一致するエントリを見つけられませんでした"
 
@@ -1838,7 +1838,7 @@ msgstr "新たにネットワークロードバランサーを作成します"
 msgid "Create new network peering"
 msgstr "新たにネットワークピアリングを作成します"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 msgid "Create new network zone record"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
@@ -1901,7 +1901,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
-#: cmd/incus/network_zone.go:840 cmd/incus/operation.go:173
+#: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -2006,11 +2006,11 @@ msgstr "ネットワークロードバランサーを削除します"
 msgid "Delete network peerings"
 msgstr "ネットワークピアリングを削除します"
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 msgid "Delete network zone record"
 msgstr "ネットワークゾーンレコードを削除します"
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 msgid "Delete network zones"
 msgstr "ネットワークゾーンを削除します"
 
@@ -2140,15 +2140,15 @@ msgstr "警告を削除します"
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
-#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408
-#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539
-#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857
-#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180
-#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357
-#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433
-#: cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
+#: cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726
+#: cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861
+#: cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184
+#: cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437
+#: cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2383,7 +2383,7 @@ msgstr "ドライバ: %v (%v)"
 msgid "Dump YAML config to stdout"
 msgstr "YAML 形式で設定を stdout に出力します"
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid "ENTRIES"
 msgstr "ENTRIES"
 
@@ -2466,11 +2466,11 @@ msgstr "ネットワークロードバランサー設定をYAMLで編集しま�
 msgid "Edit network peer configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 msgid "Edit network zone configurations as YAML"
 msgstr "ネットワークゾーン設定をYAMLで編集します"
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
@@ -2537,7 +2537,7 @@ msgstr ""
 "  これは 'incus config get core.https_address' コマンドでチェックできます。\n"
 "  まだ使用可能でない場合は、アドレスを設定することもできます。"
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid "Entry TTL"
 msgstr "TTLを指定します"
 
@@ -2573,7 +2573,7 @@ msgstr "エイリアスの取得に失敗しました: %w"
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
+#: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2594,8 +2594,8 @@ msgstr "プロパティの削除でエラーが発生しました: %v"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
-#: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3241,7 +3241,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467
@@ -3358,7 +3358,7 @@ msgstr "key をネットワークプロパティとして取得します"
 msgid "Get the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
@@ -3432,7 +3432,7 @@ msgstr "ネットワークピアの設定値を取得します"
 msgid "Get values for network zone configuration keys"
 msgstr "ネットワークゾーンの設定値を取得します"
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
@@ -4072,7 +4072,7 @@ msgstr "利用可能なネットワークピアを一覧表示します"
 msgid "List available network zone"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 msgid "List available network zone records"
 msgstr "利用可能なネットワークゾーンレコードを一覧表示します"
 
@@ -4835,11 +4835,11 @@ msgstr "ネットワークロードバランサーを管理します"
 msgid "Manage network peerings"
 msgstr "ネットワークピアリングを管理します"
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 msgid "Manage network zone record entries"
 msgstr "ネットワークゾーンレコードのエントリを管理します"
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 msgid "Manage network zone records"
 msgstr "ネットワークゾーンレコードを管理します"
 
@@ -5090,16 +5090,16 @@ msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
 #: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280
-#: cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890
-#: cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128
-#: cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467
-#: cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448
+#: cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700
+#: cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132
+#: cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1528
 msgid "Missing network zone name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 msgid "Missing network zone record name"
 msgstr "ネットワークゾーンレコード名を指定する必要があります"
 
@@ -5286,7 +5286,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5455,12 +5455,12 @@ msgstr "ネットワーク ACL %s を削除しました"
 msgid "Network ACL %s renamed to %s"
 msgstr "ネットワーク ACL 名 %s を %s に変更しました"
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, c-format
 msgid "Network Zone %s created"
 msgstr "ネットワークゾーン %s を作成しました"
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
@@ -5535,12 +5535,12 @@ msgstr "ネットワークタイプ:"
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, c-format
 msgid "Network zone record %s created"
 msgstr "ネットワークゾーンレコード %s を作成しました"
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr "ネットワークゾーンレコード %s を削除しました"
@@ -5834,7 +5834,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
+#: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -6286,7 +6286,7 @@ msgstr "クラスターグループからメンバを削除します"
 msgid "Remove a member from the cluster"
 msgstr "クラスターからメンバを削除します"
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 msgid "Remove a network zone record entry"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
@@ -6310,7 +6310,7 @@ msgstr "ロードバランサーからバックエンドを削除します"
 msgid "Remove backends from a load balancer"
 msgstr "ロードバランサーからバックエンドを削除します"
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
@@ -6838,11 +6838,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <peer_name> <key> <value>"
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 msgid "Set network zone configuration keys"
 msgstr "ネットワークゾーンの設定を行います"
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 #, fuzzy
 msgid ""
 "Set network zone configuration keys\n"
@@ -6856,7 +6856,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<Zone> <key> <value>"
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
@@ -7015,12 +7015,12 @@ msgstr "ネットワークピアの設定を行います"
 msgid "Set the key as a network property"
 msgstr "ネットワークプロパティとして設定します"
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
@@ -7160,11 +7160,11 @@ msgstr "ネットワークピアの設定を表示します"
 msgid "Show network zone configurations"
 msgstr "ネットワークゾーンの設定を表示します"
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 msgid "Show network zone record configuration"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
@@ -7689,7 +7689,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -8123,11 +8123,11 @@ msgstr "ネットワークピアの設定を削除します"
 msgid "Unset network peer keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 msgid "Unset network zone configuration keys"
 msgstr "ネットワークゾーンの設定を削除します"
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
@@ -8184,12 +8184,12 @@ msgstr "ネットワークピアの設定を削除します"
 msgid "Unset the key as a network property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "新たにネットワークゾーンレコードを作成します"
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "ネットワークゾーンレコードエントリを削除します"
@@ -8618,16 +8618,16 @@ msgstr "[<remote>:]<ACL> [key=value...]"
 msgid "[<remote>:]<API path>"
 msgstr "[<remote>:]<API path>"
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537
-#: cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541
+#: cmd/incus/network_zone.go:667
 msgid "[<remote>:]<Zone>"
 msgstr "[<remote>:]<Zone>"
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 msgid "[<remote>:]<Zone> <key>"
 msgstr "[<remote>:]<Zone> <key>"
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "[<remote>:]<Zone> <key>=<value>..."
 
@@ -9173,28 +9173,28 @@ msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgid "[<remote>:]<warning-uuid>"
 msgstr "[<remote>:]<warning-uuid>"
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 msgid "[<remote>:]<zone>"
 msgstr "[<remote>:]<zone>"
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225
-#: cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1358
 msgid "[<remote>:]<zone> <record>"
 msgstr "[<remote>:]<zone> <record>"
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "[<remote>:]<zone> <record> <key>"
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "[<remote>:]<zone> <record> <key>=<value>..."
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "[<remote>:]<zone> <record> <type> <value>"
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
@@ -9674,6 +9674,19 @@ msgid ""
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
 msgstr ""
+
+#: cmd/incus/network_zone.go:318
+#, fuzzy
+msgid ""
+"incus network zone create z1\n"
+"\n"
+"incus network zone create z1 < config.yaml\n"
+"    Create network zone z1 with configuration from config.yaml"
+msgstr ""
+"lxc init ubuntu:22.04 u1\n"
+"\n"
+"lxc init ubuntu:22.04 u1 < config.yaml\n"
+"    config.yaml の設定を使ってインスタンスを作成します"
 
 #: cmd/incus/operation.go:196
 #, fuzzy

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-26 10:40+0200\n"
+"POT-Creation-Date: 2024-04-26 12:30+0200\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -416,7 +416,7 @@ msgstr ""
 "(target_project), bestemming netwerk (target_network) en de status velden "
 "(status fielsds) niet kunnen worden aangepast."
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -442,7 +442,7 @@ msgstr ""
 "### config:\n"
 "###  user.foo: bah\n"
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -825,7 +825,7 @@ msgid "Add a cluster member to a cluster group"
 msgstr ""
 "Voeg een clusterlid (cluster member) toe aan de clustergroep (cluster group)"
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 msgid "Add a network zone record entry"
 msgstr "Voeg een netwerk (network) zone record toe"
 
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid "Add entries to a network zone record"
 msgstr "Voeg een items toe aan een netwerk (network) zone record"
 
@@ -1138,8 +1138,8 @@ msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
-#: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
@@ -1553,7 +1553,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
+#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1719,7 +1719,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1820,7 +1820,7 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 msgid "Create new network zone record"
 msgstr ""
 
@@ -1883,7 +1883,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
-#: cmd/incus/network_zone.go:840 cmd/incus/operation.go:173
+#: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 msgid "Delete network zones"
 msgstr ""
 
@@ -2121,15 +2121,15 @@ msgstr ""
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
-#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408
-#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539
-#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857
-#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180
-#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357
-#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433
-#: cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
+#: cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726
+#: cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861
+#: cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184
+#: cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437
+#: cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2355,7 +2355,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid "ENTRIES"
 msgstr ""
 
@@ -2435,11 +2435,11 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
@@ -2496,7 +2496,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid "Entry TTL"
 msgstr ""
 
@@ -2532,7 +2532,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
+#: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2553,8 +2553,8 @@ msgstr ""
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
-#: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3142,7 +3142,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467
@@ -3254,7 +3254,7 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 msgid "Get the key as a network zone record property"
 msgstr ""
 
@@ -3323,7 +3323,7 @@ msgstr ""
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
@@ -3910,7 +3910,7 @@ msgstr ""
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 msgid "List available network zone records"
 msgstr ""
 
@@ -4456,11 +4456,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 msgid "Manage network zone records"
 msgstr ""
 
@@ -4706,16 +4706,16 @@ msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280
-#: cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890
-#: cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128
-#: cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467
-#: cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448
+#: cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700
+#: cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132
+#: cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1528
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4878,7 +4878,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5043,12 +5043,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5121,12 +5121,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5411,7 +5411,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
+#: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5820,7 +5820,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5844,7 +5844,7 @@ msgstr ""
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6313,11 +6313,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6326,7 +6326,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 msgid "Set network zone record configuration keys"
 msgstr ""
 
@@ -6453,11 +6453,11 @@ msgstr ""
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 msgid "Set the key as a network zone record property"
 msgstr ""
 
@@ -6591,11 +6591,11 @@ msgstr ""
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 msgid "Show network zone record configurations"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
@@ -7477,11 +7477,11 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -7533,11 +7533,11 @@ msgstr ""
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -7930,16 +7930,16 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537
-#: cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541
+#: cmd/incus/network_zone.go:667
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
@@ -8451,28 +8451,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225
-#: cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1358
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -8790,6 +8790,14 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+msgstr ""
+
+#: cmd/incus/network_zone.go:318
+msgid ""
+"incus network zone create z1\n"
+"\n"
+"incus network zone create z1 < config.yaml\n"
+"    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/operation.go:196

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-26 10:40+0200\n"
+"POT-Creation-Date: 2024-04-26 12:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -242,7 +242,7 @@ msgid ""
 "cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -256,7 +256,7 @@ msgid ""
 "###  user.foo: bah\n"
 msgstr ""
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 msgid ""
 "### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 msgid "Add a network zone record entry"
 msgstr ""
 
@@ -579,7 +579,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -860,8 +860,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
-#: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1272,7 +1272,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
+#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1438,7 +1438,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1538,7 +1538,7 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 msgid "Create new network zone record"
 msgstr ""
 
@@ -1601,7 +1601,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
-#: cmd/incus/network_zone.go:840 cmd/incus/operation.go:173
+#: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -1704,11 +1704,11 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 msgid "Delete network zones"
 msgstr ""
 
@@ -1838,15 +1838,15 @@ msgstr ""
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
-#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408
-#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539
-#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857
-#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180
-#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357
-#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433
-#: cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
+#: cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726
+#: cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861
+#: cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184
+#: cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437
+#: cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2072,7 +2072,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid "ENTRIES"
 msgstr ""
 
@@ -2152,11 +2152,11 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
@@ -2213,7 +2213,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid "Entry TTL"
 msgstr ""
 
@@ -2249,7 +2249,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
+#: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2270,8 +2270,8 @@ msgstr ""
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
-#: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -2859,7 +2859,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467
@@ -2969,7 +2969,7 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 msgid "Get the key as a network zone record property"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
@@ -3625,7 +3625,7 @@ msgstr ""
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 msgid "List available network zone records"
 msgstr ""
 
@@ -4169,11 +4169,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 msgid "Manage network zone records"
 msgstr ""
 
@@ -4418,16 +4418,16 @@ msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280
-#: cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890
-#: cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128
-#: cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467
-#: cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448
+#: cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700
+#: cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132
+#: cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1528
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4590,7 +4590,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -4755,12 +4755,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -4833,12 +4833,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5123,7 +5123,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
+#: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5532,7 +5532,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5556,7 +5556,7 @@ msgstr ""
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6023,11 +6023,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6036,7 +6036,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 msgid "Set network zone record configuration keys"
 msgstr ""
 
@@ -6162,11 +6162,11 @@ msgstr ""
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 msgid "Set the key as a network zone record property"
 msgstr ""
 
@@ -6299,11 +6299,11 @@ msgstr ""
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 msgid "Show network zone record configurations"
 msgstr ""
 
@@ -6792,7 +6792,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
@@ -7185,11 +7185,11 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -7241,11 +7241,11 @@ msgstr ""
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -7638,16 +7638,16 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537
-#: cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541
+#: cmd/incus/network_zone.go:667
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
@@ -8159,28 +8159,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225
-#: cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1358
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -8498,6 +8498,14 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+msgstr ""
+
+#: cmd/incus/network_zone.go:318
+msgid ""
+"incus network zone create z1\n"
+"\n"
+"incus network zone create z1 < config.yaml\n"
+"    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/operation.go:196

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-26 10:40+0200\n"
+"POT-Creation-Date: 2024-04-26 12:30+0200\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -400,7 +400,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -426,7 +426,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -819,7 +819,7 @@ msgstr "Ação (padrão para o GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1128,8 +1128,8 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
-#: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
@@ -1556,7 +1556,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
+#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1724,7 +1724,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr "Criar novas redes"
 msgid "Create new network peering"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Criar novas redes"
@@ -1905,7 +1905,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
-#: cmd/incus/network_zone.go:840 cmd/incus/operation.go:173
+#: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -2019,12 +2019,12 @@ msgstr "Criar novas redes"
 msgid "Delete network peerings"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Criar novas redes"
@@ -2157,15 +2157,15 @@ msgstr ""
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
-#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408
-#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539
-#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857
-#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180
-#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357
-#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433
-#: cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
+#: cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726
+#: cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861
+#: cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184
+#: cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437
+#: cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2400,7 +2400,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid "ENTRIES"
 msgstr ""
 
@@ -2491,12 +2491,12 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network peer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2557,7 +2557,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid "Entry TTL"
 msgstr ""
 
@@ -2593,7 +2593,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
+#: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2614,8 +2614,8 @@ msgstr "Editar propriedades da imagem"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
-#: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3207,7 +3207,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467
@@ -3324,7 +3324,7 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
@@ -3405,7 +3405,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -4009,7 +4009,7 @@ msgstr ""
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Criar novas redes"
@@ -4578,12 +4578,12 @@ msgstr "Criar novas redes"
 msgid "Manage network peerings"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Criar novas redes"
@@ -4844,17 +4844,17 @@ msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280
-#: cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890
-#: cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128
-#: cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467
-#: cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448
+#: cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700
+#: cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132
+#: cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1528
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Nome de membro do cluster"
@@ -5025,7 +5025,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5190,12 +5190,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5268,12 +5268,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5559,7 +5559,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
+#: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5978,7 +5978,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
@@ -6005,7 +6005,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove backends from a load balancer"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 #, fuzzy
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
@@ -6505,12 +6505,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6519,7 +6519,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -6652,12 +6652,12 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
@@ -6807,12 +6807,12 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network zone configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -7310,7 +7310,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Nome de membro do cluster"
@@ -7722,12 +7722,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network peer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -7787,12 +7787,12 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Editar configurações de perfil como YAML"
@@ -8201,18 +8201,18 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537
-#: cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541
+#: cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
@@ -8785,33 +8785,33 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225
-#: cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -9132,6 +9132,14 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+msgstr ""
+
+#: cmd/incus/network_zone.go:318
+msgid ""
+"incus network zone create z1\n"
+"\n"
+"incus network zone create z1 < config.yaml\n"
+"    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/operation.go:196

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-26 10:40+0200\n"
+"POT-Creation-Date: 2024-04-26 12:30+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -421,7 +421,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -449,7 +449,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -840,7 +840,7 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Копирование образа: %s"
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1143,8 +1143,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
-#: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1558,7 +1558,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
+#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1726,7 +1726,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new network peering"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 #, fuzzy
 msgid "Create new network zone record"
 msgstr "Копирование образа: %s"
@@ -1907,7 +1907,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
-#: cmd/incus/network_zone.go:840 cmd/incus/operation.go:173
+#: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -2017,12 +2017,12 @@ msgstr "Копирование образа: %s"
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 #, fuzzy
 msgid "Delete network zone record"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 #, fuzzy
 msgid "Delete network zones"
 msgstr "Копирование образа: %s"
@@ -2156,15 +2156,15 @@ msgstr ""
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
-#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408
-#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539
-#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857
-#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180
-#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357
-#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433
-#: cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
+#: cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726
+#: cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861
+#: cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184
+#: cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437
+#: cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid "ENTRIES"
 msgstr ""
 
@@ -2484,12 +2484,12 @@ msgstr "Копирование образа: %s"
 msgid "Edit network peer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 #, fuzzy
 msgid "Edit network zone configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 #, fuzzy
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
@@ -2548,7 +2548,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid "Entry TTL"
 msgstr ""
 
@@ -2584,7 +2584,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
+#: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2605,8 +2605,8 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
-#: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3206,7 +3206,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467
@@ -3322,7 +3322,7 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 #, fuzzy
 msgid "Get the key as a network zone record property"
 msgstr "Копирование образа: %s"
@@ -3401,7 +3401,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 #, fuzzy
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
@@ -4010,7 +4010,7 @@ msgstr ""
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 #, fuzzy
 msgid "List available network zone records"
 msgstr "Копирование образа: %s"
@@ -4583,12 +4583,12 @@ msgstr "Копирование образа: %s"
 msgid "Manage network peerings"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 #, fuzzy
 msgid "Manage network zone record entries"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 #, fuzzy
 msgid "Manage network zone records"
 msgstr "Копирование образа: %s"
@@ -4853,17 +4853,17 @@ msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280
-#: cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890
-#: cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128
-#: cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467
-#: cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448
+#: cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700
+#: cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132
+#: cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1528
 #, fuzzy
 msgid "Missing network zone name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 #, fuzzy
 msgid "Missing network zone record name"
 msgstr "Имя контейнера: %s"
@@ -5035,7 +5035,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -5204,12 +5204,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, fuzzy, c-format
 msgid "Network Zone %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, fuzzy, c-format
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
@@ -5284,12 +5284,12 @@ msgstr " Использование сети:"
 msgid "Network usage:"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, fuzzy, c-format
 msgid "Network zone record %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, fuzzy, c-format
 msgid "Network zone record %s deleted"
 msgstr " Использование сети:"
@@ -5576,7 +5576,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
+#: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5990,7 +5990,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 #, fuzzy
 msgid "Remove a network zone record entry"
 msgstr "Копирование образа: %s"
@@ -6017,7 +6017,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove backends from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6505,12 +6505,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 #, fuzzy
 msgid "Set network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6519,7 +6519,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 #, fuzzy
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
@@ -6651,12 +6651,12 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 #, fuzzy
 msgid "Set the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 #, fuzzy
 msgid "Set the key as a network zone record property"
 msgstr "Копирование образа: %s"
@@ -6803,12 +6803,12 @@ msgstr "Копирование образа: %s"
 msgid "Show network zone configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 #, fuzzy
 msgid "Show network zone record configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 #, fuzzy
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
@@ -7309,7 +7309,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr "Копирование образа: %s"
@@ -7715,12 +7715,12 @@ msgstr "Копирование образа: %s"
 msgid "Unset network peer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 #, fuzzy
 msgid "Unset network zone configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 #, fuzzy
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
@@ -7779,12 +7779,12 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 #, fuzzy
 msgid "Unset the key as a network zone property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 #, fuzzy
 msgid "Unset the key as a network zone record property"
 msgstr "Копирование образа: %s"
@@ -8249,8 +8249,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537
-#: cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541
+#: cmd/incus/network_zone.go:667
 #, fuzzy
 msgid "[<remote>:]<Zone>"
 msgstr ""
@@ -8258,7 +8258,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
@@ -8266,7 +8266,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 #, fuzzy
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
@@ -9250,7 +9250,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 #, fuzzy
 msgid "[<remote>:]<zone>"
 msgstr ""
@@ -9258,8 +9258,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225
-#: cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1358
 #, fuzzy
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
@@ -9267,7 +9267,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
@@ -9275,7 +9275,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
@@ -9283,7 +9283,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 #, fuzzy
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
@@ -9291,7 +9291,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 #, fuzzy
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
@@ -9637,6 +9637,14 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+msgstr ""
+
+#: cmd/incus/network_zone.go:318
+msgid ""
+"incus network zone create z1\n"
+"\n"
+"incus network zone create z1 < config.yaml\n"
+"    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/operation.go:196

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-26 10:40+0200\n"
+"POT-Creation-Date: 2024-04-26 12:30+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -385,7 +385,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: cmd/incus/network_zone.go:1247
+#: cmd/incus/network_zone.go:1251
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone record.\n"
@@ -410,7 +410,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: cmd/incus/network_zone.go:555
+#: cmd/incus/network_zone.go:559
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network zone.\n"
@@ -779,7 +779,7 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1432
+#: cmd/incus/network_zone.go:1436
 msgid "Add a network zone record entry"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "Add backends to a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1433
+#: cmd/incus/network_zone.go:1437
 msgid "Add entries to a network zone record"
 msgstr ""
 
@@ -1072,8 +1072,8 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:378
-#: cmd/incus/network_zone.go:1061 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1484,7 +1484,7 @@ msgstr ""
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
-#: cmd/incus/network_zone.go:633 cmd/incus/network_zone.go:1324
+#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:594 cmd/incus/project.go:368 cmd/incus/storage.go:357
 #: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
 #: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
@@ -1650,7 +1650,7 @@ msgstr ""
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1544
+#: cmd/incus/network_zone.go:1548
 msgid "Couldn't find a matching entry"
 msgstr ""
 
@@ -1750,7 +1750,7 @@ msgstr ""
 msgid "Create new network peering"
 msgstr ""
 
-#: cmd/incus/network_zone.go:996 cmd/incus/network_zone.go:997
+#: cmd/incus/network_zone.go:1000 cmd/incus/network_zone.go:1001
 msgid "Create new network zone record"
 msgstr ""
 
@@ -1813,7 +1813,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
-#: cmd/incus/network_zone.go:840 cmd/incus/operation.go:173
+#: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:755 cmd/incus/project.go:524 cmd/incus/storage.go:721
 #: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
 #: cmd/incus/storage_volume.go:1636
@@ -1916,11 +1916,11 @@ msgstr ""
 msgid "Delete network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1356 cmd/incus/network_zone.go:1357
+#: cmd/incus/network_zone.go:1360 cmd/incus/network_zone.go:1361
 msgid "Delete network zone record"
 msgstr ""
 
-#: cmd/incus/network_zone.go:665 cmd/incus/network_zone.go:666
+#: cmd/incus/network_zone.go:669 cmd/incus/network_zone.go:670
 msgid "Delete network zones"
 msgstr ""
 
@@ -2050,15 +2050,15 @@ msgstr ""
 #: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
-#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:408
-#: cmd/incus/network_zone.go:496 cmd/incus/network_zone.go:539
-#: cmd/incus/network_zone.go:666 cmd/incus/network_zone.go:722
-#: cmd/incus/network_zone.go:779 cmd/incus/network_zone.go:857
-#: cmd/incus/network_zone.go:921 cmd/incus/network_zone.go:997
-#: cmd/incus/network_zone.go:1091 cmd/incus/network_zone.go:1180
-#: cmd/incus/network_zone.go:1227 cmd/incus/network_zone.go:1357
-#: cmd/incus/network_zone.go:1418 cmd/incus/network_zone.go:1433
-#: cmd/incus/network_zone.go:1491 cmd/incus/operation.go:24
+#: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
+#: cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543
+#: cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726
+#: cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861
+#: cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001
+#: cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184
+#: cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361
+#: cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437
+#: cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24
 #: cmd/incus/operation.go:57 cmd/incus/operation.go:107
 #: cmd/incus/operation.go:194 cmd/incus/profile.go:29 cmd/incus/profile.go:104
 #: cmd/incus/profile.go:179 cmd/incus/profile.go:270 cmd/incus/profile.go:352
@@ -2284,7 +2284,7 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
-#: cmd/incus/network_zone.go:841
+#: cmd/incus/network_zone.go:845
 msgid "ENTRIES"
 msgstr ""
 
@@ -2364,11 +2364,11 @@ msgstr ""
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:538 cmd/incus/network_zone.go:539
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:543
 msgid "Edit network zone configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1226 cmd/incus/network_zone.go:1227
+#: cmd/incus/network_zone.go:1230 cmd/incus/network_zone.go:1231
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
@@ -2425,7 +2425,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:1439
 msgid "Entry TTL"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
-#: cmd/incus/network_zone.go:471 cmd/incus/network_zone.go:1155
+#: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:986 cmd/incus/project.go:820 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
 #: cmd/incus/storage_volume.go:2040
@@ -2482,8 +2482,8 @@ msgstr ""
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:465
-#: cmd/incus/network_zone.go:1149 cmd/incus/profile.go:980
+#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:980
 #: cmd/incus/project.go:814 cmd/incus/storage.go:804
 #: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
 #: cmd/incus/storage_volume.go:2034
@@ -3071,7 +3071,7 @@ msgstr ""
 #: cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57
 #: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
-#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:782
+#: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:706 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:655 cmd/incus/storage_bucket.go:467
@@ -3181,7 +3181,7 @@ msgstr ""
 msgid "Get the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:924
+#: cmd/incus/network_zone.go:928
 msgid "Get the key as a network zone record property"
 msgstr ""
 
@@ -3250,7 +3250,7 @@ msgstr ""
 msgid "Get values for network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:920 cmd/incus/network_zone.go:921
+#: cmd/incus/network_zone.go:924 cmd/incus/network_zone.go:925
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
@@ -3837,7 +3837,7 @@ msgstr ""
 msgid "List available network zone"
 msgstr ""
 
-#: cmd/incus/network_zone.go:778 cmd/incus/network_zone.go:779
+#: cmd/incus/network_zone.go:782 cmd/incus/network_zone.go:783
 msgid "List available network zone records"
 msgstr ""
 
@@ -4381,11 +4381,11 @@ msgstr ""
 msgid "Manage network peerings"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1417 cmd/incus/network_zone.go:1418
+#: cmd/incus/network_zone.go:1421 cmd/incus/network_zone.go:1422
 msgid "Manage network zone record entries"
 msgstr ""
 
-#: cmd/incus/network_zone.go:721 cmd/incus/network_zone.go:722
+#: cmd/incus/network_zone.go:725 cmd/incus/network_zone.go:726
 msgid "Manage network zone records"
 msgstr ""
 
@@ -4630,16 +4630,16 @@ msgid "Missing network name"
 msgstr ""
 
 #: cmd/incus/network_zone.go:211 cmd/incus/network_zone.go:280
-#: cmd/incus/network_zone.go:348 cmd/incus/network_zone.go:444
-#: cmd/incus/network_zone.go:585 cmd/incus/network_zone.go:696
-#: cmd/incus/network_zone.go:810 cmd/incus/network_zone.go:890
-#: cmd/incus/network_zone.go:1031 cmd/incus/network_zone.go:1128
-#: cmd/incus/network_zone.go:1390 cmd/incus/network_zone.go:1467
-#: cmd/incus/network_zone.go:1524
+#: cmd/incus/network_zone.go:352 cmd/incus/network_zone.go:448
+#: cmd/incus/network_zone.go:589 cmd/incus/network_zone.go:700
+#: cmd/incus/network_zone.go:814 cmd/incus/network_zone.go:894
+#: cmd/incus/network_zone.go:1035 cmd/incus/network_zone.go:1132
+#: cmd/incus/network_zone.go:1394 cmd/incus/network_zone.go:1471
+#: cmd/incus/network_zone.go:1528
 msgid "Missing network zone name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:960 cmd/incus/network_zone.go:1276
+#: cmd/incus/network_zone.go:964 cmd/incus/network_zone.go:1280
 msgid "Missing network zone record name"
 msgstr ""
 
@@ -4802,7 +4802,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:581
 #: cmd/incus/network.go:1087 cmd/incus/network_acl.go:154
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
-#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:839
+#: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:754 cmd/incus/project.go:517 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:713 cmd/incus/storage_bucket.go:519
 #: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
@@ -4967,12 +4967,12 @@ msgstr ""
 msgid "Network ACL %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/network_zone.go:390
+#: cmd/incus/network_zone.go:394
 #, c-format
 msgid "Network Zone %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:706
+#: cmd/incus/network_zone.go:710
 #, c-format
 msgid "Network Zone %s deleted"
 msgstr ""
@@ -5045,12 +5045,12 @@ msgstr ""
 msgid "Network usage:"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1073
+#: cmd/incus/network_zone.go:1077
 #, c-format
 msgid "Network zone record %s created"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1400
+#: cmd/incus/network_zone.go:1404
 #, c-format
 msgid "Network zone record %s deleted"
 msgstr ""
@@ -5335,7 +5335,7 @@ msgstr ""
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
-#: cmd/incus/network_zone.go:634 cmd/incus/network_zone.go:1325
+#: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:595 cmd/incus/project.go:369 cmd/incus/storage.go:358
 #: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
 #: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
@@ -5744,7 +5744,7 @@ msgstr ""
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1490
+#: cmd/incus/network_zone.go:1494
 msgid "Remove a network zone record entry"
 msgstr ""
 
@@ -5768,7 +5768,7 @@ msgstr ""
 msgid "Remove backends from a load balancer"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1491
+#: cmd/incus/network_zone.go:1495
 msgid "Remove entries from a network zone record"
 msgstr ""
 
@@ -6235,11 +6235,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:407
+#: cmd/incus/network_zone.go:411
 msgid "Set network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:408
+#: cmd/incus/network_zone.go:412
 msgid ""
 "Set network zone configuration keys\n"
 "\n"
@@ -6248,7 +6248,7 @@ msgid ""
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1090 cmd/incus/network_zone.go:1091
+#: cmd/incus/network_zone.go:1094 cmd/incus/network_zone.go:1095
 msgid "Set network zone record configuration keys"
 msgstr ""
 
@@ -6374,11 +6374,11 @@ msgstr ""
 msgid "Set the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:415
+#: cmd/incus/network_zone.go:419
 msgid "Set the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1096
+#: cmd/incus/network_zone.go:1100
 msgid "Set the key as a network zone record property"
 msgstr ""
 
@@ -6511,11 +6511,11 @@ msgstr ""
 msgid "Show network zone configurations"
 msgstr ""
 
-#: cmd/incus/network_zone.go:856
+#: cmd/incus/network_zone.go:860
 msgid "Show network zone record configuration"
 msgstr ""
 
-#: cmd/incus/network_zone.go:857
+#: cmd/incus/network_zone.go:861
 msgid "Show network zone record configurations"
 msgstr ""
 
@@ -7004,7 +7004,7 @@ msgstr ""
 msgid "The property %q does not exist on the network zone %q: %v"
 msgstr ""
 
-#: cmd/incus/network_zone.go:972
+#: cmd/incus/network_zone.go:976
 #, c-format
 msgid "The property %q does not exist on the network zone record %q: %v"
 msgstr ""
@@ -7397,11 +7397,11 @@ msgstr ""
 msgid "Unset network peer keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:495 cmd/incus/network_zone.go:496
+#: cmd/incus/network_zone.go:499 cmd/incus/network_zone.go:500
 msgid "Unset network zone configuration keys"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1179 cmd/incus/network_zone.go:1180
+#: cmd/incus/network_zone.go:1183 cmd/incus/network_zone.go:1184
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
@@ -7453,11 +7453,11 @@ msgstr ""
 msgid "Unset the key as a network property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:499
+#: cmd/incus/network_zone.go:503
 msgid "Unset the key as a network zone property"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1183
+#: cmd/incus/network_zone.go:1187
 msgid "Unset the key as a network zone record property"
 msgstr ""
 
@@ -7850,16 +7850,16 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:537
-#: cmd/incus/network_zone.go:663
+#: cmd/incus/network_zone.go:179 cmd/incus/network_zone.go:541
+#: cmd/incus/network_zone.go:667
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:494
+#: cmd/incus/network_zone.go:242 cmd/incus/network_zone.go:498
 msgid "[<remote>:]<Zone> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:406
+#: cmd/incus/network_zone.go:410
 msgid "[<remote>:]<Zone> <key>=<value>..."
 msgstr ""
 
@@ -8371,28 +8371,28 @@ msgstr ""
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:776
+#: cmd/incus/network_zone.go:780
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:855 cmd/incus/network_zone.go:1225
-#: cmd/incus/network_zone.go:1354
+#: cmd/incus/network_zone.go:859 cmd/incus/network_zone.go:1229
+#: cmd/incus/network_zone.go:1358
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:919 cmd/incus/network_zone.go:1178
+#: cmd/incus/network_zone.go:923 cmd/incus/network_zone.go:1182
 msgid "[<remote>:]<zone> <record> <key>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:1089
+#: cmd/incus/network_zone.go:1093
 msgid "[<remote>:]<zone> <record> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_zone.go:1431 cmd/incus/network_zone.go:1489
+#: cmd/incus/network_zone.go:1435 cmd/incus/network_zone.go:1493
 msgid "[<remote>:]<zone> <record> <type> <value>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:995
+#: cmd/incus/network_zone.go:999
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
@@ -8710,6 +8710,14 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+msgstr ""
+
+#: cmd/incus/network_zone.go:318
+msgid ""
+"incus network zone create z1\n"
+"\n"
+"incus network zone create z1 < config.yaml\n"
+"    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/operation.go:196


### PR DESCRIPTION
`incus network zone create` already has support for creation from a yaml configuration file, but the same wasn't printed in the usage information of the command.

This commit updates `incus network zone create` to include an example

Part of https://github.com/lxc/incus/issues/741