### PR TITLE
incus/storage_bucket: Add example for storage bucket create

### DIFF
--- a/cmd/incus/storage_bucket.go
+++ b/cmd/incus/storage_bucket.go
@@ -94,6 +94,11 @@ func (c *cmdStorageBucketCreate) Command() *cobra.Command {
 	cmd.Use = usage("create", i18n.G("[<remote>:]<pool> <bucket> [key=value...]"))
 	cmd.Short = i18n.G("Create new custom storage buckets")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Create new custom storage buckets`))
+	cmd.Example = cli.FormatSection("", i18n.G(`incus storage bucket create p1 b01
+	Create a new storage bucket name b01 in storage pool p1
+
+incus storage bucket create p1 b01 < config.yaml
+	Craete a new storage bucket name b01 in storage pool p1 using the content of config.yaml`))
 
 	cmd.Flags().StringVar(&c.storageBucket.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-29 14:30-0400\n"
+"POT-Creation-Date: 2024-05-03 20:08+0200\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -87,7 +87,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -814,11 +814,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Profil %s erstellt\n"
@@ -963,12 +963,12 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Erstellt: %s"
@@ -1007,7 +1007,7 @@ msgstr "Aliasse:\n"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1073,12 +1073,12 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1132,23 +1132,23 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, fuzzy, c-format
 msgid "Backing up storage bucket %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344
-#: cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:3028
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
-#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:164
-#: cmd/incus/storage_volume.go:627
+#: cmd/incus/storage_volume.go:628
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1359,16 +1359,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1507,22 +1507,22 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752
 #: cmd/incus/storage.go:854 cmd/incus/storage.go:947
-#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392
-#: cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642
-#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142
-#: cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365
-#: cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578
-#: cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939
-#: cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294
-#: cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834
-#: cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083
-#: cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598
-#: cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773
-#: cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647
+#: cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788
+#: cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946
+#: cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147
+#: cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940
+#: cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300
+#: cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845
+#: cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099
+#: cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297
+#: cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619
+#: cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid "Cluster member name"
 msgstr ""
 
@@ -1532,8 +1532,8 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724
-#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532
+#: cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1592,8 +1592,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
-#: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
-#: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
+#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1688,13 +1688,13 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
 #: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1707,7 +1707,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1845,7 +1845,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1910,7 +1910,7 @@ msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:602
-#: cmd/incus/storage_volume.go:1407
+#: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1947,8 +1947,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727
-#: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
-#: cmd/incus/storage_volume.go:1636
+#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845
+#: cmd/incus/storage_volume.go:1647
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -1983,7 +1983,7 @@ msgstr "Erstellt: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2027,7 +2027,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Delete instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2078,7 +2078,7 @@ msgstr ""
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2087,12 +2087,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2226,39 +2226,39 @@ msgstr ""
 #: cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659
 #: cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257
-#: cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466
-#: cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740
-#: cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860
-#: cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002
-#: cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209
-#: cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575
-#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
-#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282
-#: cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831
-#: cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222
-#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477
-#: cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682
-#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858
-#: cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471
+#: cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642
+#: cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007
+#: cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214
+#: cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736
+#: cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931
+#: cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288
+#: cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842
+#: cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243
+#: cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403
+#: cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498
+#: cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703
+#: cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2272,12 +2272,12 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2564,12 +2564,12 @@ msgstr ""
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2577,7 +2577,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2588,7 +2588,7 @@ msgstr "Alternatives config Verzeichnis."
 
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762
-#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664
+#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2651,8 +2651,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
-#: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
-#: cmd/incus/storage_volume.go:2040
+#: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
+#: cmd/incus/storage_volume.go:2056
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2673,8 +2673,8 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
-#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
-#: cmd/incus/storage_volume.go:2034
+#: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
+#: cmd/incus/storage_volume.go:2050
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2767,8 +2767,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
-#: cmd/incus/storage_volume.go:2575
+#: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
+#: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
 msgstr ""
 
@@ -2792,7 +2792,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2807,27 +2807,27 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2904,7 +2904,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, fuzzy, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3033,7 +3033,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Akzeptiere Zertifikat"
@@ -3043,7 +3043,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3053,12 +3053,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3281,9 +3281,9 @@ msgstr ""
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467
-#: cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539
-#: cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472
+#: cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550
+#: cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3408,7 +3408,7 @@ msgstr ""
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3418,7 +3418,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3491,7 +3491,7 @@ msgstr ""
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3500,11 +3500,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3602,7 +3602,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3616,7 +3616,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3668,7 +3668,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3676,12 +3676,12 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3702,29 +3702,29 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3796,8 +3796,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295
-#: cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:2979
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Ungültiges Ziel %s"
@@ -3817,8 +3817,8 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid arguments"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305
+#: cmd/incus/storage_volume.go:2984
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3919,9 +3919,9 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215
-#: cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979
-#: cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216
+#: cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990
+#: cmd/incus/storage_volume.go:2839
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -3976,8 +3976,8 @@ msgstr ""
 
 #: cmd/incus/list.go:614 cmd/incus/network.go:1174
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
-#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524
-#: cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529
+#: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4339,22 +4339,22 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4372,12 +4372,12 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4460,7 +4460,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4734,12 +4734,12 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Manage projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4759,17 +4759,17 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage storage pools and volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4868,12 +4868,12 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224
-#: cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419
-#: cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891
-#: cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045
-#: cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673
+#: cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896
+#: cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050
+#: cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Fehlende Zusammenfassung."
@@ -4906,8 +4906,8 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970
-#: cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975
+#: cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 #, fuzzy
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
@@ -5006,22 +5006,22 @@ msgstr "Fehlende Zusammenfassung."
 
 #: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435
 #: cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220
-#: cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415
-#: cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572
-#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806
-#: cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962
-#: cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164
-#: cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202
-#: cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609
-#: cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775
-#: cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987
-#: cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570
-#: cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962
-#: cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309
-#: cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527
-#: cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722
-#: cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577
+#: cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811
+#: cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776
+#: cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581
+#: cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973
+#: cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548
+#: cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743
+#: cmd/incus/storage_volume.go:2829
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5048,12 +5048,12 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5094,7 +5094,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:522 cmd/incus/network.go:619
-#: cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5129,7 +5129,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5139,11 +5139,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5172,8 +5172,8 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773
-#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519
-#: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid "NAME"
 msgstr ""
 
@@ -5228,8 +5228,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
-#: cmd/incus/storage_volume.go:2573
+#: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
+#: cmd/incus/storage_volume.go:2594
 msgid "Name"
 msgstr ""
 
@@ -5294,7 +5294,7 @@ msgid "Name of the storage pool:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: cmd/incus/info.go:577 cmd/incus/network.go:929
-#: cmd/incus/storage_volume.go:1378
+#: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5462,7 +5462,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5483,11 +5483,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5523,15 +5523,15 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5543,7 +5543,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5561,7 +5561,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5604,7 +5604,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165
-#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654
+#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5718,8 +5718,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
-#: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
-#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
+#: cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5862,7 +5862,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "\tSupported types are custom, image, container and virtual-machine.\n"
@@ -5875,7 +5875,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5889,7 +5889,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5905,7 +5905,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5922,7 +5922,7 @@ msgid ""
 "\"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5931,7 +5931,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5944,7 +5944,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -6021,7 +6021,7 @@ msgstr ""
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid "ROLE"
 msgstr ""
 
@@ -6066,7 +6066,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6269,22 +6269,22 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Herunterfahren des Containers erzwingen."
@@ -6328,7 +6328,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -6367,7 +6367,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6471,11 +6471,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Erstellt: %s"
@@ -6720,12 +6720,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6748,12 +6748,12 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6844,7 +6844,7 @@ msgstr ""
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6854,7 +6854,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -7000,12 +7000,12 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Profil %s erstellt\n"
@@ -7014,13 +7014,13 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
@@ -7086,16 +7086,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
@@ -7175,22 +7175,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, fuzzy, c-format
 msgid "Storage bucket key %s added"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, fuzzy, c-format
 msgid "Storage bucket key %s removed"
 msgstr "Profil %s erstellt\n"
@@ -7235,27 +7235,27 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Storage pool to use or create"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Profil %s gelöscht\n"
@@ -7316,13 +7316,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088
 #: cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
 
@@ -7512,7 +7512,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7522,12 +7522,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7575,7 +7575,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
-#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -7658,7 +7658,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -7674,7 +7674,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7682,7 +7682,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7739,7 +7739,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
 #: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7761,7 +7761,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid "USAGE"
 msgstr ""
 
@@ -7779,7 +7779,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:747
 #: cmd/incus/project.go:525 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1638
+#: cmd/incus/storage_volume.go:1649
 msgid "USED BY"
 msgstr ""
 
@@ -7819,7 +7819,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768
-#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7932,7 +7932,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7941,7 +7941,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7997,7 +7997,7 @@ msgstr ""
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -8007,7 +8007,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -8050,12 +8050,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8144,7 +8144,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Version: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid "Volume Only"
 msgstr ""
 
@@ -8327,7 +8327,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -8335,7 +8335,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -9140,7 +9140,7 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477
-#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -9148,7 +9148,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
@@ -9156,7 +9156,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -9164,8 +9164,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255
-#: cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -9173,9 +9173,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704
-#: cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936
-#: cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
+#: cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -9183,7 +9183,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -9191,7 +9191,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
@@ -9232,7 +9232,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -9240,7 +9240,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -9248,7 +9248,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -9256,7 +9256,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -9264,7 +9264,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -9273,7 +9273,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -9282,7 +9282,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -9291,7 +9291,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -9300,7 +9300,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -9308,7 +9308,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -9317,7 +9317,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -9325,8 +9325,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280
-#: cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286
+#: cmd/incus/storage_volume.go:2083
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -9334,7 +9334,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -9342,7 +9342,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -9350,7 +9350,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -9359,7 +9359,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -9367,7 +9367,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -9986,38 +9986,48 @@ msgid ""
 "Restore the snapshot."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket name b01 in storage pool p1\n"
+"\n"
+"incus storage bucket create p1 b01 < config.yaml\n"
+"\tCraete a new storage bucket name b01 in storage pool p1 using the content "
+"of config.yaml"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:1216
 msgid ""
 "incus storage bucket default b1\n"
 "    Download a backup tarball of the b1 storage bucket."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -10030,7 +10040,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-29 14:30-0400\n"
+"POT-Creation-Date: 2024-05-03 20:08+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -91,7 +91,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -788,11 +788,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Expira: %s"
@@ -931,12 +931,12 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Creado: %s"
@@ -974,7 +974,7 @@ msgstr "Aliases:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 msgid "All projects"
 msgstr ""
 
@@ -1036,11 +1036,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1092,22 +1092,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, fuzzy, c-format
 msgid "Backing up storage bucket %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344
-#: cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:3028
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1119,7 +1119,7 @@ msgstr ""
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
-#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1131,7 +1131,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:164
-#: cmd/incus/storage_volume.go:627
+#: cmd/incus/storage_volume.go:628
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1180,7 +1180,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1273,7 +1273,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1313,16 +1313,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1457,22 +1457,22 @@ msgstr "Perfil %s eliminado de %s"
 #: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752
 #: cmd/incus/storage.go:854 cmd/incus/storage.go:947
-#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392
-#: cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642
-#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142
-#: cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365
-#: cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578
-#: cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939
-#: cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294
-#: cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834
-#: cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083
-#: cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598
-#: cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773
-#: cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647
+#: cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788
+#: cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946
+#: cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147
+#: cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940
+#: cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300
+#: cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845
+#: cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099
+#: cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297
+#: cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619
+#: cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1482,8 +1482,8 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724
-#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532
+#: cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
 
@@ -1542,8 +1542,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
-#: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
-#: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
+#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1565,11 +1565,11 @@ msgstr ""
 msgid "Console log:"
 msgstr "Log de la consola:"
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1635,12 +1635,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1654,7 +1654,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1775,7 +1775,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1789,7 +1789,7 @@ msgstr "Perfil %s creado"
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1845,7 +1845,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:602
-#: cmd/incus/storage_volume.go:1407
+#: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1882,8 +1882,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727
-#: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
-#: cmd/incus/storage_volume.go:1636
+#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845
+#: cmd/incus/storage_volume.go:1647
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1918,7 +1918,7 @@ msgstr "Auto actualización: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1960,7 +1960,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Delete instances"
 msgstr "Eliminar imágenes"
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -2009,7 +2009,7 @@ msgstr ""
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Perfil %s creado"
@@ -2018,12 +2018,12 @@ msgstr "Perfil %s creado"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2156,39 +2156,39 @@ msgstr ""
 #: cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659
 #: cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257
-#: cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466
-#: cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740
-#: cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860
-#: cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002
-#: cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209
-#: cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575
-#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
-#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282
-#: cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831
-#: cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222
-#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477
-#: cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682
-#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858
-#: cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471
+#: cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642
+#: cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007
+#: cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214
+#: cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736
+#: cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931
+#: cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288
+#: cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842
+#: cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243
+#: cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403
+#: cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498
+#: cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703
+#: cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr "Descripción"
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -2201,11 +2201,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2473,12 +2473,12 @@ msgstr ""
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2496,7 +2496,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762
-#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664
+#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2558,8 +2558,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
-#: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
-#: cmd/incus/storage_volume.go:2040
+#: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
+#: cmd/incus/storage_volume.go:2056
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2580,8 +2580,8 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
-#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
-#: cmd/incus/storage_volume.go:2034
+#: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
+#: cmd/incus/storage_volume.go:2050
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2666,8 +2666,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
-#: cmd/incus/storage_volume.go:2575
+#: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
+#: cmd/incus/storage_volume.go:2596
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2692,7 +2692,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2706,26 +2706,26 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket %s"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2802,7 +2802,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -2931,7 +2931,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Acepta certificado"
@@ -2941,7 +2941,7 @@ msgstr "Acepta certificado"
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Acepta certificado"
@@ -2951,12 +2951,12 @@ msgstr "Acepta certificado"
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Acepta certificado"
@@ -3176,9 +3176,9 @@ msgstr ""
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467
-#: cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539
-#: cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472
+#: cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550
+#: cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3302,7 +3302,7 @@ msgstr ""
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Perfil %s creado"
@@ -3311,7 +3311,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3379,7 +3379,7 @@ msgstr ""
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Perfil %s creado"
@@ -3388,11 +3388,11 @@ msgstr "Perfil %s creado"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3490,7 +3490,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3504,7 +3504,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3554,7 +3554,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3562,12 +3562,12 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3587,29 +3587,29 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3683,8 +3683,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295
-#: cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:2979
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Nombre del contenedor es: %s"
@@ -3704,8 +3704,8 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid arguments"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305
+#: cmd/incus/storage_volume.go:2984
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3803,9 +3803,9 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215
-#: cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979
-#: cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216
+#: cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990
+#: cmd/incus/storage_volume.go:2839
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3856,8 +3856,8 @@ msgstr ""
 
 #: cmd/incus/list.go:614 cmd/incus/network.go:1174
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
-#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524
-#: cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529
+#: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4203,21 +4203,21 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4235,11 +4235,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4574,12 +4574,12 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -4597,16 +4597,16 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4704,12 +4704,12 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224
-#: cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419
-#: cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891
-#: cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045
-#: cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673
+#: cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896
+#: cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050
+#: cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nombre del contenedor es: %s"
@@ -4742,8 +4742,8 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970
-#: cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975
+#: cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
@@ -4841,22 +4841,22 @@ msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435
 #: cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220
-#: cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415
-#: cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572
-#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806
-#: cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962
-#: cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164
-#: cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202
-#: cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609
-#: cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775
-#: cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987
-#: cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570
-#: cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962
-#: cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309
-#: cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527
-#: cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722
-#: cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577
+#: cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811
+#: cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776
+#: cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581
+#: cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973
+#: cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548
+#: cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743
+#: cmd/incus/storage_volume.go:2829
 msgid "Missing pool name"
 msgstr ""
 
@@ -4882,11 +4882,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
@@ -4927,7 +4927,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:522 cmd/incus/network.go:619
-#: cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4960,7 +4960,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4968,11 +4968,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -5000,8 +5000,8 @@ msgstr ""
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773
-#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519
-#: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid "NAME"
 msgstr ""
 
@@ -5056,8 +5056,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
-#: cmd/incus/storage_volume.go:2573
+#: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
+#: cmd/incus/storage_volume.go:2594
 msgid "Name"
 msgstr ""
 
@@ -5118,7 +5118,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:577 cmd/incus/network.go:929
-#: cmd/incus/storage_volume.go:1378
+#: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5282,7 +5282,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5302,11 +5302,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5342,15 +5342,15 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5362,7 +5362,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5380,7 +5380,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5423,7 +5423,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165
-#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654
+#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5535,8 +5535,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
-#: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
-#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
+#: cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5677,7 +5677,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "\tSupported types are custom, image, container and virtual-machine.\n"
@@ -5690,7 +5690,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5704,7 +5704,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5720,7 +5720,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5737,7 +5737,7 @@ msgid ""
 "\"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5746,7 +5746,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5759,7 +5759,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5833,7 +5833,7 @@ msgstr ""
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid "ROLE"
 msgstr ""
 
@@ -5878,7 +5878,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6072,21 +6072,21 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 msgid "Rename storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6130,7 +6130,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6167,7 +6167,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6271,11 +6271,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Creado: %s"
@@ -6506,12 +6506,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6533,11 +6533,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Nombre del contenedor es: %s"
@@ -6634,7 +6634,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6772,12 +6772,12 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Perfil %s creado"
@@ -6786,12 +6786,12 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6854,15 +6854,15 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
@@ -6939,22 +6939,22 @@ msgstr "Copiando la imagen: %s"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -6998,25 +6998,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Perfil %s eliminado"
@@ -7076,13 +7076,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088
 #: cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
 
@@ -7269,7 +7269,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -7279,12 +7279,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7332,7 +7332,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
-#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7411,7 +7411,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -7427,7 +7427,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7435,7 +7435,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7493,7 +7493,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
 #: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1398
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -7515,7 +7515,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid "USAGE"
 msgstr ""
 
@@ -7531,7 +7531,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:747
 #: cmd/incus/project.go:525 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1638
+#: cmd/incus/storage_volume.go:1649
 msgid "USED BY"
 msgstr ""
 
@@ -7570,7 +7570,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768
-#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7678,7 +7678,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Perfil %s creado"
@@ -7687,7 +7687,7 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -7742,7 +7742,7 @@ msgstr ""
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Perfil %s creado"
@@ -7751,7 +7751,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7792,12 +7792,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7882,7 +7882,7 @@ msgstr "Versión de CUDA: %v"
 msgid "Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid "Volume Only"
 msgstr ""
 
@@ -8056,12 +8056,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8561,40 +8561,40 @@ msgid "[<remote>:]<operation>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477
-#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255
-#: cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704
-#: cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936
-#: cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
+#: cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8619,88 +8619,88 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280
-#: cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286
+#: cmd/incus/storage_volume.go:2083
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9226,38 +9226,48 @@ msgid ""
 "Restore the snapshot."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket name b01 in storage pool p1\n"
+"\n"
+"incus storage bucket create p1 b01 < config.yaml\n"
+"\tCraete a new storage bucket name b01 in storage pool p1 using the content "
+"of config.yaml"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:1216
 msgid ""
 "incus storage bucket default b1\n"
 "    Download a backup tarball of the b1 storage bucket."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -9270,7 +9280,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-29 14:30-0400\n"
+"POT-Creation-Date: 2024-05-03 20:08+0200\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -87,7 +87,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -794,11 +794,11 @@ msgstr "TYPE D'AUTHENTIFICATION"
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid "Access key (auto-generated if empty)"
 msgstr "Clé d'accès (auto-généré si vide)"
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, c-format
 msgid "Access key: %s"
 msgstr "Clé d'accès: %s"
@@ -952,12 +952,12 @@ msgstr "Adresses à associé à (sans inclure les ports)"
 msgid "Address: %s"
 msgstr "Addresse : %s"
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid "Admin access key: %s"
 msgstr "Clef d'accès administrateur : %s"
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "Clef d'accès secrète administrateur : %s"
@@ -997,7 +997,7 @@ msgstr ""
 "Toutes les données seront perdues après avoir rejoint le cluster, voulez-"
 "vous continuer ?"
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 msgid "All projects"
 msgstr "Tous les projets"
 
@@ -1059,12 +1059,12 @@ msgstr "Attacher des interfaces réseaux aux profiles"
 msgid "Attach new network interfaces to instances"
 msgstr "Attacher de nouvelles interfaces aux instances"
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Attribuer de nouveaux volumes de stockage à des instances"
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid "Attach new storage volumes to profiles"
 msgstr "Attacher de nouveaux volumes de stockage aux profiles"
 
@@ -1122,22 +1122,22 @@ msgstr "Image de base"
 msgid "Backing up instance: %s"
 msgstr "Sauvegarder l'instance : %s"
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, fuzzy, c-format
 msgid "Backing up storage bucket %s"
 msgstr "Sauvegarder le volume de stockage : %s"
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Sauvegarder le volume de stockage : %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344
-#: cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:3028
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1151,7 +1151,7 @@ msgstr ""
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
-#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
@@ -1163,7 +1163,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Mauvaise association clef=valeur: %q"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:164
-#: cmd/incus/storage_volume.go:627
+#: cmd/incus/storage_volume.go:628
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Mauvaise paire clé=valeur: %s"
@@ -1211,7 +1211,7 @@ msgstr "ANNULABLE"
 msgid "COMMON NAME"
 msgstr "NOM COMMUN"
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid "CONTENT-TYPE"
 msgstr "Type de contenu"
 
@@ -1304,7 +1304,7 @@ msgstr "Impossible de spécifier --project avec --all-projects"
 msgid "Can't specify a different remote for rename"
 msgstr "Impossible de spécifier un autre serveur distant pour un renommage"
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1349,20 +1349,20 @@ msgstr ""
 "Impossible de surcharger l'appareil %q : Appareil introuvable dans les "
 "profils"
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "Impossible d'utiliser --destination-target quand le serveur distant n'est "
 "pas dans un cluster"
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "Impossible de mettre --target quand le server source n'est pas dans un "
 "cluster"
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 
@@ -1499,22 +1499,22 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 #: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752
 #: cmd/incus/storage.go:854 cmd/incus/storage.go:947
-#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392
-#: cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642
-#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142
-#: cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365
-#: cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578
-#: cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939
-#: cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294
-#: cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834
-#: cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083
-#: cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598
-#: cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773
-#: cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647
+#: cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788
+#: cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946
+#: cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147
+#: cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940
+#: cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300
+#: cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845
+#: cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099
+#: cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297
+#: cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619
+#: cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid "Cluster member name"
 msgstr "Nom du membre du cluster"
 
@@ -1524,8 +1524,8 @@ msgstr "Clustering activé"
 
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724
-#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532
+#: cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1591,8 +1591,8 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
-#: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
-#: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
+#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -1614,11 +1614,11 @@ msgstr "Connexion au démon (tentative %d)"
 msgid "Console log:"
 msgstr "Journaux console:"
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid "Content type, block or filesystem"
 msgstr "Type de contenu, bloc ou système de fichier"
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, c-format
 msgid "Content type: %s"
 msgstr "Type de contenu : %s"
@@ -1694,7 +1694,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr "Copier les profiles"
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 msgid "Copy storage volumes"
 msgstr "Copier des volumes de stockage"
 
@@ -1702,12 +1702,12 @@ msgstr "Copier des volumes de stockage"
 msgid "Copy the instance without its snapshots"
 msgstr "Copier l'instance sans ses instantanés"
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 msgid "Copy the volume without its snapshots"
 msgstr "Copier le volume sans ses instantanés"
 
 #: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr "Copie dans un projet différent de la source"
 
@@ -1720,7 +1720,7 @@ msgstr "Copier des images de machines virtuelles"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie du volume de stockage : %s"
@@ -1861,7 +1861,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Création d'instances à partir d'images"
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Création d'une clef pour un stockage de type bucket"
@@ -1876,7 +1876,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1942,7 +1942,7 @@ msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:602
-#: cmd/incus/storage_volume.go:1407
+#: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1979,8 +1979,8 @@ msgstr "ADRESSE CIBLE PAR DÉFAUT"
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727
-#: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
-#: cmd/incus/storage_volume.go:1636
+#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845
+#: cmd/incus/storage_volume.go:1647
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -2015,7 +2015,7 @@ msgstr "État : %s"
 msgid "Default VLAN ID"
 msgstr "ID VLAN par défaut"
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -2063,7 +2063,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Delete instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Copie de l'image : %s"
@@ -2115,7 +2115,7 @@ msgstr "Supprime les profiles"
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Copie de l'image : %s"
@@ -2124,12 +2124,12 @@ msgstr "Copie de l'image : %s"
 msgid "Delete storage pools"
 msgstr "Supprime les pool de stockage"
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2264,39 +2264,39 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659
 #: cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257
-#: cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466
-#: cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740
-#: cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860
-#: cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002
-#: cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209
-#: cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575
-#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
-#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282
-#: cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831
-#: cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222
-#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477
-#: cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682
-#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858
-#: cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471
+#: cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642
+#: cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007
+#: cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214
+#: cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736
+#: cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931
+#: cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288
+#: cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842
+#: cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243
+#: cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403
+#: cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498
+#: cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703
+#: cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr "Description"
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2309,12 +2309,12 @@ msgstr "Détacher les interfaces réseaux des instances"
 msgid "Detach network interfaces from profiles"
 msgstr "Détacher les interfaces réseau des profils"
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid "Detach storage volumes from profiles"
 msgstr "Détacher les volumes de stockage des profils"
 
@@ -2600,12 +2600,12 @@ msgstr "Modifier les configurations de profil au format YAML"
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid "Edit storage bucket key as YAML"
 msgstr "Modifier la clé du bucket de stockage au format YAML"
 
@@ -2613,7 +2613,7 @@ msgstr "Modifier la clé du bucket de stockage au format YAML"
 msgid "Edit storage pool configurations as YAML"
 msgstr "Modifier les configurations du pool de stockage au format YAML"
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid "Edit storage volume configurations as YAML"
 msgstr "Modifier les configurations de volume de stockage au format YAML"
 
@@ -2624,7 +2624,7 @@ msgstr "Clé de configuration invalide"
 
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762
-#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664
+#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2700,8 +2700,8 @@ msgstr "Erreur lors de la récupération des alias : %w"
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
-#: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
-#: cmd/incus/storage_volume.go:2040
+#: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
+#: cmd/incus/storage_volume.go:2056
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "Erreur lors du paramétrages des propriétés: %v"
@@ -2722,8 +2722,8 @@ msgstr "Erreur lors du déparamétrage des propriétés: %v"
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
-#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
-#: cmd/incus/storage_volume.go:2034
+#: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
+#: cmd/incus/storage_volume.go:2050
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Erreur dans le déparamétrage de la propriété: %v"
@@ -2862,8 +2862,8 @@ msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
 #: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
-#: cmd/incus/storage_volume.go:2575
+#: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
+#: cmd/incus/storage_volume.go:2596
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2894,7 +2894,7 @@ msgstr ""
 "La cible de sortie est facultative et par défaut dans le répertoire de "
 "travail."
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2909,27 +2909,27 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -3012,7 +3012,7 @@ msgstr ""
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Échec de la suppression de l'instance %q dans le projet %q : %w"
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Échec de la suppression du volume source après la copie : %w"
@@ -3143,7 +3143,7 @@ msgstr "Échec de la création de %q : %w"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec de la création de l'alias %s : %w"
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr "Échec de la création de la sauvegarde : %v"
@@ -3153,7 +3153,7 @@ msgstr "Échec de la création de la sauvegarde : %v"
 msgid "Failed to create certificate: %w"
 msgstr "Échec de la création du certificat : %w"
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Échec de la création de la sauvegarde du volume de stockage : %w"
@@ -3164,12 +3164,12 @@ msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
 "Échec de la suppression de l'instance originale après l'avoir copiée : %w"
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Échec de la récupération de la sauvegarde de l'unité de stockage : %w"
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3417,9 +3417,9 @@ msgstr ""
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467
-#: cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539
-#: cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472
+#: cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550
+#: cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 #, fuzzy
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "Format (csv|json|table|yaml|compact)"
@@ -3548,7 +3548,7 @@ msgstr "Obtenir la clé en tant que propriété du profil"
 msgid "Get the key as a project property"
 msgstr "Obtenir la clé en tant que propriété du projet"
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
@@ -3558,7 +3558,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -3633,7 +3633,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3642,11 +3642,11 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr "Obtenir les valeurs des clés de configuration du pool de stockage"
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid "Get values for storage volume configuration keys"
 msgstr "Obtenir les valeurs des clés de configuration du volume de stockage"
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3752,7 +3752,7 @@ msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 "Si l'alias de l'image existe déjà, le supprimer d'abord puis le recréer"
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "Si l'instantané de l'image existe déjà, le supprimer d'abord puis le recréer"
@@ -3770,7 +3770,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "Ignorer toute expiration automatique configurée pour l'instance"
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 "Ignorer toute expiration automatique configurée pour le volume de stockage"
@@ -3825,7 +3825,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 #, fuzzy
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
@@ -3836,12 +3836,12 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr "Importer des sauvegardes d'instances, y compris leurs instantanés."
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -3867,30 +3867,30 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr "Le type d'importation doit être \"backup\" ou \"iso\""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 #, fuzzy
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr "Type d'importation : \"backup\" ou \"iso\" (par défaut \"backup\")"
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid "Importing ISO images requires a volume name to be set"
 msgstr "L'importation d'images ISO nécessite la définition d'un nom de volume"
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3968,8 +3968,8 @@ msgstr "Type d'instance"
 msgid "Invalid IP address or DNS name"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295
-#: cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:2979
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Cible invalide %s"
@@ -3989,8 +3989,8 @@ msgstr "Cible invalide %s"
 msgid "Invalid arguments"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305
+#: cmd/incus/storage_volume.go:2984
 #, fuzzy, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "Segment de nom de sauvegarde non valide dans le chemin %q : %w"
@@ -4095,9 +4095,9 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215
-#: cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979
-#: cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216
+#: cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990
+#: cmd/incus/storage_volume.go:2839
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -4149,8 +4149,8 @@ msgstr "ADRESSE D’ÉCOUTE"
 
 #: cmd/incus/list.go:614 cmd/incus/network.go:1174
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
-#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524
-#: cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529
+#: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr "LOCALISATION"
 
@@ -4558,22 +4558,22 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4591,12 +4591,12 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4679,7 +4679,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4947,12 +4947,12 @@ msgstr ""
 msgid "Manage projects"
 msgstr "Rendre l'image publique"
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Copie de l'image : %s"
@@ -4972,17 +4972,17 @@ msgstr "Copie de l'image : %s"
 msgid "Manage storage pools and volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -5081,12 +5081,12 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224
-#: cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419
-#: cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891
-#: cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045
-#: cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673
+#: cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896
+#: cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050
+#: cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Résumé manquant."
@@ -5119,8 +5119,8 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970
-#: cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975
+#: cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 #, fuzzy
 msgid "Missing key name"
 msgstr "Résumé manquant."
@@ -5220,22 +5220,22 @@ msgstr "Résumé manquant."
 
 #: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435
 #: cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220
-#: cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415
-#: cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572
-#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806
-#: cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962
-#: cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164
-#: cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202
-#: cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609
-#: cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775
-#: cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987
-#: cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570
-#: cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962
-#: cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309
-#: cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527
-#: cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722
-#: cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577
+#: cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811
+#: cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776
+#: cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581
+#: cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973
+#: cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548
+#: cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743
+#: cmd/incus/storage_volume.go:2829
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5262,12 +5262,12 @@ msgstr "Résumé manquant."
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5310,7 +5310,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:522 cmd/incus/network.go:619
-#: cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
@@ -5346,7 +5346,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -5356,11 +5356,11 @@ msgstr "Copie de l'image : %s"
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -5389,8 +5389,8 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773
-#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519
-#: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid "NAME"
 msgstr "NOM"
 
@@ -5445,8 +5445,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
-#: cmd/incus/storage_volume.go:2573
+#: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
+#: cmd/incus/storage_volume.go:2594
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -5512,7 +5512,7 @@ msgid "Name of the storage pool:"
 msgstr "Copie de l'image : %s"
 
 #: cmd/incus/info.go:577 cmd/incus/network.go:929
-#: cmd/incus/storage_volume.go:1378
+#: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
@@ -5700,11 +5700,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5740,19 +5740,19 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 #, fuzzy
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -5767,7 +5767,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
@@ -5788,7 +5788,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5832,7 +5832,7 @@ msgid "PROFILES"
 msgstr "PROFILS"
 
 #: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165
-#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654
+#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5946,8 +5946,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
-#: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
-#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
+#: cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -6090,7 +6090,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "\tSupported types are custom, image, container and virtual-machine.\n"
@@ -6103,7 +6103,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -6117,7 +6117,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -6133,7 +6133,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -6150,7 +6150,7 @@ msgid ""
 "\"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -6159,7 +6159,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -6172,7 +6172,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -6250,7 +6250,7 @@ msgstr "SOURCE"
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid "ROLE"
 msgstr ""
 
@@ -6296,7 +6296,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
@@ -6501,22 +6501,22 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Forcer le conteneur à s'arrêter"
@@ -6576,7 +6576,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -6615,7 +6615,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6722,11 +6722,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Créé : %s"
@@ -6966,12 +6966,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6994,12 +6994,12 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7090,7 +7090,7 @@ msgstr ""
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
@@ -7100,7 +7100,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7251,12 +7251,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Afficher la configuration étendue"
@@ -7265,13 +7265,13 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
@@ -7338,16 +7338,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -7428,22 +7428,22 @@ msgstr "L'arrêt de l'instance a échoué : %s"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, fuzzy, c-format
 msgid "Storage bucket key %s added"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, fuzzy, c-format
 msgid "Storage bucket key %s removed"
 msgstr "Profil %s créé"
@@ -7487,27 +7487,27 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Storage pool to use or create"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Profil %s supprimé"
@@ -7570,13 +7570,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088
 #: cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
 #: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -7773,7 +7773,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -7783,12 +7783,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7839,7 +7839,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
-#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -7923,7 +7923,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -7939,7 +7939,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7947,7 +7947,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -8005,7 +8005,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
 #: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1398
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -8027,7 +8027,7 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid "USAGE"
 msgstr ""
 
@@ -8045,7 +8045,7 @@ msgstr "Création du conteneur"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:747
 #: cmd/incus/project.go:525 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1638
+#: cmd/incus/storage_volume.go:1649
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -8085,7 +8085,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768
-#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8200,7 +8200,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
@@ -8210,7 +8210,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -8266,7 +8266,7 @@ msgstr ""
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
@@ -8276,7 +8276,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -8319,12 +8319,12 @@ msgstr "Publié : %s"
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8410,7 +8410,7 @@ msgstr "Version CUDA : %v"
 msgid "Version: %v"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid "Volume Only"
 msgstr ""
 
@@ -8592,7 +8592,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom d'image ou utilisez --empty"
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -8600,7 +8600,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -9438,7 +9438,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477
-#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -9446,7 +9446,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
@@ -9454,7 +9454,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -9462,8 +9462,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255
-#: cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -9471,9 +9471,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704
-#: cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936
-#: cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
+#: cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -9481,7 +9481,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -9489,7 +9489,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
@@ -9533,7 +9533,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -9541,7 +9541,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -9549,7 +9549,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -9557,7 +9557,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -9565,7 +9565,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -9577,7 +9577,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -9589,7 +9589,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -9601,7 +9601,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -9613,7 +9613,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -9621,7 +9621,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -9633,7 +9633,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -9641,8 +9641,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280
-#: cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286
+#: cmd/incus/storage_volume.go:2083
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -9650,7 +9650,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -9658,7 +9658,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -9666,7 +9666,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -9678,7 +9678,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -9686,7 +9686,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10339,38 +10339,48 @@ msgid ""
 "Restore the snapshot."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket name b01 in storage pool p1\n"
+"\n"
+"incus storage bucket create p1 b01 < config.yaml\n"
+"\tCraete a new storage bucket name b01 in storage pool p1 using the content "
+"of config.yaml"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:1216
 msgid ""
 "incus storage bucket default b1\n"
 "    Download a backup tarball of the b1 storage bucket."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -10383,7 +10393,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-04-29 14:30-0400\n"
+        "POT-Creation-Date: 2024-05-03 20:08+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -28,7 +28,7 @@ msgstr  ""
 msgid   "  Motherboard:"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 msgid   "### This is a YAML representation of a storage bucket.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -56,7 +56,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -512,11 +512,11 @@ msgstr  ""
 msgid   "Accept certificate"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid   "Access key (auto-generated if empty)"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, c-format
 msgid   "Access key: %s"
 msgstr  ""
@@ -642,12 +642,12 @@ msgstr  ""
 msgid   "Address: %s"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, c-format
 msgid   "Admin secret key: %s"
 msgstr  ""
@@ -684,7 +684,7 @@ msgstr  ""
 msgid   "All existing data is lost when joining a cluster, continue?"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 msgid   "All projects"
 msgstr  ""
 
@@ -743,11 +743,11 @@ msgstr  ""
 msgid   "Attach new network interfaces to instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 msgid   "Attach new storage volumes to instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid   "Attach new storage volumes to profiles"
 msgstr  ""
 
@@ -798,21 +798,21 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, c-format
 msgid   "Backing up storage bucket %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344 cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349 cmd/incus/storage_volume.go:3028
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid   "Backups:"
 msgstr  ""
 
@@ -821,7 +821,7 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382 cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network.go:369 cmd/incus/network_acl.go:429 cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311 cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382 cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
@@ -831,7 +831,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:164 cmd/incus/storage_volume.go:627
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:164 cmd/incus/storage_volume.go:628
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -879,7 +879,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -967,7 +967,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647 cmd/incus/warning.go:225
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658 cmd/incus/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -1005,15 +1005,15 @@ msgstr  ""
 msgid   "Cannot override config for device %q: Device not found in profile devices"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid   "Cannot set --volume-only when copying a snapshot"
 msgstr  ""
 
@@ -1125,7 +1125,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64 cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880 cmd/incus/network.go:1257 cmd/incus/network.go:1350 cmd/incus/network.go:1422 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:432 cmd/incus/network_load_balancer.go:567 cmd/incus/network_load_balancer.go:722 cmd/incus/network_load_balancer.go:810 cmd/incus/network_load_balancer.go:886 cmd/incus/network_load_balancer.go:999 cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103 cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752 cmd/incus/storage.go:854 cmd/incus/storage.go:947 cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392 cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642 cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941 cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939 cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294 cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834 cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083 cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598 cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773 cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:45 cmd/incus/move.go:64 cmd/incus/network.go:328 cmd/incus/network.go:799 cmd/incus/network.go:880 cmd/incus/network.go:1257 cmd/incus/network.go:1350 cmd/incus/network.go:1422 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:432 cmd/incus/network_load_balancer.go:567 cmd/incus/network_load_balancer.go:722 cmd/incus/network_load_balancer.go:810 cmd/incus/network_load_balancer.go:886 cmd/incus/network_load_balancer.go:999 cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103 cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752 cmd/incus/storage.go:854 cmd/incus/storage.go:947 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647 cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788 cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946 cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147 cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370 cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940 cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300 cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845 cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099 cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297 cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619 cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794 cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1133,7 +1133,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421 cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724 cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521 cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421 cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724 cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532 cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1178,7 +1178,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328 cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363 cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105 cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:762 cmd/incus/network_acl.go:696 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726 cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328 cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1200,11 +1200,11 @@ msgstr  ""
 msgid   "Console log:"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1256,7 +1256,7 @@ msgstr  ""
 msgid   "Copy profiles"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 msgid   "Copy storage volumes"
 msgstr  ""
 
@@ -1264,11 +1264,11 @@ msgstr  ""
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65 cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65 cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1281,7 +1281,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -1396,7 +1396,7 @@ msgstr  ""
 msgid   "Create instances from images"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 msgid   "Create key for a storage bucket"
 msgstr  ""
 
@@ -1408,7 +1408,7 @@ msgstr  ""
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1460,7 +1460,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:602 cmd/incus/storage_volume.go:1407
+#: cmd/incus/image.go:1005 cmd/incus/info.go:602 cmd/incus/storage_volume.go:1418
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1488,7 +1488,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:503 cmd/incus/config_trust.go:435 cmd/incus/image.go:1121 cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092 cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152 cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:844 cmd/incus/operation.go:173 cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727 cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840 cmd/incus/storage_volume.go:1636
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:503 cmd/incus/config_trust.go:435 cmd/incus/image.go:1121 cmd/incus/image_alias.go:237 cmd/incus/list.go:573 cmd/incus/network.go:1092 cmd/incus/network_acl.go:155 cmd/incus/network_forward.go:152 cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:844 cmd/incus/operation.go:173 cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727 cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845 cmd/incus/storage_volume.go:1647
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1523,7 +1523,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1563,7 +1563,7 @@ msgstr  ""
 msgid   "Delete instances"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 msgid   "Delete key from a storage bucket"
 msgstr  ""
 
@@ -1607,7 +1607,7 @@ msgstr  ""
 msgid   "Delete projects"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 msgid   "Delete storage buckets"
 msgstr  ""
 
@@ -1615,11 +1615,11 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 msgid   "Delete storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 msgid   "Delete storage volumes"
 msgstr  ""
 
@@ -1627,16 +1627,16 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:719 cmd/incus/network_load_balancer.go:792 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:883 cmd/incus/network_load_balancer.go:981 cmd/incus/network_load_balancer.go:996 cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412 cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543 cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726 cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861 cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001 cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184 cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361 cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:439 cmd/incus/profile.go:497 cmd/incus/profile.go:633 cmd/incus/profile.go:709 cmd/incus/profile.go:867 cmd/incus/profile.go:955 cmd/incus/profile.go:1015 cmd/incus/profile.go:1104 cmd/incus/profile.go:1168 cmd/incus/project.go:35 cmd/incus/project.go:99 cmd/incus/project.go:195 cmd/incus/project.go:266 cmd/incus/project.go:402 cmd/incus/project.go:477 cmd/incus/project.go:692 cmd/incus/project.go:757 cmd/incus/project.go:845 cmd/incus/project.go:889 cmd/incus/project.go:950 cmd/incus/project.go:1017 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:207 cmd/incus/storage.go:265 cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659 cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257 cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466 cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637 cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740 cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860 cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002 cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209 cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55 cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282 cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831 cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222 cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382 cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477 cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682 cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858 cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:33 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:32 cmd/incus/network.go:139 cmd/incus/network.go:236 cmd/incus/network.go:321 cmd/incus/network.go:408 cmd/incus/network.go:466 cmd/incus/network.go:563 cmd/incus/network.go:660 cmd/incus/network.go:796 cmd/incus/network.go:877 cmd/incus/network.go:1011 cmd/incus/network.go:1112 cmd/incus/network.go:1191 cmd/incus/network.go:1251 cmd/incus/network.go:1347 cmd/incus/network.go:1419 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:93 cmd/incus/network_acl.go:172 cmd/incus/network_acl.go:233 cmd/incus/network_acl.go:289 cmd/incus/network_acl.go:362 cmd/incus/network_acl.go:459 cmd/incus/network_acl.go:547 cmd/incus/network_acl.go:590 cmd/incus/network_acl.go:729 cmd/incus/network_acl.go:786 cmd/incus/network_acl.go:843 cmd/incus/network_acl.go:858 cmd/incus/network_acl.go:995 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:719 cmd/incus/network_load_balancer.go:792 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:883 cmd/incus/network_load_balancer.go:981 cmd/incus/network_load_balancer.go:996 cmd/incus/network_load_balancer.go:1069 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:388 cmd/incus/network_peer.go:473 cmd/incus/network_peer.go:575 cmd/incus/network_peer.go:622 cmd/incus/network_peer.go:759 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412 cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543 cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726 cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861 cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001 cmd/incus/network_zone.go:1095 cmd/incus/network_zone.go:1184 cmd/incus/network_zone.go:1231 cmd/incus/network_zone.go:1361 cmd/incus/network_zone.go:1422 cmd/incus/network_zone.go:1437 cmd/incus/network_zone.go:1495 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:439 cmd/incus/profile.go:497 cmd/incus/profile.go:633 cmd/incus/profile.go:709 cmd/incus/profile.go:867 cmd/incus/profile.go:955 cmd/incus/profile.go:1015 cmd/incus/profile.go:1104 cmd/incus/profile.go:1168 cmd/incus/project.go:35 cmd/incus/project.go:99 cmd/incus/project.go:195 cmd/incus/project.go:266 cmd/incus/project.go:402 cmd/incus/project.go:477 cmd/incus/project.go:692 cmd/incus/project.go:757 cmd/incus/project.go:845 cmd/incus/project.go:889 cmd/incus/project.go:950 cmd/incus/project.go:1017 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:528 cmd/incus/storage.go:32 cmd/incus/storage.go:95 cmd/incus/storage.go:207 cmd/incus/storage.go:265 cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659 cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471 cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642 cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745 cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865 cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007 cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214 cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736 cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931 cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288 cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534 cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842 cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085 cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243 cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403 cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703 cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879 cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 msgid   "Destination cluster member name"
 msgstr  ""
 
@@ -1648,11 +1648,11 @@ msgstr  ""
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
@@ -1898,11 +1898,11 @@ msgstr  ""
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 msgid   "Edit storage bucket configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid   "Edit storage bucket key as YAML"
 msgstr  ""
 
@@ -1910,7 +1910,7 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
@@ -1918,7 +1918,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447 cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762 cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664 cmd/incus/warning.go:236
+#: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447 cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762 cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675 cmd/incus/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1970,7 +1970,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159 cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816 cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002 cmd/incus/storage_volume.go:2040
+#: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1325 cmd/incus/network_acl.go:522 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550 cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159 cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816 cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013 cmd/incus/storage_volume.go:2056
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1985,7 +1985,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076 cmd/incus/project.go:814 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996 cmd/incus/storage_volume.go:2034
+#: cmd/incus/cluster.go:556 cmd/incus/network.go:1319 cmd/incus/network_acl.go:516 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076 cmd/incus/project.go:814 cmd/incus/storage.go:810 cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007 cmd/incus/storage_volume.go:2050
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2064,7 +2064,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366 cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490 cmd/incus/storage_volume.go:2575
+#: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366 cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501 cmd/incus/storage_volume.go:2596
 msgid   "Expires at"
 msgstr  ""
 
@@ -2087,7 +2087,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -2099,24 +2099,24 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 msgid   "Export storage bucket"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 msgid   "Export storage buckets as tarball."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, c-format
 msgid   "Exporting backup of storage bucket %s"
 msgstr  ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2192,7 +2192,7 @@ msgstr  ""
 msgid   "Failed deleting instance %q in project %q: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, c-format
 msgid   "Failed deleting source volume after copy: %w"
 msgstr  ""
@@ -2321,7 +2321,7 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, c-format
 msgid   "Failed to create backup: %v"
 msgstr  ""
@@ -2331,7 +2331,7 @@ msgstr  ""
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, c-format
 msgid   "Failed to create storage volume backup: %w"
 msgstr  ""
@@ -2341,12 +2341,12 @@ msgstr  ""
 msgid   "Failed to delete original instance after copying it: %w"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, c-format
 msgid   "Failed to fetch storage bucket backup: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, c-format
 msgid   "Failed to fetch storage volume backup file: %w"
 msgstr  ""
@@ -2545,7 +2545,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067 cmd/incus/cluster_group.go:441 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586 cmd/incus/image.go:1100 cmd/incus/image_alias.go:157 cmd/incus/list.go:133 cmd/incus/network.go:1015 cmd/incus/network.go:1114 cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84 cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786 cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498 cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291 cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467 cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539 cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067 cmd/incus/cluster_group.go:441 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586 cmd/incus/image.go:1100 cmd/incus/image_alias.go:157 cmd/incus/list.go:133 cmd/incus/network.go:1015 cmd/incus/network.go:1114 cmd/incus/network_acl.go:96 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84 cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786 cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498 cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291 cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472 cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550 cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2661,7 +2661,7 @@ msgstr  ""
 msgid   "Get the key as a project property"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 msgid   "Get the key as a storage bucket property"
 msgstr  ""
 
@@ -2669,7 +2669,7 @@ msgstr  ""
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
@@ -2729,7 +2729,7 @@ msgstr  ""
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 msgid   "Get values for storage bucket configuration keys"
 msgstr  ""
 
@@ -2737,11 +2737,11 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
@@ -2836,7 +2836,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2848,7 +2848,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -2898,7 +2898,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2906,11 +2906,11 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 msgid   "Import backups of storage buckets."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -2928,28 +2928,28 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 msgid   "Import storage bucket"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid   "Import type needs to be \"backup\" or \"iso\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid   "Importing ISO images requires a volume name to be set"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, c-format
 msgid   "Importing bucket: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -3019,7 +3019,7 @@ msgstr  ""
 msgid   "Invalid IP address or DNS name"
 msgstr  ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295 cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300 cmd/incus/storage_volume.go:2979
 #, c-format
 msgid   "Invalid URL %q: %w"
 msgstr  ""
@@ -3038,7 +3038,7 @@ msgstr  ""
 msgid   "Invalid arguments"
 msgstr  ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300 cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305 cmd/incus/storage_volume.go:2984
 #, c-format
 msgid   "Invalid backup name segment in path %q: %w"
 msgstr  ""
@@ -3134,7 +3134,7 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215 cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979 cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216 cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990 cmd/incus/storage_volume.go:2839
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -3182,7 +3182,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: cmd/incus/list.go:614 cmd/incus/network.go:1174 cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161 cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524 cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/list.go:614 cmd/incus/network.go:1174 cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161 cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529 cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -3503,19 +3503,19 @@ msgid   "List projects\n"
         "u - Used By"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 msgid   "List storage bucket keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 msgid   "List storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 msgid   "List storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 msgid   "List storage volume snapshots\n"
         "\n"
         "	The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3532,11 +3532,11 @@ msgid   "List storage volume snapshots\n"
         "		u - Number of references (used by)"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 msgid   "List storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3614,7 +3614,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3850,11 +3850,11 @@ msgstr  ""
 msgid   "Manage projects"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 msgid   "Manage storage bucket keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 msgid   "Manage storage bucket keys."
 msgstr  ""
 
@@ -3870,15 +3870,15 @@ msgstr  ""
 msgid   "Manage storage pools and volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 msgid   "Manage storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 msgid   "Manage storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid   "Manage storage volumes\n"
         "\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
@@ -3972,7 +3972,7 @@ msgstr  ""
 msgid   "Minimum size is 1GiB"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224 cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419 cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668 cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891 cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045 cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229 cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424 cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673 cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896 cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050 cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 msgid   "Missing bucket name"
 msgstr  ""
 
@@ -3992,7 +3992,7 @@ msgstr  ""
 msgid   "Missing instance name"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970 cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975 cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 msgid   "Missing key name"
 msgstr  ""
 
@@ -4028,7 +4028,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435 cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220 cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415 cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572 cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806 cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962 cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164 cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202 cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609 cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775 cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987 cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570 cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309 cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527 cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722 cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435 cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577 cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811 cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967 cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169 cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610 cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776 cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988 cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581 cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973 cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330 cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548 cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743 cmd/incus/storage_volume.go:2829
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -4048,11 +4048,11 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 msgid   "Missing storage pool name"
 msgstr  ""
 
@@ -4088,7 +4088,7 @@ msgid   "Monitor a local or remote server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: cmd/incus/network.go:522 cmd/incus/network.go:619 cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/network.go:522 cmd/incus/network.go:619 cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -4115,7 +4115,7 @@ msgid   "Move instances within or in between servers\n"
         "The pull transfer mode is the default as it is compatible with all server versions.\n"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
@@ -4123,11 +4123,11 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
@@ -4148,7 +4148,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158 cmd/incus/cluster_group.go:502 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:666 cmd/incus/list.go:581 cmd/incus/network.go:1087 cmd/incus/network_acl.go:154 cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154 cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843 cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773 cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519 cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158 cmd/incus/cluster_group.go:502 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:666 cmd/incus/list.go:581 cmd/incus/network.go:1087 cmd/incus/network_acl.go:154 cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154 cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843 cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773 cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524 cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid   "NAME"
 msgstr  ""
 
@@ -4199,7 +4199,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364 cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488 cmd/incus/storage_volume.go:2573
+#: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364 cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499 cmd/incus/storage_volume.go:2594
 msgid   "Name"
 msgstr  ""
 
@@ -4258,7 +4258,7 @@ msgstr  ""
 msgid   "Name of the storage pool:"
 msgstr  ""
 
-#: cmd/incus/info.go:577 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1378
+#: cmd/incus/info.go:577 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1389
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -4421,7 +4421,7 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 msgid   "No device found for this storage volume"
 msgstr  ""
 
@@ -4441,11 +4441,11 @@ msgstr  ""
 msgid   "No storage backends available"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -4479,15 +4479,15 @@ msgstr  ""
 msgid   "OVN:"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -4499,7 +4499,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
@@ -4516,7 +4516,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4558,7 +4558,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165 cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:213
+#: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165 cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665 cmd/incus/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4659,7 +4659,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329 cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364 cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106 cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:763 cmd/incus/network_acl.go:697 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727 cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329 cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111 cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4796,7 +4796,7 @@ msgstr  ""
 msgid   "Protocol: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "	Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4806,7 +4806,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "		Will show the properties of snapshot \"snap0\" for a virtual machine called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, container and virtual-machine.\n"
         "\n"
@@ -4817,7 +4817,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns state information for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4830,7 +4830,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4843,7 +4843,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Will show the properties of the filesystem for a container called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4851,7 +4851,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4862,7 +4862,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4934,7 +4934,7 @@ msgstr  ""
 msgid   "RESTRICTED"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid   "ROLE"
 msgstr  ""
 
@@ -4971,7 +4971,7 @@ msgstr  ""
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
@@ -5153,20 +5153,20 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 msgid   "Rename storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, c-format
 msgid   "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr  ""
@@ -5206,7 +5206,7 @@ msgstr  ""
 msgid   "Restore instance snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -5240,7 +5240,7 @@ msgstr  ""
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid   "Role (admin or read-only)"
 msgstr  ""
 
@@ -5341,11 +5341,11 @@ msgstr  ""
 msgid   "Scanning for unknown volumes..."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid   "Secret key (auto-generated if empty)"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, c-format
 msgid   "Secret key: %s"
 msgstr  ""
@@ -5543,11 +5543,11 @@ msgid   "Set project configuration keys\n"
         "    incus project set [<remote>:]<project> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 msgid   "Set storage bucket configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 msgid   "Set storage bucket configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5565,11 +5565,11 @@ msgid   "Set storage pool configuration keys\n"
         "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5648,7 +5648,7 @@ msgstr  ""
 msgid   "Set the key as a project property"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 msgid   "Set the key as a storage bucket property"
 msgstr  ""
 
@@ -5656,7 +5656,7 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -5784,11 +5784,11 @@ msgstr  ""
 msgid   "Show project options"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 msgid   "Show storage bucket configurations"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 msgid   "Show storage bucket key configurations"
 msgstr  ""
 
@@ -5796,11 +5796,11 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069 cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085 cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 msgid   "Show storage volume state information"
 msgstr  ""
 
@@ -5862,15 +5862,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -5944,22 +5944,22 @@ msgstr  ""
 msgid   "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, c-format
 msgid   "Storage bucket %s created"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, c-format
 msgid   "Storage bucket %s deleted"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, c-format
 msgid   "Storage bucket key %s added"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, c-format
 msgid   "Storage bucket key %s removed"
 msgstr  ""
@@ -6001,25 +6001,25 @@ msgstr  ""
 msgid   "Storage pool to use or create"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, c-format
 msgid   "Storage volume snapshot %s deleted from %s"
 msgstr  ""
@@ -6075,11 +6075,11 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1129 cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088 cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26 cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157 cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634 cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1129 cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088 cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26 cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157 cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645 cmd/incus/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365 cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365 cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid   "Taken at"
 msgstr  ""
 
@@ -6254,7 +6254,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the project %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, c-format
 msgid   "The property %q does not exist on the storage bucket %q: %v"
 msgstr  ""
@@ -6264,12 +6264,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
@@ -6311,7 +6311,7 @@ msgstr  ""
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: cmd/incus/network.go:536 cmd/incus/network.go:633 cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/network.go:536 cmd/incus/network.go:633 cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -6383,7 +6383,7 @@ msgstr  ""
 msgid   "Too many links"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -6398,7 +6398,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -6406,7 +6406,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
@@ -6458,7 +6458,7 @@ msgstr  ""
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403 cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933 cmd/incus/storage_volume.go:1387
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403 cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933 cmd/incus/storage_volume.go:1398
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -6480,7 +6480,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid   "USAGE"
 msgstr  ""
 
@@ -6492,7 +6492,7 @@ msgstr  ""
 msgid   "USB devices:"
 msgstr  ""
 
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156 cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460 cmd/incus/network_zone.go:161 cmd/incus/profile.go:747 cmd/incus/project.go:525 cmd/incus/storage.go:728 cmd/incus/storage_volume.go:1638
+#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:156 cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460 cmd/incus/network_zone.go:161 cmd/incus/profile.go:747 cmd/incus/project.go:525 cmd/incus/storage.go:728 cmd/incus/storage_volume.go:1649
 msgid   "USED BY"
 msgstr  ""
 
@@ -6528,7 +6528,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455 cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768 cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672 cmd/incus/warning.go:244
+#: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455 cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768 cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683 cmd/incus/warning.go:244
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -6625,7 +6625,7 @@ msgstr  ""
 msgid   "Unset project configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 msgid   "Unset storage bucket configuration keys"
 msgstr  ""
 
@@ -6633,7 +6633,7 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
@@ -6681,7 +6681,7 @@ msgstr  ""
 msgid   "Unset the key as a project property"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 msgid   "Unset the key as a storage bucket property"
 msgstr  ""
 
@@ -6689,7 +6689,7 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -6727,12 +6727,12 @@ msgstr  ""
 msgid   "Upper devices"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -6813,7 +6813,7 @@ msgstr  ""
 msgid   "Version: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid   "Volume Only"
 msgstr  ""
 
@@ -6974,11 +6974,11 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
@@ -7350,31 +7350,31 @@ msgstr  ""
 msgid   "[<remote>:]<operation>"
 msgstr  ""
 
-#: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477 cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477 cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 msgid   "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255 cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260 cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 msgid   "[<remote>:]<pool> <bucket>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704 cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936 cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709 cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941 cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 msgid   "[<remote>:]<pool> <bucket> <key>"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 msgid   "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 msgid   "[<remote>:]<pool> <bucket> [<path>]"
 msgstr  ""
 
@@ -7394,71 +7394,71 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 msgid   "[<remote>:]<pool> <old name> <new name>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 msgid   "[<remote>:]<pool> <volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 msgid   "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 msgid   "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 msgid   "[<remote>:]<pool> [<filter>...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280 cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286 cmd/incus/storage_volume.go:2083
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
@@ -7891,32 +7891,40 @@ msgid   "incus snapshot create u1 snap0\n"
         "Restore the snapshot."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+msgid   "incus storage bucket create p1 b01\n"
+        "	Create a new storage bucket name b01 in storage pool p1\n"
+        "\n"
+        "incus storage bucket create p1 b01 < config.yaml\n"
+        "	Craete a new storage bucket name b01 in storage pool p1 using the content of config.yaml"
+msgstr  ""
+
+#: cmd/incus/storage_bucket.go:1216
 msgid   "incus storage bucket default b1\n"
         "    Download a backup tarball of the b1 storage bucket."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 msgid   "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
         "    Update a storage bucket using the content of bucket.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 msgid   "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
         "    Update a storage bucket key using the content of key.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 msgid   "incus storage bucket import default backup0.tar.gz\n"
         "		Create a new storage bucket using backup0.tar.gz as the source."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 msgid   "incus storage bucket key show default data foo\n"
         "    Will show the properties of a bucket key called \"foo\" for a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 msgid   "incus storage bucket show default data\n"
         "    Will show the properties of a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
@@ -7926,7 +7934,7 @@ msgid   "incus storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 msgid   "incus storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-29 14:30-0400\n"
+"POT-Creation-Date: 2024-05-03 20:08+0200\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -30,7 +30,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -90,7 +90,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -787,11 +787,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -930,12 +930,12 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -973,7 +973,7 @@ msgstr "Alias:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 msgid "All projects"
 msgstr ""
 
@@ -1035,11 +1035,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1091,22 +1091,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, fuzzy, c-format
 msgid "Backing up storage bucket %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344
-#: cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:3028
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgstr ""
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
-#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1130,7 +1130,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:164
-#: cmd/incus/storage_volume.go:627
+#: cmd/incus/storage_volume.go:628
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1268,7 +1268,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1308,16 +1308,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1452,22 +1452,22 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752
 #: cmd/incus/storage.go:854 cmd/incus/storage.go:947
-#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392
-#: cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642
-#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142
-#: cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365
-#: cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578
-#: cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939
-#: cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294
-#: cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834
-#: cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083
-#: cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598
-#: cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773
-#: cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647
+#: cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788
+#: cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946
+#: cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147
+#: cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940
+#: cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300
+#: cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845
+#: cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099
+#: cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297
+#: cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619
+#: cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid "Cluster member name"
 msgstr ""
 
@@ -1477,8 +1477,8 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724
-#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532
+#: cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
 
@@ -1534,8 +1534,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
-#: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
-#: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
+#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1557,11 +1557,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1619,7 +1619,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1627,12 +1627,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1767,7 +1767,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1781,7 +1781,7 @@ msgstr "Il nome del container è: %s"
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1838,7 +1838,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:602
-#: cmd/incus/storage_volume.go:1407
+#: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1875,8 +1875,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727
-#: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
-#: cmd/incus/storage_volume.go:1636
+#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845
+#: cmd/incus/storage_volume.go:1647
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1911,7 +1911,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1954,7 +1954,7 @@ msgstr "Creazione del container in corso"
 msgid "Delete instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgstr ""
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Il nome del container è: %s"
@@ -2011,12 +2011,12 @@ msgstr "Il nome del container è: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2149,39 +2149,39 @@ msgstr ""
 #: cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659
 #: cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257
-#: cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466
-#: cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740
-#: cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860
-#: cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002
-#: cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209
-#: cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575
-#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
-#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282
-#: cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831
-#: cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222
-#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477
-#: cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682
-#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858
-#: cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471
+#: cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642
+#: cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007
+#: cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214
+#: cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736
+#: cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931
+#: cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288
+#: cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842
+#: cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243
+#: cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403
+#: cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498
+#: cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703
+#: cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
@@ -2194,11 +2194,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2467,12 +2467,12 @@ msgstr ""
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2480,7 +2480,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2490,7 +2490,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762
-#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664
+#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2552,8 +2552,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
-#: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
-#: cmd/incus/storage_volume.go:2040
+#: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
+#: cmd/incus/storage_volume.go:2056
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2574,8 +2574,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
-#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
-#: cmd/incus/storage_volume.go:2034
+#: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
+#: cmd/incus/storage_volume.go:2050
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2660,8 +2660,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
-#: cmd/incus/storage_volume.go:2575
+#: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
+#: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
 msgstr ""
 
@@ -2685,7 +2685,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2699,26 +2699,26 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2795,7 +2795,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Accetta certificato"
@@ -2934,7 +2934,7 @@ msgstr "Accetta certificato"
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Accetta certificato"
@@ -2944,12 +2944,12 @@ msgstr "Accetta certificato"
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Accetta certificato"
@@ -3170,9 +3170,9 @@ msgstr ""
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467
-#: cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539
-#: cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472
+#: cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550
+#: cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3294,7 +3294,7 @@ msgstr ""
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Il nome del container è: %s"
@@ -3303,7 +3303,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3370,7 +3370,7 @@ msgstr ""
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
@@ -3379,11 +3379,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3479,7 +3479,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3493,7 +3493,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3544,7 +3544,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3552,12 +3552,12 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3577,29 +3577,29 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3671,8 +3671,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295
-#: cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:2979
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Proprietà errata: %s"
@@ -3692,8 +3692,8 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid arguments"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305
+#: cmd/incus/storage_volume.go:2984
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3792,9 +3792,9 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215
-#: cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979
-#: cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216
+#: cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990
+#: cmd/incus/storage_volume.go:2839
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -3845,8 +3845,8 @@ msgstr ""
 
 #: cmd/incus/list.go:614 cmd/incus/network.go:1174
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
-#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524
-#: cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529
+#: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4193,21 +4193,21 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4225,11 +4225,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4312,7 +4312,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4569,12 +4569,12 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -4592,16 +4592,16 @@ msgstr "Creazione del container in corso"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4699,12 +4699,12 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224
-#: cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419
-#: cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891
-#: cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045
-#: cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673
+#: cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896
+#: cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050
+#: cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Il nome del container è: %s"
@@ -4736,8 +4736,8 @@ msgstr "Il nome del container è: %s"
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970
-#: cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975
+#: cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 #, fuzzy
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
@@ -4835,22 +4835,22 @@ msgstr "Il nome del container è: %s"
 
 #: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435
 #: cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220
-#: cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415
-#: cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572
-#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806
-#: cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962
-#: cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164
-#: cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202
-#: cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609
-#: cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775
-#: cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987
-#: cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570
-#: cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962
-#: cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309
-#: cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527
-#: cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722
-#: cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577
+#: cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811
+#: cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776
+#: cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581
+#: cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973
+#: cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548
+#: cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743
+#: cmd/incus/storage_volume.go:2829
 msgid "Missing pool name"
 msgstr ""
 
@@ -4876,11 +4876,11 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
@@ -4921,7 +4921,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:522 cmd/incus/network.go:619
-#: cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4954,7 +4954,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4962,11 +4962,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4994,8 +4994,8 @@ msgstr ""
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773
-#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519
-#: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid "NAME"
 msgstr ""
 
@@ -5050,8 +5050,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
-#: cmd/incus/storage_volume.go:2573
+#: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
+#: cmd/incus/storage_volume.go:2594
 msgid "Name"
 msgstr ""
 
@@ -5112,7 +5112,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:577 cmd/incus/network.go:929
-#: cmd/incus/storage_volume.go:1378
+#: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5276,7 +5276,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5296,11 +5296,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5336,15 +5336,15 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5374,7 +5374,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5417,7 +5417,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165
-#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654
+#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5530,8 +5530,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
-#: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
-#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
+#: cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5670,7 +5670,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "\tSupported types are custom, image, container and virtual-machine.\n"
@@ -5683,7 +5683,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5697,7 +5697,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5713,7 +5713,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5730,7 +5730,7 @@ msgid ""
 "\"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5739,7 +5739,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5752,7 +5752,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5827,7 +5827,7 @@ msgstr ""
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid "ROLE"
 msgstr ""
 
@@ -5872,7 +5872,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6067,21 +6067,21 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 msgid "Rename storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6125,7 +6125,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6162,7 +6162,7 @@ msgstr "Il nome del container è: %s"
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6266,11 +6266,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6499,12 +6499,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6526,11 +6526,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6616,7 +6616,7 @@ msgstr ""
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Creazione del container in corso"
@@ -6625,7 +6625,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6763,12 +6763,12 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Il nome del container è: %s"
@@ -6777,12 +6777,12 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6845,15 +6845,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
@@ -6931,22 +6931,22 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -6989,25 +6989,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Creazione del container in corso"
@@ -7068,13 +7068,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088
 #: cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -7263,7 +7263,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Il nome del container è: %s"
@@ -7273,12 +7273,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7326,7 +7326,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
-#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7405,7 +7405,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -7421,7 +7421,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7429,7 +7429,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7486,7 +7486,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
 #: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7508,7 +7508,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid "USAGE"
 msgstr ""
 
@@ -7526,7 +7526,7 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:747
 #: cmd/incus/project.go:525 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1638
+#: cmd/incus/storage_volume.go:1649
 msgid "USED BY"
 msgstr ""
 
@@ -7566,7 +7566,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768
-#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7672,7 +7672,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
@@ -7681,7 +7681,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -7733,7 +7733,7 @@ msgstr ""
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Il nome del container è: %s"
@@ -7742,7 +7742,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7784,12 +7784,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7874,7 +7874,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid "Volume Only"
 msgstr ""
 
@@ -8051,12 +8051,12 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
@@ -8556,40 +8556,40 @@ msgid "[<remote>:]<operation>"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477
-#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255
-#: cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704
-#: cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936
-#: cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
+#: cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "Creazione del container in corso"
@@ -8614,88 +8614,88 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280
-#: cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286
+#: cmd/incus/storage_volume.go:2083
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
@@ -9221,38 +9221,48 @@ msgid ""
 "Restore the snapshot."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket name b01 in storage pool p1\n"
+"\n"
+"incus storage bucket create p1 b01 < config.yaml\n"
+"\tCraete a new storage bucket name b01 in storage pool p1 using the content "
+"of config.yaml"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:1216
 msgid ""
 "incus storage bucket default b1\n"
 "    Download a backup tarball of the b1 storage bucket."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -9265,7 +9275,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-29 14:30-0400\n"
+"POT-Creation-Date: 2024-05-03 20:08+0200\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -83,7 +83,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -775,11 +775,11 @@ msgstr "AUTH TYPE"
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid "Access key (auto-generated if empty)"
 msgstr "アクセスキー（空白の場合自動生成）"
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, c-format
 msgid "Access key: %s"
 msgstr "アクセスキー: %s"
@@ -929,12 +929,12 @@ msgstr "バインドするアドレス (ポートを含まない)"
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "管理者秘密鍵: %s"
@@ -972,7 +972,7 @@ msgstr "エイリアス:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr "クラスターに join すると、すべてのデータが削除されます。続けますか?"
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1033,11 +1033,11 @@ msgstr "プロファイルにネットワークインターフェースを追加
 msgid "Attach new network interfaces to instances"
 msgstr "新たなネットワークインターフェースをインスタンスに追加します"
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr "新たにストレージボリュームをインスタンスに追加します"
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
@@ -1093,22 +1093,22 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, c-format
 msgid "Backing up storage bucket %s"
 msgstr "ストレージバケット %s のバックアップを行います"
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344
-#: cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:3028
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1122,7 +1122,7 @@ msgstr ""
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
-#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
@@ -1134,7 +1134,7 @@ msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %q"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:164
-#: cmd/incus/storage_volume.go:627
+#: cmd/incus/storage_volume.go:628
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1182,7 +1182,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1273,7 +1273,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスターでない場合はカラムとして L は指定できません"
@@ -1315,19 +1315,19 @@ msgstr ""
 "デバイス %q の設定を上書きできません: プロファイルのデバイス内にデバイスが見"
 "つかりません"
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "スナップショットをコピーするときに --volume-only は指定できません"
 
@@ -1464,22 +1464,22 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752
 #: cmd/incus/storage.go:854 cmd/incus/storage.go:947
-#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392
-#: cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642
-#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142
-#: cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365
-#: cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578
-#: cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939
-#: cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294
-#: cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834
-#: cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083
-#: cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598
-#: cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773
-#: cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647
+#: cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788
+#: cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946
+#: cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147
+#: cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940
+#: cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300
+#: cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845
+#: cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099
+#: cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297
+#: cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619
+#: cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid "Cluster member name"
 msgstr "クラスターメンバ名"
 
@@ -1489,8 +1489,8 @@ msgstr "クラスタリングが有効になりました"
 
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724
-#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532
+#: cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1553,8 +1553,8 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
-#: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
-#: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
+#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
@@ -1576,11 +1576,11 @@ msgstr "デーモンに接続しています (試行 %d)"
 msgid "Console log:"
 msgstr "コンソールログ:"
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1654,7 +1654,7 @@ msgstr "プロファイルに継承されたデバイスをコピーし、設定
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
@@ -1662,12 +1662,12 @@ msgstr "ストレージボリュームをコピーします"
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
 #: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1680,7 +1680,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "イメージからインスタンスを作成します"
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 msgid "Create key for a storage bucket"
 msgstr "ストレージバケットに対する鍵を作成します"
 
@@ -1813,7 +1813,7 @@ msgstr "新たにネットワークピアリングを作成します"
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1867,7 +1867,7 @@ msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:602
-#: cmd/incus/storage_volume.go:1407
+#: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1903,8 +1903,8 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727
-#: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
-#: cmd/incus/storage_volume.go:1636
+#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845
+#: cmd/incus/storage_volume.go:1647
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1940,7 +1940,7 @@ msgstr "状態: %s"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1980,7 +1980,7 @@ msgstr "インスタンスのスナップショットを削除します"
 msgid "Delete instances"
 msgstr "インスタンスを削除します"
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 msgid "Delete key from a storage bucket"
 msgstr "ストレージバケットからキーを削除します"
 
@@ -2026,7 +2026,7 @@ msgstr "プロファイルを削除します"
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 msgid "Delete storage buckets"
 msgstr "ストレージバケットを削除します"
 
@@ -2034,11 +2034,11 @@ msgstr "ストレージバケットを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 msgid "Delete storage volume snapshots"
 msgstr "ストレージボリュームのスナップショットを削除します"
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
@@ -2171,39 +2171,39 @@ msgstr "警告を削除します"
 #: cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659
 #: cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257
-#: cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466
-#: cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740
-#: cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860
-#: cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002
-#: cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209
-#: cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575
-#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
-#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282
-#: cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831
-#: cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222
-#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477
-#: cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682
-#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858
-#: cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471
+#: cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642
+#: cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007
+#: cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214
+#: cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736
+#: cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931
+#: cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288
+#: cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842
+#: cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243
+#: cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403
+#: cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498
+#: cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703
+#: cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr "説明"
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
@@ -2215,11 +2215,11 @@ msgstr "インスタンスからネットワークインターフェースを取
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
@@ -2487,11 +2487,11 @@ msgstr "プロファイル設定をYAMLで編集します"
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 msgid "Edit storage bucket configurations as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid "Edit storage bucket key as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
@@ -2499,7 +2499,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
@@ -2509,7 +2509,7 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762
-#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664
+#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2581,8 +2581,8 @@ msgstr "エイリアスの取得に失敗しました: %w"
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
-#: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
-#: cmd/incus/storage_volume.go:2040
+#: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
+#: cmd/incus/storage_volume.go:2056
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "プロパティの設定でエラーが発生しました: %v"
@@ -2603,8 +2603,8 @@ msgstr "プロパティの削除でエラーが発生しました: %v"
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
-#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
-#: cmd/incus/storage_volume.go:2034
+#: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
+#: cmd/incus/storage_volume.go:2050
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "プロパティの設定解除エラー: %v"
@@ -2727,8 +2727,8 @@ msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
 #: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
-#: cmd/incus/storage_volume.go:2575
+#: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
+#: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2755,7 +2755,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2767,25 +2767,25 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 msgid "Export storage bucket"
 msgstr "ストレージバケットをエクスポートします"
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 msgid "Export storage buckets as tarball."
 msgstr "ストレージバケットを tarball 形式でエクスポートします。"
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, c-format
 msgid "Exporting backup of storage bucket %s"
 msgstr "ストレージバケット %s のバックアップをエクスポートします"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2862,7 +2862,7 @@ msgstr "join トークンのトークン変換操作に失敗しました: %w"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "インスタンス %q （プロジェクト %q 内）の削除に失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "コピー後のソースボリュームの削除に失敗しました: %w"
@@ -2991,7 +2991,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "%q の作成に失敗しました: %w"
@@ -3001,7 +3001,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "ストレージボリュームのバックアップ作成に失敗しました: %w"
@@ -3011,12 +3011,12 @@ msgstr "ストレージボリュームのバックアップ作成に失敗しま
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "移動元のインスタンスをコピーしたあとの削除に失敗しました: %w"
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "ストレージボリュームのバックアップファイルの取得に失敗しました: %w"
@@ -3250,9 +3250,9 @@ msgstr ""
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467
-#: cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539
-#: cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472
+#: cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550
+#: cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -3377,7 +3377,7 @@ msgstr "key をプロファイルプロパティとして取得します"
 msgid "Get the key as a project property"
 msgstr "key をプロジェクトプロパティとして取得します"
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
@@ -3387,7 +3387,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -3450,7 +3450,7 @@ msgstr "プロファイルの設定値を取得します"
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 msgid "Get values for storage bucket configuration keys"
 msgstr "ストレージバケットの設定値を取得します"
 
@@ -3458,11 +3458,11 @@ msgstr "ストレージバケットの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
@@ -3561,7 +3561,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -3578,7 +3578,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -3628,7 +3628,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -3639,12 +3639,12 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -3667,30 +3667,30 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "ストレージバケットを一覧表示します"
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 "インポートするタイプは \"backup\" もしくは \"iso\" である必要があります"
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr "インポートするタイプ。backup もしくは iso (デフォルト \\\"backup\\\")"
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid "Importing ISO images requires a volume name to be set"
 msgstr "ISO イメージをインポートするには、ボリューム名を設定する必要があります"
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "インスタンスのインポート中: %s"
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3763,8 +3763,8 @@ msgstr "インスタンスタイプ"
 msgid "Invalid IP address or DNS name"
 msgstr "不正なスナップショット名"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295
-#: cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:2979
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "不正なフォーマット %q"
@@ -3784,8 +3784,8 @@ msgstr "不正な引数 %q"
 msgid "Invalid arguments"
 msgstr "不正な引数 %q"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305
+#: cmd/incus/storage_volume.go:2984
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "パス %q に不正なバックアップ名のセグメントがあります: %w"
@@ -3888,9 +3888,9 @@ msgstr "不正な送り先 %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215
-#: cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979
-#: cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216
+#: cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990
+#: cmd/incus/storage_volume.go:2839
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -3940,8 +3940,8 @@ msgstr "LISTEN ADDRESS"
 
 #: cmd/incus/list.go:614 cmd/incus/network.go:1174
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
-#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524
-#: cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529
+#: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -4461,20 +4461,20 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 msgid "List storage bucket keys"
 msgstr "ストレージバケットの鍵を一覧表示します"
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 #, fuzzy
 msgid ""
 "List storage volume snapshots\n"
@@ -4507,11 +4507,11 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4644,7 +4644,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4902,11 +4902,11 @@ msgstr "プロファイルを管理します"
 msgid "Manage projects"
 msgstr "プロジェクトを管理します"
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 msgid "Manage storage bucket keys"
 msgstr "ストレージバケットの鍵を管理します"
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 msgid "Manage storage bucket keys."
 msgstr "ストレージバケットの鍵を管理します。"
 
@@ -4922,16 +4922,16 @@ msgstr "ストレージバケットを管理します。"
 msgid "Manage storage pools and volumes"
 msgstr "ストレージプール、ストレージボリュームを管理します"
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "ストレージボリュームを管理します"
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 msgid "Manage storage volumes"
 msgstr "ストレージボリュームを管理します"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -5032,12 +5032,12 @@ msgstr "ログメッセージの最小レベル（pretty フォーマット使�
 msgid "Minimum size is 1GiB"
 msgstr "最小サイズは 1GiB です"
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224
-#: cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419
-#: cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891
-#: cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045
-#: cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673
+#: cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896
+#: cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050
+#: cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 msgid "Missing bucket name"
 msgstr "バケット名を指定する必要があります"
 
@@ -5065,8 +5065,8 @@ msgstr "クラスターメンバー名がありません"
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970
-#: cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975
+#: cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
@@ -5158,22 +5158,22 @@ msgstr "ピア名を指定する必要があります"
 
 #: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435
 #: cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220
-#: cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415
-#: cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572
-#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806
-#: cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962
-#: cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164
-#: cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202
-#: cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609
-#: cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775
-#: cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987
-#: cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570
-#: cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962
-#: cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309
-#: cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527
-#: cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722
-#: cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577
+#: cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811
+#: cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776
+#: cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581
+#: cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973
+#: cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548
+#: cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743
+#: cmd/incus/storage_volume.go:2829
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -5198,11 +5198,11 @@ msgstr "プロファイル名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -5246,7 +5246,7 @@ msgstr ""
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
 #: cmd/incus/network.go:522 cmd/incus/network.go:619
-#: cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
@@ -5293,7 +5293,7 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
@@ -5301,11 +5301,11 @@ msgstr "プール間でストレージボリュームを移動します"
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
@@ -5335,8 +5335,8 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773
-#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519
-#: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid "NAME"
 msgstr "NAME"
 
@@ -5391,8 +5391,8 @@ msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
 #: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
-#: cmd/incus/storage_volume.go:2573
+#: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
+#: cmd/incus/storage_volume.go:2594
 msgid "Name"
 msgstr "名前"
 
@@ -5457,7 +5457,7 @@ msgid "Name of the storage pool:"
 msgstr "ストレージプールを作成します"
 
 #: cmd/incus/info.go:577 cmd/incus/network.go:929
-#: cmd/incus/storage_volume.go:1378
+#: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -5624,7 +5624,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
@@ -5644,11 +5644,11 @@ msgstr "マッチするルールが見つかりません"
 msgid "No storage backends available"
 msgstr "利用可能なストレージバックエンドがありません"
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -5688,15 +5688,15 @@ msgstr "配置するグループの数"
 msgid "OVN:"
 msgstr "OVN:"
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -5708,7 +5708,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
@@ -5728,7 +5728,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -5771,7 +5771,7 @@ msgid "PROFILES"
 msgstr "PROFILES"
 
 #: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165
-#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654
+#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
@@ -5884,8 +5884,8 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
-#: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
-#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
+#: cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -6024,7 +6024,7 @@ msgstr "プロパティが見つかりません"
 msgid "Protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -6040,7 +6040,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -6057,7 +6057,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -6085,7 +6085,7 @@ msgstr ""
 "    プール \"default\" 内の仮想マシン \"data\" のスナップショットの有効期限を"
 "返します。"
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -6105,7 +6105,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -6117,7 +6117,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -6133,7 +6133,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -6210,7 +6210,7 @@ msgstr "RESOURCE"
 msgid "RESTRICTED"
 msgstr "RESTRICTED"
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid "ROLE"
 msgstr "ROLE"
 
@@ -6263,7 +6263,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
@@ -6452,21 +6452,21 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -6512,7 +6512,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "スナップショットからインスタンスをリストアします"
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -6547,7 +6547,7 @@ msgstr "証明書追加トークンを失効（Revoke）させます"
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid "Role (admin or read-only)"
 msgstr "ロール（admin または read-only）"
 
@@ -6651,11 +6651,11 @@ msgstr "STP"
 msgid "Scanning for unknown volumes..."
 msgstr "未知のボリュームをスキャンしています..."
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid "Secret key (auto-generated if empty)"
 msgstr "秘密鍵（空白の場合自動生成）"
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, c-format
 msgid "Secret key: %s"
 msgstr "秘密鍵: %s"
@@ -6944,11 +6944,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc project set [<remote>:]<project> <key> <value>"
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 msgid "Set storage bucket configuration keys"
 msgstr "ストレージバケットの設定項目を設定します"
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 #, fuzzy
 msgid ""
 "Set storage bucket configuration keys\n"
@@ -6980,11 +6980,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -7081,7 +7081,7 @@ msgstr "プロファイルプロパティとして設定します"
 msgid "Set the key as a project property"
 msgstr "プロジェクトプロパティとして設定します"
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
@@ -7091,7 +7091,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -7224,11 +7224,11 @@ msgstr "プロファイルの設定を表示します"
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 msgid "Show storage bucket configurations"
 msgstr "ストレージバケットの設定を表示する"
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 msgid "Show storage bucket key configurations"
 msgstr "ストレージバケットの鍵の設定を表示する"
 
@@ -7236,12 +7236,12 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
@@ -7303,15 +7303,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -7389,22 +7389,22 @@ msgstr "インスタンスの停止に失敗しました: %s"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr "使用するストレージバックエンド (btrfs, dir, lvm, zfs, デフォルト: dir)"
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, c-format
 msgid "Storage bucket %s created"
 msgstr "ストレージバケット %s を作成しました"
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr "ストレージバケット %s を削除しました"
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr "ストレージバケットの鍵 %s を作成しました"
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr "ストレージバケットの鍵 %s を削除しました"
@@ -7448,25 +7448,25 @@ msgstr "ストレージプール名"
 msgid "Storage pool to use or create"
 msgstr "ストレージプール %s を作成しました"
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "ストレージボリューム %s を削除しました"
@@ -7526,13 +7526,13 @@ msgstr "TOKEN"
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088
 #: cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
 #: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -7752,7 +7752,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -7762,12 +7762,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7825,7 +7825,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
-#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -7928,7 +7928,7 @@ msgstr ""
 msgid "Too many links"
 msgstr "リンクが多すぎます"
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -7944,7 +7944,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -7952,7 +7952,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
@@ -8010,7 +8010,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
 #: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -8032,7 +8032,7 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid "USAGE"
 msgstr "USAGE"
 
@@ -8050,7 +8050,7 @@ msgstr "上位デバイス"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:747
 #: cmd/incus/project.go:525 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1638
+#: cmd/incus/storage_volume.go:1649
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -8089,7 +8089,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768
-#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8188,7 +8188,7 @@ msgstr "プロファイルの設定を削除します"
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 msgid "Unset storage bucket configuration keys"
 msgstr "ストレージバケットの設定を削除します"
 
@@ -8196,7 +8196,7 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -8251,7 +8251,7 @@ msgstr "プロファイルプロパティの設定を削除します"
 msgid "Unset the key as a project property"
 msgstr "プロジェクトプロパティの設定を削除します"
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
@@ -8261,7 +8261,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -8304,12 +8304,12 @@ msgstr "アップロード日時: %s"
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8398,7 +8398,7 @@ msgstr "CUDA バージョン: %v"
 msgid "Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -8595,11 +8595,11 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
@@ -9033,35 +9033,35 @@ msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operation>"
 
 #: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477
-#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255
-#: cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "[<remote>:]<pool> <bucket>"
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704
-#: cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936
-#: cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
+#: cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "[<remote>:]<pool> <bucket> <key>"
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "[<remote>:]<pool> <bucket> <key>=<value>..."
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
@@ -9082,80 +9082,80 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280
-#: cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286
+#: cmd/incus/storage_volume.go:2083
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
@@ -9871,7 +9871,20 @@ msgstr ""
 "lxc restore u1 snap0\n"
 "    スナップショットからリストアします。"
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+#, fuzzy
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket name b01 in storage pool p1\n"
+"\n"
+"incus storage bucket create p1 b01 < config.yaml\n"
+"\tCraete a new storage bucket name b01 in storage pool p1 using the content "
+"of config.yaml"
+msgstr ""
+"lxc storage edit [<remote>:]<pool> < pool.yaml\n"
+"    pool.yaml の内容でストレージプールを更新します。"
+
+#: cmd/incus/storage_bucket.go:1216
 #, fuzzy
 msgid ""
 "incus storage bucket default b1\n"
@@ -9880,7 +9893,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 #, fuzzy
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
@@ -9889,7 +9902,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    bucket.yaml の内容でストレージバケットを更新します。"
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 #, fuzzy
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
@@ -9898,7 +9911,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    key.yaml の内容でストレージバケットの鍵を更新します。"
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 #, fuzzy
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
@@ -9907,7 +9920,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 #, fuzzy
 msgid ""
 "incus storage bucket key show default data foo\n"
@@ -9918,7 +9931,7 @@ msgstr ""
 "    \"default\" プール内の \"data\" という名前のバケットに対する \"foo\" とい"
 "う名前のバケットの鍵のプロパティを表示します。"
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 #, fuzzy
 msgid ""
 "incus storage bucket show default data\n"
@@ -9937,7 +9950,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 #, fuzzy
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-29 14:30-0400\n"
+"POT-Creation-Date: 2024-05-03 20:08+0200\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -84,7 +84,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -794,11 +794,11 @@ msgstr "AUTHENTICATIE TYPE"
 msgid "Accept certificate"
 msgstr "Accepteer certificaat"
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid "Access key (auto-generated if empty)"
 msgstr "Toegangssleutel (automatisch gegenereerd wanneer leeg gegeven)"
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, c-format
 msgid "Access key: %s"
 msgstr "Toegangssleutel: %s"
@@ -945,12 +945,12 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Adres: %s"
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid "Admin access key: %s"
 msgstr "Beheer (Admin) toegangssleutel: %s"
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "Beheer (Admin) geheime toegangssleutel (secret key): %s"
@@ -990,7 +990,7 @@ msgstr ""
 "Alle huidige gegevens gaan verloren bij het lid worden (joining) van een "
 "cluster, doorgaan?"
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 msgid "All projects"
 msgstr "Alle projecten"
 
@@ -1056,11 +1056,11 @@ msgstr "Toekennen van netwerk (network) interfaces aan profielen (profiles)"
 msgid "Attach new network interfaces to instances"
 msgstr "Toekennen van nieuwe netwerk interfaces aan instanties (instances)"
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1112,22 +1112,22 @@ msgstr "BASIS IMAGEBESTAND"
 msgid "Backing up instance: %s"
 msgstr "Backup aan het maken van instantie (instance): %s"
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, fuzzy, c-format
 msgid "Backing up storage bucket %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344
-#: cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:3028
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1139,7 +1139,7 @@ msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
-#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
@@ -1151,7 +1151,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Ongeldig sleutel=waarde paar: %q"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:164
-#: cmd/incus/storage_volume.go:627
+#: cmd/incus/storage_volume.go:628
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Ongeldig sleutel=waarde paar: %s"
@@ -1199,7 +1199,7 @@ msgstr "ONDERBREEKBAAR"
 msgid "COMMON NAME"
 msgstr "GEWONE NAAM"
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid "CONTENT-TYPE"
 msgstr "INHOUDSTYPE"
 
@@ -1291,7 +1291,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1331,16 +1331,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1474,22 +1474,22 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752
 #: cmd/incus/storage.go:854 cmd/incus/storage.go:947
-#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392
-#: cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642
-#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142
-#: cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365
-#: cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578
-#: cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939
-#: cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294
-#: cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834
-#: cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083
-#: cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598
-#: cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773
-#: cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647
+#: cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788
+#: cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946
+#: cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147
+#: cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940
+#: cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300
+#: cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845
+#: cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099
+#: cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297
+#: cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619
+#: cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid "Cluster member name"
 msgstr ""
 
@@ -1499,8 +1499,8 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724
-#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532
+#: cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1555,8 +1555,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
-#: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
-#: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
+#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1578,11 +1578,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1648,12 +1648,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1666,7 +1666,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1782,7 +1782,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1795,7 +1795,7 @@ msgstr "Toekennen van netwerk interfaces aan instanties (instances)"
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1849,7 +1849,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:602
-#: cmd/incus/storage_volume.go:1407
+#: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1885,8 +1885,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727
-#: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
-#: cmd/incus/storage_volume.go:1636
+#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845
+#: cmd/incus/storage_volume.go:1647
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgstr "Cached: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgstr ""
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -2015,11 +2015,11 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 msgid "Delete storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2152,39 +2152,39 @@ msgstr ""
 #: cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659
 #: cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257
-#: cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466
-#: cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740
-#: cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860
-#: cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002
-#: cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209
-#: cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575
-#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
-#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282
-#: cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831
-#: cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222
-#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477
-#: cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682
-#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858
-#: cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471
+#: cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642
+#: cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007
+#: cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214
+#: cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736
+#: cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931
+#: cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288
+#: cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842
+#: cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243
+#: cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403
+#: cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498
+#: cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703
+#: cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2196,11 +2196,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2455,11 +2455,11 @@ msgstr ""
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2467,7 +2467,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2477,7 +2477,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762
-#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664
+#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2539,8 +2539,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
-#: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
-#: cmd/incus/storage_volume.go:2040
+#: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
+#: cmd/incus/storage_volume.go:2056
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2561,8 +2561,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
-#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
-#: cmd/incus/storage_volume.go:2034
+#: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
+#: cmd/incus/storage_volume.go:2050
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2646,8 +2646,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
-#: cmd/incus/storage_volume.go:2575
+#: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
+#: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
 msgstr ""
 
@@ -2671,7 +2671,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2683,24 +2683,24 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2777,7 +2777,7 @@ msgstr ""
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -2906,7 +2906,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
@@ -2916,7 +2916,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2926,12 +2926,12 @@ msgstr ""
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3150,9 +3150,9 @@ msgstr ""
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467
-#: cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539
-#: cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472
+#: cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550
+#: cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3271,7 +3271,7 @@ msgstr ""
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -3279,7 +3279,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3340,7 +3340,7 @@ msgstr ""
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -3348,11 +3348,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3447,7 +3447,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3461,7 +3461,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3511,7 +3511,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3519,11 +3519,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3542,28 +3542,28 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3633,8 +3633,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295
-#: cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:2979
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3653,8 +3653,8 @@ msgstr ""
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305
+#: cmd/incus/storage_volume.go:2984
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3751,9 +3751,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215
-#: cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979
-#: cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216
+#: cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990
+#: cmd/incus/storage_volume.go:2839
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3803,8 +3803,8 @@ msgstr ""
 
 #: cmd/incus/list.go:614 cmd/incus/network.go:1174
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
-#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524
-#: cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529
+#: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4139,19 +4139,19 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4169,11 +4169,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4255,7 +4255,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4497,11 +4497,11 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -4517,15 +4517,15 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 msgid "Manage storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4622,12 +4622,12 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224
-#: cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419
-#: cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891
-#: cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045
-#: cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673
+#: cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896
+#: cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050
+#: cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 msgid "Missing bucket name"
 msgstr ""
 
@@ -4655,8 +4655,8 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970
-#: cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975
+#: cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 msgid "Missing key name"
 msgstr ""
 
@@ -4748,22 +4748,22 @@ msgstr ""
 
 #: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435
 #: cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220
-#: cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415
-#: cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572
-#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806
-#: cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962
-#: cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164
-#: cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202
-#: cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609
-#: cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775
-#: cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987
-#: cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570
-#: cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962
-#: cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309
-#: cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527
-#: cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722
-#: cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577
+#: cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811
+#: cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776
+#: cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581
+#: cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973
+#: cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548
+#: cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743
+#: cmd/incus/storage_volume.go:2829
 msgid "Missing pool name"
 msgstr ""
 
@@ -4787,11 +4787,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4829,7 +4829,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:522 cmd/incus/network.go:619
-#: cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4861,7 +4861,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4869,11 +4869,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4901,8 +4901,8 @@ msgstr ""
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773
-#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519
-#: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid "NAME"
 msgstr ""
 
@@ -4957,8 +4957,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
-#: cmd/incus/storage_volume.go:2573
+#: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
+#: cmd/incus/storage_volume.go:2594
 msgid "Name"
 msgstr ""
 
@@ -5019,7 +5019,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:577 cmd/incus/network.go:929
-#: cmd/incus/storage_volume.go:1378
+#: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5183,7 +5183,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5203,11 +5203,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5243,15 +5243,15 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5263,7 +5263,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5281,7 +5281,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5324,7 +5324,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165
-#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654
+#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5435,8 +5435,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
-#: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
-#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
+#: cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5573,7 +5573,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "\tSupported types are custom, image, container and virtual-machine.\n"
@@ -5586,7 +5586,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5600,7 +5600,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5616,7 +5616,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5633,7 +5633,7 @@ msgid ""
 "\"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5642,7 +5642,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5655,7 +5655,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5729,7 +5729,7 @@ msgstr ""
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid "ROLE"
 msgstr ""
 
@@ -5772,7 +5772,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5958,20 +5958,20 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 msgid "Rename storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6012,7 +6012,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6149,11 +6149,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -6378,11 +6378,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6404,11 +6404,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6491,7 +6491,7 @@ msgstr ""
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -6499,7 +6499,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6629,11 +6629,11 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -6641,12 +6641,12 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6708,15 +6708,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
@@ -6792,22 +6792,22 @@ msgstr ""
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -6850,25 +6850,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -6928,13 +6928,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088
 #: cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
 
@@ -7121,7 +7121,7 @@ msgstr ""
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -7131,12 +7131,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7184,7 +7184,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
-#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7262,7 +7262,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7278,7 +7278,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7286,7 +7286,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7342,7 +7342,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
 #: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7364,7 +7364,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid "USAGE"
 msgstr ""
 
@@ -7380,7 +7380,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:747
 #: cmd/incus/project.go:525 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1638
+#: cmd/incus/storage_volume.go:1649
 msgid "USED BY"
 msgstr ""
 
@@ -7418,7 +7418,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768
-#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7516,7 +7516,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -7524,7 +7524,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -7572,7 +7572,7 @@ msgstr ""
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -7580,7 +7580,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7620,12 +7620,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7709,7 +7709,7 @@ msgstr "CUDA Versie: %v"
 msgid "Version: %v"
 msgstr "CUDA Versie: %v"
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid "Volume Only"
 msgstr ""
 
@@ -7882,11 +7882,11 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -8295,34 +8295,34 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477
-#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255
-#: cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704
-#: cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936
-#: cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
+#: cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
@@ -8342,72 +8342,72 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280
-#: cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286
+#: cmd/incus/storage_volume.go:2083
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -8905,38 +8905,48 @@ msgid ""
 "Restore the snapshot."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket name b01 in storage pool p1\n"
+"\n"
+"incus storage bucket create p1 b01 < config.yaml\n"
+"\tCraete a new storage bucket name b01 in storage pool p1 using the content "
+"of config.yaml"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:1216
 msgid ""
 "incus storage bucket default b1\n"
 "    Download a backup tarball of the b1 storage bucket."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -8949,7 +8959,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-29 14:30-0400\n"
+"POT-Creation-Date: 2024-05-03 20:08+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -28,7 +28,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -58,7 +58,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -537,11 +537,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -675,12 +675,12 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -718,7 +718,7 @@ msgstr ""
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 msgid "All projects"
 msgstr ""
 
@@ -778,11 +778,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -834,22 +834,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, c-format
 msgid "Backing up storage bucket %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344
-#: cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:3028
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -861,7 +861,7 @@ msgstr ""
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
-#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -873,7 +873,7 @@ msgid "Bad key=value pair: %q"
 msgstr ""
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:164
-#: cmd/incus/storage_volume.go:627
+#: cmd/incus/storage_volume.go:628
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -921,7 +921,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1050,16 +1050,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1193,22 +1193,22 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752
 #: cmd/incus/storage.go:854 cmd/incus/storage.go:947
-#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392
-#: cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642
-#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142
-#: cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365
-#: cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578
-#: cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939
-#: cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294
-#: cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834
-#: cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083
-#: cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598
-#: cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773
-#: cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647
+#: cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788
+#: cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946
+#: cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147
+#: cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940
+#: cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300
+#: cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845
+#: cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099
+#: cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297
+#: cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619
+#: cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid "Cluster member name"
 msgstr ""
 
@@ -1218,8 +1218,8 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724
-#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532
+#: cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1274,8 +1274,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
-#: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
-#: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
+#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1297,11 +1297,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:602
-#: cmd/incus/storage_volume.go:1407
+#: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1603,8 +1603,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727
-#: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
-#: cmd/incus/storage_volume.go:1636
+#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845
+#: cmd/incus/storage_volume.go:1647
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1639,7 +1639,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1679,7 +1679,7 @@ msgstr ""
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1724,7 +1724,7 @@ msgstr ""
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1732,11 +1732,11 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 msgid "Delete storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1869,39 +1869,39 @@ msgstr ""
 #: cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659
 #: cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257
-#: cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466
-#: cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740
-#: cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860
-#: cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002
-#: cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209
-#: cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575
-#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
-#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282
-#: cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831
-#: cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222
-#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477
-#: cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682
-#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858
-#: cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471
+#: cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642
+#: cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007
+#: cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214
+#: cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736
+#: cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931
+#: cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288
+#: cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842
+#: cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243
+#: cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403
+#: cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498
+#: cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703
+#: cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1913,11 +1913,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2172,11 +2172,11 @@ msgstr ""
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2184,7 +2184,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2194,7 +2194,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762
-#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664
+#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2256,8 +2256,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
-#: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
-#: cmd/incus/storage_volume.go:2040
+#: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
+#: cmd/incus/storage_volume.go:2056
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2278,8 +2278,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
-#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
-#: cmd/incus/storage_volume.go:2034
+#: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
+#: cmd/incus/storage_volume.go:2050
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2363,8 +2363,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
-#: cmd/incus/storage_volume.go:2575
+#: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
+#: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
 msgstr ""
 
@@ -2388,7 +2388,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2400,24 +2400,24 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, c-format
 msgid "Exporting backup of storage bucket %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -2623,7 +2623,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
@@ -2633,7 +2633,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2643,12 +2643,12 @@ msgstr ""
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -2867,9 +2867,9 @@ msgstr ""
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467
-#: cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539
-#: cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472
+#: cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550
+#: cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2986,7 +2986,7 @@ msgstr ""
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2994,7 +2994,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3055,7 +3055,7 @@ msgstr ""
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -3063,11 +3063,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3162,7 +3162,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3176,7 +3176,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3226,7 +3226,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3234,11 +3234,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3257,28 +3257,28 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3348,8 +3348,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295
-#: cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:2979
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3368,8 +3368,8 @@ msgstr ""
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305
+#: cmd/incus/storage_volume.go:2984
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3466,9 +3466,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215
-#: cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979
-#: cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216
+#: cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990
+#: cmd/incus/storage_volume.go:2839
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3518,8 +3518,8 @@ msgstr ""
 
 #: cmd/incus/list.go:614 cmd/incus/network.go:1174
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
-#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524
-#: cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529
+#: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3853,19 +3853,19 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -3883,11 +3883,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3969,7 +3969,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4210,11 +4210,11 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -4230,15 +4230,15 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 msgid "Manage storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4335,12 +4335,12 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224
-#: cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419
-#: cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891
-#: cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045
-#: cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673
+#: cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896
+#: cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050
+#: cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 msgid "Missing bucket name"
 msgstr ""
 
@@ -4368,8 +4368,8 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970
-#: cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975
+#: cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 msgid "Missing key name"
 msgstr ""
 
@@ -4460,22 +4460,22 @@ msgstr ""
 
 #: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435
 #: cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220
-#: cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415
-#: cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572
-#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806
-#: cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962
-#: cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164
-#: cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202
-#: cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609
-#: cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775
-#: cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987
-#: cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570
-#: cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962
-#: cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309
-#: cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527
-#: cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722
-#: cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577
+#: cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811
+#: cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776
+#: cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581
+#: cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973
+#: cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548
+#: cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743
+#: cmd/incus/storage_volume.go:2829
 msgid "Missing pool name"
 msgstr ""
 
@@ -4499,11 +4499,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4541,7 +4541,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:522 cmd/incus/network.go:619
-#: cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4573,7 +4573,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4581,11 +4581,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4613,8 +4613,8 @@ msgstr ""
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773
-#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519
-#: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid "NAME"
 msgstr ""
 
@@ -4669,8 +4669,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
-#: cmd/incus/storage_volume.go:2573
+#: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
+#: cmd/incus/storage_volume.go:2594
 msgid "Name"
 msgstr ""
 
@@ -4731,7 +4731,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:577 cmd/incus/network.go:929
-#: cmd/incus/storage_volume.go:1378
+#: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4895,7 +4895,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4915,11 +4915,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4955,15 +4955,15 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4975,7 +4975,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4993,7 +4993,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5036,7 +5036,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165
-#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654
+#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5147,8 +5147,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
-#: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
-#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
+#: cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5285,7 +5285,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "\tSupported types are custom, image, container and virtual-machine.\n"
@@ -5298,7 +5298,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5312,7 +5312,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5328,7 +5328,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5345,7 +5345,7 @@ msgid ""
 "\"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5354,7 +5354,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5367,7 +5367,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5441,7 +5441,7 @@ msgstr ""
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid "ROLE"
 msgstr ""
 
@@ -5484,7 +5484,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5669,20 +5669,20 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 msgid "Rename storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -5723,7 +5723,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5757,7 +5757,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5860,11 +5860,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -6088,11 +6088,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6114,11 +6114,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6200,7 +6200,7 @@ msgstr ""
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -6208,7 +6208,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6337,11 +6337,11 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -6349,12 +6349,12 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6416,15 +6416,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
@@ -6500,22 +6500,22 @@ msgstr ""
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -6558,25 +6558,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -6636,13 +6636,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088
 #: cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
 
@@ -6829,7 +6829,7 @@ msgstr ""
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6839,12 +6839,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6892,7 +6892,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
-#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6970,7 +6970,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6994,7 +6994,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7050,7 +7050,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
 #: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7072,7 +7072,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid "USAGE"
 msgstr ""
 
@@ -7088,7 +7088,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:747
 #: cmd/incus/project.go:525 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1638
+#: cmd/incus/storage_volume.go:1649
 msgid "USED BY"
 msgstr ""
 
@@ -7126,7 +7126,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768
-#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7224,7 +7224,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -7232,7 +7232,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -7280,7 +7280,7 @@ msgstr ""
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -7288,7 +7288,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7328,12 +7328,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7417,7 +7417,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid "Volume Only"
 msgstr ""
 
@@ -7590,11 +7590,11 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -8003,34 +8003,34 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477
-#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255
-#: cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704
-#: cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936
-#: cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
+#: cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
@@ -8050,72 +8050,72 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280
-#: cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286
+#: cmd/incus/storage_volume.go:2083
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -8613,38 +8613,48 @@ msgid ""
 "Restore the snapshot."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket name b01 in storage pool p1\n"
+"\n"
+"incus storage bucket create p1 b01 < config.yaml\n"
+"\tCraete a new storage bucket name b01 in storage pool p1 using the content "
+"of config.yaml"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:1216
 msgid ""
 "incus storage bucket default b1\n"
 "    Download a backup tarball of the b1 storage bucket."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -8657,7 +8667,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-29 14:30-0400\n"
+"POT-Creation-Date: 2024-05-03 20:08+0200\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -85,7 +85,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -787,11 +787,11 @@ msgstr "TIPO DE AUTENTICAÇÃO"
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -934,12 +934,12 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Criado: %s"
@@ -977,7 +977,7 @@ msgstr "Aliases:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -1043,12 +1043,12 @@ msgstr "Anexar interfaces de rede aos perfis"
 msgid "Attach new network interfaces to instances"
 msgstr "Anexar uma nova interface de rede aos containers"
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1102,22 +1102,22 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, fuzzy, c-format
 msgid "Backing up storage bucket %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344
-#: cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:3028
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1129,7 +1129,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
-#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
@@ -1141,7 +1141,7 @@ msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:164
-#: cmd/incus/storage_volume.go:627
+#: cmd/incus/storage_volume.go:628
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1189,7 +1189,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
@@ -1321,16 +1321,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1465,22 +1465,22 @@ msgstr "Dispositivo %s removido de %s"
 #: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752
 #: cmd/incus/storage.go:854 cmd/incus/storage.go:947
-#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392
-#: cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642
-#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142
-#: cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365
-#: cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578
-#: cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939
-#: cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294
-#: cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834
-#: cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083
-#: cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598
-#: cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773
-#: cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647
+#: cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788
+#: cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946
+#: cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147
+#: cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940
+#: cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300
+#: cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845
+#: cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099
+#: cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297
+#: cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619
+#: cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1490,8 +1490,8 @@ msgstr "Clustering ativado"
 
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724
-#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532
+#: cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1558,8 +1558,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
-#: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
-#: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
+#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -1581,11 +1581,11 @@ msgstr ""
 msgid "Console log:"
 msgstr "Log de Console:"
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1644,7 +1644,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1652,12 +1652,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1671,7 +1671,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1795,7 +1795,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1809,7 +1809,7 @@ msgstr "Criar novas redes"
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1870,7 +1870,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:602
-#: cmd/incus/storage_volume.go:1407
+#: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1907,8 +1907,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727
-#: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
-#: cmd/incus/storage_volume.go:1636
+#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845
+#: cmd/incus/storage_volume.go:1647
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr "Criado: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1989,7 +1989,7 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "Delete instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -2041,7 +2041,7 @@ msgstr ""
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Apagar projetos"
@@ -2050,12 +2050,12 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2188,39 +2188,39 @@ msgstr ""
 #: cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659
 #: cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257
-#: cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466
-#: cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740
-#: cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860
-#: cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002
-#: cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209
-#: cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575
-#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
-#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282
-#: cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831
-#: cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222
-#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477
-#: cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682
-#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858
-#: cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471
+#: cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642
+#: cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007
+#: cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214
+#: cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736
+#: cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931
+#: cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288
+#: cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842
+#: cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243
+#: cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403
+#: cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498
+#: cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703
+#: cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
@@ -2234,12 +2234,12 @@ msgstr "Desconectar interfaces de rede dos containers"
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
@@ -2515,12 +2515,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2528,7 +2528,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2539,7 +2539,7 @@ msgstr "Editar configurações de perfil como YAML"
 
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762
-#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664
+#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2601,8 +2601,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
-#: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
-#: cmd/incus/storage_volume.go:2040
+#: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
+#: cmd/incus/storage_volume.go:2056
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2623,8 +2623,8 @@ msgstr "Editar propriedades da imagem"
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
-#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
-#: cmd/incus/storage_volume.go:2034
+#: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
+#: cmd/incus/storage_volume.go:2050
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2709,8 +2709,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
-#: cmd/incus/storage_volume.go:2575
+#: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
+#: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
 msgstr ""
 
@@ -2734,7 +2734,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2746,26 +2746,26 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket %s"
 msgstr "Criar novas redes"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -2971,7 +2971,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Aceitar certificado"
@@ -2981,7 +2981,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Aceitar certificado"
@@ -2991,12 +2991,12 @@ msgstr "Aceitar certificado"
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Aceitar certificado"
@@ -3216,9 +3216,9 @@ msgstr ""
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467
-#: cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539
-#: cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472
+#: cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550
+#: cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3343,7 +3343,7 @@ msgstr ""
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Editar configurações de perfil como YAML"
@@ -3352,7 +3352,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -3425,7 +3425,7 @@ msgstr ""
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3434,11 +3434,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3533,7 +3533,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3547,7 +3547,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3599,7 +3599,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3607,12 +3607,12 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3631,29 +3631,29 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3725,8 +3725,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295
-#: cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:2979
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Editar arquivos no container"
@@ -3746,8 +3746,8 @@ msgstr "Editar arquivos no container"
 msgid "Invalid arguments"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305
+#: cmd/incus/storage_volume.go:2984
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3845,9 +3845,9 @@ msgstr "Editar arquivos no container"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215
-#: cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979
-#: cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216
+#: cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990
+#: cmd/incus/storage_volume.go:2839
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -3898,8 +3898,8 @@ msgstr ""
 
 #: cmd/incus/list.go:614 cmd/incus/network.go:1174
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
-#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524
-#: cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529
+#: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4244,20 +4244,20 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4275,11 +4275,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4623,12 +4623,12 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -4646,16 +4646,16 @@ msgstr "Criar novas redes"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4754,12 +4754,12 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224
-#: cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419
-#: cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891
-#: cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045
-#: cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673
+#: cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896
+#: cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050
+#: cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nome de membro do cluster"
@@ -4791,8 +4791,8 @@ msgstr "Nome de membro do cluster"
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970
-#: cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975
+#: cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
@@ -4890,22 +4890,22 @@ msgstr "Nome de membro do cluster"
 
 #: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435
 #: cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220
-#: cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415
-#: cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572
-#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806
-#: cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962
-#: cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164
-#: cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202
-#: cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609
-#: cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775
-#: cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987
-#: cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570
-#: cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962
-#: cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309
-#: cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527
-#: cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722
-#: cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577
+#: cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811
+#: cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776
+#: cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581
+#: cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973
+#: cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548
+#: cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743
+#: cmd/incus/storage_volume.go:2829
 msgid "Missing pool name"
 msgstr ""
 
@@ -4930,11 +4930,11 @@ msgstr "Nome de membro do cluster"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
@@ -4975,7 +4975,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:522 cmd/incus/network.go:619
-#: cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5009,7 +5009,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -5017,11 +5017,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -5049,8 +5049,8 @@ msgstr ""
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773
-#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519
-#: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid "NAME"
 msgstr ""
 
@@ -5105,8 +5105,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
-#: cmd/incus/storage_volume.go:2573
+#: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
+#: cmd/incus/storage_volume.go:2594
 msgid "Name"
 msgstr ""
 
@@ -5167,7 +5167,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:577 cmd/incus/network.go:929
-#: cmd/incus/storage_volume.go:1378
+#: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5331,7 +5331,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5351,11 +5351,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5391,15 +5391,15 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5411,7 +5411,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5429,7 +5429,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5472,7 +5472,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165
-#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654
+#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5584,8 +5584,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
-#: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
-#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
+#: cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5727,7 +5727,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "\tSupported types are custom, image, container and virtual-machine.\n"
@@ -5740,7 +5740,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5754,7 +5754,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5770,7 +5770,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5787,7 +5787,7 @@ msgid ""
 "\"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5796,7 +5796,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5809,7 +5809,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5884,7 +5884,7 @@ msgstr ""
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid "ROLE"
 msgstr ""
 
@@ -5929,7 +5929,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6130,21 +6130,21 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 msgid "Rename storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -6193,7 +6193,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6230,7 +6230,7 @@ msgstr "Nome de membro do cluster"
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6334,11 +6334,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Criado: %s"
@@ -6574,12 +6574,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6601,11 +6601,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6693,7 +6693,7 @@ msgstr ""
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Criar novas redes"
@@ -6702,7 +6702,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -6848,12 +6848,12 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6862,12 +6862,12 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6932,15 +6932,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
@@ -7016,22 +7016,22 @@ msgstr "Copiar a imagem: %s"
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -7075,25 +7075,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -7154,13 +7154,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088
 #: cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
 
@@ -7348,7 +7348,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Nome de membro do cluster"
@@ -7358,12 +7358,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7411,7 +7411,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
-#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7490,7 +7490,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7506,7 +7506,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7514,7 +7514,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7571,7 +7571,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
 #: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7593,7 +7593,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid "USAGE"
 msgstr ""
 
@@ -7611,7 +7611,7 @@ msgstr "Editar arquivos no container"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:747
 #: cmd/incus/project.go:525 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1638
+#: cmd/incus/storage_volume.go:1649
 msgid "USED BY"
 msgstr ""
 
@@ -7651,7 +7651,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768
-#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7765,7 +7765,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -7774,7 +7774,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -7829,7 +7829,7 @@ msgstr ""
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Editar configurações de perfil como YAML"
@@ -7838,7 +7838,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7880,12 +7880,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7970,7 +7970,7 @@ msgstr "Versão CUDA: %v"
 msgid "Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid "Volume Only"
 msgstr ""
 
@@ -8144,11 +8144,11 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
@@ -8607,39 +8607,39 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477
-#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255
-#: cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704
-#: cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936
-#: cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
+#: cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr "Criar perfis"
@@ -8661,84 +8661,84 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280
-#: cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286
+#: cmd/incus/storage_volume.go:2083
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
@@ -9248,38 +9248,48 @@ msgid ""
 "Restore the snapshot."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket name b01 in storage pool p1\n"
+"\n"
+"incus storage bucket create p1 b01 < config.yaml\n"
+"\tCraete a new storage bucket name b01 in storage pool p1 using the content "
+"of config.yaml"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:1216
 msgid ""
 "incus storage bucket default b1\n"
 "    Download a backup tarball of the b1 storage bucket."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -9292,7 +9302,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-29 14:30-0400\n"
+"POT-Creation-Date: 2024-05-03 20:08+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -32,7 +32,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -90,7 +90,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -809,11 +809,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -953,12 +953,12 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Авто-обновление: %s"
@@ -996,7 +996,7 @@ msgstr "Псевдонимы:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -1059,12 +1059,12 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1117,22 +1117,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, fuzzy, c-format
 msgid "Backing up storage bucket %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344
-#: cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:3028
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1144,7 +1144,7 @@ msgstr ""
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
-#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1156,7 +1156,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:164
-#: cmd/incus/storage_volume.go:627
+#: cmd/incus/storage_volume.go:628
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1204,7 +1204,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1295,7 +1295,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1335,16 +1335,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1479,22 +1479,22 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752
 #: cmd/incus/storage.go:854 cmd/incus/storage.go:947
-#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392
-#: cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642
-#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142
-#: cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365
-#: cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578
-#: cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939
-#: cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294
-#: cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834
-#: cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083
-#: cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598
-#: cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773
-#: cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647
+#: cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788
+#: cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946
+#: cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147
+#: cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940
+#: cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300
+#: cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845
+#: cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099
+#: cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297
+#: cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619
+#: cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid "Cluster member name"
 msgstr ""
 
@@ -1504,8 +1504,8 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724
-#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532
+#: cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1560,8 +1560,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
-#: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
-#: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
+#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1583,11 +1583,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
@@ -1654,12 +1654,12 @@ msgstr "Копирование образа: %s"
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1794,7 +1794,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Копирование образа: %s"
@@ -1809,7 +1809,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1872,7 +1872,7 @@ msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:602
-#: cmd/incus/storage_volume.go:1407
+#: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1909,8 +1909,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727
-#: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
-#: cmd/incus/storage_volume.go:1636
+#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845
+#: cmd/incus/storage_volume.go:1647
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1945,7 +1945,7 @@ msgstr "Авто-обновление: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1989,7 +1989,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Копирование образа: %s"
@@ -2039,7 +2039,7 @@ msgstr ""
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Копирование образа: %s"
@@ -2048,12 +2048,12 @@ msgstr "Копирование образа: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
@@ -2187,39 +2187,39 @@ msgstr ""
 #: cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659
 #: cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257
-#: cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466
-#: cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740
-#: cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860
-#: cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002
-#: cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209
-#: cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575
-#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
-#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282
-#: cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831
-#: cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222
-#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477
-#: cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682
-#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858
-#: cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471
+#: cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642
+#: cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007
+#: cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214
+#: cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736
+#: cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931
+#: cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288
+#: cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842
+#: cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243
+#: cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403
+#: cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498
+#: cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703
+#: cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
@@ -2232,12 +2232,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2507,12 +2507,12 @@ msgstr ""
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2520,7 +2520,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2530,7 +2530,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762
-#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664
+#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2592,8 +2592,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
-#: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
-#: cmd/incus/storage_volume.go:2040
+#: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
+#: cmd/incus/storage_volume.go:2056
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2614,8 +2614,8 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
-#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
-#: cmd/incus/storage_volume.go:2034
+#: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
+#: cmd/incus/storage_volume.go:2050
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2703,8 +2703,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
-#: cmd/incus/storage_volume.go:2575
+#: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
+#: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
 msgstr ""
 
@@ -2729,7 +2729,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2744,27 +2744,27 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 #, fuzzy
 msgid "Export storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 #, fuzzy
 msgid "Export storage buckets as tarball."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, fuzzy, c-format
 msgid "Exporting backup of storage bucket %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2841,7 +2841,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, fuzzy, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Копирование образа: %s"
@@ -2970,7 +2970,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, fuzzy, c-format
 msgid "Failed to create backup: %v"
 msgstr "Принять сертификат"
@@ -2980,7 +2980,7 @@ msgstr "Принять сертификат"
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Принять сертификат"
@@ -2990,12 +2990,12 @@ msgstr "Принять сертификат"
 msgid "Failed to delete original instance after copying it: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, fuzzy, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Принять сертификат"
@@ -3215,9 +3215,9 @@ msgstr ""
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467
-#: cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539
-#: cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472
+#: cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550
+#: cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3341,7 +3341,7 @@ msgstr ""
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Копирование образа: %s"
@@ -3351,7 +3351,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -3420,7 +3420,7 @@ msgstr ""
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Копирование образа: %s"
@@ -3429,11 +3429,11 @@ msgstr "Копирование образа: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3529,7 +3529,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3594,7 +3594,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3602,12 +3602,12 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 #, fuzzy
 msgid "Import backups of storage buckets."
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -3629,29 +3629,29 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 #, fuzzy
 msgid "Import storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, fuzzy, c-format
 msgid "Importing bucket: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3724,8 +3724,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295
-#: cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:2979
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Имя контейнера: %s"
@@ -3745,8 +3745,8 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid arguments"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305
+#: cmd/incus/storage_volume.go:2984
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3844,9 +3844,9 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215
-#: cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979
-#: cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216
+#: cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990
+#: cmd/incus/storage_volume.go:2839
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -3897,8 +3897,8 @@ msgstr ""
 
 #: cmd/incus/list.go:614 cmd/incus/network.go:1174
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
-#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524
-#: cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529
+#: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4246,22 +4246,22 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4279,12 +4279,12 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4367,7 +4367,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4628,12 +4628,12 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Копирование образа: %s"
@@ -4653,17 +4653,17 @@ msgstr "Копирование образа: %s"
 msgid "Manage storage pools and volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4763,12 +4763,12 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224
-#: cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419
-#: cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891
-#: cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045
-#: cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673
+#: cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896
+#: cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050
+#: cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Имя контейнера: %s"
@@ -4800,8 +4800,8 @@ msgstr "Копирование образа: %s"
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970
-#: cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975
+#: cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 #, fuzzy
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
@@ -4899,22 +4899,22 @@ msgstr "Имя контейнера: %s"
 
 #: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435
 #: cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220
-#: cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415
-#: cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572
-#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806
-#: cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962
-#: cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164
-#: cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202
-#: cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609
-#: cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775
-#: cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987
-#: cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570
-#: cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962
-#: cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309
-#: cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527
-#: cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722
-#: cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577
+#: cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811
+#: cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776
+#: cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581
+#: cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973
+#: cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548
+#: cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743
+#: cmd/incus/storage_volume.go:2829
 msgid "Missing pool name"
 msgstr ""
 
@@ -4940,12 +4940,12 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
@@ -4985,7 +4985,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:522 cmd/incus/network.go:619
-#: cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -5027,11 +5027,11 @@ msgstr "Копирование образа: %s"
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -5059,8 +5059,8 @@ msgstr ""
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773
-#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519
-#: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid "NAME"
 msgstr ""
 
@@ -5115,8 +5115,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
-#: cmd/incus/storage_volume.go:2573
+#: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
+#: cmd/incus/storage_volume.go:2594
 msgid "Name"
 msgstr ""
 
@@ -5181,7 +5181,7 @@ msgid "Name of the storage pool:"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/info.go:577 cmd/incus/network.go:929
-#: cmd/incus/storage_volume.go:1378
+#: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5347,7 +5347,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
@@ -5368,11 +5368,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5408,15 +5408,15 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5428,7 +5428,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5446,7 +5446,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165
-#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654
+#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5601,8 +5601,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
-#: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
-#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
+#: cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5739,7 +5739,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "\tSupported types are custom, image, container and virtual-machine.\n"
@@ -5752,7 +5752,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5766,7 +5766,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5782,7 +5782,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5799,7 +5799,7 @@ msgid ""
 "\"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5808,7 +5808,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5821,7 +5821,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5895,7 +5895,7 @@ msgstr ""
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid "ROLE"
 msgstr ""
 
@@ -5940,7 +5940,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
@@ -6137,22 +6137,22 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Копирование образа: %s"
@@ -6196,7 +6196,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -6234,7 +6234,7 @@ msgstr "Копирование образа: %s"
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6338,11 +6338,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Авто-обновление: %s"
@@ -6573,12 +6573,12 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6600,11 +6600,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6692,7 +6692,7 @@ msgstr ""
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Копирование образа: %s"
@@ -6702,7 +6702,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -6844,12 +6844,12 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Копирование образа: %s"
@@ -6858,12 +6858,12 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
@@ -6928,16 +6928,16 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
@@ -7016,22 +7016,22 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -7075,25 +7075,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Копирование образа: %s"
@@ -7154,13 +7154,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088
 #: cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
 
@@ -7347,7 +7347,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Копирование образа: %s"
@@ -7357,12 +7357,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7410,7 +7410,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
-#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7489,7 +7489,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -7505,7 +7505,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7513,7 +7513,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7570,7 +7570,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
 #: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7592,7 +7592,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid "USAGE"
 msgstr ""
 
@@ -7610,7 +7610,7 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:747
 #: cmd/incus/project.go:525 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1638
+#: cmd/incus/storage_volume.go:1649
 msgid "USED BY"
 msgstr ""
 
@@ -7649,7 +7649,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768
-#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7757,7 +7757,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Копирование образа: %s"
@@ -7766,7 +7766,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -7821,7 +7821,7 @@ msgstr ""
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Копирование образа: %s"
@@ -7831,7 +7831,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -7874,12 +7874,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7964,7 +7964,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid "Volume Only"
 msgstr ""
 
@@ -8138,7 +8138,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -8146,7 +8146,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -8923,7 +8923,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477
-#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -8931,7 +8931,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
@@ -8939,7 +8939,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8947,8 +8947,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255
-#: cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -8956,9 +8956,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704
-#: cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936
-#: cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
+#: cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -8966,7 +8966,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -8974,7 +8974,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
@@ -9014,7 +9014,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -9022,7 +9022,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -9030,7 +9030,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -9038,7 +9038,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
@@ -9046,7 +9046,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -9054,7 +9054,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -9062,7 +9062,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -9070,7 +9070,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -9078,7 +9078,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -9086,7 +9086,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -9094,7 +9094,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -9102,8 +9102,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280
-#: cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286
+#: cmd/incus/storage_volume.go:2083
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -9111,7 +9111,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -9119,7 +9119,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -9127,7 +9127,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -9135,7 +9135,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -9143,7 +9143,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -9753,38 +9753,48 @@ msgid ""
 "Restore the snapshot."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket name b01 in storage pool p1\n"
+"\n"
+"incus storage bucket create p1 b01 < config.yaml\n"
+"\tCraete a new storage bucket name b01 in storage pool p1 using the content "
+"of config.yaml"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:1216
 msgid ""
 "incus storage bucket default b1\n"
 "    Download a backup tarball of the b1 storage bucket."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -9797,7 +9807,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-04-29 14:30-0400\n"
+"POT-Creation-Date: 2024-05-03 20:08+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -31,7 +31,7 @@ msgstr ""
 msgid "  Motherboard:"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:268 cmd/incus/storage_bucket.go:1013
+#: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1018
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -86,7 +86,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:958
+#: cmd/incus/storage_volume.go:959
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -749,11 +749,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:870
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:921
+#: cmd/incus/storage_bucket.go:926
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -887,12 +887,12 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:177
+#: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:178
+#: cmd/incus/storage_bucket.go:183
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -930,7 +930,7 @@ msgstr ""
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2476
+#: cmd/incus/storage_volume.go:1533 cmd/incus/storage_volume.go:2497
 msgid "All projects"
 msgstr ""
 
@@ -990,11 +990,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:161 cmd/incus/storage_volume.go:162
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:252 cmd/incus/storage_volume.go:253
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1046,22 +1046,22 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1267
+#: cmd/incus/storage_bucket.go:1272
 #, c-format
 msgid "Backing up storage bucket %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2930
+#: cmd/incus/storage_volume.go:2951
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1344
-#: cmd/incus/storage_volume.go:3007
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1349
+#: cmd/incus/storage_volume.go:3028
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:768 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 #: cmd/incus/network.go:369 cmd/incus/network_acl.go:429
 #: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:331 cmd/incus/network_zone.go:382
-#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:149
+#: cmd/incus/network_zone.go:1065 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
@@ -1085,7 +1085,7 @@ msgid "Bad key=value pair: %q"
 msgstr ""
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:164
-#: cmd/incus/storage_volume.go:627
+#: cmd/incus/storage_volume.go:628
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1637
+#: cmd/incus/storage_volume.go:1648
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1222,7 +1222,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1647
+#: cmd/incus/list.go:618 cmd/incus/storage_volume.go:1658
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1262,16 +1262,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:456
+#: cmd/incus/storage_volume.go:457
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:410
+#: cmd/incus/storage_volume.go:411
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:431
+#: cmd/incus/storage_volume.go:432
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1405,22 +1405,22 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:1073 cmd/incus/storage.go:103
 #: cmd/incus/storage.go:400 cmd/incus/storage.go:483 cmd/incus/storage.go:752
 #: cmd/incus/storage.go:854 cmd/incus/storage.go:947
-#: cmd/incus/storage_bucket.go:98 cmd/incus/storage_bucket.go:198
-#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:392
-#: cmd/incus/storage_bucket.go:549 cmd/incus/storage_bucket.go:642
-#: cmd/incus/storage_bucket.go:708 cmd/incus/storage_bucket.go:783
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
-#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1142
-#: cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1365
-#: cmd/incus/storage_volume.go:364 cmd/incus/storage_volume.go:578
-#: cmd/incus/storage_volume.go:665 cmd/incus/storage_volume.go:939
-#: cmd/incus/storage_volume.go:1165 cmd/incus/storage_volume.go:1294
-#: cmd/incus/storage_volume.go:1742 cmd/incus/storage_volume.go:1834
-#: cmd/incus/storage_volume.go:1926 cmd/incus/storage_volume.go:2083
-#: cmd/incus/storage_volume.go:2175 cmd/incus/storage_volume.go:2276
-#: cmd/incus/storage_volume.go:2385 cmd/incus/storage_volume.go:2598
-#: cmd/incus/storage_volume.go:2684 cmd/incus/storage_volume.go:2773
-#: cmd/incus/storage_volume.go:2865 cmd/incus/storage_volume.go:3029
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:554 cmd/incus/storage_bucket.go:647
+#: cmd/incus/storage_bucket.go:713 cmd/incus/storage_bucket.go:788
+#: cmd/incus/storage_bucket.go:868 cmd/incus/storage_bucket.go:946
+#: cmd/incus/storage_bucket.go:1011 cmd/incus/storage_bucket.go:1147
+#: cmd/incus/storage_bucket.go:1221 cmd/incus/storage_bucket.go:1370
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:666 cmd/incus/storage_volume.go:940
+#: cmd/incus/storage_volume.go:1166 cmd/incus/storage_volume.go:1300
+#: cmd/incus/storage_volume.go:1753 cmd/incus/storage_volume.go:1845
+#: cmd/incus/storage_volume.go:1937 cmd/incus/storage_volume.go:2099
+#: cmd/incus/storage_volume.go:2196 cmd/incus/storage_volume.go:2297
+#: cmd/incus/storage_volume.go:2406 cmd/incus/storage_volume.go:2619
+#: cmd/incus/storage_volume.go:2705 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2886 cmd/incus/storage_volume.go:3050
 msgid "Cluster member name"
 msgstr ""
 
@@ -1430,8 +1430,8 @@ msgstr ""
 
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:132 cmd/incus/profile.go:724
-#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2475 cmd/incus/warning.go:93
+#: cmd/incus/project.go:496 cmd/incus/storage_volume.go:1532
+#: cmd/incus/storage_volume.go:2496 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1486,8 +1486,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:686 cmd/incus/network_peer.go:726
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1328
 #: cmd/incus/profile.go:599 cmd/incus/project.go:368 cmd/incus/storage.go:363
-#: cmd/incus/storage_bucket.go:356 cmd/incus/storage_bucket.go:1105
-#: cmd/incus/storage_volume.go:1084 cmd/incus/storage_volume.go:1116
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1110
+#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1509,11 +1509,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:580
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1393
+#: cmd/incus/storage_volume.go:1404
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:359 cmd/incus/storage_volume.go:360
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1579,12 +1579,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366
+#: cmd/incus/storage_volume.go:367
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:367
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1597,7 +1597,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:478
+#: cmd/incus/storage_volume.go:479
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1713,7 +1713,7 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:859 cmd/incus/storage_bucket.go:860
+#: cmd/incus/storage_bucket.go:864 cmd/incus/storage_bucket.go:865
 msgid "Create key for a storage bucket"
 msgstr ""
 
@@ -1725,7 +1725,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:574 cmd/incus/storage_volume.go:575
+#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1779,7 +1779,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:602
-#: cmd/incus/storage_volume.go:1407
+#: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1815,8 +1815,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:746 cmd/incus/project.go:524 cmd/incus/storage.go:727
-#: cmd/incus/storage_bucket.go:520 cmd/incus/storage_bucket.go:840
-#: cmd/incus/storage_volume.go:1636
+#: cmd/incus/storage_bucket.go:525 cmd/incus/storage_bucket.go:845
+#: cmd/incus/storage_volume.go:1647
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1215 cmd/incus/storage_volume.go:2864
+#: cmd/incus/storage_bucket.go:1220 cmd/incus/storage_volume.go:2885
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1891,7 +1891,7 @@ msgstr ""
 msgid "Delete instances"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:937 cmd/incus/storage_bucket.go:938
+#: cmd/incus/storage_bucket.go:942 cmd/incus/storage_bucket.go:943
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1936,7 +1936,7 @@ msgstr ""
 msgid "Delete projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:195 cmd/incus/storage_bucket.go:196
+#: cmd/incus/storage_bucket.go:200 cmd/incus/storage_bucket.go:201
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1944,11 +1944,11 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2381 cmd/incus/storage_volume.go:2382
+#: cmd/incus/storage_volume.go:2402 cmd/incus/storage_volume.go:2403
 msgid "Delete storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:661 cmd/incus/storage_volume.go:662
+#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:663
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2081,39 +2081,39 @@ msgstr ""
 #: cmd/incus/storage.go:397 cmd/incus/storage.go:479 cmd/incus/storage.go:659
 #: cmd/incus/storage.go:746 cmd/incus/storage.go:850 cmd/incus/storage.go:944
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
-#: cmd/incus/storage_bucket.go:196 cmd/incus/storage_bucket.go:257
-#: cmd/incus/storage_bucket.go:390 cmd/incus/storage_bucket.go:466
-#: cmd/incus/storage_bucket.go:543 cmd/incus/storage_bucket.go:637
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_bucket.go:740
-#: cmd/incus/storage_bucket.go:781 cmd/incus/storage_bucket.go:860
-#: cmd/incus/storage_bucket.go:938 cmd/incus/storage_bucket.go:1002
-#: cmd/incus/storage_bucket.go:1137 cmd/incus/storage_bucket.go:1209
-#: cmd/incus/storage_bucket.go:1360 cmd/incus/storage_volume.go:55
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:253
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:575
-#: cmd/incus/storage_volume.go:662 cmd/incus/storage_volume.go:735
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
-#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1282
-#: cmd/incus/storage_volume.go:1439 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:1738 cmd/incus/storage_volume.go:1831
-#: cmd/incus/storage_volume.go:1911 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2222
-#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2382
-#: cmd/incus/storage_volume.go:2471 cmd/incus/storage_volume.go:2477
-#: cmd/incus/storage_volume.go:2595 cmd/incus/storage_volume.go:2682
-#: cmd/incus/storage_volume.go:2762 cmd/incus/storage_volume.go:2858
-#: cmd/incus/storage_volume.go:3024 cmd/incus/version.go:22
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:471
+#: cmd/incus/storage_bucket.go:548 cmd/incus/storage_bucket.go:642
+#: cmd/incus/storage_bucket.go:711 cmd/incus/storage_bucket.go:745
+#: cmd/incus/storage_bucket.go:786 cmd/incus/storage_bucket.go:865
+#: cmd/incus/storage_bucket.go:943 cmd/incus/storage_bucket.go:1007
+#: cmd/incus/storage_bucket.go:1142 cmd/incus/storage_bucket.go:1214
+#: cmd/incus/storage_bucket.go:1365 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:663 cmd/incus/storage_volume.go:736
+#: cmd/incus/storage_volume.go:834 cmd/incus/storage_volume.go:931
+#: cmd/incus/storage_volume.go:1152 cmd/incus/storage_volume.go:1288
+#: cmd/incus/storage_volume.go:1450 cmd/incus/storage_volume.go:1534
+#: cmd/incus/storage_volume.go:1749 cmd/incus/storage_volume.go:1842
+#: cmd/incus/storage_volume.go:1922 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2184 cmd/incus/storage_volume.go:2243
+#: cmd/incus/storage_volume.go:2292 cmd/incus/storage_volume.go:2403
+#: cmd/incus/storage_volume.go:2492 cmd/incus/storage_volume.go:2498
+#: cmd/incus/storage_volume.go:2616 cmd/incus/storage_volume.go:2703
+#: cmd/incus/storage_volume.go:2783 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:3045 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1380
+#: cmd/incus/storage_volume.go:1391
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:1743
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1754
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2125,11 +2125,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:734 cmd/incus/storage_volume.go:735
+#: cmd/incus/storage_volume.go:735 cmd/incus/storage_volume.go:736
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:833
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:834
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2384,11 +2384,11 @@ msgstr ""
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:256 cmd/incus/storage_bucket.go:257
+#: cmd/incus/storage_bucket.go:261 cmd/incus/storage_bucket.go:262
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1001 cmd/incus/storage_bucket.go:1002
+#: cmd/incus/storage_bucket.go:1006 cmd/incus/storage_bucket.go:1007
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2396,7 +2396,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:930 cmd/incus/storage_volume.go:931
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2406,7 +2406,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:630 cmd/incus/profile.go:762
-#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1664
+#: cmd/incus/project.go:534 cmd/incus/storage_volume.go:1675
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2468,8 +2468,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:550
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1159
 #: cmd/incus/profile.go:1082 cmd/incus/project.go:820 cmd/incus/storage.go:816
-#: cmd/incus/storage_bucket.go:610 cmd/incus/storage_volume.go:2002
-#: cmd/incus/storage_volume.go:2040
+#: cmd/incus/storage_bucket.go:615 cmd/incus/storage_volume.go:2013
+#: cmd/incus/storage_volume.go:2056
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2490,8 +2490,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:544 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1153 cmd/incus/profile.go:1076
 #: cmd/incus/project.go:814 cmd/incus/storage.go:810
-#: cmd/incus/storage_bucket.go:604 cmd/incus/storage_volume.go:1996
-#: cmd/incus/storage_volume.go:2034
+#: cmd/incus/storage_bucket.go:609 cmd/incus/storage_volume.go:2007
+#: cmd/incus/storage_volume.go:2050
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2575,8 +2575,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:754 cmd/incus/info.go:805 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1440 cmd/incus/storage_volume.go:1490
-#: cmd/incus/storage_volume.go:2575
+#: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
+#: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
 msgstr ""
 
@@ -2600,7 +2600,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2857 cmd/incus/storage_volume.go:2858
+#: cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2879
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2612,24 +2612,24 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1208
+#: cmd/incus/storage_bucket.go:1213
 msgid "Export storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1209
+#: cmd/incus/storage_bucket.go:1214
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2861
+#: cmd/incus/storage_volume.go:2882
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1327
+#: cmd/incus/storage_bucket.go:1332
 #, c-format
 msgid "Exporting backup of storage bucket %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:2990
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3011
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2706,7 +2706,7 @@ msgstr ""
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:555
+#: cmd/incus/storage_volume.go:556
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1262
+#: cmd/incus/storage_bucket.go:1267
 #, c-format
 msgid "Failed to create backup: %v"
 msgstr ""
@@ -2845,7 +2845,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2946
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2855,12 +2855,12 @@ msgstr ""
 msgid "Failed to delete original instance after copying it: %w"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1341
+#: cmd/incus/storage_bucket.go:1346
 #, c-format
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3004
+#: cmd/incus/storage_volume.go:3025
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3079,9 +3079,9 @@ msgstr ""
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:725 cmd/incus/project.go:498
 #: cmd/incus/project.go:1019 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:467
-#: cmd/incus/storage_bucket.go:782 cmd/incus/storage_volume.go:1539
-#: cmd/incus/storage_volume.go:2492 cmd/incus/warning.go:94
+#: cmd/incus/storage.go:661 cmd/incus/storage_bucket.go:472
+#: cmd/incus/storage_bucket.go:787 cmd/incus/storage_volume.go:1550
+#: cmd/incus/storage_volume.go:2513 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3198,7 +3198,7 @@ msgstr ""
 msgid "Get the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393
+#: cmd/incus/storage_bucket.go:398
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -3206,7 +3206,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1166
+#: cmd/incus/storage_volume.go:1167
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3267,7 +3267,7 @@ msgstr ""
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:389 cmd/incus/storage_bucket.go:390
+#: cmd/incus/storage_bucket.go:394 cmd/incus/storage_bucket.go:395
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -3275,11 +3275,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1150 cmd/incus/storage_volume.go:1151
+#: cmd/incus/storage_volume.go:1151 cmd/incus/storage_volume.go:1152
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:439
+#: cmd/incus/storage_volume.go:440
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3374,7 +3374,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2275
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2296
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3388,7 +3388,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2274
+#: cmd/incus/storage_volume.go:2295
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3438,7 +3438,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3024
+#: cmd/incus/storage_volume.go:3045
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3446,11 +3446,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1360
+#: cmd/incus/storage_bucket.go:1365
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3044
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3469,28 +3469,28 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1364
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3096
+#: cmd/incus/storage_volume.go:3117
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3031
+#: cmd/incus/storage_volume.go:3052
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3101
+#: cmd/incus/storage_volume.go:3122
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1415
+#: cmd/incus/storage_bucket.go:1420
 #, c-format
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3105
+#: cmd/incus/storage_volume.go:3126
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3560,8 +3560,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1295
-#: cmd/incus/storage_volume.go:2958
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:2979
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3580,8 +3580,8 @@ msgstr ""
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:2963
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1305
+#: cmd/incus/storage_volume.go:2984
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3678,9 +3678,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:998 cmd/incus/storage_volume.go:1215
-#: cmd/incus/storage_volume.go:1339 cmd/incus/storage_volume.go:1979
-#: cmd/incus/storage_volume.go:2818
+#: cmd/incus/storage_volume.go:999 cmd/incus/storage_volume.go:1216
+#: cmd/incus/storage_volume.go:1345 cmd/incus/storage_volume.go:1990
+#: cmd/incus/storage_volume.go:2839
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3730,8 +3730,8 @@ msgstr ""
 
 #: cmd/incus/list.go:614 cmd/incus/network.go:1174
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
-#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:524
-#: cmd/incus/storage_volume.go:1643 cmd/incus/warning.go:221
+#: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:529
+#: cmd/incus/storage_volume.go:1654 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4065,19 +4065,19 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:779 cmd/incus/storage_bucket.go:781
+#: cmd/incus/storage_bucket.go:784 cmd/incus/storage_bucket.go:786
 msgid "List storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:464 cmd/incus/storage_bucket.go:466
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage_bucket.go:471
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2470 cmd/incus/storage_volume.go:2471
+#: cmd/incus/storage_volume.go:2491 cmd/incus/storage_volume.go:2492
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2477
+#: cmd/incus/storage_volume.go:2498
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4095,11 +4095,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1518
+#: cmd/incus/storage_volume.go:1529
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1523
+#: cmd/incus/storage_volume.go:1534
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4181,7 +4181,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1396
+#: cmd/incus/info.go:594 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4422,11 +4422,11 @@ msgstr ""
 msgid "Manage projects"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:739
+#: cmd/incus/storage_bucket.go:744
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:740
+#: cmd/incus/storage_bucket.go:745
 msgid "Manage storage bucket keys."
 msgstr ""
 
@@ -4442,15 +4442,15 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2221 cmd/incus/storage_volume.go:2222
+#: cmd/incus/storage_volume.go:2242 cmd/incus/storage_volume.go:2243
 msgid "Manage storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:54
+#: cmd/incus/storage_volume.go:55
 msgid "Manage storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:55
+#: cmd/incus/storage_volume.go:56
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4547,12 +4547,12 @@ msgstr ""
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:124 cmd/incus/storage_bucket.go:224
-#: cmd/incus/storage_bucket.go:300 cmd/incus/storage_bucket.go:419
-#: cmd/incus/storage_bucket.go:576 cmd/incus/storage_bucket.go:668
-#: cmd/incus/storage_bucket.go:810 cmd/incus/storage_bucket.go:891
-#: cmd/incus/storage_bucket.go:966 cmd/incus/storage_bucket.go:1045
-#: cmd/incus/storage_bucket.go:1168 cmd/incus/storage_bucket.go:1244
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:581 cmd/incus/storage_bucket.go:673
+#: cmd/incus/storage_bucket.go:815 cmd/incus/storage_bucket.go:896
+#: cmd/incus/storage_bucket.go:971 cmd/incus/storage_bucket.go:1050
+#: cmd/incus/storage_bucket.go:1173 cmd/incus/storage_bucket.go:1249
 msgid "Missing bucket name"
 msgstr ""
 
@@ -4580,8 +4580,8 @@ msgstr ""
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:895 cmd/incus/storage_bucket.go:970
-#: cmd/incus/storage_bucket.go:1049 cmd/incus/storage_bucket.go:1172
+#: cmd/incus/storage_bucket.go:900 cmd/incus/storage_bucket.go:975
+#: cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1177
 msgid "Missing key name"
 msgstr ""
 
@@ -4672,22 +4672,22 @@ msgstr ""
 
 #: cmd/incus/storage.go:239 cmd/incus/storage.go:317 cmd/incus/storage.go:435
 #: cmd/incus/storage.go:513 cmd/incus/storage.go:784 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:120 cmd/incus/storage_bucket.go:220
-#: cmd/incus/storage_bucket.go:296 cmd/incus/storage_bucket.go:415
-#: cmd/incus/storage_bucket.go:490 cmd/incus/storage_bucket.go:572
-#: cmd/incus/storage_bucket.go:664 cmd/incus/storage_bucket.go:806
-#: cmd/incus/storage_bucket.go:887 cmd/incus/storage_bucket.go:962
-#: cmd/incus/storage_bucket.go:1041 cmd/incus/storage_bucket.go:1164
-#: cmd/incus/storage_bucket.go:1239 cmd/incus/storage_volume.go:202
-#: cmd/incus/storage_volume.go:293 cmd/incus/storage_volume.go:609
-#: cmd/incus/storage_volume.go:698 cmd/incus/storage_volume.go:775
-#: cmd/incus/storage_volume.go:873 cmd/incus/storage_volume.go:987
-#: cmd/incus/storage_volume.go:1204 cmd/incus/storage_volume.go:1570
-#: cmd/incus/storage_volume.go:1868 cmd/incus/storage_volume.go:1962
-#: cmd/incus/storage_volume.go:2117 cmd/incus/storage_volume.go:2309
-#: cmd/incus/storage_volume.go:2422 cmd/incus/storage_volume.go:2527
-#: cmd/incus/storage_volume.go:2637 cmd/incus/storage_volume.go:2722
-#: cmd/incus/storage_volume.go:2808
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:495 cmd/incus/storage_bucket.go:577
+#: cmd/incus/storage_bucket.go:669 cmd/incus/storage_bucket.go:811
+#: cmd/incus/storage_bucket.go:892 cmd/incus/storage_bucket.go:967
+#: cmd/incus/storage_bucket.go:1046 cmd/incus/storage_bucket.go:1169
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:610
+#: cmd/incus/storage_volume.go:699 cmd/incus/storage_volume.go:776
+#: cmd/incus/storage_volume.go:874 cmd/incus/storage_volume.go:988
+#: cmd/incus/storage_volume.go:1205 cmd/incus/storage_volume.go:1581
+#: cmd/incus/storage_volume.go:1879 cmd/incus/storage_volume.go:1973
+#: cmd/incus/storage_volume.go:2133 cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2443 cmd/incus/storage_volume.go:2548
+#: cmd/incus/storage_volume.go:2658 cmd/incus/storage_volume.go:2743
+#: cmd/incus/storage_volume.go:2829
 msgid "Missing pool name"
 msgstr ""
 
@@ -4711,11 +4711,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:402 cmd/incus/storage_volume.go:1778
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1789
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1334
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4753,7 +4753,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:522 cmd/incus/network.go:619
-#: cmd/incus/storage_volume.go:795 cmd/incus/storage_volume.go:892
+#: cmd/incus/storage_volume.go:796 cmd/incus/storage_volume.go:893
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4785,7 +4785,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1737 cmd/incus/storage_volume.go:1738
+#: cmd/incus/storage_volume.go:1748 cmd/incus/storage_volume.go:1749
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4793,11 +4793,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1744
+#: cmd/incus/storage_volume.go:1755
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:482
+#: cmd/incus/storage_volume.go:483
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4825,8 +4825,8 @@ msgstr ""
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:744 cmd/incus/project.go:517 cmd/incus/remote.go:773
-#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:519
-#: cmd/incus/storage_bucket.go:839 cmd/incus/storage_volume.go:1635
+#: cmd/incus/storage.go:719 cmd/incus/storage_bucket.go:524
+#: cmd/incus/storage_bucket.go:844 cmd/incus/storage_volume.go:1646
 msgid "NAME"
 msgstr ""
 
@@ -4881,8 +4881,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:752 cmd/incus/info.go:803 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1438 cmd/incus/storage_volume.go:1488
-#: cmd/incus/storage_volume.go:2573
+#: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
+#: cmd/incus/storage_volume.go:2594
 msgid "Name"
 msgstr ""
 
@@ -4943,7 +4943,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:577 cmd/incus/network.go:929
-#: cmd/incus/storage_volume.go:1378
+#: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5107,7 +5107,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:804 cmd/incus/storage_volume.go:901
+#: cmd/incus/storage_volume.go:805 cmd/incus/storage_volume.go:902
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5127,11 +5127,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:416 cmd/incus/storage_volume.go:1787
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1798
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:466 cmd/incus/storage_volume.go:1798
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1809
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5167,15 +5167,15 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:222 cmd/incus/storage_volume.go:313
+#: cmd/incus/storage_volume.go:223 cmd/incus/storage_volume.go:314
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2912
+#: cmd/incus/storage_volume.go:2933
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2343
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5187,7 +5187,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1346
+#: cmd/incus/storage_volume.go:1352
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5205,7 +5205,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1492
+#: cmd/incus/info.go:807 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5248,7 +5248,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: cmd/incus/image.go:1122 cmd/incus/list.go:575 cmd/incus/network_zone.go:165
-#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1654
+#: cmd/incus/profile.go:745 cmd/incus/storage_volume.go:1665
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5359,8 +5359,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:687 cmd/incus/network_peer.go:727
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1329
 #: cmd/incus/profile.go:600 cmd/incus/project.go:369 cmd/incus/storage.go:364
-#: cmd/incus/storage_bucket.go:357 cmd/incus/storage_bucket.go:1106
-#: cmd/incus/storage_volume.go:1085 cmd/incus/storage_volume.go:1117
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1111
+#: cmd/incus/storage_volume.go:1086 cmd/incus/storage_volume.go:1118
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5497,7 +5497,7 @@ msgstr ""
 msgid "Protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2764
+#: cmd/incus/storage_volume.go:2785
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "\tSupported types are custom, image, container and virtual-machine.\n"
@@ -5510,7 +5510,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1284
+#: cmd/incus/storage_volume.go:1290
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5524,7 +5524,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1153
+#: cmd/incus/storage_volume.go:1154
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5540,7 +5540,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2071
+#: cmd/incus/storage_volume.go:2087
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5557,7 +5557,7 @@ msgid ""
 "\"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:932
+#: cmd/incus/storage_volume.go:933
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5566,7 +5566,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1916
+#: cmd/incus/storage_volume.go:1927
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5579,7 +5579,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2165
+#: cmd/incus/storage_volume.go:2186
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5653,7 +5653,7 @@ msgstr ""
 msgid "RESTRICTED"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:841
+#: cmd/incus/storage_bucket.go:846
 msgid "ROLE"
 msgstr ""
 
@@ -5696,7 +5696,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:368
+#: cmd/incus/storage_volume.go:369
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5881,20 +5881,20 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2594 cmd/incus/storage_volume.go:2595
+#: cmd/incus/storage_volume.go:2615 cmd/incus/storage_volume.go:2616
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1830 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:1841 cmd/incus/storage_volume.go:1842
 msgid "Rename storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1892
+#: cmd/incus/storage_volume.go:1903
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2687
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -5935,7 +5935,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2681 cmd/incus/storage_volume.go:2682
+#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2703
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5969,7 +5969,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:864
+#: cmd/incus/storage_bucket.go:869
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -6072,11 +6072,11 @@ msgstr ""
 msgid "Scanning for unknown volumes..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:866
+#: cmd/incus/storage_bucket.go:871
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:922
+#: cmd/incus/storage_bucket.go:927
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -6300,11 +6300,11 @@ msgid ""
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:542
+#: cmd/incus/storage_bucket.go:547
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:543
+#: cmd/incus/storage_bucket.go:548
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -6326,11 +6326,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1910
+#: cmd/incus/storage_volume.go:1921
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1911
+#: cmd/incus/storage_volume.go:1922
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6412,7 +6412,7 @@ msgstr ""
 msgid "Set the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:550
+#: cmd/incus/storage_bucket.go:555
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -6420,7 +6420,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1927
+#: cmd/incus/storage_volume.go:1938
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6549,11 +6549,11 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:636 cmd/incus/storage_bucket.go:637
+#: cmd/incus/storage_bucket.go:641 cmd/incus/storage_bucket.go:642
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1137
+#: cmd/incus/storage_bucket.go:1141 cmd/incus/storage_bucket.go:1142
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -6561,12 +6561,12 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2068 cmd/incus/storage_volume.go:2069
-#: cmd/incus/storage_volume.go:2761 cmd/incus/storage_volume.go:2762
+#: cmd/incus/storage_volume.go:2084 cmd/incus/storage_volume.go:2085
+#: cmd/incus/storage_volume.go:2782 cmd/incus/storage_volume.go:2783
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1281 cmd/incus/storage_volume.go:1282
+#: cmd/incus/storage_volume.go:1287 cmd/incus/storage_volume.go:1288
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6628,15 +6628,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2270 cmd/incus/storage_volume.go:2271
+#: cmd/incus/storage_volume.go:2291 cmd/incus/storage_volume.go:2292
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2014
+#: cmd/incus/storage_volume.go:2025
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1417
+#: cmd/incus/info.go:721 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
@@ -6712,22 +6712,22 @@ msgstr ""
 msgid "Storage backend to use (btrfs, dir, lvm or zfs, default: dir)"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:174
+#: cmd/incus/storage_bucket.go:179
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:241
+#: cmd/incus/storage_bucket.go:246
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:920
+#: cmd/incus/storage_bucket.go:925
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:986
+#: cmd/incus/storage_bucket.go:991
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -6770,25 +6770,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:644
+#: cmd/incus/storage_volume.go:645
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:718
+#: cmd/incus/storage_volume.go:719
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:480
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:484
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2468
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -6848,13 +6848,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:587 cmd/incus/network.go:1088
 #: cmd/incus/network.go:1170 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1634
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1645
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:753 cmd/incus/info.go:804 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1489 cmd/incus/storage_volume.go:2574
+#: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
 
@@ -7041,7 +7041,7 @@ msgstr ""
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:439
+#: cmd/incus/storage_bucket.go:444
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -7051,12 +7051,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1263
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1234
+#: cmd/incus/storage_volume.go:1235
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7104,7 +7104,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:536 cmd/incus/network.go:633
-#: cmd/incus/storage_volume.go:809 cmd/incus/storage_volume.go:906
+#: cmd/incus/storage_volume.go:810 cmd/incus/storage_volume.go:907
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7182,7 +7182,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1402
+#: cmd/incus/storage_volume.go:1413
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7198,7 +7198,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1741
+#: cmd/incus/storage_volume.go:1752
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7206,7 +7206,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:363
+#: cmd/incus/storage_volume.go:364
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7262,7 +7262,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
 #: cmd/incus/info.go:413 cmd/incus/info.go:588 cmd/incus/network.go:933
-#: cmd/incus/storage_volume.go:1387
+#: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7284,7 +7284,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1639
+#: cmd/incus/project.go:1087 cmd/incus/storage_volume.go:1650
 msgid "USAGE"
 msgstr ""
 
@@ -7300,7 +7300,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:747
 #: cmd/incus/project.go:525 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1638
+#: cmd/incus/storage_volume.go:1649
 msgid "USED BY"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:645 cmd/incus/profile.go:768
-#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:540 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7436,7 +7436,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:705 cmd/incus/storage_bucket.go:706
+#: cmd/incus/storage_bucket.go:710 cmd/incus/storage_bucket.go:711
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -7444,7 +7444,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2162 cmd/incus/storage_volume.go:2163
+#: cmd/incus/storage_volume.go:2183 cmd/incus/storage_volume.go:2184
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -7492,7 +7492,7 @@ msgstr ""
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:714
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -7500,7 +7500,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2176
+#: cmd/incus/storage_volume.go:2197
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7540,12 +7540,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1400
+#: cmd/incus/storage_volume.go:1411
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2863
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2884
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7629,7 +7629,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1491
+#: cmd/incus/storage_volume.go:1502
 msgid "Volume Only"
 msgstr ""
 
@@ -7802,11 +7802,11 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:831
+#: cmd/incus/storage_volume.go:832
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:251
+#: cmd/incus/storage_volume.go:252
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
@@ -8215,34 +8215,34 @@ msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: cmd/incus/storage.go:204 cmd/incus/storage.go:263 cmd/incus/storage.go:477
-#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:462
+#: cmd/incus/storage.go:848 cmd/incus/storage_bucket.go:467
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1358
+#: cmd/incus/storage_bucket.go:1363
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3022
+#: cmd/incus/storage_volume.go:3043
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:193 cmd/incus/storage_bucket.go:255
-#: cmd/incus/storage_bucket.go:635 cmd/incus/storage_bucket.go:777
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:640 cmd/incus/storage_bucket.go:782
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:388 cmd/incus/storage_bucket.go:704
-#: cmd/incus/storage_bucket.go:858 cmd/incus/storage_bucket.go:936
-#: cmd/incus/storage_bucket.go:1000 cmd/incus/storage_bucket.go:1135
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:709
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_bucket.go:941
+#: cmd/incus/storage_bucket.go:1005 cmd/incus/storage_bucket.go:1140
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:541
+#: cmd/incus/storage_bucket.go:546
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1207
+#: cmd/incus/storage_bucket.go:1212
 msgid "[<remote>:]<pool> <bucket> [<path>]"
 msgstr ""
 
@@ -8262,72 +8262,72 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1829
+#: cmd/incus/storage_volume.go:1840
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:659 cmd/incus/storage_volume.go:2469
+#: cmd/incus/storage_volume.go:660 cmd/incus/storage_volume.go:2490
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:733
+#: cmd/incus/storage_volume.go:734
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:160
+#: cmd/incus/storage_volume.go:161
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2593
+#: cmd/incus/storage_volume.go:2614
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2680
+#: cmd/incus/storage_volume.go:2400 cmd/incus/storage_volume.go:2701
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2856
+#: cmd/incus/storage_volume.go:2877
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2269
+#: cmd/incus/storage_volume.go:2290
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:573
+#: cmd/incus/storage_volume.go:574
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2760
+#: cmd/incus/storage_volume.go:2781
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1516
+#: cmd/incus/storage_volume.go:1527
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:928 cmd/incus/storage_volume.go:1280
-#: cmd/incus/storage_volume.go:2067
+#: cmd/incus/storage_volume.go:929 cmd/incus/storage_volume.go:1286
+#: cmd/incus/storage_volume.go:2083
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2161
+#: cmd/incus/storage_volume.go:2182
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1909
+#: cmd/incus/storage_volume.go:1920
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1149
+#: cmd/incus/storage_volume.go:1150
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1735
+#: cmd/incus/storage_volume.go:1746
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:357
+#: cmd/incus/storage_volume.go:358
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -8825,38 +8825,48 @@ msgid ""
 "Restore the snapshot."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1211
+#: cmd/incus/storage_bucket.go:97
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket name b01 in storage pool p1\n"
+"\n"
+"incus storage bucket create p1 b01 < config.yaml\n"
+"\tCraete a new storage bucket name b01 in storage pool p1 using the content "
+"of config.yaml"
+msgstr ""
+
+#: cmd/incus/storage_bucket.go:1216
 msgid ""
 "incus storage bucket default b1\n"
 "    Download a backup tarball of the b1 storage bucket."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:258
+#: cmd/incus/storage_bucket.go:263
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1003
+#: cmd/incus/storage_bucket.go:1008
 msgid ""
 "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1362
+#: cmd/incus/storage_bucket.go:1367
 msgid ""
 "incus storage bucket import default backup0.tar.gz\n"
 "\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1138
+#: cmd/incus/storage_bucket.go:1143
 msgid ""
 "incus storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:638
+#: cmd/incus/storage_bucket.go:643
 msgid ""
 "incus storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -8869,7 +8879,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3026
+#: cmd/incus/storage_volume.go:3047
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."


### PR DESCRIPTION
`incus storage bucket create` already has support for creation from a yaml
configuration file, but the same wasn't printed in the usage information
of the command.

This commit updates `incus storage bucket create` to include an example.

Part of https://github.com/lxc/incus/issues/741