### PR TITLE
#724-Add access endpoint for projects

### DIFF
--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -105,6 +105,7 @@ var api10 = []APIEndpoint{
 	projectCmd,
 	projectsCmd,
 	projectStateCmd,
+	projectAccessCmd,
 	storagePoolCmd,
 	storagePoolResourcesCmd,
 	storagePoolsCmd,

--- a/internal/server/auth/authorization.go
+++ b/internal/server/auth/authorization.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"github.com/lxc/incus/v6/shared/api"
 	"net/http"
 
 	"github.com/lxc/incus/v6/internal/server/certificate"
@@ -90,6 +91,8 @@ type Authorizer interface {
 
 	AddStorageBucket(ctx context.Context, projectName string, storagePoolName string, storageBucketName string, storageBucketLocation string) error
 	DeleteStorageBucket(ctx context.Context, projectName string, storagePoolName string, storageBucketName string, storageBucketLocation string) error
+
+	GetProjectAccess(ctx context.Context, projectName string) (*api.Access, error)
 }
 
 // Opts is used as part of the LoadAuthorizer function so that only the relevant configuration fields are passed into a

--- a/shared/api/access.go
+++ b/shared/api/access.go
@@ -1,0 +1,22 @@
+package api
+
+// access represents who has access to an instance or project
+//
+// swagger:model
+//
+// API extension: instances.
+type Access []AccessEntry
+
+type AccessEntry struct {
+	// Certificate fingerprint
+	// Example: 636b69519d27ae3b0e398cb7928043846ce1e3842f0ca7a589993dd913ab8cc9
+	Identifier string `json:"identifier" yaml:"identifier"`
+
+	// The role associated with the certificate
+	// Example: admin, view, operator
+	Role string `json:"role" yaml:"role"`
+
+	// Which authorization method the certificate uses
+	// Example: tls, openfga
+	Provider string `json:"provider" yaml:"provider"`
+}


### PR DESCRIPTION
- Added GetProjectAccess method for openFGA and TLS drivers. Returning an api Access object which gives details on who is allowed to access what in the project.
- Added a new api Access object to encapsulate access levels for users
- Added the new GET endpoint
- Was unable to get the documentation updated using the make command but @stgraber said he would manually update it 