### PR TITLE
incus/s3: Fix mcli minio client executable name check

### DIFF
--- a/internal/server/storage/s3/miniod/admin_client.go
+++ b/internal/server/storage/s3/miniod/admin_client.go
@@ -101,7 +101,7 @@ func (c *AdminClient) isMinIOClient() bool {
 		return false
 	}
 
-	if !strings.Contains(lines[0], "mc version") {
+	if !strings.Contains(lines[0], "mc version") && !strings.Contains(lines[0], "mcli version") {
 		return false
 	}
 


### PR DESCRIPTION
The check only passed for the `mc` executable name. This caused the client check to fail on my distribution as the fallback from `mc` to `mcli` didn't pass this condition.