### PR TITLE
incus/network_peer: Add example for create command

### DIFF
--- a/cmd/incus/network_peer.go
+++ b/cmd/incus/network_peer.go
@@ -248,7 +248,10 @@ func (c *cmdNetworkPeerCreate) Command() *cobra.Command {
 
 incus network peer create default peer2 ovn-ic --type=remote
     Create a new peering between network "default" in the current project and other remote networks through the "ovn-ic" integration
-`))
+
+incus network peer create default peer3 web/default < config.yaml
+	Create a new peering between network default in the current project and network default in the web project using the configuration
+	in the file config.yaml`))
 
 	cmd.RunE = c.Run
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-03 20:08+0200\n"
+"POT-Creation-Date: 2024-05-03 20:52-0400\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -380,7 +380,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -1159,7 +1159,7 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1589,7 +1589,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
@@ -2051,7 +2051,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete network load balancers"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 msgid "Delete network peerings"
 msgstr ""
 
@@ -2190,9 +2190,9 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:996
 #: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
-#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
-#: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
-#: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
 #: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
@@ -2541,7 +2541,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2648,7 +2648,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
 #: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
@@ -2670,7 +2670,7 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
@@ -2924,7 +2924,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed getting existing storage pools: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -3381,7 +3381,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Get the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3467,7 +3467,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network load balancer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3909,7 +3909,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Ungültiges Ziel %s"
@@ -4975,9 +4975,9 @@ msgstr "Profilname kann nicht geändert werden"
 #: cmd/incus/network_load_balancer.go:919
 #: cmd/incus/network_load_balancer.go:1032
 #: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
-#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
-#: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
-#: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291
+#: cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516
+#: cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid "Missing network name"
 msgstr ""
 
@@ -4997,9 +4997,9 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing network zone record name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292
-#: cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517
-#: cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295
+#: cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520
+#: cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Fehlende Zusammenfassung."
@@ -5062,7 +5062,7 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Profilname kann nicht geändert werden"
@@ -5388,22 +5388,22 @@ msgstr "Profil %s gelöscht\n"
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -5715,7 +5715,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
@@ -6660,12 +6660,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6817,7 +6817,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Set the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7487,7 +7487,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7733,7 +7733,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid "Type of peer (local or remote)"
 msgstr ""
 
@@ -7903,12 +7903,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network load balancer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7969,7 +7969,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as a network load balancer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -9073,7 +9073,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -9091,7 +9091,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -9099,7 +9099,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -9894,6 +9894,11 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+"\n"
+"incus network peer create default peer3 web/default < config.yaml\n"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:318

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-03 20:08+0200\n"
+"POT-Creation-Date: 2024-05-03 20:52-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -375,7 +375,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -1118,7 +1118,7 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1539,7 +1539,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
@@ -1983,7 +1983,7 @@ msgstr "Perfil %s creado"
 msgid "Delete network load balancers"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 msgid "Delete network peerings"
 msgstr ""
 
@@ -2120,9 +2120,9 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:996
 #: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
-#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
-#: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
-#: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
 #: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
@@ -2450,7 +2450,7 @@ msgstr "Perfil %s creado"
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Perfil %s creado"
@@ -2555,7 +2555,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
 #: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
@@ -2577,7 +2577,7 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
@@ -2822,7 +2822,7 @@ msgstr "Acepta certificado"
 msgid "Failed getting existing storage pools: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -3275,7 +3275,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a network load balancer property"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Perfil %s creado"
@@ -3356,7 +3356,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for network load balancer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Perfil %s creado"
@@ -3793,7 +3793,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Nombre del contenedor es: %s"
@@ -4810,9 +4810,9 @@ msgstr "Nombre del contenedor es: %s"
 #: cmd/incus/network_load_balancer.go:919
 #: cmd/incus/network_load_balancer.go:1032
 #: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
-#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
-#: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
-#: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291
+#: cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516
+#: cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid "Missing network name"
 msgstr ""
 
@@ -4832,9 +4832,9 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing network zone record name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292
-#: cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517
-#: cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295
+#: cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520
+#: cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Nombre del contenedor es: %s"
@@ -4896,7 +4896,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "%s no es un directorio"
@@ -5212,22 +5212,22 @@ msgstr "Perfil %s eliminado"
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -5532,7 +5532,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
@@ -6447,12 +6447,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6598,7 +6598,7 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network load balancer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Perfil %s creado"
@@ -7244,7 +7244,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -7487,7 +7487,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid "Type of peer (local or remote)"
 msgstr ""
 
@@ -7650,12 +7650,12 @@ msgstr "Perfil %s creado"
 msgid "Unset network load balancer keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Perfil %s creado"
@@ -7714,7 +7714,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network load balancer property"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Perfil %s creado"
@@ -8518,7 +8518,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <peer name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8530,12 +8530,12 @@ msgid ""
 "integration> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9134,6 +9134,11 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+"\n"
+"incus network peer create default peer3 web/default < config.yaml\n"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:318

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-03 20:08+0200\n"
+"POT-Creation-Date: 2024-05-03 20:52-0400\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -390,7 +390,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1150,7 +1150,7 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1588,7 +1588,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
@@ -2087,7 +2087,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete network load balancers"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 #, fuzzy
 msgid "Delete network peerings"
 msgstr "Récupération de l'image : %s"
@@ -2228,9 +2228,9 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/network_load_balancer.go:996
 #: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
