### PR TITLE
Improve storage volume help

### DIFF
--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -159,9 +159,9 @@ type cmdStorageVolumeAttach struct {
 func (c *cmdStorageVolumeAttach) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("attach", i18n.G("[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"))
-	cmd.Short = i18n.G("Attach new storage volumes to instances")
+	cmd.Short = i18n.G("Attach new custom storage volumes to instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Attach new storage volumes to instances`))
+		`Attach new custom storage volumes to instances`))
 
 	cmd.RunE = c.Run
 
@@ -250,9 +250,9 @@ type cmdStorageVolumeAttachProfile struct {
 func (c *cmdStorageVolumeAttachProfile) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("attach-profile", i18n.G("[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"))
-	cmd.Short = i18n.G("Attach new storage volumes to profiles")
+	cmd.Short = i18n.G("Attach new custom storage volumes to profiles")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Attach new storage volumes to profiles`))
+		`Attach new custom storage volumes to profiles`))
 
 	cmd.RunE = c.Run
 
@@ -357,9 +357,9 @@ func (c *cmdStorageVolumeCopy) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("copy", i18n.G("[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"))
 	cmd.Aliases = []string{"cp"}
-	cmd.Short = i18n.G("Copy storage volumes")
+	cmd.Short = i18n.G("Copy custom storage volumes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Copy storage volumes`))
+		`Copy custom storage volumes`))
 
 	cmd.Flags().StringVar(&c.flagMode, "mode", "pull", i18n.G("Transfer mode. One of pull (default), push or relay.")+"``")
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
@@ -575,10 +575,11 @@ func (c *cmdStorageVolumeCreate) Command() *cobra.Command {
 	cmd.Short = i18n.G("Create new custom storage volumes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create new custom storage volumes`))
-	cmd.Example = cli.FormatSection("", i18n.G(`incus storage volume create p1 v1
+	cmd.Example = cli.FormatSection("", i18n.G(`incus storage volume create default foo
+    Create custom storage volume "foo" in pool "default"
 
-incus storage volume create p1 v1 < config.yaml
-	Create storage volume v1 for pool p1 with configuration from config.yaml.`))
+incus storage volume create default foo < config.yaml
+    Create custom storage volume "foo" in pool "default" with configuration from config.yaml`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVar(&c.flagContentType, "type", "filesystem", i18n.G("Content type, block or filesystem")+"``")
@@ -681,9 +682,9 @@ func (c *cmdStorageVolumeDelete) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("delete", i18n.G("[<remote>:]<pool> <volume>"))
 	cmd.Aliases = []string{"rm"}
-	cmd.Short = i18n.G("Delete storage volumes")
+	cmd.Short = i18n.G("Delete custom storage volumes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Delete storage volumes`))
+		`Delete custom storage volumes`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
@@ -754,9 +755,9 @@ type cmdStorageVolumeDetach struct {
 func (c *cmdStorageVolumeDetach) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("detach", i18n.G("[<remote>:]<pool> <volume> <instance> [<device name>]"))
-	cmd.Short = i18n.G("Detach storage volumes from instances")
+	cmd.Short = i18n.G("Detach custom storage volumes from instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Detach storage volumes from instances`))
+		`Detach custom storage volumes from instances`))
 
 	cmd.RunE = c.Run
 
@@ -852,9 +853,9 @@ type cmdStorageVolumeDetachProfile struct {
 func (c *cmdStorageVolumeDetachProfile) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("detach-profile", i18n.G("[<remote:>]<pool> <volume> <profile> [<device name>]"))
-	cmd.Short = i18n.G("Detach storage volumes from profiles")
+	cmd.Short = i18n.G("Detach custom storage volumes from profiles")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Detach storage volumes from profiles`))
+		`Detach custom storage volumes from profiles`))
 
 	cmd.RunE = c.Run
 
@@ -951,13 +952,16 @@ func (c *cmdStorageVolumeEdit) Command() *cobra.Command {
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<pool> [<type>/]<volume>"))
 	cmd.Short = i18n.G("Edit storage volume configurations as YAML")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Edit storage volume configurations as YAML`))
-	cmd.Example = cli.FormatSection("", i18n.G(
-		`Provide the type of the storage volume if it is not custom.
-Supported types are custom, image, container and virtual-machine.
+		`Edit storage volume configurations as YAML
 
-incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml
-    Update a storage volume using the content of pool.yaml.`))
+If the type is not specified, incus assumes the type is "custom".
+Supported values for type are "custom", "container" and "virtual-machine".`))
+	cmd.Example = cli.FormatSection("", i18n.G(
+		`incus storage volume edit default container/c1
+    Edit container storage volume "c1" in pool "default"
+
+incus storage volume edit default foo < volume.yaml
+    Edit custom storage volume "foo" in pool "default" using the content of volume.yaml`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
@@ -984,7 +988,7 @@ func (c *cmdStorageVolumeEdit) helpTemplate() string {
 ###
 ### A storage volume consists of a set of configuration items.
 ###
-### name: vol1
+### name: foo
 ### type: custom
 ### used_by: []
 ### config:
@@ -1172,18 +1176,18 @@ func (c *cmdStorageVolumeGet) Command() *cobra.Command {
 	cmd.Use = usage("get", i18n.G("[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"))
 	cmd.Short = i18n.G("Get values for storage volume configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Get values for storage volume configuration keys`))
+		`Get values for storage volume configuration keys
+
+If the type is not specified, incus assumes the type is "custom".
+Supported values for type are "custom", "container" and "virtual-machine".
+
+For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine).`))
 	cmd.Example = cli.FormatSection("", i18n.G(
-		`Provide the type of the storage volume if it is not custom.
-Supported types are custom, image, container and virtual-machine.
-
-Add the name of the snapshot if type is one of custom, container or virtual-machine.
-
-incus storage volume get default data size
-    Returns the size of a custom volume "data" in pool "default".
+		`incus storage volume get default data size
+    Returns the size of a custom volume "data" in pool "default"
 
 incus storage volume get default virtual-machine/data snapshots.expiry
-    Returns the snapshot expiration period for a virtual machine "data" in pool "default".`))
+    Returns the snapshot expiration period for a virtual machine "data" in pool "default"`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Get the key as a storage volume property"))
@@ -1308,16 +1312,15 @@ func (c *cmdStorageVolumeInfo) Command() *cobra.Command {
 	cmd.Use = usage("info", i18n.G("[<remote>:]<pool> [<type>/]<volume>"))
 	cmd.Short = i18n.G("Show storage volume state information")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Show storage volume state information`))
-	cmd.Example = cli.FormatSection("", i18n.G(
-		`Provide the type of the storage volume if it is not custom.
-Supported types are custom, container and virtual-machine.
+		`Show storage volume state information
 
-incus storage volume info default data
-    Returns state information for a custom volume "data" in pool "default".
+If the type is not specified, Incus assumes the type is "custom".
+Supported values for type are "custom", "container" and "virtual-machine".`))
+	cmd.Example = cli.FormatSection("", i18n.G(`incus storage volume info default foo
+    Returns state information for a custom volume "foo" in pool "default"
 
-incus storage volume info default virtual-machine/data
-    Returns state information for a virtual machine "data" in pool "default".`))
+incus storage volume info default virtual-machine/v1
+    Returns state information for virtual machine "v1" in pool "default"`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
@@ -1767,9 +1770,9 @@ func (c *cmdStorageVolumeMove) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("move", i18n.G("[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"))
 	cmd.Aliases = []string{"mv"}
-	cmd.Short = i18n.G("Move storage volumes between pools")
+	cmd.Short = i18n.G("Move custom storage volumes between pools")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Move storage volumes between pools`))
+		`Move custom storage volumes between pools`))
 
 	cmd.Flags().StringVar(&c.storageVolumeCopy.flagMode, "mode", "pull", i18n.G("Transfer mode, one of pull (default), push or relay")+"``")
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
@@ -1860,9 +1863,9 @@ type cmdStorageVolumeRename struct {
 func (c *cmdStorageVolumeRename) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("rename", i18n.G("[<remote>:]<pool> <old name> <new name>"))
-	cmd.Short = i18n.G("Rename storage volumes")
+	cmd.Short = i18n.G("Rename custom storage volumes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Rename storage volumes`))
+		`Rename custom storage volumes`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
@@ -1945,16 +1948,16 @@ func (c *cmdStorageVolumeSet) Command() *cobra.Command {
 		`Set storage volume configuration keys
 
 For backward compatibility, a single configuration key may still be set with:
-    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>`))
-	cmd.Example = cli.FormatSection("", i18n.G(
-		`Provide the type of the storage volume if it is not custom.
-Supported types are custom, image, container and virtual-machine.
+    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>
 
-incus storage volume set default data size=1GiB
-    Sets the size of a custom volume "data" in pool "default" to 1 GiB.
+If the type is not specified, Incus assumes the type is "custom".
+Supported values for type are "custom", "container" and "virtual-machine".`))
+	cmd.Example = cli.FormatSection("", i18n.G(
+		`incus storage volume set default data size=1GiB
+    Sets the size of a custom volume "data" in pool "default" to 1 GiB
 
 incus storage volume set default virtual-machine/data snapshots.expiry=7d
-    Sets the snapshot expiration period for a virtual machine "data" in pool "default" to seven days.`))
+    Sets the snapshot expiration period for a virtual machine "data" in pool "default" to seven days`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Set the key as a storage volume property"))
@@ -2105,18 +2108,20 @@ func (c *cmdStorageVolumeShow) Command() *cobra.Command {
 	cmd.Use = usage("show", i18n.G("[<remote>:]<pool> [<type>/]<volume>"))
 	cmd.Short = i18n.G("Show storage volume configurations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Show storage volume configurations`))
-	cmd.Example = cli.FormatSection("", i18n.G(
-		`Provide the type of the storage volume if it is not custom.
-Supported types are custom, image, container and virtual-machine.
+		`Show storage volume configurations
 
-Add the name of the snapshot if type is one of custom, container or virtual-machine.
+If the type is not specified, Incus assumes the type is "custom".
+Supported values for type are "custom", "container" and "virtual-machine".
 
-incus storage volume show default data
-    Will show the properties of a custom volume called "data" in the "default" pool.
+For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine).`))
+	cmd.Example = cli.FormatSection("", i18n.G(`incus storage volume show default foo
+    Will show the properties of custom volume "foo" in pool "default"
 
-incus storage volume show default container/data
-    Will show the properties of the filesystem for a container called "data" in the "default" pool.`))
+incus storage volume show default virtual-machine/v1
+    Will show the properties of the virtual-machine volume "v1" in pool "default"
+
+incus storage volume show default container/c1
+    Will show the properties of the container volume "c1" in pool "default"`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
@@ -2171,6 +2176,9 @@ func (c *cmdStorageVolumeShow) Run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		// Give more context on missing volumes.
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			if volType == "custom" {
+				return fmt.Errorf("Storage pool volume \"%s/%s\" not found. Try virtual-machine or container for type", volType, volName)
+			}
 			return fmt.Errorf("Storage pool volume \"%s/%s\" not found", volType, volName)
 		}
 
@@ -2204,16 +2212,15 @@ func (c *cmdStorageVolumeUnset) Command() *cobra.Command {
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<pool> [<type>/]<volume> <key>"))
 	cmd.Short = i18n.G("Unset storage volume configuration keys")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Unset storage volume configuration keys`))
-	cmd.Example = cli.FormatSection("", i18n.G(
-		`Provide the type of the storage volume if it is not custom.
-Supported types are custom, image, container and virtual-machine.
+		`Unset storage volume configuration keys
 
-incus storage volume unset default data size
-    Remotes the size/quota of a custom volume "data" in pool "default".
+If the type is not specified, Incus assumes the type is "custom".
+Supported values for type are "custom", "container" and "virtual-machine".`))
+	cmd.Example = cli.FormatSection("", i18n.G(`incus storage volume unset default foo size
+    Removes the size/quota of custom volume "foo" in pool "default"
 
-incus storage volume unset default virtual-machine/data snapshots.expiry
-    Removes the snapshot expiration period for a virtual machine "data" in pool "default".`))
+incus storage volume unset default virtual-machine/v1 snapshots.expiry
+    Removes the snapshot expiration period of virtual machine volume "v1" in pool "default"`))
 
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().BoolVarP(&c.flagIsProperty, "property", "p", false, i18n.G("Unset the key as a storage volume property"))
@@ -2296,7 +2303,7 @@ func (c *cmdStorageVolumeSnapshot) Command() *cobra.Command {
 	return cmd
 }
 
-// Create.
+// Snapshot create.
 type cmdStorageVolumeSnapshotCreate struct {
 	global                *cmdGlobal
 	storage               *cmdStorage
@@ -2313,11 +2320,11 @@ func (c *cmdStorageVolumeSnapshotCreate) Command() *cobra.Command {
 	cmd.Short = i18n.G("Snapshot storage volumes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Snapshot storage volumes`))
-	cmd.Example = cli.FormatSection("", i18n.G(`incus storage volume snapshot create default v1 snap0
-       Create a snapshot of "v1" in pool "default" called "snap0".
+	cmd.Example = cli.FormatSection("", i18n.G(`incus storage volume snapshot create default foo snap0
+    Create a snapshot of "foo" in pool "default" called "snap0"
 
-incus storage volume snapshot create default v1 snap0 < config.yaml
-       Create a snapshot of "v1" in pool "default" called "snap0" with the configuration from "config.yaml".`))
+incus storage volume snapshot create default vol1 snap0 < config.yaml
+    Create a snapshot of "foo" in pool "default" called "snap0" with the configuration from "config.yaml"`))
 
 	cmd.Flags().BoolVar(&c.flagNoExpiry, "no-expiry", false, i18n.G("Ignore any configured auto-expiry for the storage volume"))
 	cmd.Flags().BoolVar(&c.flagReuse, "reuse", false, i18n.G("If the snapshot name already exists, delete and create a new one"))
@@ -2431,7 +2438,7 @@ func (c *cmdStorageVolumeSnapshotCreate) Run(cmd *cobra.Command, args []string) 
 	return op.Wait()
 }
 
-// Delete.
+// Snapshot delete.
 type cmdStorageVolumeSnapshotDelete struct {
 	global                *cmdGlobal
 	storage               *cmdStorage
@@ -2515,7 +2522,7 @@ func (c *cmdStorageVolumeSnapshotDelete) Run(cmd *cobra.Command, args []string) 
 	return nil
 }
 
-// List.
+// Snapshot list.
 type cmdStorageVolumeSnapshotList struct {
 	global                *cmdGlobal
 	storage               *cmdStorage
@@ -2645,7 +2652,7 @@ func (c *cmdStorageVolumeSnapshotList) listSnapshots(d incus.InstanceServer, poo
 	return nil
 }
 
-// Rename.
+// Snapshot rename.
 type cmdStorageVolumeSnapshotRename struct {
 	global                *cmdGlobal
 	storage               *cmdStorage
@@ -2732,7 +2739,7 @@ func (c *cmdStorageVolumeSnapshotRename) Run(cmd *cobra.Command, args []string) 
 	return nil
 }
 
-// Restore.
+// Snapshot restore.
 type cmdStorageVolumeSnapshotRestore struct {
 	global                *cmdGlobal
 	storage               *cmdStorage
@@ -2812,7 +2819,7 @@ func (c *cmdStorageVolumeSnapshotRestore) Run(cmd *cobra.Command, args []string)
 	return client.UpdateStoragePoolVolume(resource.name, "custom", args[1], req, etag)
 }
 
-// Restore.
+// Snapshot show.
 type cmdStorageVolumeSnapshotShow struct {
 	global                *cmdGlobal
 	storage               *cmdStorage
@@ -2823,18 +2830,9 @@ type cmdStorageVolumeSnapshotShow struct {
 func (c *cmdStorageVolumeSnapshotShow) Command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<pool> <volume>/<snapshot>"))
-	cmd.Short = i18n.G("Show storage volume configurations")
+	cmd.Short = i18n.G("Show storage volume snapshot configurations")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Show storage volume configurations`))
-	cmd.Example = cli.FormatSection("", i18n.G(
-		`Provide the type of the storage volume if it is not custom.
-	Supported types are custom, image, container and virtual-machine.
-
-	Add the name of the snapshot if type is one of custom, container or virtual-machine.
-
-	incus storage volume show default virtual-machine/data/snap0
-		Will show the properties of snapshot "snap0" for a virtual machine called "data" in the "default" pool.`))
-
+		`Show storage volume snapshhot configurations`))
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 
 	cmd.RunE = c.Run
@@ -3087,10 +3085,12 @@ func (c *cmdStorageVolumeImport) Command() *cobra.Command {
 	cmd.Use = usage("import", i18n.G("[<remote>:]<pool> <backup file> [<volume name>]"))
 	cmd.Short = i18n.G("Import custom storage volumes")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Import backups of custom volumes including their snapshots.`))
-	cmd.Example = cli.FormatSection("", i18n.G(
-		`incus storage volume import default backup0.tar.gz
-		Create a new custom volume using backup0.tar.gz as the source.`))
+		`Import custom storage volumes.`))
+	cmd.Example = cli.FormatSection("", i18n.G(`incus storage volume import default backup0.tar.gz
+    Create a new custom volume using backup0.tar.gz as the source
+
+incus storage volume import default some-installer.iso installer --type=iso
+    Create a new custom volume storing some-installer.iso for use as a CD-ROM image`))
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
 	cmd.Flags().StringVar(&c.flagType, "type", "", i18n.G("Import type, backup or iso (default \"backup\")")+"``")

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -2179,6 +2179,7 @@ func (c *cmdStorageVolumeShow) Run(cmd *cobra.Command, args []string) error {
 			if volType == "custom" {
 				return fmt.Errorf("Storage pool volume \"%s/%s\" not found. Try virtual-machine or container for type", volType, volName)
 			}
+
 			return fmt.Errorf("Storage pool volume \"%s/%s\" not found", volType, volName)
 		}
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-06-11 23:14-0400\n"
+"POT-Creation-Date: 2024-07-08 16:17-0400\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: Tobias Gerold <tobias@g3ro.eu>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -87,7 +87,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -95,7 +95,7 @@ msgid ""
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
 "###\n"
-"### name: vol1\n"
+"### name: foo\n"
 "### type: custom\n"
 "### used_by: []\n"
 "### config:\n"
@@ -1026,7 +1026,7 @@ msgstr ""
 "Alle existierenden Dateien sind verloren, wenn sie dem Cluster beitreten, "
 "Vorgang fortsetzen?"
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 msgid "All projects"
 msgstr "Alle Projekte"
 
@@ -1091,19 +1091,20 @@ msgstr "Netzwerkschnittstellen (network interfaces) zu Instanzen hinzufügen"
 msgid "Attach network interfaces to profiles"
 msgstr "Netzwerkschnittstellen (network interfaces) zu Profilen hinzufügen"
 
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#, fuzzy
+msgid "Attach new custom storage volumes to instances"
+msgstr "Storage Volumes zu Instanzen hinzufügen"
+
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#, fuzzy
+msgid "Attach new custom storage volumes to profiles"
+msgstr "Storage Volumes zu Profilen hinzufügen"
+
 #: cmd/incus/network.go:143
 #, fuzzy
 msgid "Attach new network interfaces to instances"
 msgstr "Netzwerkschnittstellen (network interfaces) zu Instanzen hinzufügen"
-
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
-#, fuzzy
-msgid "Attach new storage volumes to instances"
-msgstr "Storage Volumes zu Instanzen hinzufügen"
-
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid "Attach new storage volumes to profiles"
-msgstr "Storage Volumes zu Profilen hinzufügen"
 
 #: cmd/incus/console.go:36
 msgid "Attach to instance consoles"
@@ -1170,18 +1171,18 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Backing up storage bucket: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396
-#: cmd/incus/storage_volume.go:3072
+#: cmd/incus/storage_volume.go:3070
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1205,7 +1206,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:650
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1253,7 +1254,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1357,7 +1358,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1552,15 +1553,15 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
 #: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324
-#: cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838
-#: cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670
+#: cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836
+#: cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid "Cluster member name"
 msgstr ""
 
@@ -1571,7 +1572,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072
 #: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687
-#: cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547
 #: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1632,7 +1633,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
 #: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -1650,11 +1651,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1671,6 +1672,11 @@ msgstr ""
 #: cmd/incus/image.go:155
 msgid "Copy aliases from source"
 msgstr "Kopiere Aliasse von der Quelle"
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#, fuzzy
+msgid "Copy custom storage volumes"
+msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: cmd/incus/image.go:147
 msgid "Copy images between servers"
@@ -1712,11 +1718,6 @@ msgstr ""
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid "Copy profiles"
 msgstr ""
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-#, fuzzy
-msgid "Copy storage volumes"
-msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: cmd/incus/copy.go:57
 #, fuzzy
@@ -1945,7 +1946,7 @@ msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:657
-#: cmd/incus/storage_volume.go:1440
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1983,7 +1984,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1669
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -2022,7 +2023,7 @@ msgstr "Erstellt: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2041,6 +2042,11 @@ msgstr ""
 #: cmd/incus/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#, fuzzy
+msgid "Delete custom storage volumes"
+msgstr "Kein Zertifikat für diese Verbindung"
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
 #, fuzzy
@@ -2130,15 +2136,10 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-#, fuzzy
-msgid "Delete storage volumes"
-msgstr "Kein Zertifikat für diese Verbindung"
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
 msgid "Delete warning"
@@ -2279,32 +2280,42 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953
-#: cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310
-#: cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556
-#: cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864
-#: cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265
-#: cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447
-#: cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542
-#: cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747
-#: cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923
-#: cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272
+#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454
+#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754
+#: cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#, fuzzy
+msgid "Detach custom storage volumes from instances"
+msgstr "Profil %s erstellt\n"
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#, fuzzy
+msgid "Detach custom storage volumes from profiles"
+msgstr "Storage Volumes zu Profilen hinzufügen"
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
 #, fuzzy
@@ -2313,15 +2324,6 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid "Detach network interfaces from profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-#, fuzzy
-msgid "Detach storage volumes from instances"
-msgstr "Profil %s erstellt\n"
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid "Detach storage volumes from profiles"
 msgstr ""
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
@@ -2642,9 +2644,19 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:954
+#, fuzzy
+msgid ""
+"Edit storage volume configurations as YAML\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr "Profil %s erstellt\n"
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
 #, fuzzy
@@ -2654,7 +2666,7 @@ msgstr "Alternatives config Verzeichnis."
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722
-#: cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2730,8 +2742,8 @@ msgstr "Fehler beim Abrufen des Aliase/Namen: %w"
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163
 #: cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim Festlegen der Parameter: %v"
@@ -2752,8 +2764,8 @@ msgstr "Fehler beim Löschen der Parameter: %v"
 #: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077
 #: cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2072
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Fehler beim Löschen des Parameters: %v"
@@ -2885,8 +2897,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:2640
+#: cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/storage_volume.go:2647
 #, fuzzy
 msgid "Expires at"
 msgstr "Wird gelöscht am"
@@ -2917,7 +2929,7 @@ msgstr ""
 "angegeben wird, wird die resultierende Datei im derzeit aktiven Ordner/Pfad "
 "gespeichert."
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 msgid "Export custom storage volume"
 msgstr "Storage Volume exportieren"
 
@@ -2939,7 +2951,7 @@ msgstr "Storage Buckets exportieren"
 msgid "Export storage buckets as tarball."
 msgstr "Storage Buckets als Dateien (.tar) exportieren."
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 msgid "Export the volume without its snapshots"
 msgstr "Storage Volume ohne Snapshots exportieren"
 
@@ -2948,7 +2960,7 @@ msgstr "Storage Volume ohne Snapshots exportieren"
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Backup des Storage Bucket %s wird exportiert"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Backup %s wird exportiert"
@@ -3166,7 +3178,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3181,7 +3193,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3409,8 +3421,8 @@ msgstr ""
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572
-#: cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3545,7 +3557,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3627,9 +3639,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid "Get values for storage volume configuration keys"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:1178
+#, fuzzy
+msgid ""
+"Get values for storage volume configuration keys\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr "Profil %s erstellt\n"
 
 #: cmd/incus/storage_volume.go:440
 #, c-format
@@ -3738,7 +3763,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3752,7 +3777,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3804,10 +3829,6 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:3089
-msgid "Import backups of custom volumes including their snapshots."
-msgstr ""
-
 #: cmd/incus/import.go:27
 msgid "Import backups of instances including their snapshots."
 msgstr ""
@@ -3817,9 +3838,14 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 #, fuzzy
 msgid "Import custom storage volumes"
