### PR TITLE
Add PCI support to incus info --resources

### DIFF
--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -349,6 +349,17 @@ func (c *cmdInfo) renderUSB(usb api.ResourcesUSBDevice, prefix string) {
 	}
 }
 
+func (c *cmdInfo) renderPCI(pci api.ResourcesPCIDevice, prefix string) {
+	fmt.Printf(prefix+i18n.G("Address: %v")+"\n", pci.PCIAddress)
+	fmt.Printf(prefix+i18n.G("Vendor: %v")+"\n", pci.Vendor)
+	fmt.Printf(prefix+i18n.G("Vendor ID: %v")+"\n", pci.VendorID)
+	fmt.Printf(prefix+i18n.G("Product: %v")+"\n", pci.Product)
+	fmt.Printf(prefix+i18n.G("Product ID: %v")+"\n", pci.ProductID)
+	fmt.Printf(prefix+i18n.G("NUMA node: %v")+"\n", pci.NUMANode)
+	fmt.Printf(prefix+i18n.G("IOMMU group: %v")+"\n", pci.IOMMUGroup)
+	fmt.Printf(prefix+i18n.G("Driver: %v")+"\n", pci.Driver)
+}
+
 func (c *cmdInfo) remoteInfo(d incus.InstanceServer) error {
 	// Targeting
 	if c.flagTarget != "" {
@@ -551,6 +562,19 @@ func (c *cmdInfo) remoteInfo(d incus.InstanceServer) error {
 				c.renderUSB(usb, "    ")
 			}
 		}
+
+		// PCI
+		if len(resources.PCI.Devices) == 1 {
+			fmt.Printf("\n" + i18n.G("PCI device:") + "\n")
+			c.renderPCI(resources.PCI.Devices[0], "  ")
+		} else if len(resources.PCI.Devices) > 1 {
+			fmt.Printf("\n" + i18n.G("PCI devices:") + "\n")
+			for id, pci := range resources.PCI.Devices {
+				fmt.Printf("  "+i18n.G("Device %d:")+"\n", id)
+				c.renderPCI(pci, "    ")
+			}
+		}
+
 		return nil
 	}
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-06 17:08-0400\n"
+"POT-Creation-Date: 2024-05-06 22:26-0400\n"
 "PO-Revision-Date: 2024-01-25 23:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid "  Motherboard:"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid "--target can only be used with clusters"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:822 cmd/incus/info.go:600
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -963,6 +963,11 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Profil %s erstellt\n"
 
+#: cmd/incus/info.go:353
+#, fuzzy, c-format
+msgid "Address: %v"
+msgstr "Profil %s erstellt\n"
+
 #: cmd/incus/storage_bucket.go:182
 #, fuzzy, c-format
 msgid "Admin access key: %s"
@@ -1021,8 +1026,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470
-#: cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482
+#: cmd/incus/info.go:623
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -1123,7 +1128,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1153,7 +1158,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1209,11 +1214,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1242,19 +1247,19 @@ msgstr "Prozessorauslastung (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 msgid "CPU usage:"
 msgstr "Prozessorauslastung:"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 msgid "CPUs:"
 msgstr ""
 
@@ -1387,7 +1392,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1920,7 +1925,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634
 #: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
@@ -1989,7 +1994,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Erstellt: %s"
@@ -2300,7 +2305,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2392,22 +2397,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 #, fuzzy
 msgid "Disk:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 #, fuzzy
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
@@ -2477,6 +2482,15 @@ msgstr ""
 #: cmd/incus/network.go:959
 msgid "Down delay"
 msgstr ""
+
+#: cmd/incus/info.go:360
+#, fuzzy, c-format
+msgid "Driver: %v"
+msgstr ""
+"Benutzung: %s\n"
+"\n"
+"Optionen:\n"
+"\n"
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
 #, c-format
@@ -2808,7 +2822,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
 #: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
@@ -3228,7 +3242,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed validation request: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3346,8 +3360,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509
+#: cmd/incus/info.go:515
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3366,11 +3380,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid "GPUs:"
 msgstr ""
 
@@ -3563,12 +3577,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3614,11 +3628,16 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid "IOMMU group: %v"
+msgstr ""
+
 #: cmd/incus/network.go:1187
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
@@ -3796,7 +3815,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 msgid "Instance Only"
 msgstr ""
 
@@ -4041,7 +4060,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
@@ -4556,11 +4575,11 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4569,7 +4588,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid "Log:"
 msgstr ""
 
@@ -4608,7 +4627,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
@@ -4660,7 +4679,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid "MTU"
 msgstr ""
 
@@ -4933,19 +4952,19 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 msgid "Memory:"
 msgstr ""
 
@@ -5298,11 +5317,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid "NICs:"
 msgstr ""
 
@@ -5314,11 +5333,12 @@ msgid "NO"
 msgstr ""
 
 #: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:358
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5331,7 +5351,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
 #: cmd/incus/storage_volume.go:2594
 msgid "Name"
@@ -5397,7 +5417,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929
+#: cmd/incus/info.go:609 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
@@ -5518,7 +5538,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -5608,7 +5628,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5665,7 +5685,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5682,6 +5702,16 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
+#: cmd/incus/info.go:569
+#, fuzzy
+msgid "PCI device:"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
+#: cmd/incus/info.go:572
+#, fuzzy
+msgid "PCI devices:"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
 #: cmd/incus/network_peer.go:156
 msgid "PEER"
 msgstr ""
@@ -5690,7 +5720,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5726,11 +5756,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5856,7 +5886,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -5866,17 +5896,17 @@ msgstr "Profil %s erstellt\n"
 msgid "Processing aliases failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Erstellt: %s"
@@ -6419,7 +6449,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid "Resources:"
 msgstr ""
 
@@ -6522,7 +6552,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6611,7 +6641,7 @@ msgstr ""
 msgid "Serial Number: %v"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr ""
@@ -6620,7 +6650,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Erstellt: %s"
@@ -7217,11 +7247,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7250,7 +7280,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Erstellt: %s"
@@ -7264,7 +7294,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
@@ -7274,11 +7304,11 @@ msgstr "Erstellt: %s"
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7411,11 +7441,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7431,7 +7461,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid "System:"
 msgstr ""
 
@@ -7452,7 +7482,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
@@ -7701,7 +7731,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7780,7 +7810,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368
 #: cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7794,8 +7824,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499
-#: cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511
+#: cmd/incus/info.go:517
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7849,7 +7879,7 @@ msgstr "Administrator Passwort für %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 msgid "Type"
 msgstr ""
 
@@ -7868,14 +7898,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415
+#: cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7896,12 +7926,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 #, fuzzy
 msgid "USB device:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 #, fuzzy
 msgid "USB devices:"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -7918,7 +7948,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8147,7 +8177,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8200,8 +8230,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510
+#: cmd/incus/info.go:516
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8241,17 +8271,18 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "Fehler: %v\n"
@@ -8270,12 +8301,12 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Fehler: %v\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-06 17:08-0400\n"
+"POT-Creation-Date: 2024-05-06 22:26-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.1\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid "  Motherboard:"
 msgstr ""
 
@@ -693,7 +693,7 @@ msgid "--target can only be used with clusters"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:822 cmd/incus/info.go:600
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -931,6 +931,11 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Expira: %s"
 
+#: cmd/incus/info.go:353
+#, fuzzy, c-format
+msgid "Address: %v"
+msgstr "Expira: %s"
+
 #: cmd/incus/storage_bucket.go:182
 #, fuzzy, c-format
 msgid "Admin access key: %s"
@@ -987,8 +992,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470
-#: cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482
+#: cmd/incus/info.go:623
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -1083,7 +1088,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1112,7 +1117,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1169,11 +1174,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1202,19 +1207,19 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 msgid "CPUs:"
 msgstr ""
 
@@ -1341,7 +1346,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1855,7 +1860,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634
 #: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
@@ -1924,7 +1929,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Auto actualización: %s"
@@ -2228,7 +2233,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Dispositivo: %s"
@@ -2311,20 +2316,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, c-format
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 msgid "Disk:"
 msgstr "Disco:"
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 msgid "Disks:"
 msgstr "Discos:"
 
@@ -2393,6 +2398,11 @@ msgstr ""
 #: cmd/incus/network.go:959
 msgid "Down delay"
 msgstr ""
+
+#: cmd/incus/info.go:360
+#, fuzzy, c-format
+msgid "Driver: %v"
+msgstr "Dispositivo: %s"
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
 #, c-format
@@ -2707,7 +2717,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
 #: cmd/incus/storage_volume.go:2596
 #, fuzzy
@@ -3126,7 +3136,7 @@ msgstr "Acepta certificado"
 msgid "Failed validation request: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3241,8 +3251,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509
+#: cmd/incus/info.go:515
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3261,11 +3271,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid "GPUs:"
 msgstr ""
 
@@ -3451,12 +3461,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3502,11 +3512,16 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid "IOMMU group: %v"
+msgstr ""
+
 #: cmd/incus/network.go:1187
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
@@ -3682,7 +3697,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
@@ -3921,7 +3936,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Creado: %s"
@@ -4418,11 +4433,11 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4431,7 +4446,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid "Log:"
 msgstr "Registro:"
 
@@ -4468,7 +4483,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
@@ -4516,7 +4531,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid "MTU"
 msgstr ""
 
@@ -4769,19 +4784,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 msgid "Memory:"
 msgstr ""
 
@@ -5126,11 +5141,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid "NICs:"
 msgstr ""
 
@@ -5142,11 +5157,12 @@ msgid "NO"
 msgstr ""
 
 #: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:358
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5159,7 +5175,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
 #: cmd/incus/storage_volume.go:2594
 msgid "Name"
@@ -5221,7 +5237,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929
+#: cmd/incus/info.go:609 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
@@ -5341,7 +5357,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5427,7 +5443,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5484,7 +5500,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5501,6 +5517,14 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
+#: cmd/incus/info.go:569
+msgid "PCI device:"
+msgstr ""
+
+#: cmd/incus/info.go:572
+msgid "PCI devices:"
+msgstr ""
+
 #: cmd/incus/network_peer.go:156
 msgid "PEER"
 msgstr ""
@@ -5509,7 +5533,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5545,11 +5569,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5673,7 +5697,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -5683,17 +5707,17 @@ msgstr "Procesos: %d"
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Creado: %s"
@@ -6221,7 +6245,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid "Resources:"
 msgstr ""
 
