### PR TITLE
cmd/incusd: Add automatic live-migration to rebalance loads on incus cluster

### DIFF
--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -4573,3 +4573,72 @@ func autoHealCluster(ctx context.Context, s *state.State, offlineMembers []db.No
 
 	return nil
 }
+
+func autoClusterRebalanceTask(d *Daemon) (task.Func, task.Schedule) {
+	f := func(ctx context.Context){
+		s := d.State()
+		rebalanceThreshold := s.GlobalConfig.ClusterRebalanceThreshold()
+		if(rebalanceThreshold == 0){
+			return // Skip rebalancing if it's disabled
+		}
+
+		leader, err := d.gateway.LeaderAddress()
+		if err != nil {
+			if errors.Is(err, cluster.ErrNodeIsNotClustered) {
+				return // Skip rebalancing if not clustered.
+			}
+
+			logger.Error("Failed to get leader cluster member address", logger.Ctx{"err": err})
+			return
+		}
+
+		if s.LocalConfig.ClusterAddress() != leader {
+			return // Skip rebalancing if not cluster leader.
+		}
+
+		fmt.Println("TRYIN TO RUN AUTO CLUSTER REBALANCE")
+
+		// retrieve all of the servers by get resources
+
+		// find the per server score (based on cpu / memory / load)
+
+		// split the servers by CPU architecture
+
+		// find the most and least busy for each, check the threshold
+		// we can exit early if none of them meet it
+
+		// for each server we are trying to rebalance, look through all instances and determine which can be migrated
+
+		// MAYBE: migrate instances in order from highest to least score impact (reduce migration)
+
+		// for our list of instances to migrate, make sure to call the scheduler to verify that it's possible
+
+		opRun := func(op *operations.Operation) error{
+			err := autoClusterRebalance(ctx, s)
+			if err != nil {
+				logger.Error("Failed rebalancing cluster instances", logger.Ctx{"err": err})
+				return err
+			}
+
+			return nil
+		}
+
+		err = op.Start()
+		if err != nil {
+			logger.Error("Failed starting auto cluster rebalancing operation", logger.Ctx{"err": err})
+			return
+		}
+
+		err = op.Wait(ctx)
+		if err != nil {
+			logger.Error("Failed auto cluster rebalancing", logger.Ctx{"err": err})
+			return
+		}
+
+	}
+}
+
+func autoClusterRebalance(ctx context.Context, s *state.State) error{
+
+	return nil
+}

--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -4619,23 +4619,25 @@ func autoClusterRebalanceTask(d *Daemon) (task.Func, task.Schedule) {
 				logger.Error("Failed rebalancing cluster instances", logger.Ctx{"err": err})
 				return err
 			}
-
+			
 			return nil
 		}
-
+		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ClusterRebalance, nil, nil, opRun, nil, nil, nil)
+		
 		err = op.Start()
 		if err != nil {
 			logger.Error("Failed starting auto cluster rebalancing operation", logger.Ctx{"err": err})
-			return
+			//return err
 		}
 
 		err = op.Wait(ctx)
 		if err != nil {
 			logger.Error("Failed auto cluster rebalancing", logger.Ctx{"err": err})
-			return
+			//return err
 		}
 
 	}
