### PR TITLE
Add support for ARMv8 to use AAVMF EFI firmware

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -1,4 +1,5 @@
 AAAA
+AAVMF
 ABI
 ACL
 ACLs
@@ -68,6 +69,7 @@ Ebit
 eBPF
 ECDHE
 ECDSA
+EDK
 EiB
 Eibit
 endian

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -36,7 +36,7 @@ Name                            | Description
 `INCUS_EXEC_PATH`               | Full path to the Incus binary (used when forking subcommands)
 `INCUS_IDMAPPED_MOUNTS_DISABLE` | Disable idmapped mounts support (useful when testing traditional UID shifting)
 `INCUS_LXC_TEMPLATE_CONFIG`     | Path to the LXC template configuration directory
-`INCUS_OVMF_PATH`               | Path to an OVMF build including `OVMF_CODE.fd` and `OVMF_VARS.ms.fd`
+`INCUS_EDK2_PATH`               | Path to EDK2 firmware build including `*_CODE.fd` and `*_VARS.fd`
 `INCUS_SECURITY_APPARMOR`       | If set to `false`, forces AppArmor off
 `INCUS_UI`                      | Path to the web UI to serve through the web server
 `INCUS_USBIDS_PATH`             | Path to the hwdata `usb.ids` file

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -319,17 +319,15 @@ In addition, for normal operation, you'll also likely need
 
     sudo zypper install dnsmasq squashfs xz rsync tar attr acl qemu qemu-img qemu-spice qemu-hw-display-virtio-gpu-pci iptables ebtables nftables
 
