### PR TITLE
Avoid double user-user- in network description

### DIFF
--- a/cmd/incus-user/server.go
+++ b/cmd/incus-user/server.go
@@ -248,7 +248,7 @@ func serverSetupUser(uid uint32) error {
 	network.Config = map[string]string{}
 	network.Type = "bridge"
 	network.Name = networkName
-	network.Description = fmt.Sprintf("Network for user restricted project user-%s", projectName)
+	network.Description = fmt.Sprintf("Network for user restricted project %s", projectName)
 
 	err = client.CreateNetwork(network)
 	if err != nil {


### PR DESCRIPTION
The description was showing a description like this: `Network for user restricted project user-user-1001`.