### PR TITLE
Add support for io.bus and io.cache for shared filesystems with VMs

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2513,3 +2513,7 @@ delete everything inside of the project along with the project itself.
 ## `resources_cpu_flags`
 
 This exposes the CPU flags/extensions in our resources API to check the CPU features.
+
+## `disk_io_bus_cache_filesystem`
+
+This adds support for both `io.bus` and `io.cache` to disks that are backed by a file system.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -48,19 +48,39 @@ User keys can be used in search.
 ```
 
 ```{config:option} io.bus devices-disk
-:default: "`virtio-scsi`"
+:default: "`virtio-scsi` for block, `auto` for file system"
 :required: "no"
-:shortdesc: "Only for VMs: Override the bus for the device (`nvme`, `virtio-blk`, or `virtio-scsi`)"
+:shortdesc: "Only for VMs: Override the bus for the device"
 :type: "string"
+This controls what bus a disk device should be attached to.
 
+For block devices (disks), this is one of:
+- `nvme`
+- `virtio-blk`
+- `virtio-scsi` (default)
+
+For file systems (shared directories or custom volumes), this is one of:
+- `9p`
+- `auto` (default) (`virtiofs` + `9p`, just `9p` if `virtiofsd` is missing)
+- `virtiofs`
 ```
 
 ```{config:option} io.cache devices-disk
 :default: "`none`"
 :required: "no"
-:shortdesc: "Only for VMs: Override the caching mode for the device (`none`, `writeback` or `unsafe`)"
+:shortdesc: "Only for VMs: Override the caching mode for the device"
 :type: "string"
+This controls what bus a disk device should be attached to.
 
+For block devices (disks), this is one of:
+- `none` (default)
+- `writeback`
+- `unsafe`
+
+For file systems (shared directories or custom volumes), this is one of:
+- `none` (default)
+- `metadata`
+- `unsafe`
 ```
 
 ```{config:option} limits.max devices-disk

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -1262,7 +1262,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					logPath := filepath.Join(d.inst.LogPath(), fmt.Sprintf("disk.%s.log", d.name))
 					_ = os.Remove(logPath) // Remove old log if needed.
 
-					revertFunc, unixListener, err := DiskVMVirtiofsdStart(d.state.OS.ExecPath, d.inst, sockPath, pidPath, logPath, mount.DevPath, rawIDMaps.Entries)
+					revertFunc, unixListener, err := DiskVMVirtiofsdStart(d.state.OS.ExecPath, d.inst, sockPath, pidPath, logPath, mount.DevPath, rawIDMaps.Entries, d.config["io.cache"])
 					if err != nil {
 						var errUnsupported UnsupportedError
 						if errors.As(err, &errUnsupported) {

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -60,19 +60,19 @@
 					},
 					{
 						"io.bus": {
-							"default": "`virtio-scsi`",
-							"longdesc": "",
+							"default": "`virtio-scsi` for block, `auto` for file system",
+							"longdesc": "This controls what bus a disk device should be attached to.\n\nFor block devices (disks), this is one of:\n- `nvme`\n- `virtio-blk`\n- `virtio-scsi` (default)\n\nFor file systems (shared directories or custom volumes), this is one of:\n- `9p`\n- `auto` (default) (`virtiofs` + `9p`, just `9p` if `virtiofsd` is missing)\n- `virtiofs`",
 							"required": "no",
-							"shortdesc": "Only for VMs: Override the bus for the device (`nvme`, `virtio-blk`, or `virtio-scsi`)",
+							"shortdesc": "Only for VMs: Override the bus for the device",
 							"type": "string"
 						}
 					},
 					{
 						"io.cache": {
 							"default": "`none`",
-							"longdesc": "",
+							"longdesc": "This controls what bus a disk device should be attached to.\n\nFor block devices (disks), this is one of:\n- `none` (default)\n- `writeback`\n- `unsafe`\n\nFor file systems (shared directories or custom volumes), this is one of:\n- `none` (default)\n- `metadata`\n- `unsafe`",
 							"required": "no",
-							"shortdesc": "Only for VMs: Override the caching mode for the device (`none`, `writeback` or `unsafe`)",
+							"shortdesc": "Only for VMs: Override the caching mode for the device",
 							"type": "string"
 						}
 					},

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -425,6 +425,7 @@ var APIExtensions = []string{
 	"project_access",
 	"projects_force_delete",
 	"resources_cpu_flags",
+	"disk_io_bus_cache_filesystem",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
## Description

- feat: add support for `io.bus` and `io.cache` for shared filesystems with VMs
- relates to #599 