-#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
-#: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
-#: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
 #: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
@@ -2576,7 +2576,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2697,7 +2697,7 @@ msgstr "Erreur lors de la récupération des alias : %w"
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
 #: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
@@ -2719,7 +2719,7 @@ msgstr "Erreur lors du déparamétrage des propriétés: %v"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
@@ -3032,7 +3032,7 @@ msgstr "Échec de la génération du certificat de confiance : %w"
 msgid "Failed getting existing storage pools: %w"
 msgstr "Échec de l'obtention des pools de stockage existants : %w"
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr "Échec de la récupération du status du pair : %w"
@@ -3521,7 +3521,7 @@ msgstr "Nom du réseau"
 msgid "Get the key as a network load balancer property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Nom du réseau"
@@ -3608,7 +3608,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network load balancer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Clé de configuration invalide"
@@ -4085,7 +4085,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Cible invalide %s"
@@ -5188,9 +5188,9 @@ msgstr "Nom du réseau"
 #: cmd/incus/network_load_balancer.go:919
 #: cmd/incus/network_load_balancer.go:1032
 #: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
-#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
-#: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
-#: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291
+#: cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516
+#: cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 #, fuzzy
 msgid "Missing network name"
 msgstr "Nom du réseau"
@@ -5211,9 +5211,9 @@ msgstr "Nom du réseau"
 msgid "Missing network zone record name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292
-#: cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517
-#: cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295
+#: cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520
+#: cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Résumé manquant."
@@ -5277,7 +5277,7 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "%s n'est pas un répertoire"
@@ -5606,22 +5606,22 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Network name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -5943,7 +5943,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
@@ -6905,12 +6905,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -7063,7 +7063,7 @@ msgstr "Nom du réseau"
 msgid "Set the key as a network load balancer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Nom du réseau"
@@ -7748,7 +7748,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -7999,7 +7999,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid "Type of peer (local or remote)"
 msgstr ""
 
@@ -8170,12 +8170,12 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network load balancer keys"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Nom du réseau"
@@ -8238,7 +8238,7 @@ msgstr "Nom du réseau"
 msgid "Unset the key as a network load balancer property"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Nom du réseau"
@@ -9371,7 +9371,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -9389,7 +9389,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -9397,7 +9397,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -10247,6 +10247,11 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+"\n"
+"incus network peer create default peer3 web/default < config.yaml\n"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:318

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-05-03 20:08+0200\n"
+        "POT-Creation-Date: 2024-05-03 20:52-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -210,7 +210,7 @@ msgid   "### This is a YAML representation of the network load balancer.\n"
         "### Note that the listen_address and location cannot be changed."
 msgstr  ""
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 msgid   "### This is a YAML representation of the network peer.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -821,7 +821,7 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382 cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311 cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382 cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -1178,7 +1178,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328 cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328 cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1583,7 +1583,7 @@ msgstr  ""
 msgid   "Delete network load balancers"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 msgid   "Delete network peerings"
 msgstr  ""
 
@@ -1627,7 +1627,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:719 cmd/incus/network_load_balancer.go:792 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:883 cmd/incus/network_load_balancer.go:981 cmd/incus/network_load_balancer.go:996 cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412 cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543 cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726 cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861 cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001 cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184 cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361 cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:439 cmd/incus/profile.go:497 cmd/incus/profile.go:633 cmd/incus/profile.go:709 cmd/incus/profile.go:867 cmd/incus/profile.go:955 cmd/incus/profile.go:1015 cmd/incus/profile.go:1104 cmd/incus/profile.go:1168 cmd/incus/project.go:35 cmd/incus/project.go:99 cmd/incus/project.go:195 cmd/incus/project.go:266 cmd/incus/project.go:402 cmd/incus/project.go:477 cmd/incus/project.go:692 cmd/incus/project.go:757 cmd/incus/project.go:845 cmd/incus/project.go:889 cmd/incus/project.go:950 cmd/incus/project.go:1017 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:207 cmd/incus/storage.go:265 cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659 cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471 cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642 cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865 cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007 cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214 cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736 cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931 cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288 cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534 cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842 cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085 cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243 cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403 cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703 cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879 cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:719 cmd/incus/network_load_balancer.go:792 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:883 cmd/incus/network_load_balancer.go:981 cmd/incus/network_load_balancer.go:996 cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391 cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578 cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412 cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543 cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726 cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861 cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001 cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184 cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361 cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:439 cmd/incus/profile.go:497 cmd/incus/profile.go:633 cmd/incus/profile.go:709 cmd/incus/profile.go:867 cmd/incus/profile.go:955 cmd/incus/profile.go:1015 cmd/incus/profile.go:1104 cmd/incus/profile.go:1168 cmd/incus/project.go:35 cmd/incus/project.go:99 cmd/incus/project.go:195 cmd/incus/project.go:266 cmd/incus/project.go:402 cmd/incus/project.go:477 cmd/incus/project.go:692 cmd/incus/project.go:757 cmd/incus/project.go:845 cmd/incus/project.go:889 cmd/incus/project.go:950 cmd/incus/project.go:1017 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:207 cmd/incus/storage.go:265 cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659 cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471 cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642 cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865 cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007 cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214 cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736 cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931 cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288 cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534 cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842 cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085 cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243 cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403 cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703 cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879 cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1878,7 +1878,7 @@ msgstr  ""
 msgid   "Edit network load balancer configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 msgid   "Edit network peer configurations as YAML"
 msgstr  ""
 