-As OpenSUSE stores QEMU firmware files using an unusual filename and location, you will need to create some symlinks for them:
-
-    sudo mkdir /usr/share/OVMF
-    sudo ln -s /usr/share/qemu/ovmf-x86_64-4m-code.bin /usr/share/OVMF/OVMF_CODE.4MB.fd
-    sudo ln -s /usr/share/qemu/ovmf-x86_64-4m-vars.bin /usr/share/OVMF/OVMF_VARS.4MB.fd
-    sudo ln -s /usr/share/qemu/ovmf-x86_64-ms-4m-vars.bin /usr/share/OVMF/OVMF_VARS.4MB.ms.fd
-    sudo ln -s /usr/share/qemu/ovmf-x86_64-ms-4m-code.bin /usr/share/OVMF/OVMF_CODE.4MB.ms.fd
 ```
 
 
 ````
+
+```{note}
+On ARM64 CPUs you need to install AAVMF instead of OVMF for UEFI to work with virtual machines.
+In some distributions this is done through a separate package.
+```
 
 ### From source: Build the latest version
 

--- a/internal/server/apparmor/instance_qemu.go
+++ b/internal/server/apparmor/instance_qemu.go
@@ -39,7 +39,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /sys/devices/**                           r,
   /sys/module/vhost/**                      r,
   /tmp/incus_sev_*                          r,
-  {{ .ovmfPath }}/**                        kr,
+{{- range $index, $element := .edk2Paths }}
+  {{ $element }}/**                         kr,
+{{- end }}
   /usr/share/qemu/**                        kr,
   /usr/share/seabios/**                     kr,
   owner @{PROC}/@{pid}/cpuset               r,

--- a/internal/server/instance/drivers/edk2/driver_edk2.go
+++ b/internal/server/instance/drivers/edk2/driver_edk2.go
@@ -1,0 +1,149 @@
+package edk2
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/lxc/incus/v6/shared/osarch"
+)
+
+// FirmwarePair represents a combination of firmware code (Code) and storage (Vars).
+type FirmwarePair struct {
+	Code string
+	Vars string
+}
+
+// Installation represents a set of available firmware at a given location on the system.
+type Installation struct {
+	Path  string
+	Usage map[FirmwareUsage][]FirmwarePair
+}
+
+// FirmwareUsage represents the situation in which a given firmware file will be used.
+type FirmwareUsage int
+
+const (
+	// GENERIC is a generic EDK2 firmware.
+	GENERIC FirmwareUsage = iota
+
+	// SECUREBOOT is a UEFI Secure Boot enabled firmware.
+	SECUREBOOT
+
+	// CSM is a firmware with the UEFI Compatibility Support Module enabled to boot BIOS-only operating systems.
+	CSM
+)
+
+var architectureInstallations = map[int][]Installation{
+	osarch.ARCH_64BIT_INTEL_X86: {{
+		Path: "/usr/share/OVMF",
+		Usage: map[FirmwareUsage][]FirmwarePair{
+			GENERIC: {
+				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.fd"},
+				{Code: "OVMF_CODE_4M.fd", Vars: "OVMF_VARS_4M.fd"},
+				{Code: "OVMF_CODE.4m.fd", Vars: "OVMF_VARS.4m.fd"},
+				{Code: "OVMF_CODE.2MB.fd", Vars: "OVMF_VARS.2MB.fd"},
+				{Code: "OVMF_CODE.fd", Vars: "OVMF_VARS.fd"},
+				{Code: "OVMF_CODE.fd", Vars: "qemu.nvram"},
+			},
+			SECUREBOOT: {
+				{Code: "OVMF_CODE.4MB.fd", Vars: "OVMF_VARS.4MB.ms.fd"},
+				{Code: "OVMF_CODE_4M.ms.fd", Vars: "OVMF_VARS_4M.ms.fd"},
+				{Code: "OVMF_CODE_4M.secboot.fd", Vars: "OVMF_VARS_4M.secboot.fd"},
+				{Code: "OVMF_CODE.secboot.4m.fd", Vars: "OVMF_VARS.4m.fd"},
+				{Code: "OVMF_CODE.secboot.fd", Vars: "OVMF_VARS.secboot.fd"},
+				{Code: "OVMF_CODE.secboot.fd", Vars: "OVMF_VARS.fd"},
+				{Code: "OVMF_CODE.2MB.fd", Vars: "OVMF_VARS.2MB.ms.fd"},
+				{Code: "OVMF_CODE.fd", Vars: "OVMF_VARS.ms.fd"},
+				{Code: "OVMF_CODE.fd", Vars: "qemu.nvram"},
+			},
+			CSM: {
+				{Code: "seabios.bin", Vars: "seabios.bin"},
+				{Code: "OVMF_CODE.4MB.CSM.fd", Vars: "OVMF_VARS.4MB.CSM.fd"},
+				{Code: "OVMF_CODE.csm.4m.fd", Vars: "OVMF_VARS.4m.fd"},
+				{Code: "OVMF_CODE.2MB.CSM.fd", Vars: "OVMF_VARS.2MB.CSM.fd"},
+				{Code: "OVMF_CODE.CSM.fd", Vars: "OVMF_VARS.CSM.fd"},
+				{Code: "OVMF_CODE.csm.fd", Vars: "OVMF_VARS.fd"},
+			},
+		},
+	}, {
+		Path: "/usr/share/qemu",
+		Usage: map[FirmwareUsage][]FirmwarePair{
+			GENERIC: {
+				{Code: "ovmf-x86_64-4m-code.bin", Vars: "ovmf-x86_64-4m-vars.bin"},
+				{Code: "ovmf-x86_64.bin", Vars: "ovmf-x86_64-code.bin"},
+			},
+			SECUREBOOT: {
+				{Code: "ovmf-x86_64-ms-4m-vars.bin", Vars: "ovmf-x86_64-ms-4m-code.bin"},
+				{Code: "ovmf-x86_64-ms-code.bin", Vars: "ovmf-x86_64-ms-vars.bin"},
+			},
+		},
+	}},
+	osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN: {{
+		Path: "/usr/share/AAVMF",
+		Usage: map[FirmwareUsage][]FirmwarePair{
+			GENERIC: {
+				{Code: "AAVMF_CODE.fd", Vars: "AAVMF_VARS.fd"},
+			},
+			SECUREBOOT: {
+				{Code: "AAVMF_CODE.ms.fd", Vars: "AAVMF_VARS.ms.fd"},
+			},
+		},
+	}},
+}
+
+// GetArchitectureInstallations returns an array of installations for a specific host architecture.
+func GetArchitectureInstallations(hostArch int) []Installation {
+	installations, found := architectureInstallations[hostArch]
+	if found {
+		return installations
+	}
+
+	return []Installation{}
+}
+
+// GetAchitectureFirmwarePairs creates an array of FirmwarePair for a
+// specific host architecture. If the environment variable INCUS_EDK2_PATH
+// has been set it will override the default installation path when
+// constructing Code & Vars paths.
+func GetAchitectureFirmwarePairs(hostArch int) []FirmwarePair {
+	firmwares := make([]FirmwarePair, 0)
+
+	for _, usage := range []FirmwareUsage{GENERIC, SECUREBOOT, CSM} {
+		firmwares = append(firmwares, GetArchitectureFirmwarePairsForUsage(hostArch, usage)...)
+	}
+
+	return firmwares
+}
+
+// GetArchitectureFirmwarePairsForUsage creates an array of FirmwarePair
+// for a specific host architecture and usage combination. If the
+// environment variable INCUS_EDK2_PATH has been set it will override the
+// default installation path when constructing Code & Vars paths.
+func GetArchitectureFirmwarePairsForUsage(hostArch int, usage FirmwareUsage) []FirmwarePair {
+	firmwares := make([]FirmwarePair, 0)
+
+	for _, installation := range GetArchitectureInstallations(hostArch) {
+		usage, found := installation.Usage[usage]
+		if found {
+			for _, firmwarePair := range usage {
+				searchPath := installation.Path
+
+				if GetenvEdk2Path() != "" {
+					searchPath = GetenvEdk2Path()
+				}
+
+				firmwares = append(firmwares, FirmwarePair{
+					Code: filepath.Join(searchPath, firmwarePair.Code),
+					Vars: filepath.Join(searchPath, firmwarePair.Vars),
+				})
+			}
+		}
+	}
+
+	return firmwares
+}
+
+// GetenvEdk2Path returns the environment variable for overriding the path to use for EDK2 installations.
+func GetenvEdk2Path() string {
+	return os.Getenv("INCUS_EDK2_PATH")
+}


### PR DESCRIPTION
I discovered I wasn't able to run VMs on my RK3588 (ARM64). Although ARM64 [supports UEFI](https://github.com/lxc/incus/blob/main/internal/server/instance/drivers/driver_qemu.go#L1969-L1971) it wasn't able to find appropriate `*.fd` files because it is assumed every architecture was using OVMF. On ARM64 it should be using AAVMF as far as I can tell.

This PR adds support for using AAVMF on ARMv8 architectures and updates the documentation to reflect the code changes.

I've tested creating VMs with these changes on my ARM64 and x86_64 machines but don't have many devices to test against.