### PR TITLE
Prep work for OCI support

### DIFF
--- a/cmd/incus/action.go
+++ b/cmd/incus/action.go
@@ -341,7 +341,22 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 		console := cmdConsole{}
 		console.global = c.global
 		console.flagType = c.flagConsole
-		return console.Console(d, name)
+
+		consoleErr := console.Console(d, name)
+		if consoleErr != nil {
+			// Check if still running.
+			state, _, err := d.GetInstanceState(name)
+			if err != nil {
+				return err
+			}
+
+			if state.StatusCode != api.Stopped {
+				return consoleErr
+			}
+
+			console.flagShowLog = true
+			return console.Console(d, name)
+		}
 	}
 
 	return nil

--- a/cmd/incus/action.go
+++ b/cmd/incus/action.go
@@ -314,7 +314,7 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 		console := cmdConsole{}
 		console.global = c.global
 		console.flagType = c.flagConsole
-		return console.Console(d, name)
+		return console.console(d, name)
 	}
 
 	progress := cli.ProgressRenderer{
@@ -342,7 +342,7 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 		console.global = c.global
 		console.flagType = c.flagConsole
 
-		consoleErr := console.Console(d, name)
+		consoleErr := console.console(d, name)
 		if consoleErr != nil {
 			// Check if still running.
 			state, _, err := d.GetInstanceState(name)
@@ -355,7 +355,7 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 			}
 
 			console.flagShowLog = true
-			return console.Console(d, name)
+			return console.console(d, name)
 		}
 	}
 

--- a/cmd/incus/console.go
+++ b/cmd/incus/console.go
@@ -120,10 +120,10 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return c.Console(d, name)
+	return c.console(d, name)
 }
 