@@ -1970,7 +1970,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159 cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816 cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013 cmd/incus/storage_volume.go:2056
+#: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159 cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816 cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013 cmd/incus/storage_volume.go:2056
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1985,7 +1985,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076 cmd/incus/project.go:814 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007 cmd/incus/storage_volume.go:2050
+#: cmd/incus/cluster.go:556 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076 cmd/incus/project.go:814 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007 cmd/incus/storage_volume.go:2050
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2212,7 +2212,7 @@ msgstr  ""
 msgid   "Failed getting existing storage pools: %w"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid   "Failed getting peer's status: %w"
 msgstr  ""
@@ -2637,7 +2637,7 @@ msgstr  ""
 msgid   "Get the key as a network load balancer property"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 msgid   "Get the key as a network peer property"
 msgstr  ""
 
@@ -2709,7 +2709,7 @@ msgstr  ""
 msgid   "Get values for network load balancer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 msgid   "Get values for network peer configuration keys"
 msgstr  ""
 
@@ -3125,7 +3125,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 msgid   "Invalid peer type"
 msgstr  ""
 
@@ -4012,7 +4012,7 @@ msgstr  ""
 msgid   "Missing network integration name"
 msgstr  ""
 
-#: cmd/incus/network.go:175 cmd/incus/network.go:272 cmd/incus/network.go:440 cmd/incus/network.go:502 cmd/incus/network.go:599 cmd/incus/network.go:712 cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145 cmd/incus/network.go:1223 cmd/incus/network.go:1289 cmd/incus/network.go:1381 cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960 cmd/incus/network_load_balancer.go:127 cmd/incus/network_load_balancer.go:213 cmd/incus/network_load_balancer.go:282 cmd/incus/network_load_balancer.go:380 cmd/incus/network_load_balancer.go:465 cmd/incus/network_load_balancer.go:623 cmd/incus/network_load_balancer.go:755 cmd/incus/network_load_balancer.go:843 cmd/incus/network_load_balancer.go:919 cmd/incus/network_load_balancer.go:1032 cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118 cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288 cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513 cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network.go:175 cmd/incus/network.go:272 cmd/incus/network.go:440 cmd/incus/network.go:502 cmd/incus/network.go:599 cmd/incus/network.go:712 cmd/incus/network.go:835 cmd/incus/network.go:911 cmd/incus/network.go:1145 cmd/incus/network.go:1223 cmd/incus/network.go:1289 cmd/incus/network.go:1381 cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960 cmd/incus/network_load_balancer.go:127 cmd/incus/network_load_balancer.go:213 cmd/incus/network_load_balancer.go:282 cmd/incus/network_load_balancer.go:380 cmd/incus/network_load_balancer.go:465 cmd/incus/network_load_balancer.go:623 cmd/incus/network_load_balancer.go:755 cmd/incus/network_load_balancer.go:843 cmd/incus/network_load_balancer.go:919 cmd/incus/network_load_balancer.go:1032 cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118 cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516 cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid   "Missing network name"
 msgstr  ""
 
@@ -4024,7 +4024,7 @@ msgstr  ""
 msgid   "Missing network zone record name"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292 cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517 cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295 cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520 cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 msgid   "Missing peer name"
 msgstr  ""
 
@@ -4060,7 +4060,7 @@ msgstr  ""
 msgid   "Missing target directory"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 msgid   "Missing target network or integration"
 msgstr  ""
 
@@ -4352,22 +4352,22 @@ msgstr  ""
 msgid   "Network name"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, c-format
 msgid   "Network peer %s created"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, c-format
 msgid   "Network peer %s deleted"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid   "Network peer %s is in unexpected state %q"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid   "Network peer %s pending (please complete mutual peering on peer network)"
 msgstr  ""
@@ -4659,7 +4659,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329 cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111 cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730 cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329 cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111 cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -5495,11 +5495,11 @@ msgid   "Set network load balancer keys\n"
         "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 msgid   "Set network peer keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 msgid   "Set network peer keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5624,7 +5624,7 @@ msgstr  ""
 msgid   "Set the key as a network load balancer property"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 msgid   "Set the key as a network peer property"
 msgstr  ""
 
@@ -6229,7 +6229,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network integration %q: %v"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid   "The property %q does not exist on the network peer %q: %v"
 msgstr  ""
@@ -6454,7 +6454,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
@@ -6601,11 +6601,11 @@ msgstr  ""
 msgid   "Unset network load balancer keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 msgid   "Unset network peer configuration keys"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 msgid   "Unset network peer keys"
 msgstr  ""
 
@@ -6657,7 +6657,7 @@ msgstr  ""
 msgid   "Unset the key as a network load balancer property"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 msgid   "Unset the key as a network peer property"
 msgstr  ""
 
@@ -7318,7 +7318,7 @@ msgstr  ""
 msgid   "[<remote>:]<network> <peer name>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 msgid   "[<remote>:]<network> <peer_name>"
 msgstr  ""
 
@@ -7326,11 +7326,11 @@ msgstr  ""
 msgid   "[<remote>:]<network> <peer_name> <[target project/]<target network or integration> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 msgid   "[<remote>:]<network> <peer_name> <key>"
 msgstr  ""
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 msgid   "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr  ""
 
