### PR TITLE
Remove Socket Path to Let ConnectIncusUnix Resolve It

### DIFF
--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -598,7 +598,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		// As ServerAddress field is required to be set it means that we're using the new join API
 		// introduced with the 'clustering_join' extension.
 		// Connect to ourselves to initialize storage pools and networks using the API.
-		localClient, err := incus.ConnectIncusUnix(d.os.GetUnixSocket(), &incus.ConnectionArgs{UserAgent: clusterRequest.UserAgentJoiner})
+		localClient, err := incus.ConnectIncusUnix("", &incus.ConnectionArgs{UserAgent: clusterRequest.UserAgentJoiner})
 		if err != nil {
 			return fmt.Errorf("Failed to connect to local server: %w", err)
 		}

--- a/cmd/incusd/api_project.go
+++ b/cmd/incusd/api_project.go
@@ -1014,7 +1014,7 @@ func projectDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Connect to the local server.
-		target, err := incus.ConnectIncusUnix(s.OS.GetUnixSocket(), nil)
+		target, err := incus.ConnectIncusUnix("", nil)
 		if err != nil {
 			return response.InternalError(err)
 		}

--- a/cmd/incusd/instance_post.go
+++ b/cmd/incusd/instance_post.go
@@ -564,7 +564,7 @@ func migrateInstance(ctx context.Context, s *state.State, inst instance.Instance
 	// Handle pool and project moves.
 	if req.Project != "" || req.Pool != "" {
 		// Get a local client.
-		target, err := incus.ConnectIncusUnix(s.OS.GetUnixSocket(), nil)
+		target, err := incus.ConnectIncusUnix("", nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If the path passed to `ConnectIncusUnix` is empty it will resolve to the correct path.

The [comment above GetUnixSocket](https://github.com/lxc/incus/blob/main/internal/server/sys/os.go#L233) mentions that it is used for tests. I'm not sure if it should be used in these locations or not, but removing it fixed the issue I was having with Incus attempting to use the incorrect socket path.

Fixes #1013