### PR TITLE
Fix runtime error when chassis, motherboard and firmware are nil

### DIFF
--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -415,53 +415,59 @@ func (c *cmdInfo) remoteInfo(d incus.InstanceServer) error {
 		}
 
 		// System: Chassis
-		fmt.Printf(i18n.G("  Chassis:") + "\n")
-		if resources.System.Chassis.Vendor != "" {
-			fmt.Printf("      "+i18n.G("Vendor: %s")+"\n", resources.System.Chassis.Vendor)
-		}
+		if resources.System.Chassis != nil {
+			fmt.Printf(i18n.G("  Chassis:") + "\n")
+			if resources.System.Chassis.Vendor != "" {
+				fmt.Printf("      "+i18n.G("Vendor: %s")+"\n", resources.System.Chassis.Vendor)
+			}
 
-		if resources.System.Chassis.Type != "" {
-			fmt.Printf("      "+i18n.G("Type: %s")+"\n", resources.System.Chassis.Type)
-		}
+			if resources.System.Chassis.Type != "" {
+				fmt.Printf("      "+i18n.G("Type: %s")+"\n", resources.System.Chassis.Type)
+			}
 
-		if resources.System.Chassis.Version != "" {
-			fmt.Printf("      "+i18n.G("Version: %s")+"\n", resources.System.Chassis.Version)
-		}
+			if resources.System.Chassis.Version != "" {
+				fmt.Printf("      "+i18n.G("Version: %s")+"\n", resources.System.Chassis.Version)
+			}
 
-		if resources.System.Chassis.Serial != "" {
-			fmt.Printf("      "+i18n.G("Serial: %s")+"\n", resources.System.Chassis.Serial)
+			if resources.System.Chassis.Serial != "" {
+				fmt.Printf("      "+i18n.G("Serial: %s")+"\n", resources.System.Chassis.Serial)
+			}
 		}
 
 		// System: Motherboard
-		fmt.Printf(i18n.G("  Motherboard:") + "\n")
-		if resources.System.Motherboard.Vendor != "" {
-			fmt.Printf("      "+i18n.G("Vendor: %s")+"\n", resources.System.Motherboard.Vendor)
-		}
+		if resources.System.Motherboard != nil {
+			fmt.Printf(i18n.G("  Motherboard:") + "\n")
+			if resources.System.Motherboard.Vendor != "" {
+				fmt.Printf("      "+i18n.G("Vendor: %s")+"\n", resources.System.Motherboard.Vendor)
+			}
 
-		if resources.System.Motherboard.Product != "" {
-			fmt.Printf("      "+i18n.G("Product: %s")+"\n", resources.System.Motherboard.Product)
-		}
+			if resources.System.Motherboard.Product != "" {
+				fmt.Printf("      "+i18n.G("Product: %s")+"\n", resources.System.Motherboard.Product)
+			}
 
-		if resources.System.Motherboard.Serial != "" {
-			fmt.Printf("      "+i18n.G("Serial: %s")+"\n", resources.System.Motherboard.Serial)
-		}
+			if resources.System.Motherboard.Serial != "" {
+				fmt.Printf("      "+i18n.G("Serial: %s")+"\n", resources.System.Motherboard.Serial)
+			}
 
-		if resources.System.Motherboard.Version != "" {
-			fmt.Printf("      "+i18n.G("Version: %s")+"\n", resources.System.Motherboard.Version)
+			if resources.System.Motherboard.Version != "" {
+				fmt.Printf("      "+i18n.G("Version: %s")+"\n", resources.System.Motherboard.Version)
+			}
 		}
 
 		// System: Firmware
-		fmt.Printf(i18n.G("  Firmware:") + "\n")
-		if resources.System.Firmware.Vendor != "" {
-			fmt.Printf("      "+i18n.G("Vendor: %s")+"\n", resources.System.Firmware.Vendor)
-		}
+		if resources.System.Firmware != nil {
+			fmt.Printf(i18n.G("  Firmware:") + "\n")
+			if resources.System.Firmware.Vendor != "" {
+				fmt.Printf("      "+i18n.G("Vendor: %s")+"\n", resources.System.Firmware.Vendor)
+			}
 
-		if resources.System.Firmware.Version != "" {
-			fmt.Printf("      "+i18n.G("Version: %s")+"\n", resources.System.Firmware.Version)
-		}
+			if resources.System.Firmware.Version != "" {
+				fmt.Printf("      "+i18n.G("Version: %s")+"\n", resources.System.Firmware.Version)
+			}
 
-		if resources.System.Firmware.Date != "" {
-			fmt.Printf("      "+i18n.G("Date: %s")+"\n", resources.System.Firmware.Date)
+			if resources.System.Firmware.Date != "" {
+				fmt.Printf("      "+i18n.G("Date: %s")+"\n", resources.System.Firmware.Date)
+			}
 		}
 
 		// Load


### PR DESCRIPTION
This pull request introduces changes to the `remoteInfo` function in the `cmd/incus/info.go` file. The changes primarily involve adding nil checks for the `System` struct's `Chassis`, `Motherboard`, and `Firmware` fields before attempting to print their details. This helps prevent potential nil pointer dereference errors and fixes https://github.com/lxc/incus/issues/866.

# Test output

```
❯ incus info --resources
System:
  Type: container

Load:
  Processes: 17
  Average: 0.04 0.20 0.27

CPU:
  Architecture: aarch64
  Caches:
    - Level 1 (type: Data): 0B
    - Level 1 (type: Instruction): 0B
    - Level 2 (type: Unified): 0B
  Cores:
    - Core 0
      Frequency: 2000Mhz
      Threads:
        - 0 (id: 0, online: true, NUMA node: 0)
    - Core 1
      Frequency: 2000Mhz
      Threads:
        - 0 (id: 1, online: true, NUMA node: 0)
    - Core 2
      Frequency: 2000Mhz
      Threads:
        - 0 (id: 2, online: true, NUMA node: 0)
    - Core 3
      Frequency: 2000Mhz
      Threads:
        - 0 (id: 3, online: true, NUMA node: 0)
    - Core 4
      Frequency: 2000Mhz
      Threads:
        - 0 (id: 4, online: true, NUMA node: 0)
    - Core 5
      Frequency: 2000Mhz
      Threads:
        - 0 (id: 5, online: true, NUMA node: 0)
    - Core 6
      Frequency: 2000Mhz
      Threads:
        - 0 (id: 6, online: true, NUMA node: 0)
    - Core 7
      Frequency: 2000Mhz
      Threads:
        - 0 (id: 7, online: true, NUMA node: 0)
    - Core 8
      Frequency: 2000Mhz
      Threads:
        - 0 (id: 8, online: true, NUMA node: 0)
    - Core 9
      Frequency: 2000Mhz
      Threads:
        - 0 (id: 9, online: true, NUMA node: 0)
  Frequency: 2000Mhz (min: 2000Mhz, max: 2000Mhz)

Memory:
  Free: 5.28GiB
  Used: 519.39MiB
  Total: 5.78GiB

NICs:
  Card 0:
    NUMA node: 0
    PCI address: 0000:00:01.0
    Driver: virtio-pci (6.7.11-orbstack-00143-ge6b82e26cd22)
  Card 1:
    NUMA node: 0
    PCI address: 0000:00:02.0
    Driver: virtio-pci (6.7.11-orbstack-00143-ge6b82e26cd22)
  Card 2:
    NUMA node: 0
    PCI address: 0000:00:03.0
    Driver: virtio-pci (6.7.11-orbstack-00143-ge6b82e26cd22)

Disks:
  Disk 0:
    NUMA node: 0
    ID: vda
    Device: 254:0
    Type: virtio
    Size: 389.74MiB
    Read-Only: true
    Removable: false
  Disk 1:
    NUMA node: 0
    ID: vdb
    Device: 254:16
    Type: virtio
    Size: 8.00TiB
    Read-Only: false
    Removable: false
    Partitions:
      - Partition 1
        ID: vdb1
        Device: 254:17
        Read-Only: false
        Size: 460.43GiB
  Disk 2:
    NUMA node: 0
    ID: vdc
    Device: 254:32
    Type: virtio
    Size: 7.00GiB
    Read-Only: false
    Removable: false
    Partitions:
      - Partition 1
        ID: vdc1
        Device: 254:33
        Read-Only: false
        Size: 4.00GiB
      - Partition 2
        ID: vdc2
        Device: 254:34
        Read-Only: false
        Size: 2.00GiB

PCI devices:
  Device 0:
    Address: 0000:00:00.0
    Vendor: 
    Vendor ID: 106b
    Product: 
    Product ID: 1a05
    NUMA node: 0
    IOMMU group: 0
    Driver: 
  Device 1:
    Address: 0000:00:01.0
    Vendor: 
    Vendor ID: 1af4
    Product: 
    Product ID: 1041
    NUMA node: 0
    IOMMU group: 0
    Driver: virtio-pci
  Device 2:
    Address: 0000:00:02.0
    Vendor: 
    Vendor ID: 1af4
    Product: 
    Product ID: 1041
    NUMA node: 0
    IOMMU group: 0
    Driver: virtio-pci
  Device 3:
    Address: 0000:00:03.0
    Vendor: 
    Vendor ID: 1af4
    Product: 
    Product ID: 1041
    NUMA node: 0
    IOMMU group: 0
    Driver: virtio-pci
  Device 4:
    Address: 0000:00:05.0
    Vendor: 
    Vendor ID: 1af4
    Product: 
    Product ID: 1043
    NUMA node: 0
    IOMMU group: 0
    Driver: virtio-pci
  Device 5:
    Address: 0000:00:06.0
    Vendor: 
    Vendor ID: 1af4
    Product: 
    Product ID: 1042
    NUMA node: 0
    IOMMU group: 0
    Driver: virtio-pci
  Device 6:
    Address: 0000:00:07.0
    Vendor: 
    Vendor ID: 1af4
    Product: 
    Product ID: 1042
    NUMA node: 0
    IOMMU group: 0
    Driver: virtio-pci
  Device 7:
    Address: 0000:00:08.0
    Vendor: 
    Vendor ID: 1af4
    Product: 
    Product ID: 1042
    NUMA node: 0
    IOMMU group: 0
    Driver: virtio-pci
  Device 8:
    Address: 0000:00:09.0
    Vendor: 
    Vendor ID: 1af4
    Product: 
    Product ID: 105a
    NUMA node: 0
    IOMMU group: 0
    Driver: virtio-pci
  Device 9:
    Address: 0000:00:0a.0
    Vendor: 
    Vendor ID: 1af4
    Product: 
    Product ID: 105a
    NUMA node: 0
    IOMMU group: 0
    Driver: virtio-pci
  Device 10:
    Address: 0000:00:0b.0
    Vendor: 
    Vendor ID: 1af4
    Product: 
    Product ID: 1044
    NUMA node: 0
    IOMMU group: 0
    Driver: virtio-pci
```