### PR TITLE
Installation documentation update to work on both Debian and Ubuntu

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -288,7 +288,7 @@ Also, due to a [`gettext` issue](https://github.com/gosexy/gettext/issues/1), yo
 Install the build and required runtime dependencies with:
 
     sudo apt update
-    sudo apt install acl attr autoconf automake dnsmasq-base git golang-go libacl1-dev libcap-dev liblxc1 liblxc-dev libsqlite3-dev libtool libudev-dev liblz4-dev libuv1-dev make pkg-config rsync squashfs-tools tar tcl xz-utils ebtables
+    sudo apt install acl attr autoconf automake dnsmasq-base git golang-go libacl1-dev libcap-dev liblxc1 lxc-dev libsqlite3-dev libtool libudev-dev liblz4-dev libuv1-dev make pkg-config rsync squashfs-tools tar tcl xz-utils ebtables
 
 There are a few storage drivers for Incus besides the default `dir` driver.
 Installing these tools adds a bit to initramfs and may slow down your


### PR DESCRIPTION
Was following the instructions on Debian 12 (bookworm) and had an issue with the command that had 

`sudo apt install .... liblxc-dev ... `

because on Debian `liblxc-dev` could not be found.  

I switched to an Ubuntu 24.04 and found that `liblxc-dev` is a transitional package for `lxc-dev`.  I.e.

```
$ apt-cache search liblxc-dev
liblxc-dev - Transitional package - liblxc-dev -> lxc-dev
``` 

Thus changing `liblxc-dev`  to `lxc-dev`  documents a  process that works on both Debian and Ubuntu.

This PR updates the docs for the above reasons. 