@@ -6322,7 +6346,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6411,12 +6435,12 @@ msgstr ""
 msgid "Serial Number: %v"
 msgstr "Creado: %s"
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Creado: %s"
@@ -6984,11 +7008,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7016,7 +7040,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Auto actualización: %s"
@@ -7030,7 +7054,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
@@ -7040,11 +7064,11 @@ msgstr "Auto actualización: %s"
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7171,11 +7195,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7191,7 +7215,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid "System:"
 msgstr ""
 
@@ -7212,7 +7236,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
@@ -7458,7 +7482,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7533,7 +7557,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368
 #: cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7547,8 +7571,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499
-#: cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511
+#: cmd/incus/info.go:517
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7602,7 +7626,7 @@ msgstr "Contraseña admin para %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
@@ -7622,14 +7646,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415
+#: cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1398
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7650,11 +7674,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 msgid "USB devices:"
 msgstr ""
 
@@ -7670,7 +7694,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7890,7 +7914,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7942,8 +7966,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510
+#: cmd/incus/info.go:516
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7983,17 +8007,18 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -8008,12 +8033,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Versión de CUDA: %v"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-06 17:08-0400\n"
+"POT-Creation-Date: 2024-05-06 22:26-0400\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -18,16 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 #, fuzzy
 msgid "  Chassis:"
 msgstr "Châssis"
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid "  Motherboard:"
 msgstr ""
 
@@ -701,7 +701,7 @@ msgid "--target can only be used with clusters"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:822 cmd/incus/info.go:600
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
@@ -952,6 +952,11 @@ msgstr "Adresses à associé à (sans inclure les ports)"
 msgid "Address: %s"
 msgstr "Addresse : %s"
 
+#: cmd/incus/info.go:353
+#, fuzzy, c-format
+msgid "Address: %v"
+msgstr "Addresse : %s"
+
 #: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid "Admin access key: %s"
@@ -1009,8 +1014,8 @@ msgstr "Toutes les adresses serveurs sont indisponibles"
 msgid "Alternative certificate name"
 msgstr "Nom alternatif du certificat"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470
-#: cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482
+#: cmd/incus/info.go:623
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -1113,7 +1118,7 @@ msgstr "Mode automatique (non-interactif)"
 msgid "Available projects:"
 msgstr "Projets disponibles :"
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1142,7 +1147,7 @@ msgstr "Sauvegarder le volume de stockage : %s"
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1200,11 +1205,11 @@ msgstr "Pont:"
 msgid "Bus Address: %v"
 msgstr "Addresse : %s"
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1233,19 +1238,19 @@ msgstr "CPU (%s) :"
 msgid "CPU USAGE"
 msgstr "UTILISATION CPU"
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 #, fuzzy
 msgid "CPUs:"
 msgstr "GPUs :"
@@ -1381,7 +1386,7 @@ msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 msgid "Cannot set key: %s"
 msgstr "Impossible d'assigner les clés: %s"
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid "Card %d:"
 msgstr "Cartes %d:"
@@ -1952,7 +1957,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634
 #: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
@@ -2021,7 +2026,7 @@ msgstr "Le démon ne fonctionne toujours pas après %ds d'attente (%v)"
 msgid "Daemon still running after %ds timeout"
 msgstr "Le démon continue de fonctionner après %ds d'attente"
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "État : %s"
@@ -2337,7 +2342,7 @@ msgstr "Clé de configuration invalide"
 msgid "Detach storage volumes from profiles"
 msgstr "Détacher les volumes de stockage des profils"
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Serveur distant : %s"
@@ -2426,20 +2431,20 @@ msgstr "Désactiver l'allocation pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Disque %d:"
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 msgid "Disk usage:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 msgid "Disk:"
 msgstr "Disque utilisé :"
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 msgid "Disks:"
 msgstr "Disque utilisé :"
 
@@ -2509,6 +2514,11 @@ msgstr "Ne pas afficher les informations sur l'état d'avancement"
 #: cmd/incus/network.go:959
 msgid "Down delay"
 msgstr ""
+
+#: cmd/incus/info.go:360
+#, fuzzy, c-format
+msgid "Driver: %v"
+msgstr "Pilote: %v (%v)"
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
 #, c-format
@@ -2903,7 +2913,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
 #: cmd/incus/storage_volume.go:2596
 #, fuzzy
@@ -3343,7 +3353,7 @@ msgstr "Échec de l'écriture du fichier de certificat serveur %q : %w"
 msgid "Failed validation request: %w"
 msgstr "Échec de la demande de validation : %w"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, fuzzy, c-format
 msgid "Family: %v"
 msgstr "Nom : %s"
@@ -3486,8 +3496,8 @@ msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 "L'alias trouvé %q fait référence à un argument en dehors du nombre donné"
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509
+#: cmd/incus/info.go:515
 #, fuzzy, c-format
 msgid "Free: %v"
 msgstr "Libre : %v"
@@ -3506,11 +3516,11 @@ msgstr "Fréquence : %vMhz (min : %vMhz, max : %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid "GPU:"
 msgstr "GPU :"
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid "GPUs:"
 msgstr "GPUs :"
 
@@ -3709,12 +3719,12 @@ msgstr "ADRESSE MATÉRIEL"
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3761,11 +3771,16 @@ msgstr "IMAGES"
 msgid "INSTANCE NAME"
 msgstr ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid "IOMMU group: %v"
+msgstr ""
+
 #: cmd/incus/network.go:1187
 msgid "IP ADDRESS"
 msgstr "ADRESSE IP"
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
@@ -3963,7 +3978,7 @@ msgstr "Infiniband :"
 msgid "Input data"
 msgstr "Données d'entrée"
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
@@ -4214,7 +4229,7 @@ msgstr "ADRESSE D’ÉCOUTE"
 msgid "LOCATION"
 msgstr "LOCALISATION"
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
@@ -4775,11 +4790,11 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4788,7 +4803,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid "Log:"
 msgstr "Journal :"
 
@@ -4827,7 +4842,7 @@ msgstr "Création du conteneur"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
@@ -4875,7 +4890,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid "MTU"
 msgstr ""
 
@@ -5146,19 +5161,19 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 msgid "Memory usage:"
 msgstr "Mémoire utilisée :"
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 msgid "Memory:"
 msgstr "Mémoire utilisée :"
 
@@ -5515,11 +5530,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid "NICs:"
 msgstr ""
 
@@ -5531,11 +5546,12 @@ msgid "NO"
 msgstr "NON"
 
 #: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:358
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5548,7 +5564,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
 #: cmd/incus/storage_volume.go:2594
 #, fuzzy
@@ -5615,7 +5631,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929
+#: cmd/incus/info.go:609 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
@@ -5736,7 +5752,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
@@ -5825,7 +5841,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5892,7 +5908,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5910,6 +5926,16 @@ msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 msgid "PCI address: %v"
 msgstr ""
 
+#: cmd/incus/info.go:569
+#, fuzzy
+msgid "PCI device:"
+msgstr "Création du conteneur"
+
+#: cmd/incus/info.go:572
+#, fuzzy
+msgid "PCI devices:"
+msgstr "Création du conteneur"
+
 #: cmd/incus/network_peer.go:156
 msgid "PEER"
 msgstr ""
@@ -5918,7 +5944,7 @@ msgstr ""
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, fuzzy, c-format
 msgid "PID: %d"
 msgstr "Pid : %d"
@@ -5954,11 +5980,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -6085,7 +6111,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -6095,17 +6121,17 @@ msgstr "Processus : %d"
 msgid "Processing aliases failed: %s"
 msgstr "Le traitement des alias a échoué : %s"
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Marque : %v"
@@ -6651,7 +6677,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -6770,7 +6796,7 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, fuzzy, c-format
 msgid "SKU: %v"
 msgstr "Publié : %s"
@@ -6862,12 +6888,12 @@ msgstr ""
 msgid "Serial Number: %v"
 msgstr "Marque : %v"
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Marque : %v"
@@ -7469,11 +7495,11 @@ msgstr "Copie de l'image : %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7502,7 +7528,7 @@ msgstr "Source :"
 msgid "Start instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "État : %s"
@@ -7516,7 +7542,7 @@ msgstr "Démarrage de %s"
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
@@ -7526,12 +7552,12 @@ msgstr "État : %s"
 msgid "State: %s"
 msgstr "État : %s"
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
@@ -7663,11 +7689,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -7685,7 +7711,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid "System:"
 msgstr ""
 
@@ -7706,7 +7732,7 @@ msgstr ""
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 #, fuzzy
 msgid "Taken at"
@@ -7965,7 +7991,7 @@ msgstr ""
 "Le pool de stockage demandé \"%s\" existe déjà. Veuillez choisir un autre "
 "nom."
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -8045,7 +8071,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368
 #: cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -8059,8 +8085,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Publié : %s"
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499
-#: cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511
+#: cmd/incus/info.go:517
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -8114,7 +8140,7 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
@@ -8134,14 +8160,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415
+#: cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1398
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, fuzzy, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
@@ -8162,12 +8188,12 @@ msgstr "URL"
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 #, fuzzy
 msgid "USB device:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 #, fuzzy
 msgid "USB devices:"
 msgstr "Création du conteneur"
@@ -8184,7 +8210,7 @@ msgstr "UTILISÉ PAR"
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -8416,7 +8442,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8469,8 +8495,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510
+#: cmd/incus/info.go:516
 #, fuzzy, c-format
 msgid "Used: %v"
 msgstr "Publié : %s"
@@ -8511,17 +8537,18 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "erreur : %v"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354
+#: cmd/incus/info.go:391
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "erreur : %v"
@@ -8536,12 +8563,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Version CUDA : %v"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-05-06 17:08-0400\n"
+        "POT-Creation-Date: 2024-05-06 22:26-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,15 +16,15 @@ msgstr  "Project-Id-Version: incus\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 msgid   "  Chassis:"
 msgstr  ""
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid   "  Firmware:"
 msgstr  ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid   "  Motherboard:"
 msgstr  ""
 
@@ -423,7 +423,7 @@ msgstr  ""
 msgid   "--target can only be used with clusters"
 msgstr  ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615 cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615 cmd/incus/config.go:822 cmd/incus/info.go:600
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -642,6 +642,11 @@ msgstr  ""
 msgid   "Address: %s"
 msgstr  ""
 
