### PR TITLE
cmd/incus/admin_cluster: Add libexec path for incusd

### DIFF
--- a/cmd/incus/admin_cluster.go
+++ b/cmd/incus/admin_cluster.go
@@ -33,7 +33,9 @@ func (c *cmdAdminCluster) Run(cmd *cobra.Command, args []string) {
 	env := getEnviron()
 	path, _ := exec.LookPath("incusd")
 	if path == "" {
-		if util.PathExists("/usr/lib/incus/incusd") {
+		if util.PathExists("/usr/libexec/incus/incusd") {
+			path = "/usr/libexec/incus/incusd"
+		} else if util.PathExists("/usr/lib/incus/incusd") {
 			path = "/usr/lib/incus/incusd"
 		} else if util.PathExists("/opt/incus/bin/incusd") {
 			path = "/opt/incus/bin/incusd"


### PR DESCRIPTION
This is where incusd is installed on Fedora Linux and derivatives, and potentially other distributions that use /usr/libexec for non-path executables.