### PR TITLE
incusd/instance/qemu: Fix handling of virtiofs-only disks

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3637,7 +3637,7 @@ func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, bus *qemuBus, fdFiles *[]*os
 	}
 
 	// Add 9p share config.
-	if slices.Contains(driveConf.Opts, "bus=auto") || slices.Contains(driveConf.Opts, "bus=9p") {
+	if !slices.Contains(driveConf.Opts, "bus=virtiofs") {
 		devBus, devAddr, multi := bus.allocate(busFunctionGroup9p)
 
 		fd, err := strconv.Atoi(driveConf.DevPath)


### PR DESCRIPTION
Rather than checking that we are dealing with bus=auto or bus=9p which are only present if the user specifically requested a given bus through io.bus, check whether the user specifically requested virtiofs-only instead.