+#: cmd/incus/info.go:353
+#, c-format
+msgid   "Address: %v"
+msgstr  ""
+
 #: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid   "Admin access key: %s"
@@ -696,7 +701,7 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470 cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482 cmd/incus/info.go:623
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -789,7 +794,7 @@ msgstr  ""
 msgid   "Available projects:"
 msgstr  ""
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid   "Average: %.2f %.2f %.2f"
 msgstr  ""
@@ -817,7 +822,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid   "Backups:"
 msgstr  ""
 
@@ -868,11 +873,11 @@ msgstr  ""
 msgid   "Bus Address: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid   "Bytes received"
 msgstr  ""
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -900,19 +905,19 @@ msgstr  ""
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 msgid   "CPU usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid   "CPU:"
 msgstr  ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 msgid   "CPUs:"
 msgstr  ""
 
@@ -1031,7 +1036,7 @@ msgstr  ""
 msgid   "Cannot set key: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid   "Card %d:"
 msgstr  ""
@@ -1469,7 +1474,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609 cmd/incus/storage_volume.go:1418
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634 cmd/incus/storage_volume.go:1418
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1527,7 +1532,7 @@ msgstr  ""
 msgid   "Daemon still running after %ds timeout"
 msgstr  ""
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, c-format
 msgid   "Date: %s"
 msgstr  ""
@@ -1673,7 +1678,7 @@ msgstr  ""
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid   "Device %d:"
 msgstr  ""
@@ -1748,20 +1753,20 @@ msgstr  ""
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, c-format
 msgid   "Disk %d:"
 msgstr  ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 msgid   "Disk usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 msgid   "Disk:"
 msgstr  ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 msgid   "Disks:"
 msgstr  ""
 
@@ -1823,6 +1828,11 @@ msgstr  ""
 
 #: cmd/incus/network.go:959
 msgid   "Down delay"
+msgstr  ""
+
+#: cmd/incus/info.go:360
+#, c-format
+msgid   "Driver: %v"
 msgstr  ""
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
@@ -2101,7 +2111,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366 cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501 cmd/incus/storage_volume.go:2596
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366 cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501 cmd/incus/storage_volume.go:2596
 msgid   "Expires at"
 msgstr  ""
 
@@ -2508,7 +2518,7 @@ msgstr  ""
 msgid   "Failed validation request: %w"
 msgstr  ""
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, c-format
 msgid   "Family: %v"
 msgstr  ""
@@ -2603,7 +2613,7 @@ msgstr  ""
 msgid   "Found alias %q references an argument outside the given number"
 msgstr  ""
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497 cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509 cmd/incus/info.go:515
 #, c-format
 msgid   "Free: %v"
 msgstr  ""
@@ -2622,11 +2632,11 @@ msgstr  ""
 msgid   "GLOBAL"
 msgstr  ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid   "GPU:"
 msgstr  ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid   "GPUs:"
 msgstr  ""
 
@@ -2795,11 +2805,11 @@ msgstr  ""
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 msgid   "Host interface"
 msgstr  ""
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid   "Hugepages:\n"
 msgstr  ""
 
@@ -2845,11 +2855,16 @@ msgstr  ""
 msgid   "INSTANCE NAME"
 msgstr  ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid   "IOMMU group: %v"
+msgstr  ""
+
 #: cmd/incus/network.go:1187
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 msgid   "IP addresses"
 msgstr  ""
 
@@ -3016,7 +3031,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 msgid   "Instance Only"
 msgstr  ""
 
@@ -3239,7 +3254,7 @@ msgstr  ""
 msgid   "LOCATION"
 msgstr  ""
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, c-format
 msgid   "Last Used: %s"
 msgstr  ""
@@ -3700,11 +3715,11 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid   "Load:"
 msgstr  ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3713,7 +3728,7 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid   "Log:"
 msgstr  ""
 
@@ -3750,7 +3765,7 @@ msgstr  ""
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 msgid   "MAC address"
 msgstr  ""
 
@@ -3797,7 +3812,7 @@ msgstr  ""
 msgid   "MII state"
 msgstr  ""
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid   "MTU"
 msgstr  ""
 
@@ -4028,19 +4043,19 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid   "Memory (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 msgid   "Memory usage:"
 msgstr  ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 msgid   "Memory:"
 msgstr  ""
 
@@ -4263,11 +4278,11 @@ msgstr  ""
 msgid   "NEW: %q (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid   "NIC:"
 msgstr  ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid   "NICs:"
 msgstr  ""
 
@@ -4275,12 +4290,12 @@ msgstr  ""
 msgid   "NO"
 msgstr  ""
 
-#: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271 cmd/incus/info.go:358
 #, c-format
 msgid   "NUMA node: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid   "NUMA nodes:\n"
 msgstr  ""
 
@@ -4293,7 +4308,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364 cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499 cmd/incus/storage_volume.go:2594
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364 cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499 cmd/incus/storage_volume.go:2594
 msgid   "Name"
 msgstr  ""
 
@@ -4352,7 +4367,7 @@ msgstr  ""
 msgid   "Name of the storage pool:"
 msgstr  ""
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1389
+#: cmd/incus/info.go:609 cmd/incus/network.go:929 cmd/incus/storage_volume.go:1389
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -4470,7 +4485,7 @@ msgstr  ""
 msgid   "Network type"
 msgstr  ""
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 msgid   "Network usage:"
 msgstr  ""
 
@@ -4556,7 +4571,7 @@ msgstr  ""
 msgid   "No value found in %q"
 msgstr  ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid   "Node %d:\n"
 msgstr  ""
@@ -4610,7 +4625,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4627,6 +4642,14 @@ msgstr  ""
 msgid   "PCI address: %v"
 msgstr  ""
 
+#: cmd/incus/info.go:569
+msgid   "PCI device:"
+msgstr  ""
+
+#: cmd/incus/info.go:572
+msgid   "PCI devices:"
+msgstr  ""
+
 #: cmd/incus/network_peer.go:156
 msgid   "PEER"
 msgstr  ""
@@ -4635,7 +4658,7 @@ msgstr  ""
 msgid   "PID"
 msgstr  ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, c-format
 msgid   "PID: %d"
 msgstr  ""
@@ -4668,11 +4691,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid   "Packets received"
 msgstr  ""
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid   "Packets sent"
 msgstr  ""
 
@@ -4785,7 +4808,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -4795,17 +4818,17 @@ msgstr  ""
 msgid   "Processing aliases failed: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, c-format
 msgid   "Product ID: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, c-format
 msgid   "Product: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, c-format
 msgid   "Product: %v"
 msgstr  ""
@@ -5290,7 +5313,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid   "Resources:"
 msgstr  ""
 
@@ -5383,7 +5406,7 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, c-format
 msgid   "SKU: %v"
 msgstr  ""
@@ -5469,12 +5492,12 @@ msgstr  ""
 msgid   "Serial Number: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, c-format
 msgid   "Serial: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, c-format
 msgid   "Serial: %v"
 msgstr  ""
@@ -5980,11 +6003,11 @@ msgstr  ""
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid   "Snapshots:"
 msgstr  ""
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid   "Socket %d:"
 msgstr  ""
@@ -6010,7 +6033,7 @@ msgstr  ""
 msgid   "Start instances"
 msgstr  ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, c-format
 msgid   "Started: %s"
 msgstr  ""
@@ -6024,7 +6047,7 @@ msgstr  ""
 msgid   "Starting recovery..."
 msgstr  ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 msgid   "State"
 msgstr  ""
 
@@ -6033,11 +6056,11 @@ msgstr  ""
 msgid   "State: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 msgid   "Stateful"
 msgstr  ""
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
@@ -6162,11 +6185,11 @@ msgstr  ""
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid   "Swap (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -6182,7 +6205,7 @@ msgstr  ""
 msgid   "Symlink target path can only be used for type \"symlink\""
 msgstr  ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid   "System:"
 msgstr  ""
 
@@ -6198,7 +6221,7 @@ msgstr  ""
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365 cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365 cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid   "Taken at"
 msgstr  ""
 
@@ -6426,7 +6449,7 @@ msgstr  ""
 msgid   "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr  ""
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
@@ -6494,7 +6517,7 @@ msgid   "To start your first container, try: incus launch images:ubuntu/22.04\n"
         "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr  ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356 cmd/incus/network.go:917 cmd/incus/storage.go:524
+#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368 cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -6507,7 +6530,7 @@ msgstr  ""
 msgid   "Total: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499 cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511 cmd/incus/info.go:517
 #, c-format
 msgid   "Total: %v"
 msgstr  ""
@@ -6561,7 +6584,7 @@ msgstr  ""
 msgid   "Try `incus info --show-log %s` for more info"
 msgstr  ""
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 msgid   "Type"
 msgstr  ""
 
@@ -6577,12 +6600,12 @@ msgstr  ""
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403 cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933 cmd/incus/storage_volume.go:1398
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415 cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933 cmd/incus/storage_volume.go:1398
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, c-format
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
@@ -6603,11 +6626,11 @@ msgstr  ""
 msgid   "USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 msgid   "USB device:"
 msgstr  ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 msgid   "USB devices:"
 msgstr  ""
 
@@ -6619,7 +6642,7 @@ msgstr  ""
 msgid   "UUID"
 msgstr  ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid   "UUID: %v"
 msgstr  ""
@@ -6816,7 +6839,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
@@ -6864,7 +6887,7 @@ msgstr  ""
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498 cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510 cmd/incus/info.go:516
 #, c-format
 msgid   "Used: %v"
 msgstr  ""
@@ -6902,17 +6925,17 @@ msgstr  ""
 msgid   "VLAN:"
 msgstr  ""
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, c-format
 msgid   "Vendor ID: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, c-format
 msgid   "Vendor: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354 cmd/incus/info.go:391
 #, c-format
 msgid   "Vendor: %v"
 msgstr  ""
@@ -6927,12 +6950,12 @@ msgstr  ""
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, c-format
 msgid   "Version: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, c-format
 msgid   "Version: %v"
 msgstr  ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-06 17:08-0400\n"
+"POT-Creation-Date: 2024-05-06 22:26-0400\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -18,15 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid "  Motherboard:"
 msgstr ""
 
