### PR TITLE
Properly handle request retries on OIDC

### DIFF
--- a/client/incus.go
+++ b/client/incus.go
@@ -151,7 +151,21 @@ func (r *ProtocolIncus) DoHTTP(req *http.Request) (*http.Response, error) {
 		return r.oidcClient.do(req)
 	}
 
-	return r.http.Do(req)
+	resp, err := r.http.Do(req)
+	if resp != nil && resp.StatusCode == http.StatusUseProxy && req.GetBody != nil {
+		// Reset the request body.
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+
+		req.Body = body
+
+		// Retry the request.
+		return r.http.Do(req)
+	}
+
+	return resp, err
 }
 
 // DoWebsocket performs a websocket connection, using OIDC authentication if set.

--- a/client/incus_images.go
+++ b/client/incus_images.go
@@ -520,6 +520,8 @@ func (r *ProtocolIncus) CreateImage(image api.ImagesPost, args *ImageCreateArgs)
 		return nil, err
 	}
 
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(body), nil }
+
 	// Setup the headers
 	req.Header.Set("Content-Type", contentType)
 	if image.Public {

--- a/client/incus_instances.go
+++ b/client/incus_instances.go
@@ -550,6 +550,7 @@ func (r *ProtocolIncus) CreateInstanceFromBackup(args InstanceBackupArgs) (Opera
 		return nil, err
 	}
 
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(args.BackupFile), nil }
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	if args.PoolName != "" {
@@ -1471,6 +1472,8 @@ func (r *ProtocolIncus) CreateInstanceFile(instanceName string, filePath string,
 	if err != nil {
 		return err
 	}
+
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(args.Content), nil }
 
 	// Set the various headers
 	if args.UID > -1 {
@@ -2403,6 +2406,7 @@ func (r *ProtocolIncus) CreateInstanceTemplateFile(instanceName string, template
 		return err
 	}
 
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(content), nil }
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	// Send the request

--- a/client/incus_storage_buckets.go
+++ b/client/incus_storage_buckets.go
@@ -374,6 +374,7 @@ func (r *ProtocolIncus) CreateStoragePoolBucketFromBackup(pool string, args Stor
 		return nil, err
 	}
 
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(args.BackupFile), nil }
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	if args.Name != "" {

--- a/client/incus_storage_volumes.go
+++ b/client/incus_storage_volumes.go
@@ -983,6 +983,10 @@ func (r *ProtocolIncus) CreateStoragePoolVolumeFromISO(pool string, args Storage
 		return nil, err
 	}
 
+	if args.Name == "" {
+		return nil, fmt.Errorf("Missing volume name")
+	}
+
 	path := fmt.Sprintf("/storage-pools/%s/volumes/custom", url.PathEscape(pool))
 
 	// Prepare the HTTP request.
@@ -996,10 +1000,7 @@ func (r *ProtocolIncus) CreateStoragePoolVolumeFromISO(pool string, args Storage
 		return nil, err
 	}
 
-	if args.Name == "" {
-		return nil, fmt.Errorf("Missing volume name")
-	}
-
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(args.BackupFile), nil }
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("X-Incus-name", args.Name)
 	req.Header.Set("X-Incus-type", "iso")
@@ -1057,6 +1058,7 @@ func (r *ProtocolIncus) CreateStoragePoolVolumeFromBackup(pool string, args Stor
 		return nil, err
 	}
 
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(args.BackupFile), nil }
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	if args.Name != "" {


### PR DESCRIPTION
This fixes a few remaining issues with OIDC and request retries:
 - Some requests weren't going through our wrappers and so were missing a GetBody function
 - When using the keepalive proxy, an expiring token would cause a 502 error to be sent back to the client with no indication that a retry is needed and no ability to retry the request due to the proxy not having the original body. We now have logic to detect when a retry is needed, the proxy returns a custom status code back to the client and the client now retries the request if it has what it needs to do it.