+	return f,task.Every(time.Minute)
 }
 
 func autoClusterRebalance(ctx context.Context, s *state.State) error{

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -105,7 +105,6 @@ type Daemon struct {
 	// Indexes of tasks that need to be reset when their execution interval changes
 	taskPruneImages      *task.Task
 	taskClusterHeartbeat *task.Task
-	taskClusterRebalance *task.Task
 
 	// Stores startup time of daemon
 	startTime time.Time
@@ -1647,7 +1646,7 @@ func (d *Daemon) startClusterTasks() {
 	// Heartbeats
 	d.taskClusterHeartbeat = d.clusterTasks.Add(cluster.HeartbeatTask(d.gateway))
 
-	// Auto-rebalance instances across cluster 
+	// Auto-rebalance instances across cluster
 	d.clusterTasks.Add(autoClusterRebalanceTask(d))
 
 	// Auto-sync images across the cluster (hourly)

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1648,7 +1648,7 @@ func (d *Daemon) startClusterTasks() {
 	d.taskClusterHeartbeat = d.clusterTasks.Add(cluster.HeartbeatTask(d.gateway))
 
 	// Auto-rebalance instances across cluster 
-	d.clusterTasks.Add(autoClusterRebalance(d))
+	d.clusterTasks.Add(autoClusterRebalanceTask(d))
 
 	// Auto-sync images across the cluster (hourly)
 	d.clusterTasks.Add(autoSyncImagesTask(d))

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -167,6 +167,9 @@ type Daemon struct {
 	// OVN clients.
 	ovnnb *ovn.NB
 	ovnsb *ovn.SB
+
+	// Cooldowns map
+	instanceMigrationCooldowns map[string]time.Time
 }
 
 // DaemonConfig holds configuration values for Daemon.
@@ -196,6 +199,7 @@ func newDaemon(config *DaemonConfig, os *sys.OS) *Daemon {
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
 		shutdownDoneCh: make(chan error),
+		instanceMigrationCooldowns: make(map[string]time.Time),
 	}
 
 	d.serverCert = func() *localtls.CertInfo { return d.serverCertInt }

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -105,6 +105,7 @@ type Daemon struct {
 	// Indexes of tasks that need to be reset when their execution interval changes
 	taskPruneImages      *task.Task
 	taskClusterHeartbeat *task.Task
+	taskClusterRebalance *task.Task
 
 	// Stores startup time of daemon
 	startTime time.Time
@@ -1645,6 +1646,9 @@ func (d *Daemon) startClusterTasks() {
 
 	// Heartbeats
 	d.taskClusterHeartbeat = d.clusterTasks.Add(cluster.HeartbeatTask(d.gateway))
+
+	// Auto-rebalance instances across cluster 
+	d.clusterTasks.Add(autoClusterRebalance(d))
 
 	// Auto-sync images across the cluster (hourly)
 	d.clusterTasks.Add(autoSyncImagesTask(d))

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2460,3 +2460,7 @@ containers to another system.
 ## `profiles_all_projects`
 
 This adds support for listing profiles across all projects through the `all-projects` parameter on the `GET /1.0/profiles`API.
+
+## `cluster_rebalance`
+
+This adds the ability to automatically livemigrate instances across a cluster to automatically balance the load.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1509,6 +1509,38 @@ This must be an odd number >= `3`.
 Specify the number of seconds after which an unresponsive member is considered offline.
 ```
 
+```{config:option} cluster.rebalance.batch server-cluster
+:defaultdesc: "`5`"
+:scope: "global"
+:shortdesc: "Number of database voter members"
+:type: "stromg"
+Maximum number of instances to move during one re-balancing run TODO: adjust the default to not be fixed
+```
+
+```{config:option} cluster.rebalance.cooldown server-cluster
+:defaultdesc: "`1H`"
+:scope: "global"
+:shortdesc: "Number of database voter members"
+:type: "string"
+Amount of time during which an instance will not be moved again
+```
+
+```{config:option} cluster.rebalance.frequency server-cluster
+:defaultdesc: "`3`"
+:scope: "global"
+:shortdesc: "Number of database voter members"
+:type: "integer"
+This is how often we want to rebalance things TODO: make this more descriptive, update the validator
+```
+
+```{config:option} cluster.rebalance.threshold server-cluster
+:defaultdesc: "`3`"
+:scope: "global"
+:shortdesc: "Number of database voter members"
+:type: "integer"
+Load difference beteween most and least busy server needed to trigger a migration TODO: add a validator
+```
+
 <!-- config group server-cluster end -->
 <!-- config group server-core start -->
 ```{config:option} core.bgp_address server-core

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -54,9 +54,9 @@ func (c *Config) BGPASN() int64 {
 	return c.m.GetInt64("core.bgp_asn")
 }
 
-// ClusterRebalanceThreshold returns the relevant setting
+// ClusterRebalanceThreshold returns the relevant setting.
 func (c *Config) ClusterRebalanceThreshold() int64 {
-	return c.m.GetInt64("cluster.rebalance.threshold");
+	return c.m.GetInt64("cluster.rebalance.threshold")
 }
 
 // HTTPSAllowedHeaders returns the relevant CORS setting.
@@ -399,7 +399,7 @@ var ConfigSchema = config.Schema{
 	"cluster.rebalance.threshold": {Type: config.Int64, Default: "20"},
 
 	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.cooldown)
-	// Amount of time during which an instance will not be moved again 
+	// Amount of time during which an instance will not be moved again
 	// ---
 	//  type: string
 	//  scope: global

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -56,7 +56,7 @@ func (c *Config) BGPASN() int64 {
 
 // ClusterRebalanceThreshold returns the relevant setting
 func (c *Config) ClusterRebalanceThreshold() int64 {
-	return c.m.GetString("cluster.rebalance.threshold");
+	return c.m.GetInt64("cluster.rebalance.threshold");
 }
 
 // HTTPSAllowedHeaders returns the relevant CORS setting.

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -59,14 +59,19 @@ func (c *Config) ClusterRebalanceThreshold() int64 {
 	return c.m.GetInt64("cluster.rebalance.threshold")
 }
 
-// ClusterRebalanceThreshold returns the relevant setting.
+// ClusterRebalanceFrequency returns the relevant setting.
 func (c *Config) ClusterRebalanceFrequency() int64 {
 	return c.m.GetInt64("cluster.rebalance.frequency")
 }
 
-// ClusterRebalanceThreshold returns the relevant setting.
+// ClusterRebalanceBatch returns the relevant setting.
 func (c *Config) ClusterRebalanceBatch() int64 {
 	return c.m.GetInt64("cluster.rebalance.batch")
+}
+
+// ClusterRebalanceCooldown returns the relevant setting.
+func (c *Config) ClusterRebalanceCooldown() string {
+	return c.m.GetString("cluster.rebalance.cooldown")
 }
 
 // HTTPSAllowedHeaders returns the relevant CORS setting.
@@ -391,21 +396,21 @@ var ConfigSchema = config.Schema{
 	"cluster.max_voters": {Type: config.Int64, Default: "3", Validator: maxVotersValidator},
 
 	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.frequency)
-	// This is how often we want to rebalance things TODO: make this more descriptive, update the validator
+	// This is how often we want to check if we want to rebalance our instances (in minutes)
 	// ---
 	//  type: integer
 	//  scope: global
 	//  defaultdesc: `3`
-	//  shortdesc: Number of database voter members
+	//  shortdesc: Frequency of checking rebalance threshold in minutes
 	"cluster.rebalance.frequency": {Type: config.Int64, Default: "3"},
 
 	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.threshold)
-	// Load difference beteween most and least busy server needed to trigger a migration TODO: add a validator
+	// Load difference beteween most and least busy server needed to trigger a migration
 	// ---
 	//  type: integer
 	//  scope: global
 	//  defaultdesc: `3`
-	//  shortdesc: Number of database voter members
+	//  shortdesc: Minimum difference in load needed to trigger a migration
 	"cluster.rebalance.threshold": {Type: config.Int64, Default: "20"},
 
 	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.cooldown)
@@ -414,16 +419,16 @@ var ConfigSchema = config.Schema{
 	//  type: string
 	//  scope: global
 	//  defaultdesc: `1H`
-	//  shortdesc: Number of database voter members
+	//  shortdesc: Amount of time per instance to wait before moving it again
 	"cluster.rebalance.cooldown": {Type: config.String, Default: "1H"},
 
 	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.batch)
-	// Maximum number of instances to move during one re-balancing run TODO: adjust the default to not be fixed
+	// Maximum number of instances to move during one re-balancing run
 	// ---
 	//  type: stromg
 	//  scope: global
 	//  defaultdesc: `5`
-	//  shortdesc: Number of database voter members
+	//  shortdesc: Max number of instances to move at once
 	"cluster.rebalance.batch": {Type: config.Int64, Default: "5"},
 
 	// gendoc:generate(entity=server, group=cluster, key=cluster.max_standby)

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -59,6 +59,16 @@ func (c *Config) ClusterRebalanceThreshold() int64 {
 	return c.m.GetInt64("cluster.rebalance.threshold")
 }
 
+// ClusterRebalanceThreshold returns the relevant setting.
+func (c *Config) ClusterRebalanceFrequency() int64 {
+	return c.m.GetInt64("cluster.rebalance.frequency")
+}
+
+// ClusterRebalanceThreshold returns the relevant setting.
+func (c *Config) ClusterRebalanceBatch() int64 {
+	return c.m.GetInt64("cluster.rebalance.batch")
+}
+
 // HTTPSAllowedHeaders returns the relevant CORS setting.
 func (c *Config) HTTPSAllowedHeaders() string {
 	return c.m.GetString("core.https_allowed_headers")

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -54,6 +54,11 @@ func (c *Config) BGPASN() int64 {
 	return c.m.GetInt64("core.bgp_asn")
 }
 
+// ClusterRebalanceThreshold returns the relevant setting
+func (c *Config) ClusterRebalanceThreshold() int64 {
+	return c.m.GetString("cluster.rebalance.threshold");
+}
+
 // HTTPSAllowedHeaders returns the relevant CORS setting.
 func (c *Config) HTTPSAllowedHeaders() string {
 	return c.m.GetString("core.https_allowed_headers")

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -375,6 +375,42 @@ var ConfigSchema = config.Schema{
 	//  shortdesc: Number of database voter members
 	"cluster.max_voters": {Type: config.Int64, Default: "3", Validator: maxVotersValidator},
 
+	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.frequency)
+	// This is how often we want to rebalance things TODO: make this more descriptive, update the validator
+	// ---
+	//  type: integer
+	//  scope: global
+	//  defaultdesc: `3`
+	//  shortdesc: Number of database voter members
+	"cluster.rebalance.frequency": {Type: config.Int64, Default: "3"},
+
+	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.threshold)
+	// Load difference beteween most and least busy server needed to trigger a migration TODO: add a validator
+	// ---
+	//  type: integer
+	//  scope: global
+	//  defaultdesc: `3`
+	//  shortdesc: Number of database voter members
+	"cluster.rebalance.threshold": {Type: config.Int64, Default: "20"},
+
+	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.cooldown)
+	// Amount of time during which an instance will not be moved again 
+	// ---
+	//  type: string
+	//  scope: global
+	//  defaultdesc: `1H`
+	//  shortdesc: Number of database voter members
+	"cluster.rebalance.cooldown": {Type: config.String, Default: "1H"},
+
+	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.batch)
+	// Maximum number of instances to move during one re-balancing run TODO: adjust the default to not be fixed
+	// ---
+	//  type: stromg
+	//  scope: global
+	//  defaultdesc: `5`
+	//  shortdesc: Number of database voter members
+	"cluster.rebalance.batch": {Type: config.Int64, Default: "5"},
+
 	// gendoc:generate(entity=server, group=cluster, key=cluster.max_standby)
 	// Specify the maximum number of cluster members that are assigned the database stand-by role.
 	// This must be a number between `0` and `5`.

--- a/internal/server/db/operationtype/operation_type.go
+++ b/internal/server/db/operationtype/operation_type.go
@@ -79,6 +79,7 @@ const (
 	BucketBackupRemove
 	BucketBackupRename
 	BucketBackupRestore
+	ClusterRebalance
 )
 
 // Description return a human-readable description of the operation type.
@@ -210,6 +211,8 @@ func (t Type) Description() string {
 		return "Renaming bucket backup"
 	case BucketBackupRestore:
 		return "Restoring bucket backup"
+	case ClusterRebalance:
+		return "Rebalancing cluster"
 	default:
 		return "Executing operation"
 	}

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -1646,6 +1646,42 @@
 							"shortdesc": "Threshold when an unresponsive member is considered offline",
 							"type": "integer"
 						}
+					},
+					{
+						"cluster.rebalance.batch": {
+							"defaultdesc": "`5`",
+							"longdesc": "Maximum number of instances to move during one re-balancing run TODO: adjust the default to not be fixed",
+							"scope": "global",
+							"shortdesc": "Number of database voter members",
+							"type": "stromg"
+						}
+					},
+					{
+						"cluster.rebalance.cooldown": {
+							"defaultdesc": "`1H`",
+							"longdesc": "Amount of time during which an instance will not be moved again",
+							"scope": "global",
+							"shortdesc": "Number of database voter members",
+							"type": "string"
+						}
+					},
+					{
+						"cluster.rebalance.frequency": {
+							"defaultdesc": "`3`",
+							"longdesc": "This is how often we want to rebalance things TODO: make this more descriptive, update the validator",
+							"scope": "global",
+							"shortdesc": "Number of database voter members",
+							"type": "integer"
+						}
+					},
+					{
+						"cluster.rebalance.threshold": {
+							"defaultdesc": "`3`",
+							"longdesc": "Load difference beteween most and least busy server needed to trigger a migration TODO: add a validator",
+							"scope": "global",
+							"shortdesc": "Number of database voter members",
+							"type": "integer"
+						}
 					}
 				]
 			},

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -412,6 +412,7 @@ var APIExtensions = []string{
 	"storage_zfs_vdev",
 	"container_migration_stateful",
 	"profiles_all_projects",
+	"cluster_rebalance",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This pull request is in response to issue #485 

Currently, the score only accounts for memory usage of servers so when we need to migrate instances, we determine those with just their memory attribute. In the future, the score can include factors like CPU usage. 

P.S. Sorry but we forgot to add the signoff when committing T_T