@@ -692,7 +692,7 @@ msgid "--target can only be used with clusters"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:822 cmd/incus/info.go:600
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -930,6 +930,11 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
+#: cmd/incus/info.go:353
+#, fuzzy, c-format
+msgid "Address: %v"
+msgstr "La periferica esiste già: %s"
+
 #: cmd/incus/storage_bucket.go:182
 #, fuzzy, c-format
 msgid "Admin access key: %s"
@@ -986,8 +991,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470
-#: cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482
+#: cmd/incus/info.go:623
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -1082,7 +1087,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1111,7 +1116,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1167,11 +1172,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1200,19 +1205,19 @@ msgstr "Utilizzo CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 msgid "CPUs:"
 msgstr ""
 
@@ -1336,7 +1341,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1848,7 +1853,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634
 #: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
@@ -1917,7 +1922,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -2221,7 +2226,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Utilizzo disco:"
@@ -2303,21 +2308,21 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 #, fuzzy
 msgid "Disk:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 #, fuzzy
 msgid "Disks:"
 msgstr "Utilizzo disco:"
@@ -2387,6 +2392,11 @@ msgstr ""
 #: cmd/incus/network.go:959
 msgid "Down delay"
 msgstr ""
+
+#: cmd/incus/info.go:360
+#, fuzzy, c-format
+msgid "Driver: %v"
+msgstr "Aggiornamento automatico: %s"
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
 #, c-format
@@ -2701,7 +2711,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
 #: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
@@ -3119,7 +3129,7 @@ msgstr "Accetta certificato"
 msgid "Failed validation request: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3235,8 +3245,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509
+#: cmd/incus/info.go:515
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3255,11 +3265,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid "GPUs:"
 msgstr ""
 
@@ -3442,12 +3452,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3493,11 +3503,16 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid "IOMMU group: %v"
+msgstr ""
+
 #: cmd/incus/network.go:1187
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 msgid "IP addresses"
 msgstr ""
 
@@ -3671,7 +3686,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
@@ -3910,7 +3925,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -4408,11 +4423,11 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4421,7 +4436,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid "Log:"
 msgstr ""
 
@@ -4460,7 +4475,7 @@ msgstr "Creazione del container in corso"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 msgid "MAC address"
 msgstr ""
 
@@ -4507,7 +4522,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid "MTU"
 msgstr ""
 
@@ -4764,19 +4779,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 msgid "Memory:"
 msgstr ""
 
@@ -5120,11 +5135,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid "NICs:"
 msgstr ""
 
@@ -5136,11 +5151,12 @@ msgid "NO"
 msgstr ""
 
 #: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:358
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5153,7 +5169,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
 #: cmd/incus/storage_volume.go:2594
 msgid "Name"
@@ -5215,7 +5231,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929
+#: cmd/incus/info.go:609 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
@@ -5335,7 +5351,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5421,7 +5437,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5478,7 +5494,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5495,6 +5511,16 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
+#: cmd/incus/info.go:569
+#, fuzzy
+msgid "PCI device:"
+msgstr "Creazione del container in corso"
+
+#: cmd/incus/info.go:572
+#, fuzzy
+msgid "PCI devices:"
+msgstr "Creazione del container in corso"
+
 #: cmd/incus/network_peer.go:156
 msgid "PEER"
 msgstr ""
@@ -5503,7 +5529,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5539,11 +5565,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5668,7 +5694,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5678,17 +5704,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -6216,7 +6242,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid "Resources:"
 msgstr ""
 
@@ -6317,7 +6343,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6406,12 +6432,12 @@ msgstr ""
 msgid "Serial Number: %v"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6975,11 +7001,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7008,7 +7034,7 @@ msgstr ""
 msgid "Start instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -7022,7 +7048,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
@@ -7032,11 +7058,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7163,11 +7189,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7183,7 +7209,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid "System:"
 msgstr ""
 
@@ -7204,7 +7230,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 #, fuzzy
 msgid "Taken at"
@@ -7452,7 +7478,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7527,7 +7553,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368
 #: cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7541,8 +7567,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499
-#: cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511
+#: cmd/incus/info.go:517
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7596,7 +7622,7 @@ msgstr "Password amministratore per %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 msgid "Type"
 msgstr ""
 
@@ -7615,14 +7641,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415
+#: cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7643,12 +7669,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 #, fuzzy
 msgid "USB device:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 #, fuzzy
 msgid "USB devices:"
 msgstr "Creazione del container in corso"
@@ -7665,7 +7691,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7881,7 +7907,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7934,8 +7960,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510
+#: cmd/incus/info.go:516
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7975,17 +8001,18 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -8000,12 +8027,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, c-format
 msgid "Version: %v"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-06 17:08-0400\n"
+"POT-Creation-Date: 2024-05-06 22:26-0400\n"
 "PO-Revision-Date: 2024-02-24 03:02+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -18,16 +18,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.5-dev\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 #, fuzzy
 msgid "  Chassis:"
 msgstr "Chassis"
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid "  Motherboard:"
 msgstr ""
 
@@ -683,7 +683,7 @@ msgid "--target can only be used with clusters"
 msgstr "--target はインスタンスでは使えません"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:822 cmd/incus/info.go:600
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
 
@@ -929,6 +929,11 @@ msgstr "バインドするアドレス (ポートを含まない)"
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
+#: cmd/incus/info.go:353
+#, fuzzy, c-format
+msgid "Address: %v"
+msgstr "アドレス: %s"
+
 #: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid "Admin access key: %s"
@@ -984,8 +989,8 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470
-#: cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482
+#: cmd/incus/info.go:623
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -1084,7 +1089,7 @@ msgstr "自動（非インタラクティブ）モード"
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1113,7 +1118,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1171,11 +1176,11 @@ msgstr "ブリッジ:"
 msgid "Bus Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1204,19 +1209,19 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 #, fuzzy
 msgid "CPUs:"
 msgstr "GPUs:"
@@ -1346,7 +1351,7 @@ msgstr "スナップショットをコピーするときに --volume-only は指
 msgid "Cannot set key: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid "Card %d:"
 msgstr "カード %d:"
@@ -1877,7 +1882,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634
 #: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
@@ -1946,7 +1951,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr "%d 秒のタイムアウトが経過しましたが、デーモンがまだ実行中です"
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "状態: %s"
@@ -2243,7 +2248,7 @@ msgstr "インスタンスからストレージボリュームを取り外しま
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "デバイス: %s"
@@ -2331,20 +2336,20 @@ msgstr "擬似端末の割り当てを無効にします"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, c-format
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 msgid "Disk:"
 msgstr "ディスク:"
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 msgid "Disks:"
 msgstr "ディスク:"
 
@@ -2411,6 +2416,11 @@ msgstr "進捗情報を表示しません"
 #: cmd/incus/network.go:959
 msgid "Down delay"
 msgstr "Down delay"
+
+#: cmd/incus/info.go:360
+#, fuzzy, c-format
+msgid "Driver: %v"
+msgstr "ドライバ: %v (%v)"
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
 #, c-format
@@ -2769,7 +2779,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
 #: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
@@ -3187,7 +3197,7 @@ msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 msgid "Failed validation request: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, fuzzy, c-format
 msgid "Family: %v"
 msgstr "名前: %v"
@@ -3316,8 +3326,8 @@ msgstr "Forward delay"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "エイリアス %q が指定した番号以外の引数を参照しているのが見つかりました"
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509
+#: cmd/incus/info.go:515
 #, c-format
 msgid "Free: %v"
 msgstr "空き: %v"
@@ -3336,11 +3346,11 @@ msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid "GPU:"
 msgstr "GPU:"
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid "GPUs:"
 msgstr "GPUs:"
 
@@ -3523,11 +3533,11 @@ msgstr "MAC ADDRESS"
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
@@ -3573,11 +3583,16 @@ msgstr "IMAGES"
 msgid "INSTANCE NAME"
 msgstr ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid "IOMMU group: %v"
+msgstr ""
+
 #: cmd/incus/network.go:1187
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 msgid "IP addresses"
 msgstr "IP アドレス"
 
@@ -3765,7 +3780,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
@@ -4006,7 +4021,7 @@ msgstr "LISTEN ADDRESS"
 msgid "LOCATION"
 msgstr "LOCATION"
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
@@ -4741,11 +4756,11 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4754,7 +4769,7 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid "Log:"
 msgstr "ログ:"
 
@@ -4791,7 +4806,7 @@ msgstr "Lower devices"
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 msgid "MAC address"
 msgstr "MAC アドレス"
 
@@ -4839,7 +4854,7 @@ msgstr "MII 監視頻度"
 msgid "MII state"
 msgstr "MII 状態"
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid "MTU"
 msgstr "MTU"
 
@@ -5099,19 +5114,19 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 msgid "Memory:"
 msgstr "メモリ:"
 
@@ -5463,11 +5478,11 @@ msgstr "NETWORKS"
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr "新規: %q (バックエンド=%q, ソース=%q)"
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid "NIC:"
 msgstr "NIC:"
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid "NICs:"
 msgstr "NICs:"
 
@@ -5479,11 +5494,12 @@ msgid "NO"
 msgstr "NO"
 
 #: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:358
 #, c-format
 msgid "NUMA node: %v"
 msgstr "NUMA ノード: %v"
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid "NUMA nodes:\n"
 msgstr "NUMA ノード:\n"
 
@@ -5496,7 +5512,7 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
 #: cmd/incus/storage_volume.go:2594
 msgid "Name"
@@ -5562,7 +5578,7 @@ msgstr "使用するストレージバックエンド名 (%s)"
 msgid "Name of the storage pool:"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929
+#: cmd/incus/info.go:609 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
@@ -5684,7 +5700,7 @@ msgstr ""
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -5773,7 +5789,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
@@ -5834,7 +5850,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -5851,6 +5867,16 @@ msgstr "ターミナルモードを上書きします (auto, interactive, non-in
 msgid "PCI address: %v"
 msgstr "PCI アドレス: %v"
 
+#: cmd/incus/info.go:569
+#, fuzzy
+msgid "PCI device:"
+msgstr "device"
+
+#: cmd/incus/info.go:572
+#, fuzzy
+msgid "PCI devices:"
+msgstr "上位デバイス"
+
 #: cmd/incus/network_peer.go:156
 msgid "PEER"
 msgstr "PEER"