@@ -7813,6 +7813,10 @@ msgid   "incus network peer create default peer1 web/default\n"
         "\n"
         "incus network peer create default peer2 ovn-ic --type=remote\n"
         "    Create a new peering between network \"default\" in the current project and other remote networks through the \"ovn-ic\" integration\n"
+        "\n"
+        "incus network peer create default peer3 web/default < config.yaml\n"
+        "	Create a new peering between network default in the current project and network default in the web project using the configuration\n"
+        "	in the file config.yaml"
 msgstr  ""
 
 #: cmd/incus/network_zone.go:318

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-03 20:08+0200\n"
+"POT-Creation-Date: 2024-05-03 20:52-0400\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -379,7 +379,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -1117,7 +1117,7 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1531,7 +1531,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
@@ -1977,7 +1977,7 @@ msgstr "Il nome del container è: %s"
 msgid "Delete network load balancers"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 msgid "Delete network peerings"
 msgstr ""
 
@@ -2113,9 +2113,9 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:996
 #: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
-#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
-#: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
-#: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
 #: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
@@ -2445,7 +2445,7 @@ msgstr "Il nome del container è: %s"
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2549,7 +2549,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
 #: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
@@ -2571,7 +2571,7 @@ msgstr ""
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
@@ -2815,7 +2815,7 @@ msgstr "Accetta certificato"
 msgid "Failed getting existing storage pools: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -3268,7 +3268,7 @@ msgstr "Creazione del container in corso"
 msgid "Get the key as a network load balancer property"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 msgid "Get the key as a network peer property"
 msgstr ""
 
@@ -3347,7 +3347,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network load balancer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Il nome del container è: %s"
@@ -3782,7 +3782,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Proprietà errata: %s"
@@ -4804,9 +4804,9 @@ msgstr "Il nome del container è: %s"
 #: cmd/incus/network_load_balancer.go:919
 #: cmd/incus/network_load_balancer.go:1032
 #: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
-#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
-#: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
-#: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291
+#: cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516
+#: cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid "Missing network name"
 msgstr ""
 
@@ -4826,9 +4826,9 @@ msgstr "Il nome del container è: %s"
 msgid "Missing network zone record name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292
-#: cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517
-#: cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295
+#: cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520
+#: cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Il nome del container è: %s"
@@ -4889,7 +4889,7 @@ msgstr "Il nome del container è: %s"
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Il nome del container è: %s"
@@ -5206,22 +5206,22 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -5527,7 +5527,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
@@ -6441,11 +6441,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6590,7 +6590,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 msgid "Set the key as a network peer property"
 msgstr ""
 
@@ -7238,7 +7238,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Il nome del container è: %s"
@@ -7480,7 +7480,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid "Type of peer (local or remote)"
 msgstr ""
 
@@ -7645,12 +7645,12 @@ msgstr "Il nome del container è: %s"
 msgid "Unset network load balancer keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -7707,7 +7707,7 @@ msgstr "Creazione del container in corso"
 msgid "Unset the key as a network load balancer property"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -8513,7 +8513,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <peer name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "Creazione del container in corso"
@@ -8525,12 +8525,12 @@ msgid ""
 "integration> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -9129,6 +9129,11 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+"\n"
+"incus network peer create default peer3 web/default < config.yaml\n"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:318

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-03 20:08+0200\n"
+"POT-Creation-Date: 2024-05-03 20:52-0400\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -378,7 +378,7 @@ msgstr ""
 "###\n"
 "### Note that the listen_address and location cannot be changed."
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1121,7 +1121,7 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1550,7 +1550,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
@@ -2002,7 +2002,7 @@ msgstr "ネットワークピアリングを削除します"
 msgid "Delete network load balancers"
 msgstr "ネットワークロードバランサーを削除します"
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 msgid "Delete network peerings"
 msgstr "ネットワークピアリングを削除します"
 
@@ -2135,9 +2135,9 @@ msgstr "警告を削除します"
 #: cmd/incus/network_load_balancer.go:996
 #: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
-#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
-#: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
-#: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
 #: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
@@ -2467,7 +2467,7 @@ msgstr "ネットワークピア設定をYAMLで編集します"
 msgid "Edit network load balancer configurations as YAML"
 msgstr "ネットワークロードバランサー設定をYAMLで編集します"
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 msgid "Edit network peer configurations as YAML"
 msgstr "ネットワークピア設定をYAMLで編集します"
 
@@ -2578,7 +2578,7 @@ msgstr "エイリアスの取得に失敗しました: %w"
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
 #: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
@@ -2600,7 +2600,7 @@ msgstr "プロパティの削除でエラーが発生しました: %v"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
@@ -2882,7 +2882,7 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed getting existing storage pools: %w"
 msgstr "既存のストレージプールの取得に失敗しました: %w"
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr "ピアのステータスの取得に失敗しました: %w"
@@ -3350,7 +3350,7 @@ msgstr "ネットワークピアの設定を行います"
 msgid "Get the key as a network load balancer property"
 msgstr "ネットワークロードバランサーのポートを管理します"
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
@@ -3430,7 +3430,7 @@ msgstr "ネットワークピアの設定値を取得します"
 msgid "Get values for network load balancer configuration keys"
 msgstr "ネットワークロードバランサーの設定値を取得します"
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 msgid "Get values for network peer configuration keys"
 msgstr "ネットワークピアの設定値を取得します"
 