+msgstr "Anhalten des Containers fehlgeschlagen!"
+
+#: cmd/incus/storage_volume.go:3087
+#, fuzzy
+msgid "Import custom storage volumes."
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: cmd/incus/image.go:685
@@ -3933,7 +3959,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Ungültige Quelle %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3021
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Ungültiges Ziel %s"
@@ -3954,7 +3980,7 @@ msgid "Invalid arguments"
 msgstr "Ungültiges Ziel %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3026
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -4059,9 +4085,9 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238
-#: cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2881
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -4127,7 +4153,7 @@ msgstr ""
 #: cmd/incus/list.go:616 cmd/incus/network.go:1303
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
-#: cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4556,12 +4582,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4579,12 +4605,12 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4671,7 +4697,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4974,7 +5000,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage storage pools and volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5228,15 +5254,15 @@ msgstr "Fehlende Zusammenfassung."
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
 #: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614
-#: cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798
-#: cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010
-#: cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603
-#: cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995
-#: cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372
-#: cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592
-#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379
+#: cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2871
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5263,12 +5289,12 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5309,7 +5335,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5322,6 +5348,11 @@ msgstr ""
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#, fuzzy
+msgid "Move custom storage volumes between pools"
+msgstr "Kein Zertifikat für diese Verbindung"
 
 #: cmd/incus/move.go:34
 #, fuzzy
@@ -5344,17 +5375,12 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-#, fuzzy
-msgid "Move storage volumes between pools"
-msgstr "Kein Zertifikat für diese Verbindung"
-
 #: cmd/incus/move.go:60
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5388,7 +5414,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5444,8 +5470,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2638
+#: cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:2645
 msgid "Name"
 msgstr ""
 
@@ -5510,7 +5536,7 @@ msgid "Name of the storage pool:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: cmd/incus/info.go:632 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1411
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5678,7 +5704,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5699,11 +5725,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5743,11 +5769,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5759,7 +5785,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5777,7 +5803,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5832,7 +5858,7 @@ msgstr ""
 #: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
-#: cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5959,7 +5985,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
 #: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6101,101 +6127,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Ungültiges Ziel %s"
-
-#: cmd/incus/storage_volume.go:2829
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"\tSupported types are custom, image, container and virtual-machine.\n"
-"\n"
-"\tAdd the name of the snapshot if type is one of custom, container or "
-"virtual-machine.\n"
-"\n"
-"\tincus storage volume show default virtual-machine/data/snap0\n"
-"\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
-"called \"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1312
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, container and virtual-machine.\n"
-"\n"
-"incus storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool "
-"\"default\".\n"
-"\n"
-"incus storage volume info default virtual-machine/data\n"
-"    Returns state information for a virtual machine \"data\" in pool "
-"\"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1176
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume get default data size\n"
-"    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2109
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume show default data\n"
-"    Will show the properties of a custom volume called \"data\" in the "
-"\"default\" pool.\n"
-"\n"
-"incus storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:955
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-"    Update a storage volume using the content of pool.yaml."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1949
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume set default data size=1GiB\n"
-"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-"\n"
-"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\" to seven days."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2208
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-"    Removes the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
 
 #: cmd/incus/config_trust.go:224
 #, fuzzy, c-format
@@ -6479,6 +6410,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#, fuzzy
+msgid "Rename custom storage volumes"
+msgstr "Kein Zertifikat für diese Verbindung"
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 #, fuzzy
 msgid "Rename instance snapshots"
@@ -6516,22 +6452,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-#, fuzzy
-msgid "Rename storage volumes"
-msgstr "Kein Zertifikat für diese Verbindung"
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Herunterfahren des Containers erzwingen."
@@ -6575,7 +6506,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -7000,20 +6931,25 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
+#, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
 "For backward compatibility, a single configuration key may still be set "
 "with:\n"
 "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
-"<value>"
-msgstr ""
+"<value>\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr "Profil %s erstellt\n"
 
 #: cmd/incus/remote.go:983 cmd/incus/remote.go:984
 msgid "Set the URL for the remote"
@@ -7106,7 +7042,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -7266,15 +7202,47 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+#, fuzzy
+msgid ""
+"Show storage volume configurations\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr "Profil %s erstellt\n"
+
+#: cmd/incus/storage_volume.go:2834
+#, fuzzy
+msgid "Show storage volume snapshhot configurations"
+msgstr "Profil %s erstellt\n"
+
+#: cmd/incus/storage_volume.go:2833
+#, fuzzy
+msgid "Show storage volume snapshot configurations"
+msgstr "Profil %s erstellt\n"
+
+#: cmd/incus/storage_volume.go:1313
 #, fuzzy
 msgid "Show storage volume state information"
+msgstr "Profil %s erstellt\n"
+
+#: cmd/incus/storage_volume.go:1314
+#, fuzzy
+msgid ""
+"Show storage volume state information\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr "Profil %s erstellt\n"
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
@@ -7343,16 +7311,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7501,12 +7469,12 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Storage pool to use or create"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -7521,7 +7489,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Profil %s gelöscht\n"
@@ -7582,13 +7550,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 msgid "Taken at"
 msgstr ""
 
@@ -7788,12 +7756,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7841,7 +7809,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -7924,7 +7892,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -7940,7 +7908,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8005,7 +7973,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432
 #: cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1420
+#: cmd/incus/storage_volume.go:1423
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -8027,7 +7995,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -8045,7 +8013,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
 
@@ -8086,7 +8054,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8207,10 +8175,20 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
+
+#: cmd/incus/storage_volume.go:2214
+#, fuzzy
+msgid ""
+"Unset storage volume configuration keys\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr "Profil %s erstellt\n"
 
 #: cmd/incus/cluster.go:589
 msgid "Unset the key as a cluster property"
@@ -8273,7 +8251,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -8321,12 +8299,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8417,7 +8395,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Version: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid "Volume Only"
 msgstr ""
 
@@ -8600,7 +8578,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -9429,7 +9407,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -9505,7 +9483,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -9513,7 +9491,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -9521,7 +9499,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -9537,7 +9515,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -9546,7 +9524,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -9555,7 +9533,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -9564,7 +9542,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -9581,7 +9559,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -9590,7 +9568,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -9598,8 +9576,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308
-#: cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -9607,7 +9585,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -9615,7 +9593,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -9623,7 +9601,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -9632,7 +9610,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10446,35 +10424,14 @@ msgstr ""
 "Konfigurationsdetails aus der Datei \"pool.yaml\"."
 
 #: cmd/incus/storage_volume.go:578
+#, fuzzy
 msgid ""
-"incus storage volume create p1 v1\n"
+"incus storage volume create default foo\n"
+"    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
-msgstr ""
-"incus storage volume create p1 v1\n"
-"\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tErstellt ein storage volume mit dem Namen \"v1\" im pool \"p1\" mit den "
-"Konfigurationsdetails aus der Datei \"config.yaml\"."
-
-#: cmd/incus/storage_volume.go:3091
-msgid ""
-"incus storage volume import default backup0.tar.gz\n"
-"\t\tCreate a new custom volume using backup0.tar.gz as the source."
-msgstr ""
-"incus storage volume import default backup0.tar.gz\n"
-"\t\tErstellt ein neues benutzerdefiniertes Volume aus der Datei \"backup0."
-"tar.gz\"."
-
-#: cmd/incus/storage_volume.go:2316
-msgid ""
-"incus storage volume snapshot create default v1 snap0\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
-"\n"
-"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with "
-"the configuration from \"config.yaml\"."
+"incus storage volume create default foo < config.yaml\n"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 "incus storage volume snapshot create default v1 snap0\n"
 "       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
@@ -10484,6 +10441,108 @@ msgstr ""
 "       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
 "\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
 "yaml\"."
+
+#: cmd/incus/storage_volume.go:959
+#, fuzzy
+msgid ""
+"incus storage volume edit default container/c1\n"
+"    Edit container storage volume \"c1\" in pool \"default\"\n"
+"\n"
+"incus storage volume edit default foo < volume.yaml\n"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
+msgstr ""
+"incus storage volume snapshot create default v1 snap0\n"
+"       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
+"\"snap0\".\n"
+"\n"
+"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
+"       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
+"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
+"yaml\"."
+
+#: cmd/incus/storage_volume.go:1185
+msgid ""
+"incus storage volume get default data size\n"
+"    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+"\n"
+"incus storage volume get default virtual-machine/data snapshots.expiry\n"
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3089
+msgid ""
+"incus storage volume import default backup0.tar.gz\n"
+"    Create a new custom volume using backup0.tar.gz as the source\n"
+"\n"
+"incus storage volume import default some-installer.iso installer --type=iso\n"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1319
+msgid ""
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume info default virtual-machine/v1\n"
+"    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1955
+msgid ""
+"incus storage volume set default data size=1GiB\n"
+"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+"\n"
+"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2117
+msgid ""
+"incus storage volume show default foo\n"
+"    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume show default virtual-machine/v1\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume show default container/c1\n"
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2323
+#, fuzzy
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+"\n"
+"incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
+msgstr ""
+"incus storage volume snapshot create default v1 snap0\n"
+"       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
+"\"snap0\".\n"
+"\n"
+"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
+"       Erstellt einen Snapshot von \"v1\" im pool \"default\" mit dem Namen "
+"\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
+"yaml\"."
+
+#: cmd/incus/storage_volume.go:2219
+msgid ""
+"incus storage volume unset default foo size\n"
+"    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
+msgstr ""
 
 #: cmd/incus/storage.go:547
 msgid "info"
@@ -10551,6 +10610,67 @@ msgstr "j"
 #: cmd/incus/image.go:1184 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "ja"
+
+#, fuzzy
+#~ msgid ""
+#~ "\t\tincus storage volume show default virtual-machine/data/snap0\n"
+#~ "\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
+#~ "called \"data\" in the \"default\" pool."
+#~ msgstr ""
+#~ "incus storage bucket show default data\n"
+#~ "    Zeigt die Eigenschaften eines storage bucket namens \"data\" im pool "
+#~ "\"default\"."
+
+#, fuzzy
+#~ msgid "Copy storage volumes"
+#~ msgstr "Anhalten des Containers fehlgeschlagen!"
+
+#, fuzzy
+#~ msgid ""
+#~ "Edit storage volume configurations as YAML\n"
+#~ "\n"
+#~ "Provide the type of the storage volume if it is not custom.\n"
+#~ "Supported types are custom, image, container and virtual-machine."
+#~ msgstr "Profil %s erstellt\n"
+
+#, fuzzy
+#~ msgid ""
+#~ "Unset storage volume configuration keys\n"
+#~ "\n"
+#~ "Provide the type of the storage volume if it is not custom.\n"
+#~ "Supported types are custom, image, container and virtual-machine."
+#~ msgstr "Profil %s erstellt\n"
+
+#~ msgid ""
+#~ "incus storage volume create p1 v1\n"
+#~ "\n"
+#~ "incus storage volume create p1 v1 < config.yaml\n"
+#~ "\tCreate storage volume v1 for pool p1 with configuration from config."
+#~ "yaml."
+#~ msgstr ""
+#~ "incus storage volume create p1 v1\n"
+#~ "\n"
+#~ "incus storage volume create p1 v1 < config.yaml\n"
+#~ "\tErstellt ein storage volume mit dem Namen \"v1\" im pool \"p1\" mit den "
+#~ "Konfigurationsdetails aus der Datei \"config.yaml\"."
+
+#, fuzzy
+#~ msgid ""
+#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume."
+#~ "yaml\n"
+#~ "    Update a storage volume using the content of pool.yaml."
+#~ msgstr ""
+#~ "incus storage edit [<remote>:]<pool> < pool.yaml\n"
+#~ "    Automatisches Editieren der Konfiguration des storage pool mit den "
+#~ "Konfigurationsdetails aus der Datei \"pool.yaml\"."
+
+#~ msgid ""
+#~ "incus storage volume import default backup0.tar.gz\n"
+#~ "\t\tCreate a new custom volume using backup0.tar.gz as the source."
+#~ msgstr ""
+#~ "incus storage volume import default backup0.tar.gz\n"
+#~ "\t\tErstellt ein neues benutzerdefiniertes Volume aus der Datei \"backup0."
+#~ "tar.gz\"."
 
 #, fuzzy
 #~ msgid "The --mode flag can't be used with --storage or --target-project"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-06-11 23:14-0400\n"
+"POT-Creation-Date: 2024-07-08 16:17-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -91,7 +91,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -99,7 +99,7 @@ msgid ""
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
 "###\n"
-"### name: vol1\n"
+"### name: foo\n"
 "### type: custom\n"
 "### used_by: []\n"
 "### config:\n"
@@ -989,7 +989,7 @@ msgstr "Aliases:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 msgid "All projects"
 msgstr ""
 
@@ -1047,16 +1047,18 @@ msgstr ""
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/network.go:143
-msgid "Attach new network interfaces to instances"
-msgstr ""
-
 #: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
-msgid "Attach new storage volumes to instances"
-msgstr ""
+#, fuzzy
+msgid "Attach new custom storage volumes to instances"
+msgstr "Perfil %s creado"
 
 #: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid "Attach new storage volumes to profiles"
+#, fuzzy
+msgid "Attach new custom storage volumes to profiles"
+msgstr "Perfil %s creado"
+
+#: cmd/incus/network.go:143
+msgid "Attach new network interfaces to instances"
 msgstr ""
 
 #: cmd/incus/console.go:36
@@ -1117,17 +1119,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backing up storage bucket: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396
-#: cmd/incus/storage_volume.go:3072
+#: cmd/incus/storage_volume.go:3070
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1151,7 +1153,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:650
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1200,7 +1202,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1298,7 +1300,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1489,15 +1491,15 @@ msgstr "Perfil %s eliminado de %s"
 #: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
 #: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324
-#: cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838
-#: cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670
+#: cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836
+#: cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1508,7 +1510,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072
 #: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687
-#: cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547
 #: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1569,7 +1571,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
 #: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1587,11 +1589,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1608,6 +1610,11 @@ msgstr ""
 #: cmd/incus/image.go:155
 msgid "Copy aliases from source"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#, fuzzy
+msgid "Copy custom storage volumes"
+msgstr "Perfil %s creado"
 
 #: cmd/incus/image.go:147
 msgid "Copy images between servers"
@@ -1647,10 +1654,6 @@ msgstr ""
 
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid "Copy profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-msgid "Copy storage volumes"
 msgstr ""
 
 #: cmd/incus/copy.go:57
@@ -1867,7 +1870,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:657
-#: cmd/incus/storage_volume.go:1440
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1905,7 +1908,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1669
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1944,7 +1947,7 @@ msgstr "Auto actualización: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1963,6 +1966,11 @@ msgstr ""
 #: cmd/incus/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#, fuzzy
+msgid "Delete custom storage volumes"
+msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
 msgid "Delete files in instances"
@@ -2048,14 +2056,10 @@ msgstr "Perfil %s creado"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-msgid "Delete storage volumes"
-msgstr ""
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
 msgid "Delete warning"
@@ -2196,32 +2200,42 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953
-#: cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310
-#: cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556
-#: cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864
-#: cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265
-#: cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447
-#: cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542
-#: cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747
-#: cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923
-#: cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272
+#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454
+#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754
+#: cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr "Descripción"
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#, fuzzy
+msgid "Detach custom storage volumes from instances"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#, fuzzy
+msgid "Detach custom storage volumes from profiles"
+msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
 msgid "Detach network interfaces from instances"
@@ -2229,14 +2243,6 @@ msgstr ""
 
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid "Detach network interfaces from profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-msgid "Detach storage volumes from instances"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid "Detach storage volumes from profiles"
 msgstr ""
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
@@ -2534,8 +2540,17 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid "Edit storage volume configurations as YAML"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:954
+msgid ""
+"Edit storage volume configurations as YAML\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
@@ -2545,7 +2560,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722
-#: cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2616,8 +2631,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163
 #: cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2638,8 +2653,8 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077
 #: cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2072
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2721,8 +2736,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:2640
+#: cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/storage_volume.go:2647
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2747,7 +2762,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2771,7 +2786,7 @@ msgstr "Aliases:"
 msgid "Export storage buckets as tarball."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2780,7 +2795,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2996,7 +3011,7 @@ msgstr "Acepta certificado"
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Acepta certificado"
@@ -3011,7 +3026,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Acepta certificado"
@@ -3236,8 +3251,8 @@ msgstr ""
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572
-#: cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3370,7 +3385,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3447,8 +3462,20 @@ msgstr "Perfil %s creado"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1178
+msgid ""
+"Get values for storage volume configuration keys\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
 msgstr ""
 
 #: cmd/incus/storage_volume.go:440
@@ -3558,7 +3585,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3572,7 +3599,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3622,10 +3649,6 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3089
-msgid "Import backups of custom volumes including their snapshots."
-msgstr ""
-
 #: cmd/incus/import.go:27
 msgid "Import backups of instances including their snapshots."
 msgstr ""
@@ -3635,9 +3658,14 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 msgid "Import custom storage volumes"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:3087
+#, fuzzy
+msgid "Import custom storage volumes."
+msgstr "Perfil %s creado"
 
 #: cmd/incus/image.go:685
 msgid ""
@@ -3752,7 +3780,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3021
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Nombre del contenedor es: %s"
@@ -3773,7 +3801,7 @@ msgid "Invalid arguments"
 msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3026
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3875,9 +3903,9 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238
-#: cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2881
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3939,7 +3967,7 @@ msgstr ""
 #: cmd/incus/list.go:616 cmd/incus/network.go:1303
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
-#: cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4351,12 +4379,12 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4374,11 +4402,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4465,7 +4493,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4744,7 +4772,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Nombre del contenedor es: %s"
@@ -4995,15 +5023,15 @@ msgstr "Nombre del contenedor es: %s"
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
 #: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614
-#: cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798
-#: cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010
-#: cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603
-#: cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995
-#: cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372
-#: cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592
-#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379
+#: cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2871
 msgid "Missing pool name"
 msgstr ""
 
@@ -5029,11 +5057,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
@@ -5074,7 +5102,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5085,6 +5113,11 @@ msgstr ""
 #: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 #, fuzzy
 msgid "Mount files from instances"
+msgstr "Aliases:"
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#, fuzzy
+msgid "Move custom storage volumes between pools"
 msgstr "Aliases:"
 
 #: cmd/incus/move.go:34
@@ -5107,15 +5140,11 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-msgid "Move storage volumes between pools"
-msgstr ""
-
 #: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5148,7 +5177,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5204,8 +5233,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2638
+#: cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:2645
 msgid "Name"
 msgstr ""
 
@@ -5266,7 +5295,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:632 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1411
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5430,7 +5459,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5450,11 +5479,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5494,11 +5523,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5510,7 +5539,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5528,7 +5557,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5581,7 +5610,7 @@ msgstr ""
 #: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
-#: cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5706,7 +5735,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
 #: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5846,101 +5875,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Auto actualización: %s"
-
-#: cmd/incus/storage_volume.go:2829
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"\tSupported types are custom, image, container and virtual-machine.\n"
-"\n"
-"\tAdd the name of the snapshot if type is one of custom, container or "
-"virtual-machine.\n"
-"\n"
-"\tincus storage volume show default virtual-machine/data/snap0\n"
-"\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
-"called \"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1312
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, container and virtual-machine.\n"
-"\n"
-"incus storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool "
-"\"default\".\n"
-"\n"
-"incus storage volume info default virtual-machine/data\n"
-"    Returns state information for a virtual machine \"data\" in pool "
-"\"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1176
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume get default data size\n"
-"    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2109
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume show default data\n"
-"    Will show the properties of a custom volume called \"data\" in the "
-"\"default\" pool.\n"
-"\n"
-"incus storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:955
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-"    Update a storage volume using the content of pool.yaml."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1949
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume set default data size=1GiB\n"
-"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-"\n"
-"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\" to seven days."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2208
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-"    Removes the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
 
 #: cmd/incus/config_trust.go:224
 #, fuzzy, c-format
@@ -6214,6 +6148,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#, fuzzy
+msgid "Rename custom storage volumes"
+msgstr "No se puede proveer el nombre del container a la lista"
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 #, fuzzy
 msgid "Rename instance snapshots"
@@ -6249,21 +6188,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-msgid "Rename storage volumes"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6307,7 +6242,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6715,18 +6650,22 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
 "For backward compatibility, a single configuration key may still be set "
 "with:\n"
 "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
-"<value>"
+"<value>\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:983 cmd/incus/remote.go:984
@@ -6816,7 +6755,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6968,13 +6907,43 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+msgid ""
+"Show storage volume configurations\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2834
+#, fuzzy
+msgid "Show storage volume snapshhot configurations"
+msgstr "Perfil %s creado"
+
+#: cmd/incus/storage_volume.go:2833
+#, fuzzy
+msgid "Show storage volume snapshot configurations"
+msgstr "Perfil %s creado"
+
+#: cmd/incus/storage_volume.go:1313
 msgid "Show storage volume state information"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1314
+msgid ""
+"Show storage volume state information\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
@@ -7041,15 +7010,15 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7194,12 +7163,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7212,7 +7181,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Perfil %s eliminado"
@@ -7272,13 +7241,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 msgid "Taken at"
 msgstr ""
 
@@ -7475,12 +7444,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7528,7 +7497,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7607,7 +7576,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -7623,7 +7592,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7689,7 +7658,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432
 #: cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1420
+#: cmd/incus/storage_volume.go:1423
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -7711,7 +7680,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7727,7 +7696,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
 
@@ -7767,7 +7736,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7883,8 +7852,17 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 msgid "Unset storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2214
+msgid ""
+"Unset storage volume configuration keys\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/cluster.go:589
@@ -7947,7 +7925,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7993,12 +7971,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8085,7 +8063,7 @@ msgstr "Versión de CUDA: %v"
 msgid "Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid "Volume Only"
 msgstr ""
 
@@ -8259,7 +8237,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8774,7 +8752,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8822,17 +8800,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8842,22 +8820,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8867,38 +8845,38 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308
-#: cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9519,26 +9497,96 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:578
 msgid ""
-"incus storage volume create p1 v1\n"
+"incus storage volume create default foo\n"
+"    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
+"incus storage volume create default foo < config.yaml\n"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3091
+#: cmd/incus/storage_volume.go:959
+msgid ""
+"incus storage volume edit default container/c1\n"
+"    Edit container storage volume \"c1\" in pool \"default\"\n"
+"\n"
+"incus storage volume edit default foo < volume.yaml\n"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1185
+msgid ""
+"incus storage volume get default data size\n"
+"    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+"\n"
+"incus storage volume get default virtual-machine/data snapshots.expiry\n"
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3089
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
-"\t\tCreate a new custom volume using backup0.tar.gz as the source."
+"    Create a new custom volume using backup0.tar.gz as the source\n"
+"\n"
+"incus storage volume import default some-installer.iso installer --type=iso\n"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2316
+#: cmd/incus/storage_volume.go:1319
 msgid ""
-"incus storage volume snapshot create default v1 snap0\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
 "\n"
-"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with "
-"the configuration from \"config.yaml\"."
+"incus storage volume info default virtual-machine/v1\n"
+"    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1955
+msgid ""
+"incus storage volume set default data size=1GiB\n"
+"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+"\n"
+"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2117
+msgid ""
+"incus storage volume show default foo\n"
+"    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume show default virtual-machine/v1\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume show default container/c1\n"
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2323
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+"\n"
+"incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2219
+msgid ""
+"incus storage volume unset default foo size\n"
+"    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
 msgstr ""
 
 #: cmd/incus/storage.go:547

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-06-11 23:14-0400\n"
+"POT-Creation-Date: 2024-07-08 16:17-0400\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -84,14 +84,15 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
+#, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
 "###\n"
-"### name: vol1\n"
+"### name: foo\n"
 "### type: custom\n"
 "### used_by: []\n"
 "### config:\n"
@@ -1010,7 +1011,7 @@ msgstr ""
 "Toutes les données seront perdues après avoir rejoint le cluster, voulez-"
 "vous continuer ?"
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 msgid "All projects"
 msgstr "Tous les projets"
 
@@ -1068,18 +1069,19 @@ msgstr "Attribuer des interfaces réseaux à des instances"
 msgid "Attach network interfaces to profiles"
 msgstr "Attacher des interfaces réseaux aux profiles"
 
-#: cmd/incus/network.go:143
-msgid "Attach new network interfaces to instances"
-msgstr "Attacher de nouvelles interfaces aux instances"
-
 #: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 #, fuzzy
-msgid "Attach new storage volumes to instances"
+msgid "Attach new custom storage volumes to instances"
 msgstr "Attribuer de nouveaux volumes de stockage à des instances"
 
 #: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid "Attach new storage volumes to profiles"