@@ -5859,7 +5885,7 @@ msgstr "PEER"
 msgid "PID"
 msgstr "PID"
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, c-format
 msgid "PID: %d"
 msgstr "PID: %d"
@@ -5896,11 +5922,11 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -6026,7 +6052,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -6036,17 +6062,17 @@ msgstr "プロセス数: %d"
 msgid "Processing aliases failed: %s"
 msgstr "エイリアスの処理が失敗しました: %s"
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "製品名: %v (%v)"
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "製品名: %v (%v)"
@@ -6603,7 +6629,7 @@ msgstr "クラスターメンバーに join するためのトークンを要求
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -6704,7 +6730,7 @@ msgstr "SEVERITY"
 msgid "SIZE"
 msgstr "SIZE"
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, fuzzy, c-format
 msgid "SKU: %v"
 msgstr "UUID: %v"
@@ -6794,12 +6820,12 @@ msgstr "直接リクエスト (raw query) を LXD に送ります"
 msgid "Serial Number: %v"
 msgstr "合計: %v"
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "合計: %v"
@@ -7435,11 +7461,11 @@ msgstr "ストレージボリュームのスナップショットを取得しま
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid "Socket %d:"
 msgstr "ソケット %d:"
@@ -7469,7 +7495,7 @@ msgstr "取得元:"
 msgid "Start instances"
 msgstr "インスタンスを起動します"
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "状態: %s"
@@ -7483,7 +7509,7 @@ msgstr "%s を起動中"
 msgid "Starting recovery..."
 msgstr "リカバリーを開始します..."
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 msgid "State"
 msgstr "状態"
 
@@ -7492,11 +7518,11 @@ msgstr "状態"
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr "ステートフル"
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
@@ -7623,11 +7649,11 @@ msgstr "サポートするモード: %s"
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -7643,7 +7669,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr "シンボリックリンクのターゲットパスは \"symlink\" タイプにのみ使えます"
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid "System:"
 msgstr ""
 
@@ -7664,7 +7690,7 @@ msgstr "TOKEN"
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr "取得日時"
@@ -7953,7 +7979,7 @@ msgstr ""
 "入力したストレージプール \"%s\" はすでに存在しています。他の名前を入力してく"
 "ださい。"
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
@@ -8050,7 +8076,7 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368
 #: cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -8066,8 +8092,8 @@ msgstr "リンクが多すぎます"
 msgid "Total: %s"
 msgstr "合計: %s"
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499
-#: cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511
+#: cmd/incus/info.go:517
 #, c-format
 msgid "Total: %v"
 msgstr "合計: %v"
@@ -8121,7 +8147,7 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 msgid "Try `incus info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 msgid "Type"
 msgstr "タイプ"
 
@@ -8141,14 +8167,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415
+#: cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
@@ -8169,12 +8195,12 @@ msgstr "URL"
 msgid "USAGE"
 msgstr "USAGE"
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 #, fuzzy
 msgid "USB device:"
 msgstr "device"
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 #, fuzzy
 msgid "USB devices:"
 msgstr "上位デバイス"
@@ -8191,7 +8217,7 @@ msgstr "USED BY"
 msgid "UUID"
 msgstr "UUID"
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid "UUID: %v"
 msgstr "UUID: %v"
@@ -8403,7 +8429,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr "インスタンスプロパティの設定を削除します"
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
@@ -8458,8 +8484,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510
+#: cmd/incus/info.go:516
 #, c-format
 msgid "Used: %v"
 msgstr "使用済: %v"
@@ -8501,17 +8527,18 @@ msgstr "VLAN フィルタリング"
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "ベンダー: %v"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Vendor: %v"
 msgstr "ベンダー: %v"
@@ -8526,12 +8553,12 @@ msgstr "ベンダ: %v (%v)"
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "CUDA バージョン: %v"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-06 17:08-0400\n"
+"POT-Creation-Date: 2024-05-06 22:26-0400\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid "  Motherboard:"
 msgstr ""
 
@@ -704,7 +704,7 @@ msgid "--target can only be used with clusters"
 msgstr "--target kan niet gebruikt worden met: instances"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:822 cmd/incus/info.go:600
 msgid "--target cannot be used with instances"
 msgstr "--target kan niet gebruikt worden met: instances"
 
@@ -945,6 +945,11 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Adres: %s"
 
+#: cmd/incus/info.go:353
+#, fuzzy, c-format
+msgid "Address: %v"
+msgstr "Adres: %s"
+
 #: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid "Admin access key: %s"
@@ -1002,8 +1007,8 @@ msgstr "Alle server adressen zijn onbeschikbaar"
 msgid "Alternative certificate name"
 msgstr "Alternatieve certificaat naam"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470
-#: cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482
+#: cmd/incus/info.go:623
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architectuur: %s"
@@ -1103,7 +1108,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1132,7 +1137,7 @@ msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1188,11 +1193,11 @@ msgstr "Brug (Bridge):"
 msgid "Bus Address: %v"
 msgstr "Adres: %s"
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes ontvangen (received)"
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes verzonden"
 
@@ -1221,19 +1226,19 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU GEBRUIK"
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid "CPU usage (in seconds)"
 msgstr "CPU gebruik (in seconde)"
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 msgid "CPU usage:"
 msgstr "CPU gebruik:"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 #, fuzzy
 msgid "CPUs:"
 msgstr "CPU's (%s):"
@@ -1359,7 +1364,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1859,7 +1864,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634
 #: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
@@ -1927,7 +1932,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Cached: %s"
@@ -2223,7 +2228,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Adres: %s"
@@ -2304,20 +2309,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 msgid "Disks:"
 msgstr ""
 
@@ -2380,6 +2385,11 @@ msgstr ""
 #: cmd/incus/network.go:959
 msgid "Down delay"
 msgstr ""
+
+#: cmd/incus/info.go:360
+#, fuzzy, c-format
+msgid "Driver: %v"
+msgstr "Architectuur: %v"
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
 #, c-format
@@ -2686,7 +2696,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
 #: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
@@ -3100,7 +3110,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3214,8 +3224,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509
+#: cmd/incus/info.go:515
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3234,11 +3244,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid "GPUs:"
 msgstr ""
 
@@ -3410,11 +3420,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3460,11 +3470,16 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid "IOMMU group: %v"
+msgstr ""
+
 #: cmd/incus/network.go:1187
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 msgid "IP addresses"
 msgstr ""
 
@@ -3634,7 +3649,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 msgid "Instance Only"
 msgstr ""
 
@@ -3865,7 +3880,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4347,11 +4362,11 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4360,7 +4375,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid "Log:"
 msgstr ""
 
@@ -4397,7 +4412,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 msgid "MAC address"
 msgstr ""
 
@@ -4444,7 +4459,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid "MTU"
 msgstr ""
 
@@ -4683,19 +4698,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 msgid "Memory:"
 msgstr ""
 
@@ -5023,11 +5038,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid "NICs:"
 msgstr ""
 
@@ -5039,11 +5054,12 @@ msgid "NO"
 msgstr ""
 
 #: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:358
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5056,7 +5072,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
 #: cmd/incus/storage_volume.go:2594
 msgid "Name"
@@ -5118,7 +5134,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929
+#: cmd/incus/info.go:609 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
@@ -5238,7 +5254,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5324,7 +5340,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5381,7 +5397,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5398,6 +5414,14 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
+#: cmd/incus/info.go:569
+msgid "PCI device:"
+msgstr ""
+
+#: cmd/incus/info.go:572
+msgid "PCI devices:"
+msgstr ""
+
 #: cmd/incus/network_peer.go:156
 msgid "PEER"
 msgstr ""
@@ -5406,7 +5430,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5442,11 +5466,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5569,7 +5593,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5579,17 +5603,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Merk (Brand): %v"
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Merk (Brand): %v"
@@ -6102,7 +6126,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid "Resources:"
 msgstr ""
 
@@ -6196,7 +6220,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6285,12 +6309,12 @@ msgstr ""
 msgid "Serial Number: %v"
 msgstr "Merk (Brand): %v"
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Alias: %s"
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Merk (Brand): %v"
@@ -6834,11 +6858,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6866,7 +6890,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Cached: %s"
@@ -6880,7 +6904,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 msgid "State"
 msgstr ""
 
@@ -6889,11 +6913,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7019,11 +7043,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7039,7 +7063,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid "System:"
 msgstr ""
 
@@ -7060,7 +7084,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
@@ -7306,7 +7330,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7380,7 +7404,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368
 #: cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7394,8 +7418,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499
-#: cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511
+#: cmd/incus/info.go:517
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7449,7 +7473,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 msgid "Type"
 msgstr ""
 
@@ -7467,14 +7491,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415
+#: cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7495,11 +7519,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 msgid "USB devices:"
 msgstr ""
 
@@ -7515,7 +7539,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7715,7 +7739,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7766,8 +7790,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510
+#: cmd/incus/info.go:516
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7806,17 +7830,18 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Cached: %s"
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Cached: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7831,12 +7856,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "CUDA Versie: %v"
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "CUDA Versie: %v"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-06 17:08-0400\n"
+"POT-Creation-Date: 2024-05-06 22:26-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,15 +16,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid "  Motherboard:"
 msgstr ""
 
@@ -447,7 +447,7 @@ msgid "--target can only be used with clusters"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:822 cmd/incus/info.go:600
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -675,6 +675,11 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
+#: cmd/incus/info.go:353
+#, c-format
+msgid "Address: %v"
+msgstr ""
+
 #: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid "Admin access key: %s"
@@ -730,8 +735,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470
-#: cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482
+#: cmd/incus/info.go:623
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -825,7 +830,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -854,7 +859,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -910,11 +915,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,19 +947,19 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 msgid "CPUs:"
 msgstr ""
 
@@ -1077,7 +1082,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1576,7 +1581,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634
 #: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
@@ -1644,7 +1649,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -1939,7 +1944,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2020,20 +2025,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 msgid "Disks:"
 msgstr ""
 
@@ -2095,6 +2100,11 @@ msgstr ""
 
 #: cmd/incus/network.go:959
 msgid "Down delay"
+msgstr ""
+
+#: cmd/incus/info.go:360
+#, c-format
+msgid "Driver: %v"
 msgstr ""
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
@@ -2402,7 +2412,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
 #: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
