### PR TITLE
client/connection: Add support for the socket existing in /run/incus

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -157,7 +157,8 @@ func ConnectIncusUnix(path string, args *ConnectionArgs) (InstanceServer, error)
 //
 // If the path argument is empty, then $INCUS_SOCKET will be used, if
 // unset $INCUS_DIR/unix.socket will be used and if that one isn't set
-// either, then the path will default to /var/lib/incus/unix.socket.
+// either, then the path will default to /run/incus/unix.socket or
+// /var/lib/incus/unix.socket.
 func ConnectIncusUnixWithContext(ctx context.Context, path string, args *ConnectionArgs) (InstanceServer, error) {
 	logger.Debug("Connecting to a local Incus over a Unix socket")
 
@@ -180,7 +181,11 @@ func ConnectIncusUnixWithContext(ctx context.Context, path string, args *Connect
 		if path == "" {
 			incusDir := os.Getenv("INCUS_DIR")
 			if incusDir == "" {
-				incusDir = "/var/lib/incus"
+				if util.PathExists("/run/incus") {
+					incusDir = "/run/incus"
+				} else {
+					incusDir = "/var/lib/incus"
+				}
 			}
 
 			path = filepath.Join(incusDir, "unix.socket")


### PR DESCRIPTION
Transient sockets are supposed to be in /run rather than /var, so make it possible to detect that automatically when used.