@@ -3878,7 +3878,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "不正な送り先 %s"
@@ -5130,9 +5130,9 @@ msgstr "ネットワークゾーン名を指定する必要があります"
 #: cmd/incus/network_load_balancer.go:919
 #: cmd/incus/network_load_balancer.go:1032
 #: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
-#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
-#: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
-#: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291
+#: cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516
+#: cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
@@ -5150,9 +5150,9 @@ msgstr "ネットワークゾーン名を指定する必要があります"
 msgid "Missing network zone record name"
 msgstr "ネットワークゾーンレコード名を指定する必要があります"
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292
-#: cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517
-#: cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295
+#: cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520
+#: cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 msgid "Missing peer name"
 msgstr "ピア名を指定する必要があります"
 
@@ -5210,7 +5210,7 @@ msgstr "ストレージプール名を指定する必要があります"
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "作成するネットワーク名を指定する必要があります"
@@ -5551,22 +5551,22 @@ msgstr "ネットワークロードバランサー %s を削除しました"
 msgid "Network name"
 msgstr "ネットワーク名:"
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, c-format
 msgid "Network peer %s created"
 msgstr "ネットワークピア %s を作成しました"
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, c-format
 msgid "Network peer %s deleted"
 msgstr "ネットワークピア %s を削除しました"
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr "ネットワークピア %s は想定外のステータスです %q"
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -5881,7 +5881,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
@@ -6868,11 +6868,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <listen_address> <key> <value>"
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 msgid "Set network peer keys"
 msgstr "ネットワークピアの設定を行います"
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 #, fuzzy
 msgid ""
 "Set network peer keys\n"
@@ -7054,7 +7054,7 @@ msgstr "ネットワークピアの設定を行います"
 msgid "Set the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を行います"
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
@@ -7727,7 +7727,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -8004,7 +8004,7 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid "Type of peer (local or remote)"
 msgstr ""
 
@@ -8164,11 +8164,11 @@ msgstr "ネットワークロードバランサーの設定を削除します"
 msgid "Unset network load balancer keys"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 msgid "Unset network peer configuration keys"
 msgstr "ネットワークピアの設定を削除します"
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 msgid "Unset network peer keys"
 msgstr "ネットワークピアの設定を削除します"
 
@@ -8223,7 +8223,7 @@ msgstr "ネットワークピアの設定を削除します"
 msgid "Unset the key as a network load balancer property"
 msgstr "ネットワークロードバランサーの設定を削除します"
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "ネットワークピアの設定を削除します"
@@ -8995,7 +8995,7 @@ msgstr "[<remote>:]<network> <new-name>"
 msgid "[<remote>:]<network> <peer name>"
 msgstr "[<remote>:]<network> <peer name>"
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "[<remote>:]<network> <peer_name>"
 
@@ -9008,11 +9008,11 @@ msgstr ""
 "[<remote>:]<network> <peer_name> <[target project/]target_network> "
 "[key=value...]"
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "[<remote>:]<network> <peer_name> <key>"
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "[<remote>:]<network> <peer_name> <key>=<value>..."
 
@@ -9722,6 +9722,11 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+"\n"
+"incus network peer create default peer3 web/default < config.yaml\n"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:318

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-03 20:08+0200\n"
+"POT-Creation-Date: 2024-05-03 20:52-0400\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -385,7 +385,7 @@ msgstr ""
 "### Merk op dat het luisteradres (listen_address) en locatie (location) niet "
 "kunnen worden aangepast."
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1138,7 +1138,7 @@ msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1552,7 +1552,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
@@ -1983,7 +1983,7 @@ msgstr "Toekennen van netwerk interfaces aan instanties (instances)"
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 msgid "Delete network peerings"
 msgstr ""
 
@@ -2116,9 +2116,9 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:996
 #: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
-#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
-#: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
-#: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
 #: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
@@ -2435,7 +2435,7 @@ msgstr ""
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2536,7 +2536,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
 #: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
@@ -2558,7 +2558,7 @@ msgstr ""
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
@@ -2797,7 +2797,7 @@ msgstr ""
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -3247,7 +3247,7 @@ msgstr "Toekennen van netwerk (network) interfaces aan profielen (profiles)"
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 msgid "Get the key as a network peer property"
 msgstr ""
 
@@ -3320,7 +3320,7 @@ msgstr ""
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
@@ -3742,7 +3742,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 msgid "Invalid peer type"
 msgstr ""
 
@@ -4720,9 +4720,9 @@ msgstr "Toekennen van netwerk interfaces aan instanties (instances)"
 #: cmd/incus/network_load_balancer.go:919
 #: cmd/incus/network_load_balancer.go:1032
 #: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
-#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
-#: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
-#: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291
+#: cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516
+#: cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid "Missing network name"
 msgstr ""
 
@@ -4740,9 +4740,9 @@ msgstr ""
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292
-#: cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517
-#: cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295
+#: cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520
+#: cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 msgid "Missing peer name"
 msgstr ""
 
@@ -4799,7 +4799,7 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 msgid "Missing target network or integration"
 msgstr ""
 
@@ -5113,22 +5113,22 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -5432,7 +5432,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
@@ -6322,11 +6322,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6467,7 +6467,7 @@ msgstr "Toekennen van netwerk (network) interfaces aan profielen (profiles)"
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 msgid "Set the key as a network peer property"
 msgstr ""
 
@@ -7096,7 +7096,7 @@ msgstr ""
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
@@ -7336,7 +7336,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid "Type of peer (local or remote)"
 msgstr ""
 