@@ -2816,7 +2826,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -2930,8 +2940,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509
+#: cmd/incus/info.go:515
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -2950,11 +2960,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid "GPUs:"
 msgstr ""
 
@@ -3124,11 +3134,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3174,11 +3184,16 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid "IOMMU group: %v"
+msgstr ""
+
 #: cmd/incus/network.go:1187
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 msgid "IP addresses"
 msgstr ""
 
@@ -3348,7 +3363,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 msgid "Instance Only"
 msgstr ""
 
@@ -3579,7 +3594,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4059,11 +4074,11 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4072,7 +4087,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid "Log:"
 msgstr ""
 
@@ -4109,7 +4124,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 msgid "MAC address"
 msgstr ""
 
@@ -4156,7 +4171,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid "MTU"
 msgstr ""
 
@@ -4394,19 +4409,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 msgid "Memory:"
 msgstr ""
 
@@ -4733,11 +4748,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid "NICs:"
 msgstr ""
 
@@ -4749,11 +4764,12 @@ msgid "NO"
 msgstr ""
 
 #: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:358
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4766,7 +4782,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
 #: cmd/incus/storage_volume.go:2594
 msgid "Name"
@@ -4828,7 +4844,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929
+#: cmd/incus/info.go:609 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
@@ -4948,7 +4964,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5034,7 +5050,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5091,7 +5107,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5108,6 +5124,14 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
+#: cmd/incus/info.go:569
+msgid "PCI device:"
+msgstr ""
+
+#: cmd/incus/info.go:572
+msgid "PCI devices:"
+msgstr ""
+
 #: cmd/incus/network_peer.go:156
 msgid "PEER"
 msgstr ""
@@ -5116,7 +5140,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5152,11 +5176,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5279,7 +5303,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5289,17 +5313,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -5811,7 +5835,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid "Resources:"
 msgstr ""
 
@@ -5905,7 +5929,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -5993,12 +6017,12 @@ msgstr ""
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6539,11 +6563,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6571,7 +6595,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, c-format
 msgid "Started: %s"
 msgstr ""
@@ -6585,7 +6609,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 msgid "State"
 msgstr ""
 
@@ -6594,11 +6618,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6724,11 +6748,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6744,7 +6768,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid "System:"
 msgstr ""
 
@@ -6765,7 +6789,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
@@ -7011,7 +7035,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7085,7 +7109,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368
 #: cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7099,8 +7123,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499
-#: cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511
+#: cmd/incus/info.go:517
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7154,7 +7178,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 msgid "Type"
 msgstr ""
 
@@ -7172,14 +7196,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415
+#: cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7200,11 +7224,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 msgid "USB devices:"
 msgstr ""
 
@@ -7220,7 +7244,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7420,7 +7444,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7471,8 +7495,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510
+#: cmd/incus/info.go:516
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7511,17 +7535,18 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7536,12 +7561,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, c-format
 msgid "Version: %v"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-06 17:08-0400\n"
+"POT-Creation-Date: 2024-05-06 22:26-0400\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.4-dev\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid "  Motherboard:"
 msgstr ""
 
@@ -692,7 +692,7 @@ msgid "--target can only be used with clusters"
 msgstr "--refresh só pode ser usado com containers"
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:822 cmd/incus/info.go:600
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -934,6 +934,11 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
+#: cmd/incus/info.go:353
+#, fuzzy, c-format
+msgid "Address: %v"
+msgstr "O dispositivo já existe: %s"
+
 #: cmd/incus/storage_bucket.go:182
 #, fuzzy, c-format
 msgid "Admin access key: %s"
@@ -991,8 +996,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470
-#: cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482
+#: cmd/incus/info.go:623
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
@@ -1093,7 +1098,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr "Criar projetos"
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1122,7 +1127,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1178,11 +1183,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1211,19 +1216,19 @@ msgstr "Utilização do CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid "CPU:"
 msgstr "CPU:"
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 #, fuzzy
 msgid "CPUs:"
 msgstr "CPUs:"
@@ -1349,7 +1354,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid "Card %d:"
 msgstr "Cartão %d:"
@@ -1880,7 +1885,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634
 #: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
@@ -1949,7 +1954,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Criado: %s"
@@ -2262,7 +2267,7 @@ msgstr "Desconectar volumes de armazenamento dos containers"
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr "Em cache: %s"
@@ -2344,21 +2349,21 @@ msgstr "Desabilitar alocação de pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desabilitar stdin (ler de /dev/null)"
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 #, fuzzy
 msgid "Disk:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso de disco:"
@@ -2427,6 +2432,11 @@ msgstr ""
 #: cmd/incus/network.go:959
 msgid "Down delay"
 msgstr ""
+
+#: cmd/incus/info.go:360
+#, fuzzy, c-format
+msgid "Driver: %v"
+msgstr "Em cache: %s"
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
 #, c-format
@@ -2750,7 +2760,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
 #: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
@@ -3166,7 +3176,7 @@ msgstr "Aceitar certificado"
 msgid "Failed validation request: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3281,8 +3291,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509
+#: cmd/incus/info.go:515
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3301,11 +3311,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid "GPUs:"
 msgstr ""
 
@@ -3497,11 +3507,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3547,11 +3557,16 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid "IOMMU group: %v"
+msgstr ""
+
 #: cmd/incus/network.go:1187
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 msgid "IP addresses"
 msgstr ""
 
@@ -3726,7 +3741,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 msgid "Instance Only"
 msgstr ""
 
@@ -3963,7 +3978,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Criado: %s"
@@ -4457,11 +4472,11 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4470,7 +4485,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid "Log:"
 msgstr ""
 
@@ -4509,7 +4524,7 @@ msgstr "Editar arquivos no container"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 msgid "MAC address"
 msgstr ""
 
@@ -4556,7 +4571,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid "MTU"
 msgstr ""
 
@@ -4819,19 +4834,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 msgid "Memory:"
 msgstr ""
 
@@ -5175,11 +5190,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid "NICs:"
 msgstr ""
 
@@ -5191,11 +5206,12 @@ msgid "NO"
 msgstr ""
 
 #: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:358
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5208,7 +5224,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
 #: cmd/incus/storage_volume.go:2594
 msgid "Name"
@@ -5270,7 +5286,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929
+#: cmd/incus/info.go:609 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
@@ -5390,7 +5406,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5476,7 +5492,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5533,7 +5549,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5550,6 +5566,16 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
+#: cmd/incus/info.go:569
+#, fuzzy
+msgid "PCI device:"
+msgstr "Editar arquivos no container"
+
+#: cmd/incus/info.go:572
+#, fuzzy
+msgid "PCI devices:"
+msgstr "Editar arquivos no container"
+
 #: cmd/incus/network_peer.go:156
 msgid "PEER"
 msgstr ""
@@ -5558,7 +5584,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5594,11 +5620,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5722,7 +5748,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5732,17 +5758,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, fuzzy, c-format
 msgid "Product: %v"
 msgstr "Marca: %v"
@@ -6279,7 +6305,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid "Resources:"
 msgstr ""
 
@@ -6385,7 +6411,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6474,12 +6500,12 @@ msgstr ""
 msgid "Serial Number: %v"
 msgstr "Marca: %v"
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, fuzzy, c-format
 msgid "Serial: %v"
 msgstr "Marca: %v"
@@ -7062,11 +7088,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7094,7 +7120,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Criado: %s"
@@ -7108,7 +7134,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 msgid "State"
 msgstr ""
 
@@ -7117,11 +7143,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7249,11 +7275,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7269,7 +7295,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid "System:"
 msgstr ""
 
@@ -7290,7 +7316,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
@@ -7537,7 +7563,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7612,7 +7638,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368
 #: cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7626,8 +7652,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499
-#: cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511
+#: cmd/incus/info.go:517
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7681,7 +7707,7 @@ msgstr "Senha de administrador para %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 msgid "Type"
 msgstr ""
 
@@ -7700,14 +7726,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415
+#: cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7728,12 +7754,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 #, fuzzy
 msgid "USB device:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 #, fuzzy
 msgid "USB devices:"
 msgstr "Editar arquivos no container"
@@ -7750,7 +7776,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7977,7 +8003,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8030,8 +8056,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510
+#: cmd/incus/info.go:516
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8071,17 +8097,18 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -8096,12 +8123,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, fuzzy, c-format
 msgid "Version: %s"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, fuzzy, c-format
 msgid "Version: %v"
 msgstr "Versão CUDA: %v"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-06 17:08-0400\n"
+"POT-Creation-Date: 2024-05-06 22:26-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,15 +20,15 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid "  Motherboard:"
 msgstr ""
 
@@ -707,7 +707,7 @@ msgid "--target can only be used with clusters"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:822 cmd/incus/info.go:600
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -953,6 +953,11 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
+#: cmd/incus/info.go:353
+#, c-format
+msgid "Address: %v"
+msgstr ""
+
 #: cmd/incus/storage_bucket.go:182
 #, fuzzy, c-format
 msgid "Admin access key: %s"
@@ -1010,8 +1015,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470
-#: cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482
+#: cmd/incus/info.go:623
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -1108,7 +1113,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr "Доступные команды:"
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1137,7 +1142,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1193,11 +1198,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1226,20 +1231,20 @@ msgstr " Использование ЦП:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 msgid "CPUs:"
 msgstr ""
 
@@ -1363,7 +1368,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1882,7 +1887,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634
 #: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
@@ -1951,7 +1956,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, fuzzy, c-format
 msgid "Date: %s"
 msgstr "Авто-обновление: %s"
@@ -2260,7 +2265,7 @@ msgstr "Копирование образа: %s"
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, fuzzy, c-format
 msgid "Device %d:"
 msgstr " Использование диска:"
@@ -2341,22 +2346,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 #, fuzzy
 msgid "Disk:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 #, fuzzy
 msgid "Disks:"
 msgstr " Использование диска:"
@@ -2426,6 +2431,11 @@ msgstr ""
 #: cmd/incus/network.go:959
 msgid "Down delay"
 msgstr ""
+
+#: cmd/incus/info.go:360
+#, fuzzy, c-format
+msgid "Driver: %v"
+msgstr "Авто-обновление: %s"
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
 #, c-format
@@ -2744,7 +2754,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
 #: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
