### PR TITLE
OCI container fixes

### DIFF
--- a/client/oci_images.go
+++ b/client/oci_images.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -55,6 +56,11 @@ func (r *ProtocolOCI) GetImagesWithFilter(filters []string) ([]api.Image, error)
 func (r *ProtocolOCI) GetImage(fingerprint string) (*api.Image, string, error) {
 	info, ok := r.cache[fingerprint]
 	if !ok {
+		_, err := exec.LookPath("skopeo")
+		if err != nil {
+			return nil, "", fmt.Errorf("OCI container handling requires \"skopeo\" be present on the system")
+		}
+
 		return nil, "", fmt.Errorf("Image not found")
 	}
 
@@ -93,6 +99,11 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 
 	info, ok := r.cache[fingerprint]
 	if !ok {
+		_, err := exec.LookPath("skopeo")
+		if err != nil {
+			return nil, fmt.Errorf("OCI container handling requires \"skopeo\" be present on the system")
+		}
+
 		return nil, fmt.Errorf("Image not found")
 	}
 

--- a/client/oci_images.go
+++ b/client/oci_images.go
@@ -116,6 +116,11 @@ func (r *ProtocolOCI) GetImageFile(fingerprint string, req ImageFileRequest) (*I
 		return nil, fmt.Errorf("OCI image export currently requires root access")
 	}
 
+	_, err := exec.LookPath("umoci")
+	if err != nil {
+		return nil, fmt.Errorf("OCI container handling requires \"umoci\" be present on the system")
+	}
+
 	// Get some temporary storage.
 	ociPath, err := os.MkdirTemp("", "incus-oci-")
 	if err != nil {

--- a/cmd/incusd/instance.go
+++ b/cmd/incusd/instance.go
@@ -190,6 +190,9 @@ func instanceCreateFromImage(ctx context.Context, s *state.State, r *http.Reques
 
 	// If dealing with an OCI image, parse the configuration.
 	if args.Type == instancetype.Container && inst.LocalConfig()["image.type"] == "oci" {
+		// Reset the config to the post-generation one.
+		args.Config = inst.LocalConfig()
+
 		// Mount the instance.
 		_, err = pool.MountInstance(inst, nil)
 		if err != nil {


### PR DESCRIPTION
This fixes a rather nasty bug in OCI container internal structure creation which would discard some rather critical volatile keys during creation.

On top of that, this also adds additional errors on the client side when tools are missing.