### PR TITLE
incusd/instance_post: Always set the target project

### DIFF
--- a/cmd/incusd/instance_post.go
+++ b/cmd/incusd/instance_post.go
@@ -577,9 +577,10 @@ func migrateInstance(ctx context.Context, s *state.State, inst instance.Instance
 
 		targetProject := inst.Project().Name
 		if req.Project != "" {
-			target = target.UseProject(req.Project)
 			targetProject = req.Project
 		}
+
+		target = target.UseProject(targetProject)
 
 		// Check if we have a root disk in local config.
 		_, _, err = internalInstance.GetRootDiskDevice(targetInstInfo.Devices)

--- a/internal/server/storage/drivers/driver_btrfs.go
+++ b/internal/server/storage/drivers/driver_btrfs.go
@@ -101,6 +101,7 @@ func (d *btrfs) Info() Info {
 		PreservesInodes:              !d.state.OS.RunningInUserNS,
 		Remote:                       d.isRemote(),
 		VolumeTypes:                  []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		VolumeMultiNode:              d.isRemote(),
 		BlockBacking:                 false,
 		RunningCopyFreeze:            false,
 		DirectIO:                     true,

--- a/internal/server/storage/drivers/driver_ceph.go
+++ b/internal/server/storage/drivers/driver_ceph.go
@@ -88,6 +88,7 @@ func (d *ceph) Info() Info {
 		PreservesInodes:              false,
 		Remote:                       d.isRemote(),
 		VolumeTypes:                  []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		VolumeMultiNode:              d.isRemote(),
 		BlockBacking:                 true,
 		RunningCopyFreeze:            true,
 		DirectIO:                     true,

--- a/internal/server/storage/drivers/driver_cephfs.go
+++ b/internal/server/storage/drivers/driver_cephfs.go
@@ -87,7 +87,7 @@ func (d *cephfs) Info() Info {
 		PreservesInodes:              false,
 		Remote:                       d.isRemote(),
 		VolumeTypes:                  []VolumeType{VolumeTypeCustom},
-		VolumeMultiNode:              true,
+		VolumeMultiNode:              d.isRemote(),
 		BlockBacking:                 false,
 		RunningCopyFreeze:            false,
 		DirectIO:                     true,

--- a/internal/server/storage/drivers/driver_dir.go
+++ b/internal/server/storage/drivers/driver_dir.go
@@ -42,6 +42,7 @@ func (d *dir) Info() Info {
 		PreservesInodes:              false,
 		Remote:                       d.isRemote(),
 		VolumeTypes:                  []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		VolumeMultiNode:              d.isRemote(),
 		BlockBacking:                 false,
 		RunningCopyFreeze:            true,
 		DirectIO:                     true,

--- a/internal/server/storage/drivers/driver_lvm.go
+++ b/internal/server/storage/drivers/driver_lvm.go
@@ -121,6 +121,7 @@ func (d *lvm) Info() Info {
 		PreservesInodes:              false,
 		Remote:                       d.isRemote(),
 		VolumeTypes:                  []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		VolumeMultiNode:              d.isRemote(),
 		BlockBacking:                 true,
 		RunningCopyFreeze:            true,
 		DirectIO:                     true,

--- a/internal/server/storage/drivers/driver_zfs.go
+++ b/internal/server/storage/drivers/driver_zfs.go
@@ -138,6 +138,7 @@ func (d *zfs) Info() Info {
 		PreservesInodes:              true,
 		Remote:                       d.isRemote(),
 		VolumeTypes:                  []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		VolumeMultiNode:              d.isRemote(),
 		BlockBacking:                 util.IsTrue(d.config["volume.zfs.block_mode"]),
 		RunningCopyFreeze:            false,
 		DirectIO:                     zfsDirectIO,


### PR DESCRIPTION
As we're dealing with a new internal client, we can't assume that it's got its project set to match that of the instance, as a result we need to set the project even in the case where the instance remains where it is.