@@ -3165,7 +3175,7 @@ msgstr "Принять сертификат"
 msgid "Failed validation request: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3280,8 +3290,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509
+#: cmd/incus/info.go:515
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3300,11 +3310,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid "GPUs:"
 msgstr ""
 
@@ -3492,12 +3502,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3543,11 +3553,16 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid "IOMMU group: %v"
+msgstr ""
+
 #: cmd/incus/network.go:1187
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 msgid "IP addresses"
 msgstr ""
 
@@ -3723,7 +3738,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
@@ -3962,7 +3977,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
@@ -4463,11 +4478,11 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4476,7 +4491,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid "Log:"
 msgstr ""
 
@@ -4515,7 +4530,7 @@ msgstr "Копирование образа: %s"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 msgid "MAC address"
 msgstr ""
 
@@ -4562,7 +4577,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid "MTU"
 msgstr ""
 
@@ -4826,20 +4841,20 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 #, fuzzy
 msgid "Memory:"
 msgstr " Использование памяти:"
@@ -5185,11 +5200,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid "NICs:"
 msgstr ""
 
@@ -5201,11 +5216,12 @@ msgid "NO"
 msgstr ""
 
 #: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:358
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -5218,7 +5234,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
 #: cmd/incus/storage_volume.go:2594
 msgid "Name"
@@ -5284,7 +5300,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929
+#: cmd/incus/info.go:609 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
@@ -5405,7 +5421,7 @@ msgstr ""
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -5493,7 +5509,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5550,7 +5566,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5567,6 +5583,16 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
+#: cmd/incus/info.go:569
+#, fuzzy
+msgid "PCI device:"
+msgstr "Копирование образа: %s"
+
+#: cmd/incus/info.go:572
+#, fuzzy
+msgid "PCI devices:"
+msgstr "Копирование образа: %s"
+
 #: cmd/incus/network_peer.go:156
 msgid "PEER"
 msgstr ""
@@ -5575,7 +5601,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5611,11 +5637,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5739,7 +5765,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5749,17 +5775,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, fuzzy, c-format
 msgid "Product ID: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, fuzzy, c-format
 msgid "Product: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -6287,7 +6313,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid "Resources:"
 msgstr ""
 
@@ -6389,7 +6415,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6478,12 +6504,12 @@ msgstr ""
 msgid "Serial Number: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, fuzzy, c-format
 msgid "Serial: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -7059,11 +7085,11 @@ msgstr "Копирование образа: %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -7091,7 +7117,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, fuzzy, c-format
 msgid "Started: %s"
 msgstr "Авто-обновление: %s"
@@ -7105,7 +7131,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
@@ -7115,11 +7141,11 @@ msgstr "Авто-обновление: %s"
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -7249,11 +7275,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7269,7 +7295,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid "System:"
 msgstr ""
 
@@ -7290,7 +7316,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
@@ -7536,7 +7562,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7611,7 +7637,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368
 #: cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7625,8 +7651,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499
-#: cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511
+#: cmd/incus/info.go:517
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7680,7 +7706,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 msgid "Type"
 msgstr ""
 
@@ -7699,14 +7725,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415
+#: cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7727,12 +7753,12 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 #, fuzzy
 msgid "USB device:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 #, fuzzy
 msgid "USB devices:"
 msgstr "Копирование образа: %s"
@@ -7749,7 +7775,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7971,7 +7997,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8024,8 +8050,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510
+#: cmd/incus/info.go:516
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -8065,17 +8091,18 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, fuzzy, c-format
 msgid "Vendor ID: %v"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, fuzzy, c-format
 msgid "Vendor: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -8090,12 +8117,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, c-format
 msgid "Version: %v"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-05-06 17:08-0400\n"
+"POT-Creation-Date: 2024-05-06 22:26-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -19,15 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: cmd/incus/info.go:407
+#: cmd/incus/info.go:419
 msgid "  Chassis:"
 msgstr ""
 
-#: cmd/incus/info.go:443
+#: cmd/incus/info.go:455
 msgid "  Firmware:"
 msgstr ""
 
-#: cmd/incus/info.go:425
+#: cmd/incus/info.go:437
 msgid "  Motherboard:"
 msgstr ""
 
@@ -659,7 +659,7 @@ msgid "--target can only be used with clusters"
 msgstr ""
 
 #: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
-#: cmd/incus/config.go:822 cmd/incus/info.go:575
+#: cmd/incus/config.go:822 cmd/incus/info.go:600
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -887,6 +887,11 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
+#: cmd/incus/info.go:353
+#, c-format
+msgid "Address: %v"
+msgstr ""
+
 #: cmd/incus/storage_bucket.go:182
 #, c-format
 msgid "Admin access key: %s"
@@ -942,8 +947,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:466 cmd/incus/info.go:470
-#: cmd/incus/info.go:598
+#: cmd/incus/image.go:999 cmd/incus/info.go:478 cmd/incus/info.go:482
+#: cmd/incus/info.go:623
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1037,7 +1042,7 @@ msgstr ""
 msgid "Available projects:"
 msgstr ""
 
-#: cmd/incus/info.go:460
+#: cmd/incus/info.go:472
 #, c-format
 msgid "Average: %.2f %.2f %.2f"
 msgstr ""
@@ -1066,7 +1071,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:779 cmd/incus/storage_volume.go:1464
+#: cmd/incus/info.go:804 cmd/incus/storage_volume.go:1464
 msgid "Backups:"
 msgstr ""
 
@@ -1122,11 +1127,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:702 cmd/incus/network.go:947
+#: cmd/incus/info.go:727 cmd/incus/network.go:947
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:703 cmd/incus/network.go:948
+#: cmd/incus/info.go:728 cmd/incus/network.go:948
 msgid "Bytes sent"
 msgstr ""
 
@@ -1154,19 +1159,19 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:643
+#: cmd/incus/info.go:668
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:647
+#: cmd/incus/info.go:672
 msgid "CPU usage:"
 msgstr ""
 
-#: cmd/incus/info.go:465
+#: cmd/incus/info.go:477
 msgid "CPU:"
 msgstr ""
 
-#: cmd/incus/info.go:469
+#: cmd/incus/info.go:481
 msgid "CPUs:"
 msgstr ""
 
@@ -1289,7 +1294,7 @@ msgstr ""
 msgid "Cannot set key: %s"
 msgstr ""
 
-#: cmd/incus/info.go:514 cmd/incus/info.go:526
+#: cmd/incus/info.go:526 cmd/incus/info.go:538
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1788,7 +1793,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:609
+#: cmd/incus/image.go:1005 cmd/incus/info.go:634
 #: cmd/incus/storage_volume.go:1418
 #, c-format
 msgid "Created: %s"
@@ -1856,7 +1861,7 @@ msgstr ""
 msgid "Daemon still running after %ds timeout"
 msgstr ""
 
-#: cmd/incus/info.go:453
+#: cmd/incus/info.go:465
 #, c-format
 msgid "Date: %s"
 msgstr ""
@@ -2151,7 +2156,7 @@ msgstr ""
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: cmd/incus/info.go:550
+#: cmd/incus/info.go:562 cmd/incus/info.go:574
 #, c-format
 msgid "Device %d:"
 msgstr ""
@@ -2232,20 +2237,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: cmd/incus/info.go:538
+#: cmd/incus/info.go:550
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:636
+#: cmd/incus/info.go:661
 msgid "Disk usage:"
 msgstr ""
 
-#: cmd/incus/info.go:533
+#: cmd/incus/info.go:545
 msgid "Disk:"
 msgstr ""
 
-#: cmd/incus/info.go:536
+#: cmd/incus/info.go:548
 msgid "Disks:"
 msgstr ""
 
@@ -2307,6 +2312,11 @@ msgstr ""
 
 #: cmd/incus/network.go:959
 msgid "Down delay"
+msgstr ""
+
+#: cmd/incus/info.go:360
+#, c-format
+msgid "Driver: %v"
 msgstr ""
 
 #: cmd/incus/info.go:113 cmd/incus/info.go:199
@@ -2614,7 +2624,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:765 cmd/incus/info.go:816 cmd/incus/snapshot.go:366
+#: cmd/incus/info.go:790 cmd/incus/info.go:841 cmd/incus/snapshot.go:366
 #: cmd/incus/storage_volume.go:1451 cmd/incus/storage_volume.go:1501
 #: cmd/incus/storage_volume.go:2596
 msgid "Expires at"
@@ -3028,7 +3038,7 @@ msgstr ""
 msgid "Failed validation request: %w"
 msgstr ""
 
-#: cmd/incus/info.go:387
+#: cmd/incus/info.go:399
 #, c-format
 msgid "Family: %v"
 msgstr ""
@@ -3142,8 +3152,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:481 cmd/incus/info.go:492 cmd/incus/info.go:497
-#: cmd/incus/info.go:503
+#: cmd/incus/info.go:493 cmd/incus/info.go:504 cmd/incus/info.go:509
+#: cmd/incus/info.go:515
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -3162,11 +3172,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: cmd/incus/info.go:509
+#: cmd/incus/info.go:521
 msgid "GPU:"
 msgstr ""
 
-#: cmd/incus/info.go:512
+#: cmd/incus/info.go:524
 msgid "GPUs:"
 msgstr ""
 
@@ -3336,11 +3346,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:691
+#: cmd/incus/info.go:716
 msgid "Host interface"
 msgstr ""
 
-#: cmd/incus/info.go:480 cmd/incus/info.go:491
+#: cmd/incus/info.go:492 cmd/incus/info.go:503
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -3386,11 +3396,16 @@ msgstr ""
 msgid "INSTANCE NAME"
 msgstr ""
 
+#: cmd/incus/info.go:359
+#, c-format
+msgid "IOMMU group: %v"
+msgstr ""
+
 #: cmd/incus/network.go:1187
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:707
+#: cmd/incus/info.go:732
 msgid "IP addresses"
 msgstr ""
 
@@ -3560,7 +3575,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:817
+#: cmd/incus/info.go:842
 msgid "Instance Only"
 msgstr ""
 
@@ -3791,7 +3806,7 @@ msgstr ""
 msgid "LOCATION"
 msgstr ""
 