+#, fuzzy
+msgid "Attach new custom storage volumes to profiles"
 msgstr "Attacher de nouveaux volumes de stockage aux profiles"
+
+#: cmd/incus/network.go:143
+msgid "Attach new network interfaces to instances"
+msgstr "Attacher de nouvelles interfaces aux instances"
 
 #: cmd/incus/console.go:36
 msgid "Attach to instance consoles"
@@ -1145,17 +1147,17 @@ msgstr "Sauvegarder l'instance : %s"
 msgid "Backing up storage bucket: %s"
 msgstr "Sauvegarder le volume de stockage : %s"
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Sauvegarder le volume de stockage : %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396
-#: cmd/incus/storage_volume.go:3072
+#: cmd/incus/storage_volume.go:3070
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1181,7 +1183,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Mauvaise association clef=valeur: %q"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:650
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Mauvaise paire clé=valeur: %s"
@@ -1229,7 +1231,7 @@ msgstr "ANNULABLE"
 msgid "COMMON NAME"
 msgstr "NOM COMMUN"
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid "CONTENT-TYPE"
 msgstr "Type de contenu"
 
@@ -1327,7 +1329,7 @@ msgstr "Impossible de spécifier --project avec --all-projects"
 msgid "Can't specify a different remote for rename"
 msgstr "Impossible de spécifier un autre serveur distant pour un renommage"
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1529,15 +1531,15 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 #: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
 #: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324
-#: cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838
-#: cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670
+#: cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836
+#: cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid "Cluster member name"
 msgstr "Nom du membre du cluster"
 
@@ -1548,7 +1550,7 @@ msgstr "Clustering activé"
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072
 #: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687
-#: cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547
 #: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1616,7 +1618,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
 #: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -1634,11 +1636,11 @@ msgstr "Configurer le démon"
 msgid "Connecting to the daemon (attempt %d)"
 msgstr "Connexion au démon (tentative %d)"
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid "Content type, block or filesystem"
 msgstr "Type de contenu, bloc ou système de fichier"
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, c-format
 msgid "Content type: %s"
 msgstr "Type de contenu : %s"
@@ -1655,6 +1657,11 @@ msgstr "Copie une instance avec état"
 #: cmd/incus/image.go:155
 msgid "Copy aliases from source"
 msgstr "Copier les alias depuis la source"
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#, fuzzy
+msgid "Copy custom storage volumes"
+msgstr "Copie de l'image : %s"
 
 #: cmd/incus/image.go:147
 msgid "Copy images between servers"
@@ -1713,10 +1720,6 @@ msgstr ""
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid "Copy profiles"
 msgstr "Copier les profiles"
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-msgid "Copy storage volumes"
-msgstr "Copier des volumes de stockage"
 
 #: cmd/incus/copy.go:57
 msgid "Copy the instance without its snapshots"
@@ -1962,7 +1965,7 @@ msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:657
-#: cmd/incus/storage_volume.go:1440
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -2000,7 +2003,7 @@ msgstr "ADRESSE CIBLE PAR DÉFAUT"
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1669
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -2039,7 +2042,7 @@ msgstr "État : %s"
 msgid "Default VLAN ID"
 msgstr "ID VLAN par défaut"
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -2060,6 +2063,11 @@ msgstr "Supprime un groupe de serveurs"
 #, fuzzy
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#, fuzzy
+msgid "Delete custom storage volumes"
+msgstr "Copie de l'image : %s"
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
 #, fuzzy
@@ -2152,15 +2160,10 @@ msgstr "Copie de l'image : %s"
 msgid "Delete storage pools"
 msgstr "Supprime les pool de stockage"
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-#, fuzzy
-msgid "Delete storage volumes"
-msgstr "Copie de l'image : %s"
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
 #, fuzzy
@@ -2302,32 +2305,42 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953
-#: cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310
-#: cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556
-#: cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864
-#: cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265
-#: cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447
-#: cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542
-#: cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747
-#: cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923
-#: cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272
+#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454
+#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754
+#: cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr "Description"
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#, fuzzy
+msgid "Detach custom storage volumes from instances"
+msgstr "Clé de configuration invalide"
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#, fuzzy
+msgid "Detach custom storage volumes from profiles"
+msgstr "Détacher les volumes de stockage des profils"
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
 msgid "Detach network interfaces from instances"
@@ -2336,15 +2349,6 @@ msgstr "Détacher les interfaces réseaux des instances"
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid "Detach network interfaces from profiles"
 msgstr "Détacher les interfaces réseau des profils"
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-#, fuzzy
-msgid "Detach storage volumes from instances"
-msgstr "Clé de configuration invalide"
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid "Detach storage volumes from profiles"
-msgstr "Détacher les volumes de stockage des profils"
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
 #, fuzzy, c-format
@@ -2659,9 +2663,18 @@ msgstr "Modifier la clé du bucket de stockage au format YAML"
 msgid "Edit storage pool configurations as YAML"
 msgstr "Modifier les configurations du pool de stockage au format YAML"
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid "Edit storage volume configurations as YAML"
 msgstr "Modifier les configurations de volume de stockage au format YAML"
+
+#: cmd/incus/storage_volume.go:954
+msgid ""
+"Edit storage volume configurations as YAML\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
 #, fuzzy
@@ -2671,7 +2684,7 @@ msgstr "Clé de configuration invalide"
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722
-#: cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2756,8 +2769,8 @@ msgstr "Erreur lors de la récupération des alias : %w"
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163
 #: cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "Erreur lors du paramétrages des propriétés: %v"
@@ -2778,8 +2791,8 @@ msgstr "Erreur lors du déparamétrage des propriétés: %v"
 #: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077
 #: cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2072
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Erreur dans le déparamétrage de la propriété: %v"
@@ -2916,8 +2929,8 @@ msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
 #: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:2640
+#: cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/storage_volume.go:2647
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2948,7 +2961,7 @@ msgstr ""
 "La cible de sortie est facultative et par défaut dans le répertoire de "
 "travail."
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2973,7 +2986,7 @@ msgstr "Copie de l'image : %s"
 msgid "Export storage buckets as tarball."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
@@ -2983,7 +2996,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -3207,7 +3220,7 @@ msgstr "Échec de la création de la sauvegarde : %v"
 msgid "Failed to create certificate: %w"
 msgstr "Échec de la création du certificat : %w"
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Échec de la création de la sauvegarde du volume de stockage : %w"
@@ -3223,7 +3236,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Échec de la récupération de la sauvegarde de l'unité de stockage : %w"
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3476,8 +3489,8 @@ msgstr ""
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572
-#: cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 #, fuzzy
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "Format (csv|json|table|yaml|compact)"
@@ -3616,7 +3629,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -3700,9 +3713,21 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr "Obtenir les valeurs des clés de configuration du pool de stockage"
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid "Get values for storage volume configuration keys"
 msgstr "Obtenir les valeurs des clés de configuration du volume de stockage"
+
+#: cmd/incus/storage_volume.go:1178
+msgid ""
+"Get values for storage volume configuration keys\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
 
 #: cmd/incus/storage_volume.go:440
 #, c-format
@@ -3819,7 +3844,7 @@ msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 "Si l'alias de l'image existe déjà, le supprimer d'abord puis le recréer"
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "Si l'instantané de l'image existe déjà, le supprimer d'abord puis le recréer"
@@ -3837,7 +3862,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "Ignorer toute expiration automatique configurée pour l'instance"
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 "Ignorer toute expiration automatique configurée pour le volume de stockage"
@@ -3892,13 +3917,6 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/storage_volume.go:3089
-#, fuzzy
-msgid "Import backups of custom volumes including their snapshots."
-msgstr ""
-"Importer des sauvegardes de volumes personnalisés, y compris leurs "
-"instantanés."
-
 #: cmd/incus/import.go:27
 msgid "Import backups of instances including their snapshots."
 msgstr "Importer des sauvegardes d'instances, y compris leurs instantanés."
@@ -3908,9 +3926,14 @@ msgstr "Importer des sauvegardes d'instances, y compris leurs instantanés."
 msgid "Import backups of storage buckets."
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 #, fuzzy
 msgid "Import custom storage volumes"
+msgstr "Copie de l'image : %s"
+
+#: cmd/incus/storage_volume.go:3087
+#, fuzzy
+msgid "Import custom storage volumes."
 msgstr "Copie de l'image : %s"
 
 #: cmd/incus/image.go:685
@@ -4036,7 +4059,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Le nom du conteneur est : %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3021
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Cible invalide %s"
@@ -4057,7 +4080,7 @@ msgid "Invalid arguments"
 msgstr "Cible invalide %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3026
 #, fuzzy, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "Segment de nom de sauvegarde non valide dans le chemin %q : %w"
@@ -4166,9 +4189,9 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238
-#: cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2881
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -4231,7 +4254,7 @@ msgstr "ADRESSE D’ÉCOUTE"
 #: cmd/incus/list.go:616 cmd/incus/network.go:1303
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
-#: cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr "LOCALISATION"
 
@@ -4706,12 +4729,12 @@ msgstr "Copie de l'image : %s"
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4729,12 +4752,12 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4821,7 +4844,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5118,7 +5141,7 @@ msgstr "Copie de l'image : %s"
 msgid "Manage storage pools and volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Copie de l'image : %s"
@@ -5373,15 +5396,15 @@ msgstr "Résumé manquant."
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
 #: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614
-#: cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798
-#: cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010
-#: cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603
-#: cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995
-#: cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372
-#: cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592
-#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379
+#: cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2871
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5408,12 +5431,12 @@ msgstr "Résumé manquant."
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5456,7 +5479,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
@@ -5470,6 +5493,11 @@ msgstr ""
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#, fuzzy
+msgid "Move custom storage volumes between pools"
+msgstr "Copie de l'image : %s"
 
 #: cmd/incus/move.go:34
 #, fuzzy
@@ -5492,17 +5520,12 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-#, fuzzy
-msgid "Move storage volumes between pools"
-msgstr "Copie de l'image : %s"
-
 #: cmd/incus/move.go:60
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5536,7 +5559,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr "NOM"
 
@@ -5592,8 +5615,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2638
+#: cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:2645
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -5659,7 +5682,7 @@ msgid "Name of the storage pool:"
 msgstr "Copie de l'image : %s"
 
 #: cmd/incus/info.go:632 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1411
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -5826,7 +5849,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
@@ -5847,11 +5870,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5893,13 +5916,13 @@ msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -5914,7 +5937,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
@@ -5935,7 +5958,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5991,7 +6014,7 @@ msgstr "PROFILS"
 #: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
-#: cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -6118,7 +6141,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
 #: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -6260,101 +6283,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Cible invalide %s"
-
-#: cmd/incus/storage_volume.go:2829
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"\tSupported types are custom, image, container and virtual-machine.\n"
-"\n"
-"\tAdd the name of the snapshot if type is one of custom, container or "
-"virtual-machine.\n"
-"\n"
-"\tincus storage volume show default virtual-machine/data/snap0\n"
-"\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
-"called \"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1312
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, container and virtual-machine.\n"
-"\n"
-"incus storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool "
-"\"default\".\n"
-"\n"
-"incus storage volume info default virtual-machine/data\n"
-"    Returns state information for a virtual machine \"data\" in pool "
-"\"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1176
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume get default data size\n"
-"    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2109
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume show default data\n"
-"    Will show the properties of a custom volume called \"data\" in the "
-"\"default\" pool.\n"
-"\n"
-"incus storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:955
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-"    Update a storage volume using the content of pool.yaml."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1949
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume set default data size=1GiB\n"
-"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-"\n"
-"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\" to seven days."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2208
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-"    Removes the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
 
 #: cmd/incus/config_trust.go:224
 #, fuzzy, c-format
@@ -6643,6 +6571,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#, fuzzy
+msgid "Rename custom storage volumes"
+msgstr "Copie de l'image : %s"
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 #, fuzzy
 msgid "Rename instance snapshots"
@@ -6679,22 +6612,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-#, fuzzy
-msgid "Rename storage volumes"
-msgstr "Copie de l'image : %s"
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Forcer le conteneur à s'arrêter"
@@ -6754,7 +6682,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -7177,19 +7105,23 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
 "For backward compatibility, a single configuration key may still be set "
 "with:\n"
 "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
-"<value>"
+"<value>\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:983 cmd/incus/remote.go:984
@@ -7283,7 +7215,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7448,16 +7380,46 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+msgid ""
+"Show storage volume configurations\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2834
+#, fuzzy
+msgid "Show storage volume snapshhot configurations"
+msgstr "Afficher la configuration étendue"
+
+#: cmd/incus/storage_volume.go:2833
+#, fuzzy
+msgid "Show storage volume snapshot configurations"
+msgstr "Afficher la configuration étendue"
+
+#: cmd/incus/storage_volume.go:1313
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
+
+#: cmd/incus/storage_volume.go:1314
+msgid ""
+"Show storage volume state information\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr ""
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
 #, fuzzy
@@ -7526,16 +7488,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -7684,12 +7646,12 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Storage pool to use or create"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
@@ -7704,7 +7666,7 @@ msgstr "Image copiée avec succès !"
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Profil %s supprimé"
@@ -7767,13 +7729,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
 #: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -7980,12 +7942,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8036,7 +7998,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -8120,7 +8082,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -8136,7 +8098,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8202,7 +8164,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432
 #: cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1420
+#: cmd/incus/storage_volume.go:1423
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -8224,7 +8186,7 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -8242,7 +8204,7 @@ msgstr "Création du conteneur"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -8283,7 +8245,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8407,10 +8369,19 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
+
+#: cmd/incus/storage_volume.go:2214
+msgid ""
+"Unset storage volume configuration keys\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr ""
 
 #: cmd/incus/cluster.go:589
 msgid "Unset the key as a cluster property"
@@ -8473,7 +8444,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -8521,12 +8492,12 @@ msgstr "Publié : %s"
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8614,7 +8585,7 @@ msgstr "Version CUDA : %v"
 msgid "Version: %v"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid "Volume Only"
 msgstr ""
 
@@ -8796,7 +8767,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom d'image ou utilisez --empty"
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -9658,7 +9629,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -9737,7 +9708,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -9745,7 +9716,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -9753,7 +9724,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -9769,7 +9740,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -9781,7 +9752,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -9793,7 +9764,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -9805,7 +9776,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -9825,7 +9796,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -9837,7 +9808,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -9845,8 +9816,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308
-#: cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -9854,7 +9825,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -9862,7 +9833,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -9870,7 +9841,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -9882,7 +9853,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10633,26 +10604,96 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:578
 msgid ""
-"incus storage volume create p1 v1\n"
+"incus storage volume create default foo\n"
+"    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
+"incus storage volume create default foo < config.yaml\n"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3091
+#: cmd/incus/storage_volume.go:959
+msgid ""
+"incus storage volume edit default container/c1\n"
+"    Edit container storage volume \"c1\" in pool \"default\"\n"
+"\n"
+"incus storage volume edit default foo < volume.yaml\n"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1185
+msgid ""
+"incus storage volume get default data size\n"
+"    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+"\n"
+"incus storage volume get default virtual-machine/data snapshots.expiry\n"
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3089
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
-"\t\tCreate a new custom volume using backup0.tar.gz as the source."
+"    Create a new custom volume using backup0.tar.gz as the source\n"
+"\n"
+"incus storage volume import default some-installer.iso installer --type=iso\n"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2316
+#: cmd/incus/storage_volume.go:1319
 msgid ""
-"incus storage volume snapshot create default v1 snap0\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
 "\n"
-"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with "
-"the configuration from \"config.yaml\"."
+"incus storage volume info default virtual-machine/v1\n"
+"    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1955
+msgid ""
+"incus storage volume set default data size=1GiB\n"
+"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+"\n"
+"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2117
+msgid ""
+"incus storage volume show default foo\n"
+"    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume show default virtual-machine/v1\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume show default container/c1\n"
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2323
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+"\n"
+"incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2219
+msgid ""
+"incus storage volume unset default foo size\n"
+"    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
 msgstr ""
 
 #: cmd/incus/storage.go:547
@@ -10720,6 +10761,15 @@ msgstr "o"
 #: cmd/incus/image.go:1184 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "oui"
+
+#~ msgid "Copy storage volumes"
+#~ msgstr "Copier des volumes de stockage"
+
+#, fuzzy
+#~ msgid "Import backups of custom volumes including their snapshots."
+#~ msgstr ""
+#~ "Importer des sauvegardes de volumes personnalisés, y compris leurs "
+#~ "instantanés."
 
 #~ msgid "Console log:"
 #~ msgstr "Journaux console:"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-06-11 23:14-0400\n"
+        "POT-Creation-Date: 2024-07-08 16:17-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,13 +56,13 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
         "### A storage volume consists of a set of configuration items.\n"
         "###\n"
-        "### name: vol1\n"
+        "### name: foo\n"
         "### type: custom\n"
         "### used_by: []\n"
         "### config:\n"
@@ -699,7 +699,7 @@ msgstr  ""
 msgid   "All existing data is lost when joining a cluster, continue?"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 msgid   "All projects"
 msgstr  ""
 
@@ -754,16 +754,16 @@ msgstr  ""
 msgid   "Attach network interfaces to profiles"
 msgstr  ""
 
-#: cmd/incus/network.go:143
-msgid   "Attach new network interfaces to instances"
-msgstr  ""
-
 #: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
-msgid   "Attach new storage volumes to instances"
+msgid   "Attach new custom storage volumes to instances"
 msgstr  ""
 
 #: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid   "Attach new storage volumes to profiles"
+msgid   "Attach new custom storage volumes to profiles"
+msgstr  ""
+
+#: cmd/incus/network.go:143
+msgid   "Attach new network interfaces to instances"
 msgstr  ""
 
 #: cmd/incus/console.go:36
@@ -823,16 +823,16 @@ msgstr  ""
 msgid   "Backing up storage bucket: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396 cmd/incus/storage_volume.go:3072
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396 cmd/incus/storage_volume.go:3070
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid   "Backups:"
 msgstr  ""
 
@@ -851,7 +851,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169 cmd/incus/storage_volume.go:650
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:169 cmd/incus/storage_volume.go:651
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -899,7 +899,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -991,7 +991,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680 cmd/incus/warning.go:225
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683 cmd/incus/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -1149,7 +1149,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:47 cmd/incus/move.go:64 cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386 cmd/incus/network.go:1479 cmd/incus/network.go:1551 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:432 cmd/incus/network_load_balancer.go:567 cmd/incus/network_load_balancer.go:732 cmd/incus/network_load_balancer.go:820 cmd/incus/network_load_balancer.go:896 cmd/incus/network_load_balancer.go:1009 cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108 cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832 cmd/incus/storage.go:934 cmd/incus/storage.go:1027 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417 cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583 cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962 cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322 cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121 cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663 cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838 cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:47 cmd/incus/move.go:64 cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386 cmd/incus/network.go:1479 cmd/incus/network.go:1551 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:432 cmd/incus/network_load_balancer.go:567 cmd/incus/network_load_balancer.go:732 cmd/incus/network_load_balancer.go:820 cmd/incus/network_load_balancer.go:896 cmd/incus/network_load_balancer.go:1009 cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108 cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832 cmd/incus/storage.go:934 cmd/incus/storage.go:1027 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417 cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966 cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325 cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126 cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331 cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670 cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836 cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1157,7 +1157,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421 cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072 cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687 cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540 cmd/incus/warning.go:93
+#: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421 cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072 cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687 cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547 cmd/incus/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1202,7 +1202,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:802 cmd/incus/network_acl.go:714 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157 cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:396 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:483 cmd/incus/network.go:802 cmd/incus/network_acl.go:714 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157 cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1220,11 +1220,11 @@ msgstr  ""
 msgid   "Connecting to the daemon (attempt %d)"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1240,6 +1240,10 @@ msgstr  ""
 
 #: cmd/incus/image.go:155
 msgid   "Copy aliases from source"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+msgid   "Copy custom storage volumes"
 msgstr  ""
 
 #: cmd/incus/image.go:147
@@ -1274,10 +1278,6 @@ msgstr  ""
 
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid   "Copy profiles"
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-msgid   "Copy storage volumes"
 msgstr  ""
 
 #: cmd/incus/copy.go:57
@@ -1480,7 +1480,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:1005 cmd/incus/info.go:657 cmd/incus/storage_volume.go:1440
+#: cmd/incus/image.go:1005 cmd/incus/info.go:657 cmd/incus/storage_volume.go:1443
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1508,7 +1508,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:503 cmd/incus/config_trust.go:435 cmd/incus/image.go:1121 cmd/incus/image_alias.go:237 cmd/incus/list.go:574 cmd/incus/network.go:1098 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152 cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:844 cmd/incus/operation.go:173 cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864 cmd/incus/storage_volume.go:1669
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:503 cmd/incus/config_trust.go:435 cmd/incus/image.go:1121 cmd/incus/image_alias.go:237 cmd/incus/list.go:574 cmd/incus/network.go:1098 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152 cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:844 cmd/incus/operation.go:173 cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864 cmd/incus/storage_volume.go:1672
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1547,7 +1547,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1565,6 +1565,10 @@ msgstr  ""
 
 #: cmd/incus/warning.go:361
 msgid   "Delete all warnings"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+msgid   "Delete custom storage volumes"
 msgstr  ""
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
@@ -1643,29 +1647,33 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 msgid   "Delete storage volume snapshots"
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-msgid   "Delete storage volumes"
 msgstr  ""
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:34 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241 cmd/incus/network.go:1320 cmd/incus/network.go:1380 cmd/incus/network.go:1476 cmd/incus/network.go:1548 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:729 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:817 cmd/incus/network_load_balancer.go:893 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1006 cmd/incus/network_load_balancer.go:1079 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391 cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578 cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412 cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543 cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726 cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861 cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001 cmd/incus/network_zone.go:1099 cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1235 cmd/incus/network_zone.go:1365 cmd/incus/network_zone.go:1426 cmd/incus/network_zone.go:1441 cmd/incus/network_zone.go:1499 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473 cmd/incus/storage_bucket.go:567 cmd/incus/storage_bucket.go:661 cmd/incus/storage_bucket.go:730 cmd/incus/storage_bucket.go:764 cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884 cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261 cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953 cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310 cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556 cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864 cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107 cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265 cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447 cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747 cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923 cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:84 cmd/incus/cluster_group.go:169 cmd/incus/cluster_group.go:255 cmd/incus/cluster_group.go:315 cmd/incus/cluster_group.go:439 cmd/incus/cluster_group.go:521 cmd/incus/cluster_group.go:606 cmd/incus/cluster_group.go:662 cmd/incus/cluster_group.go:724 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:327 cmd/incus/image.go:382 cmd/incus/image.go:517 cmd/incus/image.go:685 cmd/incus/image.go:930 cmd/incus/image.go:1073 cmd/incus/image.go:1423 cmd/incus/image.go:1507 cmd/incus/image.go:1574 cmd/incus/image.go:1639 cmd/incus/image.go:1703 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:34 cmd/incus/launch.go:24 cmd/incus/list.go:49 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241 cmd/incus/network.go:1320 cmd/incus/network.go:1380 cmd/incus/network.go:1476 cmd/incus/network.go:1548 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:729 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:817 cmd/incus/network_load_balancer.go:893 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1006 cmd/incus/network_load_balancer.go:1079 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391 cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578 cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412 cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543 cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726 cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861 cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001 cmd/incus/network_zone.go:1099 cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1235 cmd/incus/network_zone.go:1365 cmd/incus/network_zone.go:1426 cmd/incus/network_zone.go:1441 cmd/incus/network_zone.go:1499 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:38 cmd/incus/remote.go:102 cmd/incus/remote.go:630 cmd/incus/remote.go:676 cmd/incus/remote.go:712 cmd/incus/remote.go:796 cmd/incus/remote.go:875 cmd/incus/remote.go:938 cmd/incus/remote.go:984 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473 cmd/incus/storage_bucket.go:567 cmd/incus/storage_bucket.go:661 cmd/incus/storage_bucket.go:730 cmd/incus/storage_bucket.go:764 cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884 cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261 cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549 cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754 cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921 cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 msgid   "Destination cluster member name"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+msgid   "Detach custom storage volumes from instances"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+msgid   "Detach custom storage volumes from profiles"
 msgstr  ""
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
@@ -1674,14 +1682,6 @@ msgstr  ""
 
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid   "Detach network interfaces from profiles"
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-msgid   "Detach storage volumes from instances"
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
@@ -1955,15 +1955,22 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid   "Edit storage volume configurations as YAML"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:954
+msgid   "Edit storage volume configurations as YAML\n"
+        "\n"
+        "If the type is not specified, incus assumes the type is \"custom\".\n"
+        "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447 cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113 cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722 cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447 cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113 cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722 cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -2023,7 +2030,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454 cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896 cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035 cmd/incus/storage_volume.go:2078
+#: cmd/incus/cluster.go:562 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454 cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896 cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038 cmd/incus/storage_volume.go:2081
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -2038,7 +2045,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/network.go:1448 cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029 cmd/incus/storage_volume.go:2072
+#: cmd/incus/cluster.go:556 cmd/incus/network.go:1448 cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2114,7 +2121,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366 cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523 cmd/incus/storage_volume.go:2640
+#: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366 cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526 cmd/incus/storage_volume.go:2647
 msgid   "Expires at"
 msgstr  ""
 
