### PR TITLE
Change RunDir file mode to 0711

### DIFF
--- a/internal/server/sys/fs.go
+++ b/internal/server/sys/fs.go
@@ -50,7 +50,7 @@ func (s *OS) initDirs() error {
 		{filepath.Join(s.VarDir, "images"), 0700},
 		{s.LogDir, 0700},
 		{filepath.Join(s.VarDir, "networks"), 0711},
-		{s.RunDir, 0700},
+		{s.RunDir, 0711},
 		{filepath.Join(s.VarDir, "security"), 0700},
 		{filepath.Join(s.VarDir, "security", "apparmor"), 0700},
 		{filepath.Join(s.VarDir, "security", "apparmor", "cache"), 0700},


### PR DESCRIPTION
This change updates the file mode of `RunDir` to 0711 allowing non-root clients to connect to the unix socket.

Fixes #1003