-#: cmd/incus/info.go:613
+#: cmd/incus/info.go:638
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -4271,11 +4286,11 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: cmd/incus/info.go:457
+#: cmd/incus/info.go:469
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:601 cmd/incus/storage_volume.go:1407
+#: cmd/incus/info.go:626 cmd/incus/storage_volume.go:1407
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4284,7 +4299,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:845
+#: cmd/incus/info.go:870
 msgid "Log:"
 msgstr ""
 
@@ -4321,7 +4336,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:695
+#: cmd/incus/info.go:720
 msgid "MAC address"
 msgstr ""
 
@@ -4368,7 +4383,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:699
+#: cmd/incus/info.go:724
 msgid "MTU"
 msgstr ""
 
@@ -4606,19 +4621,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:654
+#: cmd/incus/info.go:679
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:658
+#: cmd/incus/info.go:683
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:670
+#: cmd/incus/info.go:695
 msgid "Memory usage:"
 msgstr ""
 
-#: cmd/incus/info.go:478
+#: cmd/incus/info.go:490
 msgid "Memory:"
 msgstr ""
 
@@ -4945,11 +4960,11 @@ msgstr ""
 msgid "NEW: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/info.go:521
+#: cmd/incus/info.go:533
 msgid "NIC:"
 msgstr ""
 
-#: cmd/incus/info.go:524
+#: cmd/incus/info.go:536
 msgid "NICs:"
 msgstr ""
 
@@ -4961,11 +4976,12 @@ msgid "NO"
 msgstr ""
 
 #: cmd/incus/info.go:98 cmd/incus/info.go:184 cmd/incus/info.go:271
+#: cmd/incus/info.go:358
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
 
-#: cmd/incus/info.go:487
+#: cmd/incus/info.go:499
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4978,7 +4994,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:763 cmd/incus/info.go:814 cmd/incus/snapshot.go:364
+#: cmd/incus/info.go:788 cmd/incus/info.go:839 cmd/incus/snapshot.go:364
 #: cmd/incus/storage_volume.go:1449 cmd/incus/storage_volume.go:1499
 #: cmd/incus/storage_volume.go:2594
 msgid "Name"
@@ -5040,7 +5056,7 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:584 cmd/incus/network.go:929
+#: cmd/incus/info.go:609 cmd/incus/network.go:929
 #: cmd/incus/storage_volume.go:1389
 #, c-format
 msgid "Name: %s"
@@ -5160,7 +5176,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:720 cmd/incus/network.go:946
+#: cmd/incus/info.go:745 cmd/incus/network.go:946
 msgid "Network usage:"
 msgstr ""
 
@@ -5246,7 +5262,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: cmd/incus/info.go:489
+#: cmd/incus/info.go:501
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -5303,7 +5319,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/storage_volume.go:1503
+#: cmd/incus/info.go:843 cmd/incus/storage_volume.go:1503
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5320,6 +5336,14 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
+#: cmd/incus/info.go:569
+msgid "PCI device:"
+msgstr ""
+
+#: cmd/incus/info.go:572
+msgid "PCI devices:"
+msgstr ""
+
 #: cmd/incus/network_peer.go:156
 msgid "PEER"
 msgstr ""
@@ -5328,7 +5352,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: cmd/incus/info.go:605
+#: cmd/incus/info.go:630
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -5364,11 +5388,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:704 cmd/incus/network.go:949
+#: cmd/incus/info.go:729 cmd/incus/network.go:949
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:705 cmd/incus/network.go:950
+#: cmd/incus/info.go:730 cmd/incus/network.go:950
 msgid "Packets sent"
 msgstr ""
 
@@ -5491,7 +5515,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:459 cmd/incus/info.go:623
+#: cmd/incus/info.go:471 cmd/incus/info.go:648
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5501,17 +5525,17 @@ msgstr ""
 msgid "Processing aliases failed: %s"
 msgstr ""
 
-#: cmd/incus/info.go:344
+#: cmd/incus/info.go:344 cmd/incus/info.go:357
 #, c-format
 msgid "Product ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:431
+#: cmd/incus/info.go:443
 #, c-format
 msgid "Product: %s"
 msgstr ""
 
-#: cmd/incus/info.go:343 cmd/incus/info.go:383
+#: cmd/incus/info.go:343 cmd/incus/info.go:356 cmd/incus/info.go:395
 #, c-format
 msgid "Product: %v"
 msgstr ""
@@ -6023,7 +6047,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:621
+#: cmd/incus/info.go:646
 msgid "Resources:"
 msgstr ""
 
@@ -6117,7 +6141,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: cmd/incus/info.go:395
+#: cmd/incus/info.go:407
 #, c-format
 msgid "SKU: %v"
 msgstr ""
@@ -6205,12 +6229,12 @@ msgstr ""
 msgid "Serial Number: %v"
 msgstr ""
 
-#: cmd/incus/info.go:421 cmd/incus/info.go:435
+#: cmd/incus/info.go:433 cmd/incus/info.go:447
 #, c-format
 msgid "Serial: %s"
 msgstr ""
 
-#: cmd/incus/info.go:399
+#: cmd/incus/info.go:411
 #, c-format
 msgid "Serial: %v"
 msgstr ""
@@ -6751,11 +6775,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:732 cmd/incus/storage_volume.go:1428
+#: cmd/incus/info.go:757 cmd/incus/storage_volume.go:1428
 msgid "Snapshots:"
 msgstr ""
 
-#: cmd/incus/info.go:472
+#: cmd/incus/info.go:484
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -6783,7 +6807,7 @@ msgstr ""
 msgid "Start instances"
 msgstr ""
 
-#: cmd/incus/info.go:618
+#: cmd/incus/info.go:643
 #, c-format
 msgid "Started: %s"
 msgstr ""
@@ -6797,7 +6821,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:689
+#: cmd/incus/info.go:714
 msgid "State"
 msgstr ""
 
@@ -6806,11 +6830,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:766 cmd/incus/snapshot.go:367
+#: cmd/incus/info.go:791 cmd/incus/snapshot.go:367
 msgid "Stateful"
 msgstr ""
 
-#: cmd/incus/info.go:586
+#: cmd/incus/info.go:611
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -6936,11 +6960,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:662
+#: cmd/incus/info.go:687
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:666
+#: cmd/incus/info.go:691
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6956,7 +6980,7 @@ msgstr ""
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
-#: cmd/incus/info.go:373
+#: cmd/incus/info.go:385
 msgid "System:"
 msgstr ""
 
@@ -6977,7 +7001,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:764 cmd/incus/info.go:815 cmd/incus/snapshot.go:365
+#: cmd/incus/info.go:789 cmd/incus/info.go:840 cmd/incus/snapshot.go:365
 #: cmd/incus/storage_volume.go:1500 cmd/incus/storage_volume.go:2595
 msgid "Taken at"
 msgstr ""
@@ -7223,7 +7247,7 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
-#: cmd/incus/info.go:364
+#: cmd/incus/info.go:376
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -7297,7 +7321,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:356
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:368
 #: cmd/incus/network.go:917 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7311,8 +7335,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:483 cmd/incus/info.go:494 cmd/incus/info.go:499
-#: cmd/incus/info.go:505
+#: cmd/incus/info.go:495 cmd/incus/info.go:506 cmd/incus/info.go:511
+#: cmd/incus/info.go:517
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -7366,7 +7390,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:688
+#: cmd/incus/info.go:713
 msgid "Type"
 msgstr ""
 
@@ -7384,14 +7408,14 @@ msgstr ""
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:403
-#: cmd/incus/info.go:413 cmd/incus/info.go:595 cmd/incus/network.go:933
+#: cmd/incus/image.go:1000 cmd/incus/info.go:281 cmd/incus/info.go:415
+#: cmd/incus/info.go:425 cmd/incus/info.go:620 cmd/incus/network.go:933
 #: cmd/incus/storage_volume.go:1398
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/info.go:593
+#: cmd/incus/info.go:618
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -7412,11 +7436,11 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:545
+#: cmd/incus/info.go:557
 msgid "USB device:"
 msgstr ""
 
-#: cmd/incus/info.go:548
+#: cmd/incus/info.go:560
 msgid "USB devices:"
 msgstr ""
 
@@ -7432,7 +7456,7 @@ msgstr ""
 msgid "UUID"
 msgstr ""
 
-#: cmd/incus/info.go:140 cmd/incus/info.go:375
+#: cmd/incus/info.go:140 cmd/incus/info.go:387
 #, c-format
 msgid "UUID: %v"
 msgstr ""
@@ -7632,7 +7656,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:837
+#: cmd/incus/info.go:862
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7683,8 +7707,8 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:482 cmd/incus/info.go:493 cmd/incus/info.go:498
-#: cmd/incus/info.go:504
+#: cmd/incus/info.go:494 cmd/incus/info.go:505 cmd/incus/info.go:510
+#: cmd/incus/info.go:516
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7723,17 +7747,18 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: cmd/incus/info.go:342
+#: cmd/incus/info.go:342 cmd/incus/info.go:355
 #, c-format
 msgid "Vendor ID: %v"
 msgstr ""
 
-#: cmd/incus/info.go:409 cmd/incus/info.go:427 cmd/incus/info.go:445
+#: cmd/incus/info.go:421 cmd/incus/info.go:439 cmd/incus/info.go:457
 #, c-format
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:379
+#: cmd/incus/info.go:307 cmd/incus/info.go:341 cmd/incus/info.go:354
+#: cmd/incus/info.go:391
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7748,12 +7773,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: cmd/incus/info.go:417 cmd/incus/info.go:439 cmd/incus/info.go:449
+#: cmd/incus/info.go:429 cmd/incus/info.go:451 cmd/incus/info.go:461
 #, c-format
 msgid "Version: %s"
 msgstr ""
 
-#: cmd/incus/info.go:391
+#: cmd/incus/info.go:403
 #, c-format
 msgid "Version: %v"
 msgstr ""


### PR DESCRIPTION
commit 879954bb7e4a2b821c5047d1494bd334e6cda289 closes #704 

Signed off by: Joshua Dierker <joshuadierker@gmail.com>

I am still unable to run make static-analysis locally due to shellcheck error.

Also, I get a runtime error locally when I do incus info --resources. It happens on the main branch, at the chassis  info section. It is likely something with my environment but I wanted to bring it to your attention. See image below 
![image](https://github.com/lxc/incus/assets/25874763/10e3b3f6-cad1-47a2-9441-f6e6eaac2f06)