@@ -7492,11 +7492,11 @@ msgstr ""
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -7548,7 +7548,7 @@ msgstr ""
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -8260,7 +8260,7 @@ msgstr ""
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
@@ -8270,11 +8270,11 @@ msgid ""
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
@@ -8813,6 +8813,11 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+"\n"
+"incus network peer create default peer3 web/default < config.yaml\n"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:318

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-03 20:08+0200\n"
+"POT-Creation-Date: 2024-05-03 20:52-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -225,7 +225,7 @@ msgid ""
 "### Note that the listen_address and location cannot be changed."
 msgstr ""
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 msgid ""
 "### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -860,7 +860,7 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1271,7 +1271,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
@@ -1700,7 +1700,7 @@ msgstr ""
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 msgid "Delete network peerings"
 msgstr ""
 
@@ -1833,9 +1833,9 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:996
 #: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
-#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
-#: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
-#: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
 #: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
@@ -2152,7 +2152,7 @@ msgstr ""
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
 #: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
@@ -2275,7 +2275,7 @@ msgstr ""
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -2962,7 +2962,7 @@ msgstr ""
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 msgid "Get the key as a network peer property"
 msgstr ""
 
@@ -3035,7 +3035,7 @@ msgstr ""
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
@@ -3457,7 +3457,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 msgid "Invalid peer type"
 msgstr ""
 
@@ -4432,9 +4432,9 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:919
 #: cmd/incus/network_load_balancer.go:1032
 #: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
-#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
-#: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
-#: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291
+#: cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516
+#: cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid "Missing network name"
 msgstr ""
 
@@ -4452,9 +4452,9 @@ msgstr ""
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292
-#: cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517
-#: cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295
+#: cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520
+#: cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 msgid "Missing peer name"
 msgstr ""
 
@@ -4511,7 +4511,7 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 msgid "Missing target network or integration"
 msgstr ""
 
@@ -4825,22 +4825,22 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -5144,7 +5144,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
@@ -6032,11 +6032,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 msgid "Set the key as a network peer property"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgstr ""
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
@@ -7044,7 +7044,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid "Type of peer (local or remote)"
 msgstr ""
 
@@ -7200,11 +7200,11 @@ msgstr ""
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -7256,7 +7256,7 @@ msgstr ""
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -7968,7 +7968,7 @@ msgstr ""
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
@@ -7978,11 +7978,11 @@ msgid ""
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
@@ -8521,6 +8521,11 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+"\n"
+"incus network peer create default peer3 web/default < config.yaml\n"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:318

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-03 20:08+0200\n"
+"POT-Creation-Date: 2024-05-03 20:52-0400\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -368,7 +368,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -1128,7 +1128,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1555,7 +1555,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
@@ -2014,7 +2014,7 @@ msgstr "Criar novas redes"
 msgid "Delete network load balancers"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 #, fuzzy
 msgid "Delete network peerings"
 msgstr "Criar novas redes"
@@ -2152,9 +2152,9 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:996
 #: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
-#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
-#: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
-#: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
 #: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
@@ -2491,7 +2491,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2598,7 +2598,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
 #: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
@@ -2620,7 +2620,7 @@ msgstr "Editar propriedades da imagem"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
@@ -2862,7 +2862,7 @@ msgstr "Aceitar certificado"
 msgid "Failed getting existing storage pools: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -3316,7 +3316,7 @@ msgstr "Criar novas redes"
 msgid "Get the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Criar novas redes"
@@ -3401,7 +3401,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network load balancer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3835,7 +3835,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Editar arquivos no container"
@@ -4859,9 +4859,9 @@ msgstr "Nome de membro do cluster"
 #: cmd/incus/network_load_balancer.go:919
 #: cmd/incus/network_load_balancer.go:1032
 #: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
-#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
-#: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
-#: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291
+#: cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516
+#: cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid "Missing network name"
 msgstr ""
 
@@ -4881,9 +4881,9 @@ msgstr "Nome de membro do cluster"
 msgid "Missing network zone record name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292
-#: cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517
-#: cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295
+#: cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520
+#: cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Nome de membro do cluster"
@@ -4943,7 +4943,7 @@ msgstr "Nome de membro do cluster"
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Nome de membro do cluster"
@@ -5261,22 +5261,22 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -5581,7 +5581,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
@@ -6514,12 +6514,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6666,7 +6666,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Criar novas redes"
@@ -7323,7 +7323,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Nome de membro do cluster"
@@ -7565,7 +7565,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid "Type of peer (local or remote)"
 msgstr ""
 
@@ -7736,12 +7736,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network load balancer keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Criar novas redes"
@@ -7801,7 +7801,7 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network load balancer property"
 msgstr "Criar novas redes"
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Criar novas redes"
@@ -8568,7 +8568,7 @@ msgstr ""
 msgid "[<remote>:]<network> <peer name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr "Criar perfis"
@@ -8580,12 +8580,12 @@ msgid ""
 "integration> [key=value...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr "Criar perfis"
@@ -9156,6 +9156,11 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+"\n"
+"incus network peer create default peer3 web/default < config.yaml\n"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:318

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-03 20:08+0200\n"
+"POT-Creation-Date: 2024-05-03 20:52-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -386,7 +386,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -1143,7 +1143,7 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1557,7 +1557,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
@@ -2013,7 +2013,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete network load balancers"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 msgid "Delete network peerings"
 msgstr ""
 
