### PR TITLE
Incus action support --console vga

### DIFF
--- a/cmd/incus/action.go
+++ b/cmd/incus/action.go
@@ -430,6 +430,19 @@ func (c *cmdAction) Run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf(i18n.G("--console can't be used with --all"))
 		}
 
+		if len(names) > 1 {
+			idx := slices.Index(names, "vga")
+			idx2 := slices.Index(names, "console")
+			if idx == -1 || (idx2 != -1 && idx > idx2) {
+				idx = idx2
+			}
+
+			if idx != -1 {
+				c.flagConsole = names[idx]
+				names = append(names[0:idx], names[idx+1:]...)
+			}
+		}
+
 		if len(names) != 1 {
 			return fmt.Errorf(i18n.G("--console only works with a single instance"))
 		}


### PR DESCRIPTION
Supports below usage:
1. incus start instance --console,
2. incus start instance --console=vga,
3. incus start instance --console vga # my favor one