### PR TITLE
Extend resources API to include CPU flags

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2509,3 +2509,7 @@ This introduces a new API endpoint at `GET /1.0/projects/NAME/access` which expo
 
 This extends `DELETE /1.0/projects` to allow `?force=true` which will
 delete everything inside of the project along with the project itself.
+
+## `resources_cpu_flags`
+
+This exposes the CPU flags/extensions in our resources API to check the CPU features.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -4239,6 +4239,13 @@ definitions:
                 format: uint64
                 type: integer
                 x-go-name: Die
+            flags:
+                description: List of CPU flags
+                example: []
+                items:
+                    type: string
+                type: array
+                x-go-name: Flags
             frequency:
                 description: Current frequency
                 example: 3500

--- a/internal/server/resources/cpu.go
+++ b/internal/server/resources/cpu.go
@@ -235,6 +235,9 @@ func GetCPU() (*api.ResourcesCPU, error) {
 		return nil, fmt.Errorf("Failed to list %q: %w", sysDevicesCPU, err)
 	}
 
+	// CPU flags
+	var flagList []string
+
 	// Process all entries
 	cpu.Total = 0
 	for _, entry := range entries {
@@ -308,7 +311,7 @@ func GetCPU() (*api.ResourcesCPU, error) {
 					}
 
 					// Check if we already have the data and seek to next
-					if resSocket.Vendor != "" && resSocket.Name != "" {
+					if resSocket.Vendor != "" && resSocket.Name != "" && len(flagList) > 0 {
 						continue
 					}
 
@@ -329,6 +332,11 @@ func GetCPU() (*api.ResourcesCPU, error) {
 
 					if key == "cpu" {
 						resSocket.Name = value
+						continue
+					}
+
+					if key == "flags" {
+						flagList = strings.SplitN(value, " ", -1)
 						continue
 					}
 				}
@@ -404,6 +412,9 @@ func GetCPU() (*api.ResourcesCPU, error) {
 
 			// Die number
 			resCore.Die = uint64(cpuDie)
+
+			// flag List
+			resCore.Flags = flagList
 
 			// Frequency
 			if sysfsExists(filepath.Join(entryPath, "cpufreq", "scaling_cur_freq")) {

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -424,6 +424,7 @@ var APIExtensions = []string{
 	"instance_access",
 	"project_access",
 	"projects_force_delete",
+	"resources_cpu_flags",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -146,6 +146,12 @@ type ResourcesCPUCore struct {
 	// Current frequency
 	// Example: 3500
 	Frequency uint64 `json:"frequency,omitempty" yaml:"frequency,omitempty"`
+
+	// List of CPU flags
+	// Example: []
+	//
+	// API extension: resources_cpu_flags
+	Flags []string `json:"flags" yaml:"flags"`
 }
 
 // ResourcesCPUThread represents a CPU thread on the system


### PR DESCRIPTION
Part of #486

This implements the first stage of the work to build a profile of CPU flags for servers within a cluster. This stage extends our internal resources API to have access to CPU flags of the servers.