### PR TITLE
Make run-parts running compatible with different versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ endif
 	flake8 test/deps/import-busybox
 	shellcheck --shell sh test/*.sh test/includes/*.sh test/suites/*.sh test/backends/*.sh test/lint/*.sh
 	shellcheck test/extras/*.sh
-	run-parts --verbose --exit-on-error --regex '.sh' test/lint
+	run-parts $(shell run-parts -V >/dev/null 2>&1 && echo -n "--verbose --exit-on-error --regex '.sh'") test/lint
 
 .PHONY: staticcheck
 staticcheck:


### PR DESCRIPTION
The option `--exit-on-error' exists only on debian run-parts version. On centos, redhat or federa, run-parts has no such option.

The fix checks version and adds options accordingly.