@@ -2151,9 +2151,9 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:996
 #: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
-#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
-#: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
-#: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
 #: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
@@ -2484,7 +2484,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit network load balancer configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 #, fuzzy
 msgid "Edit network peer configurations as YAML"
 msgstr "Копирование образа: %s"
@@ -2589,7 +2589,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
 #: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
@@ -2611,7 +2611,7 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
@@ -2861,7 +2861,7 @@ msgstr "Принять сертификат"
 msgid "Failed getting existing storage pools: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -3314,7 +3314,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 #, fuzzy
 msgid "Get the key as a network peer property"
 msgstr "Копирование образа: %s"
@@ -3397,7 +3397,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network load balancer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 #, fuzzy
 msgid "Get values for network peer configuration keys"
 msgstr "Копирование образа: %s"
@@ -3834,7 +3834,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 #, fuzzy
 msgid "Invalid peer type"
 msgstr "Имя контейнера: %s"
@@ -4868,9 +4868,9 @@ msgstr "Имя контейнера: %s"
 #: cmd/incus/network_load_balancer.go:919
 #: cmd/incus/network_load_balancer.go:1032
 #: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
-#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
-#: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
-#: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291
+#: cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516
+#: cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid "Missing network name"
 msgstr ""
 
@@ -4890,9 +4890,9 @@ msgstr "Имя контейнера: %s"
 msgid "Missing network zone record name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292
-#: cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517
-#: cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295
+#: cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520
+#: cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 #, fuzzy
 msgid "Missing peer name"
 msgstr "Имя контейнера: %s"
@@ -4954,7 +4954,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 #, fuzzy
 msgid "Missing target network or integration"
 msgstr "Имя контейнера: %s"
@@ -5275,22 +5275,22 @@ msgstr " Использование сети:"
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, fuzzy, c-format
 msgid "Network peer %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, fuzzy, c-format
 msgid "Network peer %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -5598,7 +5598,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
@@ -6514,12 +6514,12 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 #, fuzzy
 msgid "Set network peer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6665,7 +6665,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 #, fuzzy
 msgid "Set the key as a network peer property"
 msgstr "Копирование образа: %s"
@@ -7322,7 +7322,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr "Копирование образа: %s"
@@ -7564,7 +7564,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid "Type of peer (local or remote)"
 msgstr ""
 
@@ -7729,12 +7729,12 @@ msgstr "Копирование образа: %s"
 msgid "Unset network load balancer keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 #, fuzzy
 msgid "Unset network peer configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 #, fuzzy
 msgid "Unset network peer keys"
 msgstr "Копирование образа: %s"
@@ -7793,7 +7793,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network load balancer property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 #, fuzzy
 msgid "Unset the key as a network peer property"
 msgstr "Копирование образа: %s"
@@ -8856,7 +8856,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
@@ -8874,7 +8874,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
@@ -8882,7 +8882,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
@@ -9661,6 +9661,11 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+"\n"
+"incus network peer create default peer3 web/default < config.yaml\n"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:318

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-03 20:08+0200\n"
+"POT-Creation-Date: 2024-05-03 20:52-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -350,7 +350,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: cmd/incus/network_peer.go:641
+#: cmd/incus/network_peer.go:644
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network peer.\n"
@@ -1072,7 +1072,7 @@ msgstr ""
 
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
-#: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
+#: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
@@ -1483,7 +1483,7 @@ msgstr ""
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
 #: cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696
 #: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
+#: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:729
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Delete network load balancers"
 msgstr ""
 
-#: cmd/incus/network_peer.go:758 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:761 cmd/incus/network_peer.go:762
 msgid "Delete network peerings"
 msgstr ""
 
@@ -2045,9 +2045,9 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:996
 #: cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28
 #: cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174
-#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388
-#: cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575
-#: cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759
+#: cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762
 #: cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85
 #: cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244
 #: cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412
@@ -2364,7 +2364,7 @@ msgstr ""
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_peer.go:621 cmd/incus/network_peer.go:622
+#: cmd/incus/network_peer.go:624 cmd/incus/network_peer.go:625
 msgid "Edit network peer configurations as YAML"
 msgstr ""
 
@@ -2465,7 +2465,7 @@ msgstr ""
 #: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673
 #: cmd/incus/network.go:1325 cmd/incus/network_acl.go:522
 #: cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587
-#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
+#: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
 #: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
@@ -2487,7 +2487,7 @@ msgstr ""
 #: cmd/incus/cluster.go:556 cmd/incus/network.go:1319
 #: cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515
 #: cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501
-#: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
+#: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
 #: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
@@ -2726,7 +2726,7 @@ msgstr ""
 msgid "Failed getting existing storage pools: %w"
 msgstr ""
 
-#: cmd/incus/network_peer.go:361
+#: cmd/incus/network_peer.go:364
 #, c-format
 msgid "Failed getting peer's status: %w"
 msgstr ""
@@ -3174,7 +3174,7 @@ msgstr ""
 msgid "Get the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:391
+#: cmd/incus/network_peer.go:394
 msgid "Get the key as a network peer property"
 msgstr ""
 
@@ -3247,7 +3247,7 @@ msgstr ""
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:387 cmd/incus/network_peer.go:388
+#: cmd/incus/network_peer.go:390 cmd/incus/network_peer.go:391
 msgid "Get values for network peer configuration keys"
 msgstr ""
 