@@ -2137,7 +2144,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -2157,7 +2164,7 @@ msgstr  ""
 msgid   "Export storage buckets as tarball."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
@@ -2166,7 +2173,7 @@ msgstr  ""
 msgid   "Exporting backup of storage bucket: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2381,7 +2388,7 @@ msgstr  ""
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, c-format
 msgid   "Failed to create storage volume backup: %w"
 msgstr  ""
@@ -2396,7 +2403,7 @@ msgstr  ""
 msgid   "Failed to fetch storage bucket backup: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, c-format
 msgid   "Failed to fetch storage volume backup file: %w"
 msgstr  ""
@@ -2599,7 +2606,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067 cmd/incus/cluster_group.go:441 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586 cmd/incus/image.go:1100 cmd/incus/image_alias.go:157 cmd/incus/list.go:134 cmd/incus/network.go:1073 cmd/incus/network.go:1243 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84 cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786 cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572 cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067 cmd/incus/cluster_group.go:441 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586 cmd/incus/image.go:1100 cmd/incus/image_alias.go:157 cmd/incus/list.go:134 cmd/incus/network.go:1073 cmd/incus/network.go:1243 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84 cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786 cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2723,7 +2730,7 @@ msgstr  ""
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
@@ -2791,8 +2798,17 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid   "Get values for storage volume configuration keys"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:1178
+msgid   "Get values for storage volume configuration keys\n"
+        "\n"
+        "If the type is not specified, incus assumes the type is \"custom\".\n"
+        "Supported values for type are \"custom\", \"container\" and \"virtual-machine\".\n"
+        "\n"
+        "For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine)."
 msgstr  ""
 
 #: cmd/incus/storage_volume.go:440
@@ -2899,7 +2915,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2911,7 +2927,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -2961,10 +2977,6 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3089
-msgid   "Import backups of custom volumes including their snapshots."
-msgstr  ""
-
 #: cmd/incus/import.go:27
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
@@ -2973,8 +2985,12 @@ msgstr  ""
 msgid   "Import backups of storage buckets."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 msgid   "Import custom storage volumes"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:3087
+msgid   "Import custom storage volumes."
 msgstr  ""
 
 #: cmd/incus/image.go:685
@@ -3082,7 +3098,7 @@ msgstr  ""
 msgid   "Invalid IP address or DNS name"
 msgstr  ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347 cmd/incus/storage_volume.go:3023
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347 cmd/incus/storage_volume.go:3021
 #, c-format
 msgid   "Invalid URL %q: %w"
 msgstr  ""
@@ -3101,7 +3117,7 @@ msgstr  ""
 msgid   "Invalid arguments"
 msgstr  ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352 cmd/incus/storage_volume.go:3028
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352 cmd/incus/storage_volume.go:3026
 #, c-format
 msgid   "Invalid backup name segment in path %q: %w"
 msgstr  ""
@@ -3201,7 +3217,7 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238 cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012 cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242 cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015 cmd/incus/storage_volume.go:2881
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -3257,7 +3273,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: cmd/incus/list.go:616 cmd/incus/network.go:1303 cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161 cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544 cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/list.go:616 cmd/incus/network.go:1303 cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161 cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544 cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -3639,11 +3655,11 @@ msgstr  ""
 msgid   "List storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 msgid   "List storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 msgid   "List storage volume snapshots\n"
         "\n"
         "	The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3660,11 +3676,11 @@ msgid   "List storage volume snapshots\n"
         "		u - Number of references (used by)"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 msgid   "List storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3746,7 +3762,7 @@ msgstr  ""
 msgid   "Load:"
 msgstr  ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -4006,7 +4022,7 @@ msgstr  ""
 msgid   "Manage storage pools and volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 msgid   "Manage storage volume snapshots"
 msgstr  ""
 
@@ -4164,7 +4180,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970 cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596 cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014 cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614 cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798 cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010 cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603 cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995 cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372 cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592 cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787 cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970 cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596 cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014 cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379 cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599 cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794 cmd/incus/storage_volume.go:2871
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -4184,11 +4200,11 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 msgid   "Missing storage pool name"
 msgstr  ""
 
@@ -4224,7 +4240,7 @@ msgid   "Monitor a local or remote server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659 cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/network.go:562 cmd/incus/network.go:659 cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -4234,6 +4250,10 @@ msgstr  ""
 
 #: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 msgid   "Mount files from instances"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+msgid   "Move custom storage volumes between pools"
 msgstr  ""
 
 #: cmd/incus/move.go:34
@@ -4251,15 +4271,11 @@ msgid   "Move instances within or in between servers\n"
         "The pull transfer mode is the default as it is compatible with all server versions.\n"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-msgid   "Move storage volumes between pools"
-msgstr  ""
-
 #: cmd/incus/move.go:60
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid   "Move to a project different from the source"
 msgstr  ""
 
@@ -4284,7 +4300,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158 cmd/incus/cluster_group.go:502 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:666 cmd/incus/list.go:582 cmd/incus/network.go:1093 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154 cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843 cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158 cmd/incus/cluster_group.go:502 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:666 cmd/incus/list.go:582 cmd/incus/network.go:1093 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154 cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843 cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid   "NAME"
 msgstr  ""
 
@@ -4335,7 +4351,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364 cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521 cmd/incus/storage_volume.go:2638
+#: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364 cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524 cmd/incus/storage_volume.go:2645
 msgid   "Name"
 msgstr  ""
 
@@ -4394,7 +4410,7 @@ msgstr  ""
 msgid   "Name of the storage pool:"
 msgstr  ""
 
-#: cmd/incus/info.go:632 cmd/incus/network.go:969 cmd/incus/storage_volume.go:1411
+#: cmd/incus/info.go:632 cmd/incus/network.go:969 cmd/incus/storage_volume.go:1414
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -4557,7 +4573,7 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 msgid   "No device found for this storage volume"
 msgstr  ""
 
@@ -4577,11 +4593,11 @@ msgstr  ""
 msgid   "No storage backends available"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -4619,11 +4635,11 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -4635,7 +4651,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
@@ -4652,7 +4668,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4702,7 +4718,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092 cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165 cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548 cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341 cmd/incus/warning.go:213
+#: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092 cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165 cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548 cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341 cmd/incus/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4815,7 +4831,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:803 cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730 cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333 cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158 cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:397 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:484 cmd/incus/network.go:803 cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730 cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333 cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158 cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4950,83 +4966,6 @@ msgstr  ""
 #: cmd/incus/image.go:1042
 #, c-format
 msgid   "Protocol: %s"
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:2829
-msgid   "Provide the type of the storage volume if it is not custom.\n"
-        "	Supported types are custom, image, container and virtual-machine.\n"
-        "\n"
-        "	Add the name of the snapshot if type is one of custom, container or virtual-machine.\n"
-        "\n"
-        "	incus storage volume show default virtual-machine/data/snap0\n"
-        "		Will show the properties of snapshot \"snap0\" for a virtual machine called \"data\" in the \"default\" pool."
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:1312
-msgid   "Provide the type of the storage volume if it is not custom.\n"
-        "Supported types are custom, container and virtual-machine.\n"
-        "\n"
-        "incus storage volume info default data\n"
-        "    Returns state information for a custom volume \"data\" in pool \"default\".\n"
-        "\n"
-        "incus storage volume info default virtual-machine/data\n"
-        "    Returns state information for a virtual machine \"data\" in pool \"default\"."
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:1176
-msgid   "Provide the type of the storage volume if it is not custom.\n"
-        "Supported types are custom, image, container and virtual-machine.\n"
-        "\n"
-        "Add the name of the snapshot if type is one of custom, container or virtual-machine.\n"
-        "\n"
-        "incus storage volume get default data size\n"
-        "    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-        "\n"
-        "incus storage volume get default virtual-machine/data snapshots.expiry\n"
-        "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:2109
-msgid   "Provide the type of the storage volume if it is not custom.\n"
-        "Supported types are custom, image, container and virtual-machine.\n"
-        "\n"
-        "Add the name of the snapshot if type is one of custom, container or virtual-machine.\n"
-        "\n"
-        "incus storage volume show default data\n"
-        "    Will show the properties of a custom volume called \"data\" in the \"default\" pool.\n"
-        "\n"
-        "incus storage volume show default container/data\n"
-        "    Will show the properties of the filesystem for a container called \"data\" in the \"default\" pool."
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:955
-msgid   "Provide the type of the storage volume if it is not custom.\n"
-        "Supported types are custom, image, container and virtual-machine.\n"
-        "\n"
-        "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-        "    Update a storage volume using the content of pool.yaml."
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:1949
-msgid   "Provide the type of the storage volume if it is not custom.\n"
-        "Supported types are custom, image, container and virtual-machine.\n"
-        "\n"
-        "incus storage volume set default data size=1GiB\n"
-        "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-        "\n"
-        "incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-        "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:2208
-msgid   "Provide the type of the storage volume if it is not custom.\n"
-        "Supported types are custom, image, container and virtual-machine.\n"
-        "\n"
-        "incus storage volume unset default data size\n"
-        "    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-        "\n"
-        "incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-        "    Removes the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
 #: cmd/incus/config_trust.go:224
@@ -5282,6 +5221,10 @@ msgstr  ""
 msgid   "Rename aliases"
 msgstr  ""
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+msgid   "Rename custom storage volumes"
+msgstr  ""
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 msgid   "Rename instance snapshots"
 msgstr  ""
@@ -5314,20 +5257,16 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 msgid   "Rename storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-msgid   "Rename storage volumes"
-msgstr  ""
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, c-format
 msgid   "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr  ""
@@ -5367,7 +5306,7 @@ msgstr  ""
 msgid   "Restore instance snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -5730,15 +5669,18 @@ msgid   "Set storage pool configuration keys\n"
         "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
-        "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
+        "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>\n"
+        "\n"
+        "If the type is not specified, Incus assumes the type is \"custom\".\n"
+        "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
 #: cmd/incus/remote.go:983 cmd/incus/remote.go:984
@@ -5821,7 +5763,7 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -5961,12 +5903,36 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107 cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+msgid   "Show storage volume configurations\n"
+        "\n"
+        "If the type is not specified, Incus assumes the type is \"custom\".\n"
+        "Supported values for type are \"custom\", \"container\" and \"virtual-machine\".\n"
+        "\n"
+        "For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine)."
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:2834
+msgid   "Show storage volume snapshhot configurations"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:2833
+msgid   "Show storage volume snapshot configurations"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:1313
 msgid   "Show storage volume state information"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:1314
+msgid   "Show storage volume state information\n"
+        "\n"
+        "If the type is not specified, Incus assumes the type is \"custom\".\n"
+        "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
@@ -6031,15 +5997,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -6179,12 +6145,12 @@ msgstr  ""
 msgid   "Storage pool to use or create"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
@@ -6197,7 +6163,7 @@ msgstr  ""
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, c-format
 msgid   "Storage volume snapshot %s deleted from %s"
 msgstr  ""
@@ -6253,11 +6219,11 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1129 cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094 cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26 cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157 cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667 cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1129 cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094 cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26 cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157 cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365 cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365 cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 msgid   "Taken at"
 msgstr  ""
 
@@ -6442,12 +6408,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
@@ -6489,7 +6455,7 @@ msgstr  ""
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673 cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/network.go:576 cmd/incus/network.go:673 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -6561,7 +6527,7 @@ msgstr  ""
 msgid   "Too many links"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -6576,7 +6542,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -6636,7 +6602,7 @@ msgstr  ""
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
-#: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432 cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973 cmd/incus/storage_volume.go:1420
+#: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432 cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973 cmd/incus/storage_volume.go:1423
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -6658,7 +6624,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid   "USAGE"
 msgstr  ""
 
@@ -6670,7 +6636,7 @@ msgstr  ""
 msgid   "USB devices:"
 msgstr  ""
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460 cmd/incus/network_zone.go:161 cmd/incus/profile.go:748 cmd/incus/project.go:556 cmd/incus/storage.go:712 cmd/incus/storage_volume.go:1671
+#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460 cmd/incus/network_zone.go:161 cmd/incus/profile.go:748 cmd/incus/project.go:556 cmd/incus/storage.go:712 cmd/incus/storage_volume.go:1674
 msgid   "USED BY"
 msgstr  ""
 
@@ -6706,7 +6672,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455 cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119 cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728 cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455 cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119 cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728 cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -6811,8 +6777,15 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 msgid   "Unset storage volume configuration keys"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:2214
+msgid   "Unset storage volume configuration keys\n"
+        "\n"
+        "If the type is not specified, Incus assumes the type is \"custom\".\n"
+        "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
 #: cmd/incus/cluster.go:589
@@ -6867,7 +6840,7 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -6910,12 +6883,12 @@ msgstr  ""
 msgid   "Upper devices"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -6996,7 +6969,7 @@ msgstr  ""
 msgid   "Version: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid   "Volume Only"
 msgstr  ""
 
@@ -7157,7 +7130,7 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
@@ -7541,7 +7514,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -7577,15 +7550,15 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 msgid   "[<remote>:]<pool> <old name> <new name>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 msgid   "[<remote>:]<pool> <volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr  ""
 
