### PR TITLE
incusd/apparmor/dnsmasq: Relax rules a bit

### DIFF
--- a/internal/server/apparmor/network_dnsmasq.go
+++ b/internal/server/apparmor/network_dnsmasq.go
@@ -28,6 +28,8 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # Network access
   network inet raw,
   network inet6 raw,
+  network unix stream,
+  network unix dgram,
 
   # Network-specific paths
   {{ .varPath }}/networks/{{ .networkName }}/dnsmasq.hosts/{,*} r,


### PR DESCRIPTION
Apparently those rules are needed when running Incus nested within an unprivileged container on some platforms.