### PR TITLE
create_detached_idmapped_mount: avoid double close

### DIFF
--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -394,7 +394,6 @@ static int create_detached_idmapped_mount(const char *path, const char *fstype)
 	if (ret < 0)
 		return -errno;
 
-	close(fd_userns);
 	return 0;
 }
 */


### PR DESCRIPTION
fd_userns is defiend ad __do_close, so if it is not -EBADF, it will be closed on exit.  So we need to either set it to -EBADF after closing it, or just not manually close it.

My mistake in reviewing the previous patch.