@@ -7593,19 +7566,19 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 msgid   "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
@@ -7613,31 +7586,31 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 msgid   "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 msgid   "[<remote>:]<pool> [<filter>...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308 cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312 cmd/incus/storage_volume.go:2108
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
@@ -8147,23 +8120,78 @@ msgid   "incus storage edit [<remote>:]<pool> < pool.yaml\n"
 msgstr  ""
 
 #: cmd/incus/storage_volume.go:578
-msgid   "incus storage volume create p1 v1\n"
+msgid   "incus storage volume create default foo\n"
+        "    Create custom storage volume \"foo\" in pool \"default\"\n"
         "\n"
-        "incus storage volume create p1 v1 < config.yaml\n"
-        "	Create storage volume v1 for pool p1 with configuration from config.yaml."
+        "incus storage volume create default foo < config.yaml\n"
+        "    Create custom storage volume \"foo\" in pool \"default\" with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3091
+#: cmd/incus/storage_volume.go:959
+msgid   "incus storage volume edit default container/c1\n"
+        "    Edit container storage volume \"c1\" in pool \"default\"\n"
+        "\n"
+        "incus storage volume edit default foo < volume.yaml\n"
+        "    Edit custom storage volume \"foo\" in pool \"default\" using the content of volume.yaml"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:1185
+msgid   "incus storage volume get default data size\n"
+        "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+        "\n"
+        "incus storage volume get default virtual-machine/data snapshots.expiry\n"
+        "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\""
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:3089
 msgid   "incus storage volume import default backup0.tar.gz\n"
-        "		Create a new custom volume using backup0.tar.gz as the source."
+        "    Create a new custom volume using backup0.tar.gz as the source\n"
+        "\n"
+        "incus storage volume import default some-installer.iso installer --type=iso\n"
+        "    Create a new custom volume storing some-installer.iso for use as a CD-ROM image"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2316
-msgid   "incus storage volume snapshot create default v1 snap0\n"
-        "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
+#: cmd/incus/storage_volume.go:1319
+msgid   "incus storage volume info default foo\n"
+        "    Returns state information for a custom volume \"foo\" in pool \"default\"\n"
         "\n"
-        "incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-        "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with the configuration from \"config.yaml\"."
+        "incus storage volume info default virtual-machine/v1\n"
+        "    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:1955
+msgid   "incus storage volume set default data size=1GiB\n"
+        "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+        "\n"
+        "incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+        "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:2117
+msgid   "incus storage volume show default foo\n"
+        "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+        "\n"
+        "incus storage volume show default virtual-machine/v1\n"
+        "    Will show the properties of the virtual-machine volume \"v1\" in pool \"default\"\n"
+        "\n"
+        "incus storage volume show default container/c1\n"
+        "    Will show the properties of the container volume \"c1\" in pool \"default\""
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:2323
+msgid   "incus storage volume snapshot create default foo snap0\n"
+        "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+        "\n"
+        "incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+        "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with the configuration from \"config.yaml\""
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:2219
+msgid   "incus storage volume unset default foo size\n"
+        "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+        "\n"
+        "incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+        "    Removes the snapshot expiration period of virtual machine volume \"v1\" in pool \"default\""
 msgstr  ""
 
 #: cmd/incus/storage.go:547

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-06-11 23:14-0400\n"
+"POT-Creation-Date: 2024-07-08 16:17-0400\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -90,7 +90,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
 "###\n"
-"### name: vol1\n"
+"### name: foo\n"
 "### type: custom\n"
 "### used_by: []\n"
 "### config:\n"
@@ -988,7 +988,7 @@ msgstr "Alias:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 msgid "All projects"
 msgstr ""
 
@@ -1046,16 +1046,18 @@ msgstr ""
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/network.go:143
-msgid "Attach new network interfaces to instances"
-msgstr ""
-
 #: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
-msgid "Attach new storage volumes to instances"
-msgstr ""
+#, fuzzy
+msgid "Attach new custom storage volumes to instances"
+msgstr "Creazione del container in corso"
 
 #: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid "Attach new storage volumes to profiles"
+#, fuzzy
+msgid "Attach new custom storage volumes to profiles"
+msgstr "Creazione del container in corso"
+
+#: cmd/incus/network.go:143
+msgid "Attach new network interfaces to instances"
 msgstr ""
 
 #: cmd/incus/console.go:36
@@ -1116,17 +1118,17 @@ msgstr "Creazione del container in corso"
 msgid "Backing up storage bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396
-#: cmd/incus/storage_volume.go:3072
+#: cmd/incus/storage_volume.go:3070
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1150,7 +1152,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:650
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1198,7 +1200,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1293,7 +1295,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1484,15 +1486,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
 #: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324
-#: cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838
-#: cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670
+#: cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836
+#: cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid "Cluster member name"
 msgstr ""
 
@@ -1503,7 +1505,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072
 #: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687
-#: cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547
 #: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1561,7 +1563,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
 #: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1579,11 +1581,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1600,6 +1602,11 @@ msgstr ""
 #: cmd/incus/image.go:155
 msgid "Copy aliases from source"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#, fuzzy
+msgid "Copy custom storage volumes"
+msgstr "Creazione del container in corso"
 
 #: cmd/incus/image.go:147
 msgid "Copy images between servers"
@@ -1639,10 +1646,6 @@ msgstr ""
 
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid "Copy profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-msgid "Copy storage volumes"
 msgstr ""
 
 #: cmd/incus/copy.go:57
@@ -1860,7 +1863,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:657
-#: cmd/incus/storage_volume.go:1440
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1898,7 +1901,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1669
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1937,7 +1940,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1956,6 +1959,11 @@ msgstr ""
 #: cmd/incus/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#, fuzzy
+msgid "Delete custom storage volumes"
+msgstr "Creazione del container in corso"
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
 #, fuzzy
@@ -2041,14 +2049,10 @@ msgstr "Il nome del container è: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Creazione del container in corso"
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-msgid "Delete storage volumes"
-msgstr ""
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
 msgid "Delete warning"
@@ -2189,32 +2193,42 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953
-#: cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310
-#: cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556
-#: cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864
-#: cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265
-#: cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447
-#: cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542
-#: cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747
-#: cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923
-#: cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272
+#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454
+#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754
+#: cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#, fuzzy
+msgid "Detach custom storage volumes from instances"
+msgstr "Creazione del container in corso"
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#, fuzzy
+msgid "Detach custom storage volumes from profiles"
+msgstr "Creazione del container in corso"
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
 msgid "Detach network interfaces from instances"
@@ -2222,14 +2236,6 @@ msgstr ""
 
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid "Detach network interfaces from profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-msgid "Detach storage volumes from instances"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid "Detach storage volumes from profiles"
 msgstr ""
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
@@ -2528,8 +2534,17 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid "Edit storage volume configurations as YAML"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:954
+msgid ""
+"Edit storage volume configurations as YAML\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
@@ -2539,7 +2554,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722
-#: cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2610,8 +2625,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163
 #: cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2632,8 +2647,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077
 #: cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2072
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2715,8 +2730,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:2640
+#: cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/storage_volume.go:2647
 msgid "Expires at"
 msgstr ""
 
@@ -2740,7 +2755,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2764,7 +2779,7 @@ msgstr "Creazione del container in corso"
 msgid "Export storage buckets as tarball."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2773,7 +2788,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2989,7 +3004,7 @@ msgstr "Accetta certificato"
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Accetta certificato"
@@ -3004,7 +3019,7 @@ msgstr "Accetta certificato"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Accetta certificato"
@@ -3230,8 +3245,8 @@ msgstr ""
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572
-#: cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3362,7 +3377,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3438,8 +3453,20 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1178
+msgid ""
+"Get values for storage volume configuration keys\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
 msgstr ""
 
 #: cmd/incus/storage_volume.go:440
@@ -3547,7 +3574,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3561,7 +3588,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3612,10 +3639,6 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3089
-msgid "Import backups of custom volumes including their snapshots."
-msgstr ""
-
 #: cmd/incus/import.go:27
 msgid "Import backups of instances including their snapshots."
 msgstr ""
@@ -3625,9 +3648,14 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 msgid "Import custom storage volumes"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:3087
+#, fuzzy
+msgid "Import custom storage volumes."
+msgstr "Creazione del container in corso"
 
 #: cmd/incus/image.go:685
 msgid ""
@@ -3740,7 +3768,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Il nome del container è: %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3021
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Proprietà errata: %s"
@@ -3761,7 +3789,7 @@ msgid "Invalid arguments"
 msgstr "Proprietà errata: %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3026
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3864,9 +3892,9 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238
-#: cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2881
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -3928,7 +3956,7 @@ msgstr ""
 #: cmd/incus/list.go:616 cmd/incus/network.go:1303
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
-#: cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4341,12 +4369,12 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4364,11 +4392,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4455,7 +4483,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4739,7 +4767,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Creazione del container in corso"
@@ -4989,15 +5017,15 @@ msgstr "Il nome del container è: %s"
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
 #: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614
-#: cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798
-#: cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010
-#: cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603
-#: cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995
-#: cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372
-#: cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592
-#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379
+#: cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2871
 msgid "Missing pool name"
 msgstr ""
 
@@ -5023,11 +5051,11 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
@@ -5068,7 +5096,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5079,6 +5107,11 @@ msgstr ""
 #: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 #, fuzzy
 msgid "Mount files from instances"
+msgstr "Creazione del container in corso"
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#, fuzzy
+msgid "Move custom storage volumes between pools"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/move.go:34
@@ -5101,15 +5134,11 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-msgid "Move storage volumes between pools"
-msgstr ""
-
 #: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5142,7 +5171,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5198,8 +5227,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2638
+#: cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:2645
 msgid "Name"
 msgstr ""
 
@@ -5260,7 +5289,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:632 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1411
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5424,7 +5453,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5444,11 +5473,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5488,11 +5517,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5504,7 +5533,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5522,7 +5551,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5577,7 +5606,7 @@ msgstr ""
 #: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
-#: cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5703,7 +5732,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
 #: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5841,101 +5870,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Proprietà errata: %s"
-
-#: cmd/incus/storage_volume.go:2829
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"\tSupported types are custom, image, container and virtual-machine.\n"
-"\n"
-"\tAdd the name of the snapshot if type is one of custom, container or "
-"virtual-machine.\n"
-"\n"
-"\tincus storage volume show default virtual-machine/data/snap0\n"
-"\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
-"called \"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1312
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, container and virtual-machine.\n"
-"\n"
-"incus storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool "
-"\"default\".\n"
-"\n"
-"incus storage volume info default virtual-machine/data\n"
-"    Returns state information for a virtual machine \"data\" in pool "
-"\"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1176
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume get default data size\n"
-"    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2109
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume show default data\n"
-"    Will show the properties of a custom volume called \"data\" in the "
-"\"default\" pool.\n"
-"\n"
-"incus storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:955
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-"    Update a storage volume using the content of pool.yaml."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1949
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume set default data size=1GiB\n"
-"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-"\n"
-"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\" to seven days."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2208
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-"    Removes the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
 
 #: cmd/incus/config_trust.go:224
 #, fuzzy, c-format
@@ -6211,6 +6145,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#, fuzzy
+msgid "Rename custom storage volumes"
+msgstr "Creazione del container in corso"
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 #, fuzzy
 msgid "Rename instance snapshots"
@@ -6246,21 +6185,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-msgid "Rename storage volumes"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6304,7 +6239,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6710,18 +6645,22 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
 "For backward compatibility, a single configuration key may still be set "
 "with:\n"
 "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
-"<value>"
+"<value>\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:983 cmd/incus/remote.go:984
@@ -6809,7 +6748,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6961,13 +6900,43 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+msgid ""
+"Show storage volume configurations\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2834
+#, fuzzy
+msgid "Show storage volume snapshhot configurations"
+msgstr "Il nome del container è: %s"
+
+#: cmd/incus/storage_volume.go:2833
+#, fuzzy
+msgid "Show storage volume snapshot configurations"
+msgstr "Il nome del container è: %s"
+
+#: cmd/incus/storage_volume.go:1313
 msgid "Show storage volume state information"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1314
+msgid ""
+"Show storage volume state information\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
@@ -7035,15 +7004,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7188,12 +7157,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7206,7 +7175,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Creazione del container in corso"
@@ -7267,13 +7236,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -7472,12 +7441,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7525,7 +7494,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7604,7 +7573,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -7620,7 +7589,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7685,7 +7654,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432
 #: cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1420
+#: cmd/incus/storage_volume.go:1423
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7707,7 +7676,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7725,7 +7694,7 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
 
@@ -7766,7 +7735,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7880,8 +7849,17 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 msgid "Unset storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2214
+msgid ""
+"Unset storage volume configuration keys\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/cluster.go:589
@@ -7941,7 +7919,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7988,12 +7966,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8080,7 +8058,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid "Volume Only"
 msgstr ""
 
@@ -8257,7 +8235,7 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -8772,7 +8750,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -8820,17 +8798,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -8840,22 +8818,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
@@ -8865,38 +8843,38 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308
-#: cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
@@ -9517,26 +9495,96 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:578
 msgid ""
-"incus storage volume create p1 v1\n"
+"incus storage volume create default foo\n"
+"    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
+"incus storage volume create default foo < config.yaml\n"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3091
+#: cmd/incus/storage_volume.go:959
+msgid ""
+"incus storage volume edit default container/c1\n"
+"    Edit container storage volume \"c1\" in pool \"default\"\n"
+"\n"
+"incus storage volume edit default foo < volume.yaml\n"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1185
+msgid ""
+"incus storage volume get default data size\n"
+"    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+"\n"
+"incus storage volume get default virtual-machine/data snapshots.expiry\n"
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3089
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
-"\t\tCreate a new custom volume using backup0.tar.gz as the source."
+"    Create a new custom volume using backup0.tar.gz as the source\n"
+"\n"
+"incus storage volume import default some-installer.iso installer --type=iso\n"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2316
+#: cmd/incus/storage_volume.go:1319
 msgid ""
-"incus storage volume snapshot create default v1 snap0\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
 "\n"
-"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with "
-"the configuration from \"config.yaml\"."
+"incus storage volume info default virtual-machine/v1\n"
+"    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1955
+msgid ""
+"incus storage volume set default data size=1GiB\n"
+"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+"\n"
+"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2117
+msgid ""
+"incus storage volume show default foo\n"
+"    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume show default virtual-machine/v1\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume show default container/c1\n"
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2323
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+"\n"
+"incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2219
+msgid ""
+"incus storage volume unset default foo size\n"
+"    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
 msgstr ""
 
 #: cmd/incus/storage.go:547

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-06-11 23:14-0400\n"
+"POT-Creation-Date: 2024-07-08 16:17-0400\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -83,14 +83,15 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
+#, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
 "###\n"
-"### name: vol1\n"
+"### name: foo\n"
 "### type: custom\n"
 "### used_by: []\n"
 "### config:\n"
@@ -988,7 +989,7 @@ msgstr "エイリアス:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr "クラスターに join すると、すべてのデータが削除されます。続けますか?"
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1045,17 +1046,19 @@ msgstr "インスタンスにネットワークインターフェースを追加
 msgid "Attach network interfaces to profiles"
 msgstr "プロファイルにネットワークインターフェースを追加します"
 
-#: cmd/incus/network.go:143
-msgid "Attach new network interfaces to instances"
-msgstr "新たなネットワークインターフェースをインスタンスに追加します"
-
 #: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
-msgid "Attach new storage volumes to instances"
+#, fuzzy
+msgid "Attach new custom storage volumes to instances"
 msgstr "新たにストレージボリュームをインスタンスに追加します"
 
 #: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid "Attach new storage volumes to profiles"
+#, fuzzy
+msgid "Attach new custom storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
+
+#: cmd/incus/network.go:143
+msgid "Attach new network interfaces to instances"
+msgstr "新たなネットワークインターフェースをインスタンスに追加します"
 
 #: cmd/incus/console.go:36
 msgid "Attach to instance consoles"
@@ -1119,17 +1122,17 @@ msgstr "インスタンスのバックアップ中: %s"
 msgid "Backing up storage bucket: %s"
 msgstr "ストレージバケット %s のバックアップを行います"
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396
-#: cmd/incus/storage_volume.go:3072
+#: cmd/incus/storage_volume.go:3070
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1155,7 +1158,7 @@ msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %q"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:650
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1203,7 +1206,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1299,7 +1302,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスターでない場合はカラムとして L は指定できません"
@@ -1497,15 +1500,15 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
 #: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324
-#: cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838
-#: cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670
+#: cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836
+#: cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid "Cluster member name"
 msgstr "クラスターメンバ名"
 
@@ -1516,7 +1519,7 @@ msgstr "クラスタリングが有効になりました"
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072
 #: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687
-#: cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547
 #: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1581,7 +1584,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
 #: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
@@ -1599,11 +1602,11 @@ msgstr "デーモンの設定"
 msgid "Connecting to the daemon (attempt %d)"
 msgstr "デーモンに接続しています (試行 %d)"
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1620,6 +1623,11 @@ msgstr "ステートフルなインスタンスをステートレスにコピー
 #: cmd/incus/image.go:155
 msgid "Copy aliases from source"
 msgstr "ソースからエイリアスをコピーしました"
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#, fuzzy
+msgid "Copy custom storage volumes"
+msgstr "新たにカスタムストレージボリュームをインポートします"
 
 #: cmd/incus/image.go:147
 msgid "Copy images between servers"
@@ -1676,10 +1684,6 @@ msgstr "プロファイルに継承されたデバイスをコピーし、設定
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-msgid "Copy storage volumes"
-msgstr "ストレージボリュームをコピーします"
 
 #: cmd/incus/copy.go:57
 msgid "Copy the instance without its snapshots"
@@ -1890,7 +1894,7 @@ msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:657
-#: cmd/incus/storage_volume.go:1440
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1927,7 +1931,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1669
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1967,7 +1971,7 @@ msgstr "状態: %s"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1987,6 +1991,11 @@ msgstr "クラスターグループを削除します"
 #: cmd/incus/warning.go:361
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#, fuzzy
+msgid "Delete custom storage volumes"
+msgstr "ストレージボリュームを削除します"
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
 msgid "Delete files in instances"
@@ -2066,13 +2075,9 @@ msgstr "ストレージバケットを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 msgid "Delete storage volume snapshots"
 msgstr "ストレージボリュームのスナップショットを削除します"
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-msgid "Delete storage volumes"
-msgstr "ストレージボリュームを削除します"
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
 msgid "Delete warning"
@@ -2213,31 +2218,41 @@ msgstr "警告を削除します"
 #: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953
-#: cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310
-#: cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556
-#: cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864
-#: cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265
-#: cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447
-#: cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542
-#: cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747
-#: cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923
-#: cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272
+#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454
+#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754
+#: cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr "説明"
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#, fuzzy
+msgid "Detach custom storage volumes from instances"
+msgstr "インスタンスからストレージボリュームを取り外します"
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#, fuzzy
+msgid "Detach custom storage volumes from profiles"
+msgstr "プロファイルからストレージボリュームを取り外します"
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
 msgid "Detach network interfaces from instances"
@@ -2246,14 +2261,6 @@ msgstr "インスタンスからネットワークインターフェースを取
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-msgid "Detach storage volumes from instances"
-msgstr "インスタンスからストレージボリュームを取り外します"
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid "Detach storage volumes from profiles"
-msgstr "プロファイルからストレージボリュームを取り外します"
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
 #, fuzzy, c-format
@@ -2549,9 +2556,18 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
+
+#: cmd/incus/storage_volume.go:954
+msgid ""
+"Edit storage volume configurations as YAML\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
 msgid "Edit trust configurations as YAML"
@@ -2560,7 +2576,7 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722
-#: cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2641,8 +2657,8 @@ msgstr "エイリアスの取得に失敗しました: %w"
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163
 #: cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "プロパティの設定でエラーが発生しました: %v"
@@ -2663,8 +2679,8 @@ msgstr "プロパティの削除でエラーが発生しました: %v"
 #: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077
 #: cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2072
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "プロパティの設定解除エラー: %v"
@@ -2785,8 +2801,8 @@ msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
 #: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:2640
+#: cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/storage_volume.go:2647
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2813,7 +2829,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2833,7 +2849,7 @@ msgstr "ストレージバケットをエクスポートします"
 msgid "Export storage buckets as tarball."
 msgstr "ストレージバケットを tarball 形式でエクスポートします。"
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
@@ -2843,7 +2859,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "ストレージバケット %s のバックアップをエクスポートします"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -3059,7 +3075,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "ストレージボリュームのバックアップ作成に失敗しました: %w"
@@ -3074,7 +3090,7 @@ msgstr "移動元のインスタンスをコピーしたあとの削除に失敗
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "ストレージボリュームのバックアップファイルの取得に失敗しました: %w"
@@ -3313,8 +3329,8 @@ msgstr ""
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572
-#: cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -3449,7 +3465,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -3520,9 +3536,24 @@ msgstr "ストレージバケットの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
+
+#: cmd/incus/storage_volume.go:1178
+#, fuzzy
+msgid ""
+"Get values for storage volume configuration keys\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
+"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+"    pool.yaml の内容でストレージボリュームを更新します。"
 
 #: cmd/incus/storage_volume.go:440
 #, c-format
@@ -3632,7 +3663,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -3649,7 +3680,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -3699,12 +3730,6 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: cmd/incus/storage_volume.go:3089
-msgid "Import backups of custom volumes including their snapshots."
-msgstr ""
-"カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
-"ます。"
-
 #: cmd/incus/import.go:27
 msgid "Import backups of instances including their snapshots."
 msgstr ""
@@ -3715,8 +3740,13 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 msgid "Import custom storage volumes"
+msgstr "新たにカスタムストレージボリュームをインポートします"
+
+#: cmd/incus/storage_volume.go:3087
+#, fuzzy
+msgid "Import custom storage volumes."
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
 #: cmd/incus/image.go:685
@@ -3835,7 +3865,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "不正なスナップショット名"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3021
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "不正なフォーマット %q"
@@ -3856,7 +3886,7 @@ msgid "Invalid arguments"
 msgstr "不正な引数 %q"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3026
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "パス %q に不正なバックアップ名のセグメントがあります: %w"
@@ -3963,9 +3993,9 @@ msgstr "不正な送り先 %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238
-#: cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2881
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -4026,7 +4056,7 @@ msgstr "LISTEN ADDRESS"
 #: cmd/incus/list.go:616 cmd/incus/network.go:1303
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
-#: cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -4636,12 +4666,12 @@ msgstr "ストレージバケットの鍵を一覧表示します"
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 #, fuzzy
 msgid ""
 "List storage volume snapshots\n"
@@ -4674,11 +4704,11 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4815,7 +4845,7 @@ msgstr "バックグラウンド操作の一覧表示、表示、削除を行い
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -5098,7 +5128,7 @@ msgstr "ストレージバケットを管理します。"
 msgid "Manage storage pools and volumes"
 msgstr "ストレージプール、ストレージボリュームを管理します"
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "ストレージボリュームを管理します"
@@ -5341,15 +5371,15 @@ msgstr "ピア名を指定する必要があります"
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
 #: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614
-#: cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798
-#: cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010
-#: cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603
-#: cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995
-#: cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372
-#: cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592
-#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379
+#: cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2871
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -5374,11 +5404,11 @@ msgstr "プロファイル名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -5422,7 +5452,7 @@ msgstr ""
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
@@ -5435,6 +5465,11 @@ msgstr ""
 #: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#, fuzzy
+msgid "Move custom storage volumes between pools"
+msgstr "プール間でストレージボリュームを移動します"
 
 #: cmd/incus/move.go:34
 #, fuzzy
@@ -5469,15 +5504,11 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-msgid "Move storage volumes between pools"
-msgstr "プール間でストレージボリュームを移動します"
-
 #: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
@@ -5512,7 +5543,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr "NAME"
 
@@ -5568,8 +5599,8 @@ msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
 #: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2638
+#: cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:2645
 msgid "Name"
 msgstr "名前"
 
@@ -5634,7 +5665,7 @@ msgid "Name of the storage pool:"
 msgstr "ストレージプールを作成します"
 
 #: cmd/incus/info.go:632 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1411
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -5801,7 +5832,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
@@ -5821,11 +5852,11 @@ msgstr "マッチするルールが見つかりません"
 msgid "No storage backends available"
 msgstr "利用可能なストレージバックエンドがありません"
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -5869,11 +5900,11 @@ msgstr "OVN:"
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -5885,7 +5916,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
@@ -5905,7 +5936,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -5960,7 +5991,7 @@ msgstr "PROFILES"
 #: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
-#: cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
@@ -6086,7 +6117,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
 #: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -6224,131 +6255,6 @@ msgstr "プロパティが見つかりません"
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "不正なプロトコル: %s"
-
-#: cmd/incus/storage_volume.go:2829
-#, fuzzy
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"\tSupported types are custom, image, container and virtual-machine.\n"
-"\n"
-"\tAdd the name of the snapshot if type is one of custom, container or "
-"virtual-machine.\n"
-"\n"
-"\tincus storage volume show default virtual-machine/data/snap0\n"
-"\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
-"called \"data\" in the \"default\" pool."
-msgstr ""
-"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
-"    pool.yaml の内容でストレージボリュームを更新します。"
-
-#: cmd/incus/storage_volume.go:1312
-#, fuzzy
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, container and virtual-machine.\n"
-"\n"
-"incus storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool "
-"\"default\".\n"
-"\n"
-"incus storage volume info default virtual-machine/data\n"
-"    Returns state information for a virtual machine \"data\" in pool "
-"\"default\"."
-msgstr ""
-"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
-"    pool.yaml の内容でストレージボリュームを更新します。"
-
-#: cmd/incus/storage_volume.go:1176
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume get default data size\n"
-"    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-"カスタムでない場合、ストレージボリュームのタイプを指定します。\n"
-"サポートしているタイプは、custom, image, container, virtual-machine です。\n"
-"\n"
-"タイプが custom, container, virtual-machine のいずれかの場合、スナップショッ"
-"トの名前を追加します。\n"
-"\n"
-"incus storage volume get default data size\n"
-"    プール \"default\" 内のカスタムボリューム \"data\" のサイズを返します。\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    プール \"default\" 内の仮想マシン \"data\" のスナップショットの有効期限を"
-"返します。"
-
-#: cmd/incus/storage_volume.go:2109
-#, fuzzy
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume show default data\n"
-"    Will show the properties of a custom volume called \"data\" in the "
-"\"default\" pool.\n"
-"\n"
-"incus storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
-msgstr ""
-"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
-"    pool.yaml の内容でストレージボリュームを更新します。"
-
-#: cmd/incus/storage_volume.go:955
-#, fuzzy
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-"    Update a storage volume using the content of pool.yaml."
-msgstr ""
-"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
-"    pool.yaml の内容でストレージボリュームを更新します。"
-
-#: cmd/incus/storage_volume.go:1949
-#, fuzzy
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume set default data size=1GiB\n"
-"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-"\n"
-"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\" to seven days."
-msgstr ""
-"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
-"    pool.yaml の内容でストレージボリュームを更新します。"
-
-#: cmd/incus/storage_volume.go:2208
-#, fuzzy
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-"    Removes the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
-"    pool.yaml の内容でストレージボリュームを更新します。"
 
 #: cmd/incus/config_trust.go:224
 #, fuzzy, c-format
@@ -6625,6 +6531,11 @@ msgstr "クラスターメンバの名前を変更します"
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#, fuzzy
+msgid "Rename custom storage volumes"
+msgstr "ストレージボリューム名を変更します"
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 #, fuzzy
 msgid "Rename instance snapshots"
@@ -6660,21 +6571,17 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-msgid "Rename storage volumes"
-msgstr "ストレージボリューム名を変更します"
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -6720,7 +6627,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "スナップショットからインスタンスをリストアします"
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -7193,11 +7100,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -7205,7 +7112,11 @@ msgid ""
 "For backward compatibility, a single configuration key may still be set "
 "with:\n"
 "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
-"<value>"
+"<value>\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 "ストレージボリュームを設定します\n"
 "\n"
@@ -7304,7 +7215,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -7449,14 +7360,47 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+#, fuzzy
+msgid ""
+"Show storage volume configurations\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
+"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+"    pool.yaml の内容でストレージボリュームを更新します。"
+
+#: cmd/incus/storage_volume.go:2834
+#, fuzzy
+msgid "Show storage volume snapshhot configurations"
+msgstr "ストレージボリュームの設定を表示する"
+
+#: cmd/incus/storage_volume.go:2833
+#, fuzzy
+msgid "Show storage volume snapshot configurations"
+msgstr "ストレージボリュームの設定を表示する"
+
+#: cmd/incus/storage_volume.go:1313
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
+
+#: cmd/incus/storage_volume.go:1314
+msgid ""
+"Show storage volume state information\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr ""
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
 msgid "Show the default remote"
@@ -7522,15 +7466,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -7676,12 +7620,12 @@ msgstr "ストレージプール名"
 msgid "Storage pool to use or create"
 msgstr "ストレージプール %s を作成しました"
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
@@ -7694,7 +7638,7 @@ msgstr "ストレージボリュームのコピーが成功しました!"
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "ストレージボリューム %s を削除しました"
@@ -7754,13 +7698,13 @@ msgstr "TOKEN"
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
 #: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -7990,12 +7934,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8053,7 +7997,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -8156,7 +8100,7 @@ msgstr ""
 msgid "Too many links"
 msgstr "リンクが多すぎます"
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -8172,7 +8116,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -8238,7 +8182,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432
 #: cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1420
+#: cmd/incus/storage_volume.go:1423
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -8260,7 +8204,7 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr "USAGE"
 
@@ -8278,7 +8222,7 @@ msgstr "上位デバイス"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -8318,7 +8262,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -8424,9 +8368,18 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
+
+#: cmd/incus/storage_volume.go:2214
+msgid ""
+"Unset storage volume configuration keys\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr ""
 
 #: cmd/incus/cluster.go:589
 msgid "Unset the key as a cluster property"
@@ -8489,7 +8442,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -8537,12 +8490,12 @@ msgstr "アップロード日時: %s"
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8633,7 +8586,7 @@ msgstr "CUDA バージョン: %v"
 msgid "Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -8830,7 +8783,7 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
@@ -9277,7 +9230,7 @@ msgstr "[<remote>:]<pool>"
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -9317,17 +9270,17 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
@@ -9335,20 +9288,20 @@ msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
@@ -9356,37 +9309,37 @@ msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308
-#: cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
@@ -10228,39 +10181,129 @@ msgstr ""
 #: cmd/incus/storage_volume.go:578
 #, fuzzy
 msgid ""
-"incus storage volume create p1 v1\n"
+"incus storage volume create default foo\n"
+"    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
+"incus storage volume create default foo < config.yaml\n"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/storage_volume.go:3091
+#: cmd/incus/storage_volume.go:959
 #, fuzzy
+msgid ""
+"incus storage volume edit default container/c1\n"
+"    Edit container storage volume \"c1\" in pool \"default\"\n"
+"\n"
+"incus storage volume edit default foo < volume.yaml\n"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
+msgstr ""
+"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+"    pool.yaml の内容でストレージボリュームを更新します。"
+
+#: cmd/incus/storage_volume.go:1185
+#, fuzzy
+msgid ""
+"incus storage volume get default data size\n"
+"    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+"\n"
+"incus storage volume get default virtual-machine/data snapshots.expiry\n"
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
+msgstr ""
+"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+"    pool.yaml の内容でストレージボリュームを更新します。"
+
+#: cmd/incus/storage_volume.go:3089
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
-"\t\tCreate a new custom volume using backup0.tar.gz as the source."
+"    Create a new custom volume using backup0.tar.gz as the source\n"
+"\n"
+"incus storage volume import default some-installer.iso installer --type=iso\n"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
 msgstr ""
-"lxc storage volume import default backup0.tar.gz\n"
-"\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: cmd/incus/storage_volume.go:2316
+#: cmd/incus/storage_volume.go:1319
 #, fuzzy
 msgid ""
-"incus storage volume snapshot create default v1 snap0\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
 "\n"
-"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with "
-"the configuration from \"config.yaml\"."
+"incus storage volume info default virtual-machine/v1\n"
+"    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr ""
+"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+"    pool.yaml の内容でストレージボリュームを更新します。"
+
+#: cmd/incus/storage_volume.go:1955
+#, fuzzy
+msgid ""
+"incus storage volume set default data size=1GiB\n"
+"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+"\n"
+"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
+msgstr ""
+"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+"    pool.yaml の内容でストレージボリュームを更新します。"
+
+#: cmd/incus/storage_volume.go:2117
+#, fuzzy
+msgid ""
+"incus storage volume show default foo\n"
+"    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume show default virtual-machine/v1\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume show default container/c1\n"
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
+msgstr ""
+"lxc storage volume show default data\n"
+"    \"default\" プール内のカスタムボリューム \"data\" のプロパティを表示しま"
+"す。\n"
+"\n"
+"lxc storage volume show default container/data\n"
+"    \"default\" プール内のコンテナ \"data\" のファイルシステムプロパティを表"
+"示します。"
+
+#: cmd/incus/storage_volume.go:2323
+#, fuzzy
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+"\n"
+"incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
 msgstr ""
 "lxc init ubuntu:22.04 u1\n"
 "\n"
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
+
+#: cmd/incus/storage_volume.go:2219
+#, fuzzy
+msgid ""
+"incus storage volume unset default foo size\n"
+"    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
+msgstr ""
+"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+"    pool.yaml の内容でストレージボリュームを更新します。"
 
 #: cmd/incus/storage.go:547
 msgid "info"
@@ -10328,6 +10371,130 @@ msgstr "y"
 #: cmd/incus/image.go:1184 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "yes"
+
+#, fuzzy
+#~ msgid ""
+#~ "\t\tincus storage volume show default virtual-machine/data/snap0\n"
+#~ "\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
+#~ "called \"data\" in the \"default\" pool."
+#~ msgstr ""
+#~ "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+#~ "    pool.yaml の内容でストレージボリュームを更新します。"
+
+#~ msgid "Copy storage volumes"
+#~ msgstr "ストレージボリュームをコピーします"
+
+#, fuzzy
+#~ msgid ""
+#~ "If type is not specified, incus assumes \"custom\"\n"
+#~ "Values for type can be custom, image, container and virtual-machine.\n"
+#~ "\n"
+#~ "incus storage volume set default data size=1GiB\n"
+#~ "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 "
+#~ "GiB.\n"
+#~ "\n"
+#~ "incus storage volume set default virtual-machine/data snapshots."
+#~ "expiry=7d\n"
+#~ "    Sets the snapshot expiration period for a virtual machine \"data\" in "
+#~ "pool \"default\" to seven days."
+#~ msgstr ""
+#~ "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+#~ "    pool.yaml の内容でストレージボリュームを更新します。"
+
+#~ msgid "Import backups of custom volumes including their snapshots."
+#~ msgstr ""
+#~ "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポート"
+#~ "します。"
+
+#, fuzzy
+#~ msgid ""
+#~ "incus storage volume create p1 v1\n"
+#~ "\n"
+#~ "incus storage volume create p1 v1 < config.yaml\n"
+#~ "\tCreate storage volume v1 for pool p1 with configuration from config."
+#~ "yaml."
+#~ msgstr ""
+#~ "lxc init ubuntu:22.04 u1\n"
+#~ "\n"
+#~ "lxc init ubuntu:22.04 u1 < config.yaml\n"
+#~ "    config.yaml の設定を使ってインスタンスを作成します"
+
+#, fuzzy
+#~ msgid ""
+#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume."
+#~ "yaml\n"
+#~ "    Update a storage volume using the content of pool.yaml."
+#~ msgstr ""
+#~ "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
+#~ "    pool.yaml の内容でストレージプールを更新します。"
+
+#, fuzzy
+#~ msgid ""
+#~ "incus storage volume import default backup0.tar.gz\n"
+#~ "\t\tCreate a new custom volume using backup0.tar.gz as the source."
+#~ msgstr ""
+#~ "lxc storage volume import default backup0.tar.gz\n"
+#~ "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
+
+#~ msgid ""
+#~ "Provide the type of the storage volume if it is not custom.\n"
+#~ "Supported types are custom, image, container and virtual-machine.\n"
+#~ "\n"
+#~ "Add the name of the snapshot if type is one of custom, container or "
+#~ "virtual-machine.\n"
+#~ "\n"
+#~ "incus storage volume get default data size\n"
+#~ "    Returns the size of a custom volume \"data\" in pool \"default\".\n"
+#~ "\n"
+#~ "incus storage volume get default virtual-machine/data snapshots.expiry\n"
+#~ "    Returns the snapshot expiration period for a virtual machine \"data\" "
+#~ "in pool \"default\"."
+#~ msgstr ""
+#~ "カスタムでない場合、ストレージボリュームのタイプを指定します。\n"
+#~ "サポートしているタイプは、custom, image, container, virtual-machine で"
+#~ "す。\n"
+#~ "\n"
+#~ "タイプが custom, container, virtual-machine のいずれかの場合、スナップ"
+#~ "ショットの名前を追加します。\n"
+#~ "\n"
+#~ "incus storage volume get default data size\n"
+#~ "    プール \"default\" 内のカスタムボリューム \"data\" のサイズを返しま"
+#~ "す。\n"
+#~ "\n"
+#~ "incus storage volume get default virtual-machine/data snapshots.expiry\n"
+#~ "    プール \"default\" 内の仮想マシン \"data\" のスナップショットの有効期"
+#~ "限を返します。"
+
+#, fuzzy
+#~ msgid ""
+#~ "Provide the type of the storage volume if it is not custom.\n"
+#~ "Supported types are custom, image, container and virtual-machine.\n"
+#~ "\n"
+#~ "Add the name of the snapshot if type is one of custom, container or "
+#~ "virtual-machine.\n"
+#~ "\n"
+#~ "incus storage volume show default data\n"
+#~ "    Will show the properties of a custom volume called \"data\" in the "
+#~ "\"default\" pool.\n"
+#~ "\n"
+#~ "incus storage volume show default container/data\n"
+#~ "    Will show the properties of the filesystem for a container called "
+#~ "\"data\" in the \"default\" pool."
+#~ msgstr ""
+#~ "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+#~ "    pool.yaml の内容でストレージボリュームを更新します。"
+
+#, fuzzy
+#~ msgid ""
+#~ "Provide the type of the storage volume if it is not custom.\n"
+#~ "Supported types are custom, image, container and virtual-machine.\n"
+#~ "\n"
+#~ "incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume."
+#~ "yaml\n"
+#~ "    Update a storage volume using the content of pool.yaml."
+#~ msgstr ""
+#~ "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+#~ "    pool.yaml の内容でストレージボリュームを更新します。"
 
 #, fuzzy
 #~ msgid ""
@@ -10499,23 +10666,6 @@ msgstr "yes"
 #, fuzzy
 #~ msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>=<value>..."
 #~ msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
-
-#~ msgid ""
-#~ "lxc storage volume show default data\n"
-#~ "    Will show the properties of a custom volume called \"data\" in the "
-#~ "\"default\" pool.\n"
-#~ "\n"
-#~ "lxc storage volume show default container/data\n"
-#~ "    Will show the properties of the filesystem for a container called "
-#~ "\"data\" in the \"default\" pool."
-#~ msgstr ""
-#~ "lxc storage volume show default data\n"
-#~ "    \"default\" プール内のカスタムボリューム \"data\" のプロパティを表示し"
-#~ "ます。\n"
-#~ "\n"
-#~ "lxc storage volume show default container/data\n"
-#~ "    \"default\" プール内のコンテナ \"data\" のファイルシステムプロパティを"
-#~ "表示します。"
 
 #~ msgid "%v (interrupt two more times to force)"
 #~ msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-06-11 23:14-0400\n"
+"POT-Creation-Date: 2024-07-08 16:17-0400\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -84,14 +84,15 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
+#, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
 "###\n"
-"### name: vol1\n"
+"### name: foo\n"
 "### type: custom\n"
 "### used_by: []\n"
 "### config:\n"
@@ -1006,7 +1007,7 @@ msgstr ""
 "Alle huidige gegevens gaan verloren bij het lid worden (joining) van een "
 "cluster, doorgaan?"
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 msgid "All projects"
 msgstr "Alle projecten"
 
@@ -1068,17 +1069,19 @@ msgstr "Toekennen van netwerk interfaces aan instanties (instances)"
 msgid "Attach network interfaces to profiles"
 msgstr "Toekennen van netwerk (network) interfaces aan profielen (profiles)"
 
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#, fuzzy
+msgid "Attach new custom storage volumes to instances"
+msgstr "Toekennen van nieuwe netwerk interfaces aan instanties (instances)"
+
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#, fuzzy
+msgid "Attach new custom storage volumes to profiles"
+msgstr "Toekennen van netwerk (network) interfaces aan profielen (profiles)"
+
 #: cmd/incus/network.go:143
 msgid "Attach new network interfaces to instances"
 msgstr "Toekennen van nieuwe netwerk interfaces aan instanties (instances)"
-
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
-msgid "Attach new storage volumes to instances"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid "Attach new storage volumes to profiles"
-msgstr ""
 
 #: cmd/incus/console.go:36
 msgid "Attach to instance consoles"
@@ -1138,17 +1141,17 @@ msgstr "Backup aan het maken van instantie (instance): %s"
 msgid "Backing up storage bucket: %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396
-#: cmd/incus/storage_volume.go:3072
+#: cmd/incus/storage_volume.go:3070
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1172,7 +1175,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Ongeldig sleutel=waarde paar: %q"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:650
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Ongeldig sleutel=waarde paar: %s"
@@ -1220,7 +1223,7 @@ msgstr "ONDERBREEKBAAR"
 msgid "COMMON NAME"
 msgstr "GEWONE NAAM"
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid "CONTENT-TYPE"
 msgstr "INHOUDSTYPE"
 
@@ -1317,7 +1320,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1507,15 +1510,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
 #: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324
-#: cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838
-#: cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670
+#: cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836
+#: cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid "Cluster member name"
 msgstr ""
 
@@ -1526,7 +1529,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072
 #: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687
-#: cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547
 #: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1583,7 +1586,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
 #: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1601,11 +1604,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1622,6 +1625,11 @@ msgstr ""
 #: cmd/incus/image.go:155
 msgid "Copy aliases from source"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#, fuzzy
+msgid "Copy custom storage volumes"
+msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
 #: cmd/incus/image.go:147
 msgid "Copy images between servers"
@@ -1661,10 +1669,6 @@ msgstr ""
 
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid "Copy profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-msgid "Copy storage volumes"
 msgstr ""
 
 #: cmd/incus/copy.go:57
@@ -1872,7 +1876,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:657
-#: cmd/incus/storage_volume.go:1440
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1909,7 +1913,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1669
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1948,7 +1952,7 @@ msgstr "Cached: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1967,6 +1971,11 @@ msgstr ""
 #: cmd/incus/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#, fuzzy
+msgid "Delete custom storage volumes"
+msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
 msgid "Delete files in instances"
@@ -2046,12 +2055,8 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 msgid "Delete storage volume snapshots"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-msgid "Delete storage volumes"
 msgstr ""
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
@@ -2193,31 +2198,41 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953
-#: cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310
-#: cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556
-#: cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864
-#: cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265
-#: cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447
-#: cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542
-#: cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747
-#: cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923
-#: cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272
+#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454
+#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754
+#: cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 msgid "Destination cluster member name"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#, fuzzy
+msgid "Detach custom storage volumes from instances"
+msgstr "Toekennen van netwerk interfaces aan instanties (instances)"
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#, fuzzy
+msgid "Detach custom storage volumes from profiles"
+msgstr "Toekennen van netwerk (network) interfaces aan profielen (profiles)"
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
 msgid "Detach network interfaces from instances"
@@ -2225,14 +2240,6 @@ msgstr ""
 
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid "Detach network interfaces from profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-msgid "Detach storage volumes from instances"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid "Detach storage volumes from profiles"
 msgstr ""
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
@@ -2515,8 +2522,17 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid "Edit storage volume configurations as YAML"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:954
+msgid ""
+"Edit storage volume configurations as YAML\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
@@ -2526,7 +2542,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722
-#: cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2597,8 +2613,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163
 #: cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2619,8 +2635,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077
 #: cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2072
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2701,8 +2717,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:2640
+#: cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/storage_volume.go:2647
 msgid "Expires at"
 msgstr ""
 
@@ -2726,7 +2742,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2746,7 +2762,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2755,7 +2771,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2971,7 +2987,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2986,7 +3002,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3210,8 +3226,8 @@ msgstr ""
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572
-#: cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3338,7 +3354,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3407,8 +3423,20 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1178
+msgid ""
+"Get values for storage volume configuration keys\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
 msgstr ""
 
 #: cmd/incus/storage_volume.go:440
@@ -3515,7 +3543,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3529,7 +3557,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3579,10 +3607,6 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3089
-msgid "Import backups of custom volumes including their snapshots."
-msgstr ""
-
 #: cmd/incus/import.go:27
 msgid "Import backups of instances including their snapshots."
 msgstr ""
@@ -3591,9 +3615,14 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 msgid "Import custom storage volumes"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:3087
+#, fuzzy
+msgid "Import custom storage volumes."
+msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
 #: cmd/incus/image.go:685
 msgid ""
@@ -3702,7 +3731,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3021
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3722,7 +3751,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3026
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3823,9 +3852,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238
-#: cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2881
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3884,7 +3913,7 @@ msgstr ""
 #: cmd/incus/list.go:616 cmd/incus/network.go:1303
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
-#: cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4283,11 +4312,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4305,11 +4334,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4395,7 +4424,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4661,7 +4690,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -4899,15 +4928,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
 #: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614
-#: cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798
-#: cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010
-#: cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603
-#: cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995
-#: cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372
-#: cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592
-#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379
+#: cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2871
 msgid "Missing pool name"
 msgstr ""
 
@@ -4931,11 +4960,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4973,7 +5002,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4983,6 +5012,10 @@ msgstr ""
 
 #: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 msgid "Mount files from instances"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+msgid "Move custom storage volumes between pools"
 msgstr ""
 
 #: cmd/incus/move.go:34
@@ -5005,15 +5038,11 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-msgid "Move storage volumes between pools"
-msgstr ""
-
 #: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5046,7 +5075,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5102,8 +5131,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2638
+#: cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:2645
 msgid "Name"
 msgstr ""
 
@@ -5164,7 +5193,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:632 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1411
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5328,7 +5357,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5348,11 +5377,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5392,11 +5421,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5408,7 +5437,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5426,7 +5455,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5479,7 +5508,7 @@ msgstr ""
 #: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
-#: cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5603,7 +5632,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
 #: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5738,101 +5767,6 @@ msgstr ""
 #: cmd/incus/image.go:1042
 #, c-format
 msgid "Protocol: %s"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2829
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"\tSupported types are custom, image, container and virtual-machine.\n"
-"\n"
-"\tAdd the name of the snapshot if type is one of custom, container or "
-"virtual-machine.\n"
-"\n"
-"\tincus storage volume show default virtual-machine/data/snap0\n"
-"\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
-"called \"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1312
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, container and virtual-machine.\n"
-"\n"
-"incus storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool "
-"\"default\".\n"
-"\n"
-"incus storage volume info default virtual-machine/data\n"
-"    Returns state information for a virtual machine \"data\" in pool "
-"\"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1176
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume get default data size\n"
-"    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2109
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume show default data\n"
-"    Will show the properties of a custom volume called \"data\" in the "
-"\"default\" pool.\n"
-"\n"
-"incus storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:955
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-"    Update a storage volume using the content of pool.yaml."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1949
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume set default data size=1GiB\n"
-"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-"\n"
-"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\" to seven days."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2208
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-"    Removes the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:224
@@ -6099,6 +6033,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#, fuzzy
+msgid "Rename custom storage volumes"
+msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 msgid "Rename instance snapshots"
 msgstr ""
@@ -6132,20 +6071,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-msgid "Rename storage volumes"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6186,7 +6121,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6583,18 +6518,22 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
 "For backward compatibility, a single configuration key may still be set "
 "with:\n"
 "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
-"<value>"
+"<value>\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:983 cmd/incus/remote.go:984
@@ -6678,7 +6617,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6820,13 +6759,41 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+msgid ""
+"Show storage volume configurations\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2834
+msgid "Show storage volume snapshhot configurations"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2833
+msgid "Show storage volume snapshot configurations"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1313
 msgid "Show storage volume state information"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1314
+msgid ""
+"Show storage volume state information\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
@@ -6891,15 +6858,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7042,12 +7009,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7060,7 +7027,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7120,13 +7087,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 msgid "Taken at"
 msgstr ""
 
@@ -7323,12 +7290,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7376,7 +7343,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7454,7 +7421,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7470,7 +7437,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7534,7 +7501,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432
 #: cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1420
+#: cmd/incus/storage_volume.go:1423
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7556,7 +7523,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7572,7 +7539,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
 
@@ -7611,7 +7578,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7716,8 +7683,17 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 msgid "Unset storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2214
+msgid ""
+"Unset storage volume configuration keys\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/cluster.go:589
@@ -7772,7 +7748,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7817,12 +7793,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7908,7 +7884,7 @@ msgstr "CUDA Versie: %v"
 msgid "Version: %v"
 msgstr "CUDA Versie: %v"
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid "Volume Only"
 msgstr ""
 
@@ -8081,7 +8057,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8502,7 +8478,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -8541,15 +8517,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -8557,19 +8533,19 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -8577,32 +8553,32 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308
-#: cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -9194,26 +9170,96 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:578
 msgid ""
-"incus storage volume create p1 v1\n"
+"incus storage volume create default foo\n"
+"    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
+"incus storage volume create default foo < config.yaml\n"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3091
+#: cmd/incus/storage_volume.go:959
+msgid ""
+"incus storage volume edit default container/c1\n"
+"    Edit container storage volume \"c1\" in pool \"default\"\n"
+"\n"
+"incus storage volume edit default foo < volume.yaml\n"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1185
+msgid ""
+"incus storage volume get default data size\n"
+"    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+"\n"
+"incus storage volume get default virtual-machine/data snapshots.expiry\n"
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3089
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
-"\t\tCreate a new custom volume using backup0.tar.gz as the source."
+"    Create a new custom volume using backup0.tar.gz as the source\n"
+"\n"
+"incus storage volume import default some-installer.iso installer --type=iso\n"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2316
+#: cmd/incus/storage_volume.go:1319
 msgid ""
-"incus storage volume snapshot create default v1 snap0\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
 "\n"
-"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with "
-"the configuration from \"config.yaml\"."
+"incus storage volume info default virtual-machine/v1\n"
+"    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1955
+msgid ""
+"incus storage volume set default data size=1GiB\n"
+"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+"\n"
+"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2117
+msgid ""
+"incus storage volume show default foo\n"
+"    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume show default virtual-machine/v1\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume show default container/c1\n"
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2323
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+"\n"
+"incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2219
+msgid ""
+"incus storage volume unset default foo size\n"
+"    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
 msgstr ""
 
 #: cmd/incus/storage.go:547

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-06-11 23:14-0400\n"
+"POT-Creation-Date: 2024-07-08 16:17-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -58,14 +58,14 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
 "###\n"
-"### name: vol1\n"
+"### name: foo\n"
 "### type: custom\n"
 "### used_by: []\n"
 "### config:\n"
@@ -733,7 +733,7 @@ msgstr ""
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 msgid "All projects"
 msgstr ""
 
@@ -789,16 +789,16 @@ msgstr ""
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/network.go:143
-msgid "Attach new network interfaces to instances"
-msgstr ""
-
 #: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
-msgid "Attach new storage volumes to instances"
+msgid "Attach new custom storage volumes to instances"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid "Attach new storage volumes to profiles"
+msgid "Attach new custom storage volumes to profiles"
+msgstr ""
+
+#: cmd/incus/network.go:143
+msgid "Attach new network interfaces to instances"
 msgstr ""
 
 #: cmd/incus/console.go:36
@@ -859,17 +859,17 @@ msgstr ""
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396
-#: cmd/incus/storage_volume.go:3072
+#: cmd/incus/storage_volume.go:3070
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -893,7 +893,7 @@ msgid "Bad key=value pair: %q"
 msgstr ""
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:650
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -941,7 +941,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1034,7 +1034,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1224,15 +1224,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
 #: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324
-#: cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838
-#: cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670
+#: cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836
+#: cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid "Cluster member name"
 msgstr ""
 
@@ -1243,7 +1243,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072
 #: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687
-#: cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547
 #: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1300,7 +1300,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
 #: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1318,11 +1318,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1338,6 +1338,10 @@ msgstr ""
 
 #: cmd/incus/image.go:155
 msgid "Copy aliases from source"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+msgid "Copy custom storage volumes"
 msgstr ""
 
 #: cmd/incus/image.go:147
@@ -1378,10 +1382,6 @@ msgstr ""
 
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid "Copy profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-msgid "Copy storage volumes"
 msgstr ""
 
 #: cmd/incus/copy.go:57
@@ -1588,7 +1588,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:657
-#: cmd/incus/storage_volume.go:1440
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1625,7 +1625,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1669
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1682,6 +1682,10 @@ msgstr ""
 
 #: cmd/incus/warning.go:361
 msgid "Delete all warnings"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+msgid "Delete custom storage volumes"
 msgstr ""
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
@@ -1761,12 +1765,8 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 msgid "Delete storage volume snapshots"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-msgid "Delete storage volumes"
 msgstr ""
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
@@ -1908,30 +1908,38 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953
-#: cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310
-#: cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556
-#: cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864
-#: cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265
-#: cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447
-#: cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542
-#: cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747
-#: cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923
-#: cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272
+#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454
+#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754
+#: cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 msgid "Destination cluster member name"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+msgid "Detach custom storage volumes from instances"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
@@ -1940,14 +1948,6 @@ msgstr ""
 
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid "Detach network interfaces from profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-msgid "Detach storage volumes from instances"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid "Detach storage volumes from profiles"
 msgstr ""
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
@@ -2230,8 +2230,17 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid "Edit storage volume configurations as YAML"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:954
+msgid ""
+"Edit storage volume configurations as YAML\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
@@ -2241,7 +2250,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722
-#: cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2312,8 +2321,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163
 #: cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2334,8 +2343,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077
 #: cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2072
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2416,8 +2425,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:2640
+#: cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/storage_volume.go:2647
 msgid "Expires at"
 msgstr ""
 
@@ -2441,7 +2450,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2461,7 +2470,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2470,7 +2479,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2686,7 +2695,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2701,7 +2710,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -2925,8 +2934,8 @@ msgstr ""
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572
-#: cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3051,7 +3060,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3120,8 +3129,20 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1178
+msgid ""
+"Get values for storage volume configuration keys\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
 msgstr ""
 
 #: cmd/incus/storage_volume.go:440
@@ -3228,7 +3249,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3242,7 +3263,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3292,10 +3313,6 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3089
-msgid "Import backups of custom volumes including their snapshots."
-msgstr ""
-
 #: cmd/incus/import.go:27
 msgid "Import backups of instances including their snapshots."
 msgstr ""
@@ -3304,8 +3321,12 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 msgid "Import custom storage volumes"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3087
+msgid "Import custom storage volumes."
 msgstr ""
 
 #: cmd/incus/image.go:685
@@ -3415,7 +3436,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3021
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3435,7 +3456,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3026
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3536,9 +3557,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238
-#: cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2881
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3597,7 +3618,7 @@ msgstr ""
 #: cmd/incus/list.go:616 cmd/incus/network.go:1303
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
-#: cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3994,11 +4015,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4016,11 +4037,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4106,7 +4127,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4371,7 +4392,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -4608,15 +4629,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
 #: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614
-#: cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798
-#: cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010
-#: cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603
-#: cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995
-#: cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372
-#: cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592
-#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379
+#: cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2871
 msgid "Missing pool name"
 msgstr ""
 
@@ -4640,11 +4661,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4682,7 +4703,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4692,6 +4713,10 @@ msgstr ""
 
 #: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 msgid "Mount files from instances"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+msgid "Move custom storage volumes between pools"
 msgstr ""
 
 #: cmd/incus/move.go:34
@@ -4714,15 +4739,11 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-msgid "Move storage volumes between pools"
-msgstr ""
-
 #: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4755,7 +4776,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -4811,8 +4832,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2638
+#: cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:2645
 msgid "Name"
 msgstr ""
 
@@ -4873,7 +4894,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:632 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1411
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5037,7 +5058,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5057,11 +5078,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5101,11 +5122,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5117,7 +5138,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5135,7 +5156,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5188,7 +5209,7 @@ msgstr ""
 #: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
-#: cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5312,7 +5333,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
 #: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5447,101 +5468,6 @@ msgstr ""
 #: cmd/incus/image.go:1042
 #, c-format
 msgid "Protocol: %s"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2829
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"\tSupported types are custom, image, container and virtual-machine.\n"
-"\n"
-"\tAdd the name of the snapshot if type is one of custom, container or "
-"virtual-machine.\n"
-"\n"
-"\tincus storage volume show default virtual-machine/data/snap0\n"
-"\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
-"called \"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1312
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, container and virtual-machine.\n"
-"\n"
-"incus storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool "
-"\"default\".\n"
-"\n"
-"incus storage volume info default virtual-machine/data\n"
-"    Returns state information for a virtual machine \"data\" in pool "
-"\"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1176
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume get default data size\n"
-"    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2109
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume show default data\n"
-"    Will show the properties of a custom volume called \"data\" in the "
-"\"default\" pool.\n"
-"\n"
-"incus storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:955
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-"    Update a storage volume using the content of pool.yaml."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1949
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume set default data size=1GiB\n"
-"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-"\n"
-"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\" to seven days."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2208
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-"    Removes the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:224
@@ -5808,6 +5734,10 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+msgid "Rename custom storage volumes"
+msgstr ""
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 msgid "Rename instance snapshots"
 msgstr ""
@@ -5840,20 +5770,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-msgid "Rename storage volumes"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -5894,7 +5820,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6289,18 +6215,22 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
 "For backward compatibility, a single configuration key may still be set "
 "with:\n"
 "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
-"<value>"
+"<value>\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:983 cmd/incus/remote.go:984
@@ -6383,7 +6313,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6524,13 +6454,41 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+msgid ""
+"Show storage volume configurations\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2834
+msgid "Show storage volume snapshhot configurations"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2833
+msgid "Show storage volume snapshot configurations"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1313
 msgid "Show storage volume state information"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1314
+msgid ""
+"Show storage volume state information\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
@@ -6595,15 +6553,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -6746,12 +6704,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -6764,7 +6722,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -6824,13 +6782,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 msgid "Taken at"
 msgstr ""
 
@@ -7027,12 +6985,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7080,7 +7038,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7158,7 +7116,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7174,7 +7132,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7238,7 +7196,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432
 #: cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1420
+#: cmd/incus/storage_volume.go:1423
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7260,7 +7218,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7276,7 +7234,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
 
@@ -7315,7 +7273,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7420,8 +7378,17 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 msgid "Unset storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2214
+msgid ""
+"Unset storage volume configuration keys\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/cluster.go:589
@@ -7476,7 +7443,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7521,12 +7488,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7612,7 +7579,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid "Volume Only"
 msgstr ""
 
@@ -7785,7 +7752,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8206,7 +8173,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -8245,15 +8212,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -8261,19 +8228,19 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -8281,32 +8248,32 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308
-#: cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -8898,26 +8865,96 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:578
 msgid ""
-"incus storage volume create p1 v1\n"
+"incus storage volume create default foo\n"
+"    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
+"incus storage volume create default foo < config.yaml\n"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3091
+#: cmd/incus/storage_volume.go:959
+msgid ""
+"incus storage volume edit default container/c1\n"
+"    Edit container storage volume \"c1\" in pool \"default\"\n"
+"\n"
+"incus storage volume edit default foo < volume.yaml\n"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1185
+msgid ""
+"incus storage volume get default data size\n"
+"    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+"\n"
+"incus storage volume get default virtual-machine/data snapshots.expiry\n"
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3089
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
-"\t\tCreate a new custom volume using backup0.tar.gz as the source."
+"    Create a new custom volume using backup0.tar.gz as the source\n"
+"\n"
+"incus storage volume import default some-installer.iso installer --type=iso\n"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2316
+#: cmd/incus/storage_volume.go:1319
 msgid ""
-"incus storage volume snapshot create default v1 snap0\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
 "\n"
-"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with "
-"the configuration from \"config.yaml\"."
+"incus storage volume info default virtual-machine/v1\n"
+"    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1955
+msgid ""
+"incus storage volume set default data size=1GiB\n"
+"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+"\n"
+"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2117
+msgid ""
+"incus storage volume show default foo\n"
+"    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume show default virtual-machine/v1\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume show default container/c1\n"
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2323
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+"\n"
+"incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2219
+msgid ""
+"incus storage volume unset default foo size\n"
+"    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
 msgstr ""
 
 #: cmd/incus/storage.go:547

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-06-11 23:14-0400\n"
+"POT-Creation-Date: 2024-07-08 16:17-0400\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -85,14 +85,15 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
+#, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
 "###\n"
-"### name: vol1\n"
+"### name: foo\n"
 "### type: custom\n"
 "### used_by: []\n"
 "### config:\n"
@@ -992,7 +993,7 @@ msgstr "Aliases:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -1053,19 +1054,20 @@ msgstr "Anexar interfaces de rede aos containers"
 msgid "Attach network interfaces to profiles"
 msgstr "Anexar interfaces de rede aos perfis"
 
+#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
+#, fuzzy
+msgid "Attach new custom storage volumes to instances"
+msgstr "Desconectar volumes de armazenamento dos containers"
+
+#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
+#, fuzzy
+msgid "Attach new custom storage volumes to profiles"
+msgstr "Desconectar volumes de armazenamento dos containers"
+
 #: cmd/incus/network.go:143
 #, fuzzy
 msgid "Attach new network interfaces to instances"
 msgstr "Anexar uma nova interface de rede aos containers"
-
-#: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
-#, fuzzy
-msgid "Attach new storage volumes to instances"
-msgstr "Desconectar volumes de armazenamento dos containers"
-
-#: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid "Attach new storage volumes to profiles"
-msgstr ""
 
 #: cmd/incus/console.go:36
 #, fuzzy
@@ -1127,17 +1129,17 @@ msgstr "Editar arquivos no container"
 msgid "Backing up storage bucket: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396
-#: cmd/incus/storage_volume.go:3072
+#: cmd/incus/storage_volume.go:3070
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1161,7 +1163,7 @@ msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:650
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1209,7 +1211,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1306,7 +1308,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
@@ -1497,15 +1499,15 @@ msgstr "Dispositivo %s removido de %s"
 #: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
 #: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324
-#: cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838
-#: cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670
+#: cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836
+#: cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1516,7 +1518,7 @@ msgstr "Clustering ativado"
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072
 #: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687
-#: cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547
 #: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1585,7 +1587,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
 #: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -1603,11 +1605,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1624,6 +1626,11 @@ msgstr ""
 #: cmd/incus/image.go:155
 msgid "Copy aliases from source"
 msgstr "Aliases de cópia da fonte"
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#, fuzzy
+msgid "Copy custom storage volumes"
+msgstr "Criar novas redes"
 
 #: cmd/incus/image.go:147
 msgid "Copy images between servers"
@@ -1665,10 +1672,6 @@ msgstr ""
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid "Copy profiles"
 msgstr "Copiar perfis"
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-msgid "Copy storage volumes"
-msgstr ""
 
 #: cmd/incus/copy.go:57
 msgid "Copy the instance without its snapshots"
@@ -1892,7 +1895,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:657
-#: cmd/incus/storage_volume.go:1440
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1930,7 +1933,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1669
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1969,7 +1972,7 @@ msgstr "Criado: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1989,6 +1992,11 @@ msgstr ""
 #: cmd/incus/warning.go:361
 #, fuzzy
 msgid "Delete all warnings"
+msgstr "Apagar nomes alternativos da imagem"
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#, fuzzy
+msgid "Delete custom storage volumes"
 msgstr "Apagar nomes alternativos da imagem"
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
@@ -2080,14 +2088,10 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Apagar nomes alternativos da imagem"
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-msgid "Delete storage volumes"
-msgstr ""
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
 msgid "Delete warning"
@@ -2228,32 +2232,42 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953
-#: cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310
-#: cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556
-#: cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864
-#: cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265
-#: cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447
-#: cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542
-#: cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747
-#: cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923
-#: cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272
+#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454
+#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754
+#: cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#, fuzzy
+msgid "Detach custom storage volumes from instances"
+msgstr "Desconectar volumes de armazenamento dos containers"
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#, fuzzy
+msgid "Detach custom storage volumes from profiles"
+msgstr "Desconectar volumes de armazenamento dos perfis"
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
 #, fuzzy
@@ -2263,15 +2277,6 @@ msgstr "Desconectar interfaces de rede dos containers"
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-#, fuzzy
-msgid "Detach storage volumes from instances"
-msgstr "Desconectar volumes de armazenamento dos containers"
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid "Detach storage volumes from profiles"
-msgstr "Desconectar volumes de armazenamento dos perfis"
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
 #, fuzzy, c-format
@@ -2576,8 +2581,17 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid "Edit storage volume configurations as YAML"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:954
+msgid ""
+"Edit storage volume configurations as YAML\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
@@ -2588,7 +2602,7 @@ msgstr "Editar configurações de perfil como YAML"
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722
-#: cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2659,8 +2673,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163
 #: cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2681,8 +2695,8 @@ msgstr "Editar propriedades da imagem"
 #: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077
 #: cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2072
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2764,8 +2778,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:2640
+#: cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/storage_volume.go:2647
 msgid "Expires at"
 msgstr ""
 
@@ -2789,7 +2803,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2811,7 +2825,7 @@ msgstr "Apagar projetos"
 msgid "Export storage buckets as tarball."
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2820,7 +2834,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Criar novas redes"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -3036,7 +3050,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Aceitar certificado"
@@ -3051,7 +3065,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Aceitar certificado"
@@ -3276,8 +3290,8 @@ msgstr ""
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572
-#: cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3411,7 +3425,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -3493,8 +3507,20 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1178
+msgid ""
+"Get values for storage volume configuration keys\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
 msgstr ""
 
 #: cmd/incus/storage_volume.go:440
@@ -3601,7 +3627,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3615,7 +3641,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3667,10 +3693,6 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: cmd/incus/storage_volume.go:3089
-msgid "Import backups of custom volumes including their snapshots."
-msgstr ""
-
 #: cmd/incus/import.go:27
 msgid "Import backups of instances including their snapshots."
 msgstr ""
@@ -3680,9 +3702,14 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 msgid "Import custom storage volumes"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:3087
+#, fuzzy
+msgid "Import custom storage volumes."
+msgstr "Criar novas redes"
 
 #: cmd/incus/image.go:685
 msgid ""
@@ -3794,7 +3821,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Editar arquivos no container"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3021
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Editar arquivos no container"
@@ -3815,7 +3842,7 @@ msgid "Invalid arguments"
 msgstr "Editar arquivos no container"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3026
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3917,9 +3944,9 @@ msgstr "Editar arquivos no container"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238
-#: cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2881
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -3981,7 +4008,7 @@ msgstr ""
 #: cmd/incus/list.go:616 cmd/incus/network.go:1303
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
-#: cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4391,12 +4418,12 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4414,11 +4441,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4504,7 +4531,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4793,7 +4820,7 @@ msgstr "Criar novas redes"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Criar novas redes"
@@ -5044,15 +5071,15 @@ msgstr "Nome de membro do cluster"
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
 #: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614
-#: cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798
-#: cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010
-#: cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603
-#: cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995
-#: cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372
-#: cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592
-#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379
+#: cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2871
 msgid "Missing pool name"
 msgstr ""
 
@@ -5077,11 +5104,11 @@ msgstr "Nome de membro do cluster"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
@@ -5122,7 +5149,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5134,6 +5161,11 @@ msgstr ""
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#, fuzzy
+msgid "Move custom storage volumes between pools"
+msgstr "Desconectar volumes de armazenamento dos containers"
 
 #: cmd/incus/move.go:34
 #, fuzzy
@@ -5156,15 +5188,11 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-msgid "Move storage volumes between pools"
-msgstr ""
-
 #: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5197,7 +5225,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5253,8 +5281,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2638
+#: cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:2645
 msgid "Name"
 msgstr ""
 
@@ -5315,7 +5343,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:632 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1411
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5479,7 +5507,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5499,11 +5527,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5543,11 +5571,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5559,7 +5587,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5577,7 +5605,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5632,7 +5660,7 @@ msgstr ""
 #: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
-#: cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5757,7 +5785,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
 #: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5897,101 +5925,6 @@ msgstr ""
 #: cmd/incus/image.go:1042
 #, c-format
 msgid "Protocol: %s"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2829
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"\tSupported types are custom, image, container and virtual-machine.\n"
-"\n"
-"\tAdd the name of the snapshot if type is one of custom, container or "
-"virtual-machine.\n"
-"\n"
-"\tincus storage volume show default virtual-machine/data/snap0\n"
-"\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
-"called \"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1312
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, container and virtual-machine.\n"
-"\n"
-"incus storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool "
-"\"default\".\n"
-"\n"
-"incus storage volume info default virtual-machine/data\n"
-"    Returns state information for a virtual machine \"data\" in pool "
-"\"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1176
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume get default data size\n"
-"    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2109
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume show default data\n"
-"    Will show the properties of a custom volume called \"data\" in the "
-"\"default\" pool.\n"
-"\n"
-"incus storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:955
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-"    Update a storage volume using the content of pool.yaml."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1949
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume set default data size=1GiB\n"
-"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-"\n"
-"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\" to seven days."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2208
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-"    Removes the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:224
@@ -6273,6 +6206,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#, fuzzy
+msgid "Rename custom storage volumes"
+msgstr "Desconectar volumes de armazenamento dos containers"
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 #, fuzzy
 msgid "Rename instance snapshots"
@@ -6309,21 +6247,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-msgid "Rename storage volumes"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -6372,7 +6306,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6785,18 +6719,22 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
 "For backward compatibility, a single configuration key may still be set "
 "with:\n"
 "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
-"<value>"
+"<value>\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:983 cmd/incus/remote.go:984
@@ -6886,7 +6824,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -7046,15 +6984,45 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+msgid ""
+"Show storage volume configurations\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2834
+#, fuzzy
+msgid "Show storage volume snapshhot configurations"
+msgstr "Editar configurações do container ou do servidor como YAML"
+
+#: cmd/incus/storage_volume.go:2833
+#, fuzzy
+msgid "Show storage volume snapshot configurations"
+msgstr "Editar configurações do container ou do servidor como YAML"
+
+#: cmd/incus/storage_volume.go:1313
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
+
+#: cmd/incus/storage_volume.go:1314
+msgid ""
+"Show storage volume state information\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr ""
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
 msgid "Show the default remote"
@@ -7122,15 +7090,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7274,12 +7242,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7292,7 +7260,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -7353,13 +7321,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 msgid "Taken at"
 msgstr ""
 
@@ -7557,12 +7525,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7610,7 +7578,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7689,7 +7657,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7705,7 +7673,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7770,7 +7738,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432
 #: cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1420
+#: cmd/incus/storage_volume.go:1423
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7792,7 +7760,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7810,7 +7778,7 @@ msgstr "Editar arquivos no container"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
 
@@ -7851,7 +7819,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7973,8 +7941,17 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 msgid "Unset storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2214
+msgid ""
+"Unset storage volume configuration keys\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/cluster.go:589
@@ -8037,7 +8014,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8084,12 +8061,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8176,7 +8153,7 @@ msgstr "Versão CUDA: %v"
 msgid "Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid "Volume Only"
 msgstr ""
 
@@ -8350,7 +8327,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8822,7 +8799,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -8867,17 +8844,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -8886,21 +8863,21 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -8908,38 +8885,38 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308
-#: cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
@@ -9544,26 +9521,96 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:578
 msgid ""
-"incus storage volume create p1 v1\n"
+"incus storage volume create default foo\n"
+"    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
+"incus storage volume create default foo < config.yaml\n"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3091
+#: cmd/incus/storage_volume.go:959
+msgid ""
+"incus storage volume edit default container/c1\n"
+"    Edit container storage volume \"c1\" in pool \"default\"\n"
+"\n"
+"incus storage volume edit default foo < volume.yaml\n"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1185
+msgid ""
+"incus storage volume get default data size\n"
+"    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+"\n"
+"incus storage volume get default virtual-machine/data snapshots.expiry\n"
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3089
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
-"\t\tCreate a new custom volume using backup0.tar.gz as the source."
+"    Create a new custom volume using backup0.tar.gz as the source\n"
+"\n"
+"incus storage volume import default some-installer.iso installer --type=iso\n"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2316
+#: cmd/incus/storage_volume.go:1319
 msgid ""
-"incus storage volume snapshot create default v1 snap0\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
 "\n"
-"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with "
-"the configuration from \"config.yaml\"."
+"incus storage volume info default virtual-machine/v1\n"
+"    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1955
+msgid ""
+"incus storage volume set default data size=1GiB\n"
+"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+"\n"
+"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2117
+msgid ""
+"incus storage volume show default foo\n"
+"    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume show default virtual-machine/v1\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume show default container/c1\n"
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2323
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+"\n"
+"incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2219
+msgid ""
+"incus storage volume unset default foo size\n"
+"    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
 msgstr ""
 
 #: cmd/incus/storage.go:547

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-06-11 23:14-0400\n"
+"POT-Creation-Date: 2024-07-08 16:17-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -90,7 +90,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -98,7 +98,7 @@ msgid ""
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
 "###\n"
-"### name: vol1\n"
+"### name: foo\n"
 "### type: custom\n"
 "### used_by: []\n"
 "### config:\n"
@@ -1011,7 +1011,7 @@ msgstr "Псевдонимы:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -1070,17 +1070,18 @@ msgstr ""
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/network.go:143
-msgid "Attach new network interfaces to instances"
-msgstr ""
-
 #: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
 #, fuzzy
-msgid "Attach new storage volumes to instances"
+msgid "Attach new custom storage volumes to instances"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid "Attach new storage volumes to profiles"
+#, fuzzy
+msgid "Attach new custom storage volumes to profiles"
+msgstr "Копирование образа: %s"
+
+#: cmd/incus/network.go:143
+msgid "Attach new network interfaces to instances"
 msgstr ""
 
 #: cmd/incus/console.go:36
@@ -1142,17 +1143,17 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Backing up storage bucket: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396
-#: cmd/incus/storage_volume.go:3072
+#: cmd/incus/storage_volume.go:3070
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1176,7 +1177,7 @@ msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:650
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1224,7 +1225,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1320,7 +1321,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1511,15 +1512,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
 #: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324
-#: cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838
-#: cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670
+#: cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836
+#: cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid "Cluster member name"
 msgstr ""
 
@@ -1530,7 +1531,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072
 #: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687
-#: cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547
 #: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1587,7 +1588,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
 #: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1605,11 +1606,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1626,6 +1627,11 @@ msgstr ""
 #: cmd/incus/image.go:155
 msgid "Copy aliases from source"
 msgstr "Копировать псевдонимы из источника"
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#, fuzzy
+msgid "Copy custom storage volumes"
+msgstr "Копирование образа: %s"
 
 #: cmd/incus/image.go:147
 msgid "Copy images between servers"
@@ -1666,11 +1672,6 @@ msgstr ""
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid "Copy profiles"
 msgstr ""
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-#, fuzzy
-msgid "Copy storage volumes"
-msgstr "Копирование образа: %s"
 
 #: cmd/incus/copy.go:57
 msgid "Copy the instance without its snapshots"
@@ -1894,7 +1895,7 @@ msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:657
-#: cmd/incus/storage_volume.go:1440
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1932,7 +1933,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1669
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1971,7 +1972,7 @@ msgstr "Авто-обновление: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1990,6 +1991,11 @@ msgstr ""
 #: cmd/incus/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#, fuzzy
+msgid "Delete custom storage volumes"
+msgstr "Копирование образа: %s"
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
 #, fuzzy
@@ -2078,14 +2084,9 @@ msgstr "Копирование образа: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 #, fuzzy
 msgid "Delete storage volume snapshots"
-msgstr "Копирование образа: %s"
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-#, fuzzy
-msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
@@ -2227,31 +2228,41 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953
-#: cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310
-#: cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556
-#: cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864
-#: cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265
-#: cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447
-#: cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542
-#: cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747
-#: cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923
-#: cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272
+#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454
+#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754
+#: cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 #, fuzzy
 msgid "Destination cluster member name"
+msgstr "Копирование образа: %s"
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#, fuzzy
+msgid "Detach custom storage volumes from instances"
+msgstr "Копирование образа: %s"
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#, fuzzy
+msgid "Detach custom storage volumes from profiles"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
@@ -2260,15 +2271,6 @@ msgstr ""
 
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid "Detach network interfaces from profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-#, fuzzy
-msgid "Detach storage volumes from instances"
-msgstr "Копирование образа: %s"
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid "Detach storage volumes from profiles"
 msgstr ""
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
@@ -2568,8 +2570,17 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid "Edit storage volume configurations as YAML"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:954
+msgid ""
+"Edit storage volume configurations as YAML\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
@@ -2579,7 +2590,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722
-#: cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2650,8 +2661,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163
 #: cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2672,8 +2683,8 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077
 #: cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2072
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2758,8 +2769,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:2640
+#: cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/storage_volume.go:2647
 msgid "Expires at"
 msgstr ""
 
@@ -2784,7 +2795,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2809,7 +2820,7 @@ msgstr "Копирование образа: %s"
 msgid "Export storage buckets as tarball."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
@@ -2819,7 +2830,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -3035,7 +3046,7 @@ msgstr "Принять сертификат"
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Принять сертификат"
@@ -3050,7 +3061,7 @@ msgstr "Принять сертификат"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Принять сертификат"
@@ -3275,8 +3286,8 @@ msgstr ""
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572
-#: cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3410,7 +3421,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -3488,8 +3499,20 @@ msgstr "Копирование образа: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1178
+msgid ""
+"Get values for storage volume configuration keys\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
 msgstr ""
 
 #: cmd/incus/storage_volume.go:440
@@ -3597,7 +3620,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3611,7 +3634,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3662,10 +3685,6 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3089
-msgid "Import backups of custom volumes including their snapshots."
-msgstr ""
-
 #: cmd/incus/import.go:27
 msgid "Import backups of instances including their snapshots."
 msgstr ""
@@ -3675,9 +3694,14 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 #, fuzzy
 msgid "Import custom storage volumes"
+msgstr "Копирование образа: %s"
+
+#: cmd/incus/storage_volume.go:3087
+#, fuzzy
+msgid "Import custom storage volumes."
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/image.go:685
@@ -3793,7 +3817,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Имя контейнера: %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3021
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Имя контейнера: %s"
@@ -3814,7 +3838,7 @@ msgid "Invalid arguments"
 msgstr "Имя контейнера: %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3026
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3916,9 +3940,9 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238
-#: cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2881
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -3980,7 +4004,7 @@ msgstr ""
 #: cmd/incus/list.go:616 cmd/incus/network.go:1303
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
-#: cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4395,12 +4419,12 @@ msgstr "Копирование образа: %s"
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4418,12 +4442,12 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4510,7 +4534,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4800,7 +4824,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage storage pools and volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -5053,15 +5077,15 @@ msgstr "Имя контейнера: %s"
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
 #: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614
-#: cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798
-#: cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010
-#: cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603
-#: cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995
-#: cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372
-#: cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592
-#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379
+#: cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2871
 msgid "Missing pool name"
 msgstr ""
 
@@ -5087,12 +5111,12 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
@@ -5132,7 +5156,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5144,6 +5168,11 @@ msgstr ""
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#, fuzzy
+msgid "Move custom storage volumes between pools"
+msgstr "Копирование образа: %s"
 
 #: cmd/incus/move.go:34
 msgid "Move instances within or in between servers"
@@ -5165,16 +5194,11 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-#, fuzzy
-msgid "Move storage volumes between pools"
-msgstr "Копирование образа: %s"
-
 #: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -5207,7 +5231,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5263,8 +5287,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2638
+#: cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:2645
 msgid "Name"
 msgstr ""
 
@@ -5329,7 +5353,7 @@ msgid "Name of the storage pool:"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/info.go:632 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1411
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5495,7 +5519,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
@@ -5516,11 +5540,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5560,11 +5584,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5576,7 +5600,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5594,7 +5618,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5649,7 +5673,7 @@ msgstr ""
 #: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
-#: cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5774,7 +5798,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
 #: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5910,101 +5934,6 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Protocol: %s"
 msgstr "Авто-обновление: %s"
-
-#: cmd/incus/storage_volume.go:2829
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"\tSupported types are custom, image, container and virtual-machine.\n"
-"\n"
-"\tAdd the name of the snapshot if type is one of custom, container or "
-"virtual-machine.\n"
-"\n"
-"\tincus storage volume show default virtual-machine/data/snap0\n"
-"\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
-"called \"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1312
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, container and virtual-machine.\n"
-"\n"
-"incus storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool "
-"\"default\".\n"
-"\n"
-"incus storage volume info default virtual-machine/data\n"
-"    Returns state information for a virtual machine \"data\" in pool "
-"\"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1176
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume get default data size\n"
-"    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2109
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume show default data\n"
-"    Will show the properties of a custom volume called \"data\" in the "
-"\"default\" pool.\n"
-"\n"
-"incus storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:955
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-"    Update a storage volume using the content of pool.yaml."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1949
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume set default data size=1GiB\n"
-"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-"\n"
-"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\" to seven days."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2208
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-"    Removes the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
 
 #: cmd/incus/config_trust.go:224
 #, fuzzy, c-format
@@ -6281,6 +6210,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#, fuzzy
+msgid "Rename custom storage volumes"
+msgstr "Копирование образа: %s"
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 #, fuzzy
 msgid "Rename instance snapshots"
@@ -6316,22 +6250,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-#, fuzzy
-msgid "Rename storage volumes"
-msgstr "Копирование образа: %s"
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Копирование образа: %s"
@@ -6375,7 +6304,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -6784,18 +6713,22 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
 "For backward compatibility, a single configuration key may still be set "
 "with:\n"
 "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
-"<value>"
+"<value>\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:983 cmd/incus/remote.go:984
@@ -6886,7 +6819,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -7042,15 +6975,45 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+msgid ""
+"Show storage volume configurations\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2834
+#, fuzzy
+msgid "Show storage volume snapshhot configurations"
+msgstr "Копирование образа: %s"
+
+#: cmd/incus/storage_volume.go:2833
+#, fuzzy
+msgid "Show storage volume snapshot configurations"
+msgstr "Копирование образа: %s"
+
+#: cmd/incus/storage_volume.go:1313
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
+
+#: cmd/incus/storage_volume.go:1314
+msgid ""
+"Show storage volume state information\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
+msgstr ""
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
 msgid "Show the default remote"
@@ -7118,16 +7081,16 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7274,12 +7237,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -7292,7 +7255,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Копирование образа: %s"
@@ -7353,13 +7316,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 msgid "Taken at"
 msgstr ""
 
@@ -7556,12 +7519,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7609,7 +7572,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7688,7 +7651,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -7704,7 +7667,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7769,7 +7732,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432
 #: cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1420
+#: cmd/incus/storage_volume.go:1423
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7791,7 +7754,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7809,7 +7772,7 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
 
@@ -7849,7 +7812,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7965,8 +7928,17 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 msgid "Unset storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2214
+msgid ""
+"Unset storage volume configuration keys\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/cluster.go:589
@@ -8030,7 +8002,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -8078,12 +8050,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8170,7 +8142,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid "Volume Only"
 msgstr ""
 
@@ -8344,7 +8316,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -9145,7 +9117,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -9220,7 +9192,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -9228,7 +9200,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -9236,7 +9208,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -9252,7 +9224,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -9260,7 +9232,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -9268,7 +9240,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -9276,7 +9248,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -9292,7 +9264,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -9300,7 +9272,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -9308,8 +9280,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308
-#: cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -9317,7 +9289,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -9325,7 +9297,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -9333,7 +9305,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -9341,7 +9313,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10049,26 +10021,96 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:578
 msgid ""
-"incus storage volume create p1 v1\n"
+"incus storage volume create default foo\n"
+"    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
+"incus storage volume create default foo < config.yaml\n"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3091
+#: cmd/incus/storage_volume.go:959
+msgid ""
+"incus storage volume edit default container/c1\n"
+"    Edit container storage volume \"c1\" in pool \"default\"\n"
+"\n"
+"incus storage volume edit default foo < volume.yaml\n"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1185
+msgid ""
+"incus storage volume get default data size\n"
+"    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+"\n"
+"incus storage volume get default virtual-machine/data snapshots.expiry\n"
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3089
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
-"\t\tCreate a new custom volume using backup0.tar.gz as the source."
+"    Create a new custom volume using backup0.tar.gz as the source\n"
+"\n"
+"incus storage volume import default some-installer.iso installer --type=iso\n"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2316
+#: cmd/incus/storage_volume.go:1319
 msgid ""
-"incus storage volume snapshot create default v1 snap0\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
 "\n"
-"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with "
-"the configuration from \"config.yaml\"."
+"incus storage volume info default virtual-machine/v1\n"
+"    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1955
+msgid ""
+"incus storage volume set default data size=1GiB\n"
+"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+"\n"
+"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2117
+msgid ""
+"incus storage volume show default foo\n"
+"    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume show default virtual-machine/v1\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume show default container/c1\n"
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2323
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+"\n"
+"incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2219
+msgid ""
+"incus storage volume unset default foo size\n"
+"    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
 msgstr ""
 
 #: cmd/incus/storage.go:547
@@ -10134,6 +10176,10 @@ msgstr ""
 #: cmd/incus/image.go:1184 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "да"
+
+#, fuzzy
+#~ msgid "Copy storage volumes"
+#~ msgstr "Копирование образа: %s"
 
 #, fuzzy, c-format
 #~ msgid "Usb %d:"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-06-11 23:14-0400\n"
+"POT-Creation-Date: 2024-07-08 16:17-0400\n"
 "PO-Revision-Date: 2024-06-26 04:09+0000\n"
 "Last-Translator: Meng Zhuo <mengzhuo1203@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -83,14 +83,15 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:981
+#: cmd/incus/storage_volume.go:985
+#, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
 "###\n"
-"### name: vol1\n"
+"### name: foo\n"
 "### type: custom\n"
 "### used_by: []\n"
 "### config:\n"
@@ -919,7 +920,7 @@ msgstr ""
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1555 cmd/incus/storage_volume.go:2541
+#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2548
 msgid "All projects"
 msgstr ""
 
@@ -975,16 +976,16 @@ msgstr ""
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: cmd/incus/network.go:143
-msgid "Attach new network interfaces to instances"
-msgstr ""
-
 #: cmd/incus/storage_volume.go:162 cmd/incus/storage_volume.go:163
-msgid "Attach new storage volumes to instances"
+msgid "Attach new custom storage volumes to instances"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:253 cmd/incus/storage_volume.go:254
-msgid "Attach new storage volumes to profiles"
+msgid "Attach new custom storage volumes to profiles"
+msgstr ""
+
+#: cmd/incus/network.go:143
+msgid "Attach new network interfaces to instances"
 msgstr ""
 
 #: cmd/incus/console.go:36
@@ -1045,17 +1046,17 @@ msgstr ""
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2995
+#: cmd/incus/storage_volume.go:2993
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1396
-#: cmd/incus/storage_volume.go:3072
+#: cmd/incus/storage_volume.go:3070
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1486
+#: cmd/incus/info.go:827 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1079,7 +1080,7 @@ msgid "Bad key=value pair: %q"
 msgstr ""
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:650
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1127,7 +1128,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1670
+#: cmd/incus/storage_volume.go:1673
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1220,7 +1221,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1680
+#: cmd/incus/list.go:620 cmd/incus/storage_volume.go:1683
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1410,15 +1411,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
 #: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
 #: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:583
-#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:962
-#: cmd/incus/storage_volume.go:1188 cmd/incus/storage_volume.go:1322
-#: cmd/incus/storage_volume.go:1775 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1959 cmd/incus/storage_volume.go:2121
-#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2324
-#: cmd/incus/storage_volume.go:2450 cmd/incus/storage_volume.go:2663
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2838
-#: cmd/incus/storage_volume.go:2930 cmd/incus/storage_volume.go:3094
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2225 cmd/incus/storage_volume.go:2331
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2670
+#: cmd/incus/storage_volume.go:2756 cmd/incus/storage_volume.go:2836
+#: cmd/incus/storage_volume.go:2928 cmd/incus/storage_volume.go:3094
 msgid "Cluster member name"
 msgstr ""
 
@@ -1429,7 +1430,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/config_trust.go:421
 #: cmd/incus/image.go:1099 cmd/incus/list.go:133 cmd/incus/network.go:1072
 #: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/storage.go:687
-#: cmd/incus/storage_volume.go:1554 cmd/incus/storage_volume.go:2540
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2547
 #: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1486,7 +1487,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
 #: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
-#: cmd/incus/storage_volume.go:1107 cmd/incus/storage_volume.go:1139
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1504,11 +1505,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:585
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1426
+#: cmd/incus/storage_volume.go:1429
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1524,6 +1525,10 @@ msgstr ""
 
 #: cmd/incus/image.go:155
 msgid "Copy aliases from source"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+msgid "Copy custom storage volumes"
 msgstr ""
 
 #: cmd/incus/image.go:147
@@ -1564,10 +1569,6 @@ msgstr ""
 
 #: cmd/incus/profile.go:274 cmd/incus/profile.go:275
 msgid "Copy profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
-msgid "Copy storage volumes"
 msgstr ""
 
 #: cmd/incus/copy.go:57
@@ -1774,7 +1775,7 @@ msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:1005 cmd/incus/info.go:657
-#: cmd/incus/storage_volume.go:1440
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1811,7 +1812,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
 #: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1669
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1850,7 +1851,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2929
+#: cmd/incus/storage_bucket.go:1267 cmd/incus/storage_volume.go:2927
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1868,6 +1869,10 @@ msgstr ""
 
 #: cmd/incus/warning.go:361
 msgid "Delete all warnings"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+msgid "Delete custom storage volumes"
 msgstr ""
 
 #: cmd/incus/file.go:309 cmd/incus/file.go:310
@@ -1947,12 +1952,8 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2446 cmd/incus/storage_volume.go:2447
+#: cmd/incus/storage_volume.go:2453 cmd/incus/storage_volume.go:2454
 msgid "Delete storage volume snapshots"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:684 cmd/incus/storage_volume.go:685
-msgid "Delete storage volumes"
 msgstr ""
 
 #: cmd/incus/warning.go:357 cmd/incus/warning.go:358
@@ -2094,30 +2095,38 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
 #: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:758
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:953
-#: cmd/incus/storage_volume.go:1174 cmd/incus/storage_volume.go:1310
-#: cmd/incus/storage_volume.go:1472 cmd/incus/storage_volume.go:1556
-#: cmd/incus/storage_volume.go:1771 cmd/incus/storage_volume.go:1864
-#: cmd/incus/storage_volume.go:1944 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2206 cmd/incus/storage_volume.go:2265
-#: cmd/incus/storage_volume.go:2314 cmd/incus/storage_volume.go:2447
-#: cmd/incus/storage_volume.go:2536 cmd/incus/storage_volume.go:2542
-#: cmd/incus/storage_volume.go:2660 cmd/incus/storage_volume.go:2747
-#: cmd/incus/storage_volume.go:2827 cmd/incus/storage_volume.go:2923
-#: cmd/incus/storage_volume.go:3089 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2214 cmd/incus/storage_volume.go:2272
+#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2454
+#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2754
+#: cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:3087 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1413
+#: cmd/incus/storage_volume.go:1416
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1776
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
 msgid "Destination cluster member name"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+msgid "Detach custom storage volumes from instances"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
 #: cmd/incus/network.go:505 cmd/incus/network.go:506
@@ -2126,14 +2135,6 @@ msgstr ""
 
 #: cmd/incus/network.go:602 cmd/incus/network.go:603
 msgid "Detach network interfaces from profiles"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:757 cmd/incus/storage_volume.go:758
-msgid "Detach storage volumes from instances"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:855 cmd/incus/storage_volume.go:856
-msgid "Detach storage volumes from profiles"
 msgstr ""
 
 #: cmd/incus/info.go:585 cmd/incus/info.go:597
@@ -2416,8 +2417,17 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:953
 msgid "Edit storage volume configurations as YAML"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:954
+msgid ""
+"Edit storage volume configurations as YAML\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
@@ -2427,7 +2437,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/config_trust.go:447
 #: cmd/incus/image.go:1139 cmd/incus/list.go:632 cmd/incus/network.go:1113
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/storage.go:722
-#: cmd/incus/storage_volume.go:1697 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2498,8 +2508,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553
 #: cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163
 #: cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2035
-#: cmd/incus/storage_volume.go:2078
+#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2520,8 +2530,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469
 #: cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077
 #: cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2029
-#: cmd/incus/storage_volume.go:2072
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2602,8 +2612,8 @@ msgid "Expected a struct, got a %v"
 msgstr ""
 
 #: cmd/incus/info.go:813 cmd/incus/info.go:864 cmd/incus/snapshot.go:366
-#: cmd/incus/storage_volume.go:1473 cmd/incus/storage_volume.go:1523
-#: cmd/incus/storage_volume.go:2640
+#: cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/storage_volume.go:2647
 msgid "Expires at"
 msgstr ""
 
@@ -2627,7 +2637,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2920 cmd/incus/storage_volume.go:2921
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2647,7 +2657,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2926
+#: cmd/incus/storage_volume.go:2924
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2656,7 +2666,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3055
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3053
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2872,7 +2882,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2990
+#: cmd/incus/storage_volume.go:2988
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2887,7 +2897,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3069
+#: cmd/incus/storage_volume.go:3067
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3111,8 +3121,8 @@ msgstr ""
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:716 cmd/incus/snapshot.go:291
 #: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1572
-#: cmd/incus/storage_volume.go:2557 cmd/incus/warning.go:94
+#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3237,7 +3247,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1189
+#: cmd/incus/storage_volume.go:1193
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3306,8 +3316,20 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1173 cmd/incus/storage_volume.go:1174
+#: cmd/incus/storage_volume.go:1177
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1178
+msgid ""
+"Get values for storage volume configuration keys\n"
+"\n"
+"If the type is not specified, incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
 msgstr ""
 
 #: cmd/incus/storage_volume.go:440
@@ -3414,7 +3436,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2323
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2330
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3428,7 +3450,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2329
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3478,10 +3500,6 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3089
-msgid "Import backups of custom volumes including their snapshots."
-msgstr ""
-
 #: cmd/incus/import.go:27
 msgid "Import backups of instances including their snapshots."
 msgstr ""
@@ -3490,8 +3508,12 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3086
 msgid "Import custom storage volumes"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3087
+msgid "Import custom storage volumes."
 msgstr ""
 
 #: cmd/incus/image.go:685
@@ -3601,7 +3623,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1347
-#: cmd/incus/storage_volume.go:3023
+#: cmd/incus/storage_volume.go:3021
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3621,7 +3643,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1352
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3026
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3722,9 +3744,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1021 cmd/incus/storage_volume.go:1238
-#: cmd/incus/storage_volume.go:1367 cmd/incus/storage_volume.go:2012
-#: cmd/incus/storage_volume.go:2883
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2881
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3783,7 +3805,7 @@ msgstr ""
 #: cmd/incus/list.go:616 cmd/incus/network.go:1303
 #: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
-#: cmd/incus/storage_volume.go:1676 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4180,11 +4202,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2535 cmd/incus/storage_volume.go:2536
+#: cmd/incus/storage_volume.go:2542 cmd/incus/storage_volume.go:2543
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:2549
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4202,11 +4224,11 @@ msgid ""
 "\t\tu - Number of references (used by)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1551
+#: cmd/incus/storage_volume.go:1554
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1556
+#: cmd/incus/storage_volume.go:1559
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4292,7 +4314,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1429
+#: cmd/incus/info.go:649 cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4557,7 +4579,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2264 cmd/incus/storage_volume.go:2265
+#: cmd/incus/storage_volume.go:2271 cmd/incus/storage_volume.go:2272
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -4794,15 +4816,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
 #: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:614
-#: cmd/incus/storage_volume.go:721 cmd/incus/storage_volume.go:798
-#: cmd/incus/storage_volume.go:896 cmd/incus/storage_volume.go:1010
-#: cmd/incus/storage_volume.go:1227 cmd/incus/storage_volume.go:1603
-#: cmd/incus/storage_volume.go:1901 cmd/incus/storage_volume.go:1995
-#: cmd/incus/storage_volume.go:2155 cmd/incus/storage_volume.go:2372
-#: cmd/incus/storage_volume.go:2487 cmd/incus/storage_volume.go:2592
-#: cmd/incus/storage_volume.go:2702 cmd/incus/storage_volume.go:2787
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2379
+#: cmd/incus/storage_volume.go:2494 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2871
 msgid "Missing pool name"
 msgstr ""
 
@@ -4826,11 +4848,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1811
+#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1356
+#: cmd/incus/storage_volume.go:1359
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4868,7 +4890,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:818 cmd/incus/storage_volume.go:915
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4878,6 +4900,10 @@ msgstr ""
 
 #: cmd/incus/file.go:1152 cmd/incus/file.go:1153
 msgid "Mount files from instances"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+msgid "Move custom storage volumes between pools"
 msgstr ""
 
 #: cmd/incus/move.go:34
@@ -4900,15 +4926,11 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1770 cmd/incus/storage_volume.go:1771
-msgid "Move storage volumes between pools"
-msgstr ""
-
 #: cmd/incus/move.go:60
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Move to a project different from the source"
 msgstr ""
 
@@ -4941,7 +4963,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:773
 #: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1668
+#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -4997,8 +5019,8 @@ msgid "NVRM Version: %v"
 msgstr ""
 
 #: cmd/incus/info.go:811 cmd/incus/info.go:862 cmd/incus/snapshot.go:364
-#: cmd/incus/storage_volume.go:1471 cmd/incus/storage_volume.go:1521
-#: cmd/incus/storage_volume.go:2638
+#: cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:2645
 msgid "Name"
 msgstr ""
 
@@ -5059,7 +5081,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:632 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1411
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5223,7 +5245,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:827 cmd/incus/storage_volume.go:924
+#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5243,11 +5265,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1820
+#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1831
+#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5287,11 +5309,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2977
+#: cmd/incus/storage_volume.go:2975
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2385
+#: cmd/incus/storage_volume.go:2392
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5303,7 +5325,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1374
+#: cmd/incus/storage_volume.go:1377
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5321,7 +5343,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:866 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5374,7 +5396,7 @@ msgstr ""
 #: cmd/incus/image.go:1122 cmd/incus/list.go:576 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
-#: cmd/incus/storage_volume.go:1687 cmd/incus/top.go:341
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:341
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5498,7 +5520,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
 #: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1108 cmd/incus/storage_volume.go:1140
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5633,101 +5655,6 @@ msgstr ""
 #: cmd/incus/image.go:1042
 #, c-format
 msgid "Protocol: %s"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2829
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"\tSupported types are custom, image, container and virtual-machine.\n"
-"\n"
-"\tAdd the name of the snapshot if type is one of custom, container or "
-"virtual-machine.\n"
-"\n"
-"\tincus storage volume show default virtual-machine/data/snap0\n"
-"\t\tWill show the properties of snapshot \"snap0\" for a virtual machine "
-"called \"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1312
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, container and virtual-machine.\n"
-"\n"
-"incus storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool "
-"\"default\".\n"
-"\n"
-"incus storage volume info default virtual-machine/data\n"
-"    Returns state information for a virtual machine \"data\" in pool "
-"\"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1176
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume get default data size\n"
-"    Returns the size of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2109
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"Add the name of the snapshot if type is one of custom, container or virtual-"
-"machine.\n"
-"\n"
-"incus storage volume show default data\n"
-"    Will show the properties of a custom volume called \"data\" in the "
-"\"default\" pool.\n"
-"\n"
-"incus storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:955
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml\n"
-"    Update a storage volume using the content of pool.yaml."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1949
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume set default data size=1GiB\n"
-"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB.\n"
-"\n"
-"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\" to seven days."
-msgstr ""
-
-#: cmd/incus/storage_volume.go:2208
-msgid ""
-"Provide the type of the storage volume if it is not custom.\n"
-"Supported types are custom, image, container and virtual-machine.\n"
-"\n"
-"incus storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
-"\n"
-"incus storage volume unset default virtual-machine/data snapshots.expiry\n"
-"    Removes the snapshot expiration period for a virtual machine \"data\" in "
-"pool \"default\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:224
@@ -5994,6 +5921,10 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
+#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+msgid "Rename custom storage volumes"
+msgstr ""
+
 #: cmd/incus/snapshot.go:384 cmd/incus/snapshot.go:385
 msgid "Rename instance snapshots"
 msgstr ""
@@ -6026,20 +5957,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2659 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:2666 cmd/incus/storage_volume.go:2667
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1863 cmd/incus/storage_volume.go:1864
-msgid "Rename storage volumes"
-msgstr ""
-
-#: cmd/incus/storage_volume.go:1925
+#: cmd/incus/storage_volume.go:1928
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2731
+#: cmd/incus/storage_volume.go:2738
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6080,7 +6007,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2746 cmd/incus/storage_volume.go:2747
+#: cmd/incus/storage_volume.go:2753 cmd/incus/storage_volume.go:2754
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6475,18 +6402,22 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1943
+#: cmd/incus/storage_volume.go:1946
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1944
+#: cmd/incus/storage_volume.go:1947
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
 "For backward compatibility, a single configuration key may still be set "
 "with:\n"
 "    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
-"<value>"
+"<value>\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:983 cmd/incus/remote.go:984
@@ -6569,7 +6500,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1960
+#: cmd/incus/storage_volume.go:1963
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6710,13 +6641,41 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2106 cmd/incus/storage_volume.go:2107
-#: cmd/incus/storage_volume.go:2826 cmd/incus/storage_volume.go:2827
+#: cmd/incus/storage_volume.go:2109
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1309 cmd/incus/storage_volume.go:1310
+#: cmd/incus/storage_volume.go:2110
+msgid ""
+"Show storage volume configurations\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
+"\n"
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2834
+msgid "Show storage volume snapshhot configurations"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2833
+msgid "Show storage volume snapshot configurations"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1313
 msgid "Show storage volume state information"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1314
+msgid ""
+"Show storage volume state information\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:675 cmd/incus/remote.go:676
@@ -6781,15 +6740,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2313 cmd/incus/storage_volume.go:2314
+#: cmd/incus/storage_volume.go:2320 cmd/incus/storage_volume.go:2321
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2047
+#: cmd/incus/storage_volume.go:2050
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1450
+#: cmd/incus/info.go:780 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -6932,12 +6891,12 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:667
+#: cmd/incus/storage_volume.go:668
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:741
+#: cmd/incus/storage_volume.go:742
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -6950,7 +6909,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2512
+#: cmd/incus/storage_volume.go:2519
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7010,13 +6969,13 @@ msgstr ""
 #: cmd/incus/image_alias.go:236 cmd/incus/list.go:588 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
 #: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1667
+#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
 #: cmd/incus/info.go:812 cmd/incus/info.go:863 cmd/incus/snapshot.go:365
-#: cmd/incus/storage_volume.go:1522 cmd/incus/storage_volume.go:2639
+#: cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2646
 msgid "Taken at"
 msgstr ""
 
@@ -7213,12 +7172,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1285
+#: cmd/incus/storage_volume.go:1289
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1257
+#: cmd/incus/storage_volume.go:1261
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7266,7 +7225,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:832 cmd/incus/storage_volume.go:929
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7344,7 +7303,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1435
+#: cmd/incus/storage_volume.go:1438
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7360,7 +7319,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1777
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7424,7 +7383,7 @@ msgstr ""
 
 #: cmd/incus/image.go:1000 cmd/incus/info.go:299 cmd/incus/info.go:432
 #: cmd/incus/info.go:443 cmd/incus/info.go:643 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1420
+#: cmd/incus/storage_volume.go:1423
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7446,7 +7405,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1672
+#: cmd/incus/project.go:1135 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7462,7 +7421,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
 
@@ -7501,7 +7460,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/config_trust.go:455
 #: cmd/incus/image.go:1147 cmd/incus/list.go:647 cmd/incus/network.go:1119
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/storage.go:728
-#: cmd/incus/storage_volume.go:1705 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7606,8 +7565,17 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2205 cmd/incus/storage_volume.go:2206
+#: cmd/incus/storage_volume.go:2213
 msgid "Unset storage volume configuration keys"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2214
+msgid ""
+"Unset storage volume configuration keys\n"
+"\n"
+"If the type is not specified, Incus assumes the type is \"custom\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/cluster.go:589
@@ -7662,7 +7630,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2219
+#: cmd/incus/storage_volume.go:2226
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -7707,12 +7675,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1433
+#: cmd/incus/storage_volume.go:1436
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2928
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2926
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7798,7 +7766,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/storage_volume.go:1527
 msgid "Volume Only"
 msgstr ""
 
@@ -7971,7 +7939,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:854
+#: cmd/incus/storage_volume.go:855
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8392,7 +8360,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3085
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -8431,15 +8399,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1862
+#: cmd/incus/storage_volume.go:1865
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:682 cmd/incus/storage_volume.go:2534
+#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2541
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:756
+#: cmd/incus/storage_volume.go:757
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -8447,19 +8415,19 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2658
+#: cmd/incus/storage_volume.go:2665
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2444 cmd/incus/storage_volume.go:2745
+#: cmd/incus/storage_volume.go:2451 cmd/incus/storage_volume.go:2752
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:2919
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2312
+#: cmd/incus/storage_volume.go:2319
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -8467,32 +8435,32 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2825
+#: cmd/incus/storage_volume.go:2832
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1549
+#: cmd/incus/storage_volume.go:1552
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:951 cmd/incus/storage_volume.go:1308
-#: cmd/incus/storage_volume.go:2105
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2204
+#: cmd/incus/storage_volume.go:2212
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1942
+#: cmd/incus/storage_volume.go:1945
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1172
+#: cmd/incus/storage_volume.go:1176
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1768
+#: cmd/incus/storage_volume.go:1771
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -9084,26 +9052,96 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:578
 msgid ""
-"incus storage volume create p1 v1\n"
+"incus storage volume create default foo\n"
+"    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
-"incus storage volume create p1 v1 < config.yaml\n"
-"\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
+"incus storage volume create default foo < config.yaml\n"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3091
+#: cmd/incus/storage_volume.go:959
+msgid ""
+"incus storage volume edit default container/c1\n"
+"    Edit container storage volume \"c1\" in pool \"default\"\n"
+"\n"
+"incus storage volume edit default foo < volume.yaml\n"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1185
+msgid ""
+"incus storage volume get default data size\n"
+"    Returns the size of a custom volume \"data\" in pool \"default\"\n"
+"\n"
+"incus storage volume get default virtual-machine/data snapshots.expiry\n"
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:3089
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
-"\t\tCreate a new custom volume using backup0.tar.gz as the source."
+"    Create a new custom volume using backup0.tar.gz as the source\n"
+"\n"
+"incus storage volume import default some-installer.iso installer --type=iso\n"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2316
+#: cmd/incus/storage_volume.go:1319
 msgid ""
-"incus storage volume snapshot create default v1 snap0\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
 "\n"
-"incus storage volume snapshot create default v1 snap0 < config.yaml\n"
-"       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with "
-"the configuration from \"config.yaml\"."
+"incus storage volume info default virtual-machine/v1\n"
+"    Returns state information for virtual machine \"v1\" in pool \"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:1955
+msgid ""
+"incus storage volume set default data size=1GiB\n"
+"    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
+"\n"
+"incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2117
+msgid ""
+"incus storage volume show default foo\n"
+"    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume show default virtual-machine/v1\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
+"\n"
+"incus storage volume show default container/c1\n"
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2323
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
+"\n"
+"incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
+msgstr ""
+
+#: cmd/incus/storage_volume.go:2219
+msgid ""
+"incus storage volume unset default foo size\n"
+"    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
+"\n"
+"incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
 msgstr ""
 
 #: cmd/incus/storage.go:547


### PR DESCRIPTION
As someone who was new to incus, I had some confusion about "type" as it related to volumes. This help text update hopefully helps others who are  new to incus not have that same confusion. 

This update does the following: 

* Moved description text from "cmd.Example" section to cmd.Long section.  Now the example sections only have examples. 

* Added additional example to --help for "incus storage volume" command to show virtual-machine example

* added Error text for when the default (custom) is used and reports "not found". Note: this introduces an `if` statement which gives different error messages depending on if someone uses `custom` or not. If that is not ok, feel free to remove. 

* Ran `make i18n` (separate commit)

