### PR TITLE
incus/incusd: Add support for ARM64 to use AAVMF EFI firmware

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -1,4 +1,5 @@
 AAAA
+AAVMF
 ABI
 ACL
 ACLs

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -36,7 +36,7 @@ Name                            | Description
 `INCUS_EXEC_PATH`               | Full path to the Incus binary (used when forking subcommands)
 `INCUS_IDMAPPED_MOUNTS_DISABLE` | Disable idmapped mounts support (useful when testing traditional UID shifting)
 `INCUS_LXC_TEMPLATE_CONFIG`     | Path to the LXC template configuration directory
-`INCUS_OVMF_PATH`               | Path to an OVMF build including `OVMF_CODE.fd` and `OVMF_VARS.ms.fd`
+`INCUS_EFI_PATH`                | Path to EFI firmware build including `*_CODE.fd` and `*_VARS.fd`
 `INCUS_SECURITY_APPARMOR`       | If set to `false`, forces AppArmor off
 `INCUS_UI`                      | Path to the web UI to serve through the web server
 `INCUS_USBIDS_PATH`             | Path to the hwdata `usb.ids` file

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -322,6 +322,10 @@ As OpenSUSE stores QEMU firmware files using an unusual filename and location, y
 
 ````
 
+```{note}
+On ARM64 CPUs you need to install AAVMF instead of OVMF for UEFI to work with virtual machines.
+```
+
 ### From source: Build the latest version
 
 These instructions for building from source are suitable for individual developers who want to build the latest version

--- a/internal/server/apparmor/instance.go
+++ b/internal/server/apparmor/instance.go
@@ -13,6 +13,7 @@ import (
 	localUtil "github.com/lxc/incus/v6/internal/server/util"
 	internalUtil "github.com/lxc/incus/v6/internal/util"
 	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/osarch"
 	"github.com/lxc/incus/v6/shared/util"
 )
 
@@ -191,12 +192,19 @@ func instanceProfile(sysOS *sys.OS, inst instance, extraBinaries []string) (stri
 			return "", err
 		}
 
-		ovmfPath := "/usr/share/OVMF"
-		if os.Getenv("INCUS_OVMF_PATH") != "" {
-			ovmfPath = os.Getenv("INCUS_OVMF_PATH")
+		var efiPath string
+		switch arch, _ := osarch.ArchitectureGetLocalID(); arch {
+		case osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN:
+			efiPath = "/usr/share/AAVMF"
+		default:
+			efiPath = "/usr/share/OVMF"
 		}
 
-		ovmfPath, err = filepath.EvalSymlinks(ovmfPath)
+		if os.Getenv("INCUS_EFI_PATH") != "" {
+			efiPath = os.Getenv("INCUS_EFI_PATH")
+		}
+
+		efiPath, err = filepath.EvalSymlinks(efiPath)
 		if err != nil {
 			return "", err
 		}
@@ -225,7 +233,7 @@ func instanceProfile(sysOS *sys.OS, inst instance, extraBinaries []string) (stri
 			"name":           InstanceProfileName(inst),
 			"path":           path,
 			"raw":            rawContent,
-			"ovmfPath":       ovmfPath,
+			"efiPath":        efiPath,
 			"agentPath":      agentPath,
 		})
 		if err != nil {

--- a/internal/server/apparmor/instance_qemu.go
+++ b/internal/server/apparmor/instance_qemu.go
@@ -38,7 +38,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /sys/devices/**                           r,
   /sys/module/vhost/**                      r,
   /tmp/incus_sev_*                          r,
-  {{ .ovmfPath }}/**                        kr,
+  {{ .efiPath }}/**                         kr,
   /usr/share/qemu/**                        kr,
   /usr/share/seabios/**                     kr,
   owner @{PROC}/@{pid}/cpuset               r,


### PR DESCRIPTION
**DRAFT STATUS:**
- ~~Validate launching VMs on and ARM64~~
- Validate launching VMs on x86_64

---

I wasn't be to originally run VMs on my RK3588 (ARM64). Although it's clear [UEFI](https://github.com/lxc/incus/blob/main/internal/server/instance/drivers/driver_qemu.go#L1969-L1971) is supported it wasn't able to find the appropriate *.fd files because it assumed every architecture was using OVMF. On ARM64 it should be using AAVMF.

This PR adds support for using AAVMF on ARMv8 architectures and updates the documentation to reflect the code changes.