-func (c *cmdConsole) Console(d incus.InstanceServer, name string) error {
+func (c *cmdConsole) console(d incus.InstanceServer, name string) error {
 	// Show the current log if requested.
 	if c.flagShowLog {
 		if c.flagType != "console" {
@@ -152,7 +152,7 @@ func (c *cmdConsole) Console(d incus.InstanceServer, name string) error {
 
 	switch c.flagType {
 	case "console":
-		return c.console(d, name)
+		return c.text(d, name)
 	case "vga":
 		return c.vga(d, name)
 	}
@@ -160,7 +160,7 @@ func (c *cmdConsole) Console(d incus.InstanceServer, name string) error {
 	return fmt.Errorf(i18n.G("Unknown console type %q"), c.flagType)
 }
 
-func (c *cmdConsole) console(d incus.InstanceServer, name string) error {
+func (c *cmdConsole) text(d incus.InstanceServer, name string) error {
 	// Configure the terminal
 	cfd := int(os.Stdin.Fd())
 

--- a/cmd/incus/console.go
+++ b/cmd/incus/console.go
@@ -120,7 +120,11 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Show the current log if requested
+	return c.Console(d, name)
+}
+
+func (c *cmdConsole) Console(d incus.InstanceServer, name string) error {
+	// Show the current log if requested.
 	if c.flagShowLog {
 		if c.flagType != "console" {
 			return fmt.Errorf(i18n.G("The --show-log flag is only supported for by 'console' output type"))
@@ -141,10 +145,7 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return c.Console(d, name)
-}
-
-func (c *cmdConsole) Console(d incus.InstanceServer, name string) error {
+	// Handle running consoles.
 	if c.flagType == "" {
 		c.flagType = "console"
 	}
@@ -207,13 +208,13 @@ func (c *cmdConsole) console(d incus.InstanceServer, name string) error {
 		close(consoleDisconnect)
 	}()
 
-	fmt.Printf(i18n.G("To detach from the console, press: <ctrl>+a q") + "\n\r")
-
 	// Attach to the instance console
 	op, err := d.ConsoleInstance(name, req, &consoleArgs)
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf(i18n.G("To detach from the console, press: <ctrl>+a q") + "\n\r")
 
 	// Wait for the operation to complete
 	err = op.Wait()

--- a/cmd/incus/create.go
+++ b/cmd/incus/create.go
@@ -360,7 +360,7 @@ func (c *cmdCreate) create(conf *config.Config, args []string, launch bool) (inc
 			return nil, "", err
 		}
 
-		if conf.Remotes[iremote].Protocol != "simplestreams" {
+		if conf.Remotes[iremote].Protocol == "incus" {
 			if imgInfo.Type != "virtual-machine" && c.flagVM {
 				return nil, "", fmt.Errorf(i18n.G("Asked for a VM but image is of type container"))
 			}

--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -203,7 +203,7 @@ func (c *cmdImageCopy) Run(cmd *cobra.Command, args []string) error {
 	// Revert project for `sourceServer` which may have been overwritten
 	// by `--project` flag in `GetImageServer` method
 	remote := conf.Remotes[remoteName]
-	if remote.Protocol != "simplestream" && !remote.Public {
+	if remote.Protocol == "incus" && !remote.Public {
 		d, ok := sourceServer.(incus.InstanceServer)
 		if ok {
 			sourceServer = d.UseProject(remote.Project)
@@ -235,8 +235,8 @@ func (c *cmdImageCopy) Run(cmd *cobra.Command, args []string) error {
 	// Copy the image
 	var imgInfo *api.Image
 	var fp string
-	if conf.Remotes[remoteName].Protocol == "simplestreams" && !c.flagCopyAliases && len(c.flagAliases) == 0 {
-		// All simplestreams images are always public, so unless we
+	if conf.Remotes[remoteName].Protocol != "incus" && !c.flagCopyAliases && len(c.flagAliases) == 0 {
+		// All image servers outside of other Incus servers are always public, so unless we
 		// need the aliases list too or the real fingerprint, we can skip the otherwise very expensive
 		// alias resolution and image info retrieval step.
 		imgInfo = &api.Image{}

--- a/cmd/incus/launch.go
+++ b/cmd/incus/launch.go
@@ -75,7 +75,7 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 			console.global = c.global
 			console.flagType = c.flagConsole
 
-			consoleErr := console.Console(d, name)
+			consoleErr := console.console(d, name)
 			if consoleErr != nil {
 				// Check if still running.
 				state, _, err := d.GetInstanceState(name)
@@ -88,7 +88,7 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 				}
 
 				console.flagShowLog = true
-				return console.Console(d, name)
+				return console.console(d, name)
 			}
 		}
 
@@ -154,7 +154,7 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 		console.global = c.global
 		console.flagType = c.flagConsole
 
-		consoleErr := console.Console(d, name)
+		consoleErr := console.console(d, name)
 		if consoleErr != nil {
 			// Check if still running.
 			state, _, err := d.GetInstanceState(name)
@@ -167,7 +167,7 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 			}
 
 			console.flagShowLog = true
-			return console.Console(d, name)
+			return console.console(d, name)
 		}
 	}
 

--- a/cmd/incus/launch.go
+++ b/cmd/incus/launch.go
@@ -74,7 +74,22 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 			console := cmdConsole{}
 			console.global = c.global
 			console.flagType = c.flagConsole
-			return console.Console(d, name)
+
+			consoleErr := console.Console(d, name)
+			if consoleErr != nil {
+				// Check if still running.
+				state, _, err := d.GetInstanceState(name)
+				if err != nil {
+					return err
+				}
+
+				if state.StatusCode != api.Stopped {
+					return consoleErr
+				}
+
+				console.flagShowLog = true
+				return console.Console(d, name)
+			}
 		}
 
 		return nil
@@ -138,7 +153,22 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 		console := cmdConsole{}
 		console.global = c.global
 		console.flagType = c.flagConsole
-		return console.Console(d, name)
+
+		consoleErr := console.Console(d, name)
+		if consoleErr != nil {
+			// Check if still running.
+			state, _, err := d.GetInstanceState(name)
+			if err != nil {
+				return err
+			}
+
+			if state.StatusCode != api.Stopped {
+				return consoleErr
+			}
+
+			console.flagShowLog = true
+			return console.Console(d, name)
+		}
 	}
 
 	return nil

--- a/cmd/incus/rebuild.go
+++ b/cmd/incus/rebuild.go
@@ -126,7 +126,7 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 			return err
 		}
 
-		if conf.Remotes[iremote].Protocol != "simplestreams" {
+		if conf.Remotes[iremote].Protocol == "incus" {
 			if imgInfo.Type != "virtual-machine" && current.Type == "virtual-machine" {
 				return fmt.Errorf(i18n.G("Asked for a VM but image is of type container"))
 			}

--- a/cmd/incus/remote.go
+++ b/cmd/incus/remote.go
@@ -752,7 +752,7 @@ func (c *cmdRemoteList) Run(cmd *cobra.Command, args []string) error {
 		if rc.AuthType == "" {
 			if strings.HasPrefix(rc.Addr, "unix:") {
 				rc.AuthType = "file access"
-			} else if rc.Protocol == "simplestreams" {
+			} else if rc.Protocol != "incus" {
 				rc.AuthType = "none"
 			} else {
 				rc.AuthType = api.AuthenticationMethodTLS

--- a/cmd/incus/utils.go
+++ b/cmd/incus/utils.go
@@ -370,8 +370,8 @@ func getImgInfo(d incus.InstanceServer, conf *config.Config, imgRemote string, i
 		}
 	}
 
-	// Optimisation for simplestreams
-	if conf.Remotes[imgRemote].Protocol == "simplestreams" {
+	// Optimisation for public image servers.
+	if conf.Remotes[imgRemote].Protocol != "incus" {
 		imgInfo = &api.Image{}
 		imgInfo.Fingerprint = imageRef
 		imgInfo.Public = true

--- a/shared/cliconfig/default.go
+++ b/shared/cliconfig/default.go
@@ -2,9 +2,10 @@ package cliconfig
 
 // LocalRemote is the default local remote (over the unix socket).
 var LocalRemote = Remote{
-	Addr:   "unix://",
-	Static: true,
-	Public: false,
+	Addr:     "unix://",
+	Static:   true,
+	Public:   false,
+	Protocol: "incus",
 }
 
 // ImagesRemote is the community image server (over simplestreams).

--- a/shared/cliconfig/file.go
+++ b/shared/cliconfig/file.go
@@ -66,6 +66,14 @@ func LoadConfig(path string) (*Config, error) {
 		c.Remotes[k] = v
 	}
 
+	// Fill in defaults.
+	for k, r := range c.Remotes {
+		if r.Protocol == "" {
+			r.Protocol = "incus"
+			c.Remotes[k] = r
+		}
+	}
+
 	// If the environment specifies a remote this takes priority over what
 	// is defined in the configuration
 	envDefaultRemote := os.Getenv("INCUS_REMOTE")

--- a/shared/cliconfig/file.go
+++ b/shared/cliconfig/file.go
@@ -75,17 +75,6 @@ func LoadConfig(path string) (*Config, error) {
 		c.DefaultRemote = DefaultConfig().DefaultRemote
 	}
 
-	// NOTE: Remove this once we only see a small fraction of non-simplestreams users
-	// Upgrade users to the "simplestreams" protocol
-	images, ok := c.Remotes["images"]
-	if ok && images.Protocol != ImagesRemote.Protocol && images.Addr == ImagesRemote.Addr {
-		c.Remotes["images"] = ImagesRemote
-		err = c.SaveConfig(path)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return c, nil
 }
 

--- a/shared/cliconfig/remote.go
+++ b/shared/cliconfig/remote.go
@@ -68,7 +68,7 @@ func (c *Config) GetInstanceServer(name string) (incus.InstanceServer, error) {
 	}
 
 	// Quick checks.
-	if remote.Public || remote.Protocol == "simplestreams" {
+	if remote.Public || remote.Protocol != "incus" {
 		return nil, fmt.Errorf("The remote isn't a private server")
 	}
 
@@ -273,7 +273,7 @@ func (c *Config) getConnectionArgs(name string) (*incus.ConnectionArgs, error) {
 	}
 
 	// Stop here if no client certificate involved
-	if remote.Protocol == "simplestreams" || slices.Contains([]string{api.AuthenticationMethodOIDC}, remote.AuthType) {
+	if remote.Protocol != "incus" || slices.Contains([]string{api.AuthenticationMethodOIDC}, remote.AuthType) {
 		return &args, nil
 	}
 


### PR DESCRIPTION
This updates a bunch of logic to make it less specific to any specific image server protocol.

Basically replacing the bulk of the assumptions that "simplestreams" is the only public image server protocol with instead assuming that when not talking the "incus" protocol, we're likely dealing with an image server.

It also removes a bit of legacy migration logic and ensures that any remote with an empty protocol is properly treated as an Incus server.

Lastly, the `incus console` logic is tweaked to properly handle containers that have stopped quickly before an interactive console can be set up.