@@ -3669,7 +3669,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: cmd/incus/network_peer.go:276
+#: cmd/incus/network_peer.go:279
 msgid "Invalid peer type"
 msgstr ""
 
@@ -4644,9 +4644,9 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:919
 #: cmd/incus/network_load_balancer.go:1032
 #: cmd/incus/network_load_balancer.go:1106 cmd/incus/network_peer.go:118
-#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:288
-#: cmd/incus/network_peer.go:429 cmd/incus/network_peer.go:513
-#: cmd/incus/network_peer.go:672 cmd/incus/network_peer.go:793
+#: cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291
+#: cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516
+#: cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid "Missing network name"
 msgstr ""
 
@@ -4664,9 +4664,9 @@ msgstr ""
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:292
-#: cmd/incus/network_peer.go:433 cmd/incus/network_peer.go:517
-#: cmd/incus/network_peer.go:676 cmd/incus/network_peer.go:797
+#: cmd/incus/network_peer.go:212 cmd/incus/network_peer.go:295
+#: cmd/incus/network_peer.go:436 cmd/incus/network_peer.go:520
+#: cmd/incus/network_peer.go:679 cmd/incus/network_peer.go:800
 msgid "Missing peer name"
 msgstr ""
 
@@ -4723,7 +4723,7 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: cmd/incus/network_peer.go:296
+#: cmd/incus/network_peer.go:299
 msgid "Missing target network or integration"
 msgstr ""
 
@@ -5037,22 +5037,22 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:365
+#: cmd/incus/network_peer.go:368
 #, c-format
 msgid "Network peer %s created"
 msgstr ""
 
-#: cmd/incus/network_peer.go:809
+#: cmd/incus/network_peer.go:812
 #, c-format
 msgid "Network peer %s deleted"
 msgstr ""
 
-#: cmd/incus/network_peer.go:369
+#: cmd/incus/network_peer.go:372
 #, c-format
 msgid "Network peer %s is in unexpected state %q"
 msgstr ""
 
-#: cmd/incus/network_peer.go:367
+#: cmd/incus/network_peer.go:370
 #, c-format
 msgid ""
 "Network peer %s pending (please complete mutual peering on peer network)"
@@ -5356,7 +5356,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:484
 #: cmd/incus/network.go:763 cmd/incus/network_acl.go:697
 #: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
-#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
+#: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
@@ -6244,11 +6244,11 @@ msgid ""
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:472
+#: cmd/incus/network_peer.go:475
 msgid "Set network peer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:473
+#: cmd/incus/network_peer.go:476
 msgid ""
 "Set network peer keys\n"
 "\n"
@@ -6388,7 +6388,7 @@ msgstr ""
 msgid "Set the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:480
+#: cmd/incus/network_peer.go:483
 msgid "Set the key as a network peer property"
 msgstr ""
 
@@ -7016,7 +7016,7 @@ msgstr ""
 msgid "The property %q does not exist on the network integration %q: %v"
 msgstr ""
 
-#: cmd/incus/network_peer.go:446
+#: cmd/incus/network_peer.go:449
 #, c-format
 msgid "The property %q does not exist on the network peer %q: %v"
 msgstr ""
@@ -7256,7 +7256,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: cmd/incus/network_peer.go:255
+#: cmd/incus/network_peer.go:258
 msgid "Type of peer (local or remote)"
 msgstr ""
 
@@ -7412,11 +7412,11 @@ msgstr ""
 msgid "Unset network load balancer keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:574
+#: cmd/incus/network_peer.go:577
 msgid "Unset network peer configuration keys"
 msgstr ""
 
-#: cmd/incus/network_peer.go:575
+#: cmd/incus/network_peer.go:578
 msgid "Unset network peer keys"
 msgstr ""
 
@@ -7468,7 +7468,7 @@ msgstr ""
 msgid "Unset the key as a network load balancer property"
 msgstr ""
 
-#: cmd/incus/network_peer.go:578
+#: cmd/incus/network_peer.go:581
 msgid "Unset the key as a network peer property"
 msgstr ""
 
@@ -8180,7 +8180,7 @@ msgstr ""
 msgid "[<remote>:]<network> <peer name>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:620 cmd/incus/network_peer.go:756
+#: cmd/incus/network_peer.go:623 cmd/incus/network_peer.go:759
 msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
@@ -8190,11 +8190,11 @@ msgid ""
 "integration> [key=value...]"
 msgstr ""
 
-#: cmd/incus/network_peer.go:386 cmd/incus/network_peer.go:573
+#: cmd/incus/network_peer.go:389 cmd/incus/network_peer.go:576
 msgid "[<remote>:]<network> <peer_name> <key>"
 msgstr ""
 
-#: cmd/incus/network_peer.go:471
+#: cmd/incus/network_peer.go:474
 msgid "[<remote>:]<network> <peer_name> <key>=<value>..."
 msgstr ""
 
@@ -8733,6 +8733,11 @@ msgid ""
 "incus network peer create default peer2 ovn-ic --type=remote\n"
 "    Create a new peering between network \"default\" in the current project "
 "and other remote networks through the \"ovn-ic\" integration\n"
+"\n"
+"incus network peer create default peer3 web/default < config.yaml\n"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:318


### PR DESCRIPTION
`incus network peer create` already has support for creation from a yaml configuration file, but the same wasn't printed in the usage information of the command.

This commit updates `incus network peer create` to include an example.

Part of https://github.com/lxc/incus/issues/741