### PR TITLE
Fix automatic re-send of unseekable POST queries

### DIFF
--- a/client/incus_images.go
+++ b/client/incus_images.go
@@ -520,8 +520,6 @@ func (r *ProtocolIncus) CreateImage(image api.ImagesPost, args *ImageCreateArgs)
 		return nil, err
 	}
 
-	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(body), nil }
-
 	// Setup the headers
 	req.Header.Set("Content-Type", contentType)
 	if image.Public {

--- a/client/incus_instances.go
+++ b/client/incus_instances.go
@@ -1472,7 +1472,14 @@ func (r *ProtocolIncus) CreateInstanceFile(instanceName string, filePath string,
 		return err
 	}
 
-	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(args.Content), nil }
+	req.GetBody = func() (io.ReadCloser, error) {
+		_, err := args.Content.Seek(0, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		return io.NopCloser(args.Content), nil
+	}
 
 	// Set the various headers
 	if args.UID > -1 {
@@ -2405,7 +2412,15 @@ func (r *ProtocolIncus) CreateInstanceTemplateFile(instanceName string, template
 		return err
 	}
 
-	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(content), nil }
+	req.GetBody = func() (io.ReadCloser, error) {
+		_, err := content.Seek(0, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		return io.NopCloser(content), nil
+	}
+
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	// Send the request

--- a/client/incus_instances.go
+++ b/client/incus_instances.go
@@ -550,7 +550,6 @@ func (r *ProtocolIncus) CreateInstanceFromBackup(args InstanceBackupArgs) (Opera
 		return nil, err
 	}
 
-	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(args.BackupFile), nil }
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	if args.PoolName != "" {

--- a/client/incus_storage_buckets.go
+++ b/client/incus_storage_buckets.go
@@ -374,7 +374,6 @@ func (r *ProtocolIncus) CreateStoragePoolBucketFromBackup(pool string, args Stor
 		return nil, err
 	}
 
-	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(args.BackupFile), nil }
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	if args.Name != "" {

--- a/client/incus_storage_volumes.go
+++ b/client/incus_storage_volumes.go
@@ -1000,7 +1000,6 @@ func (r *ProtocolIncus) CreateStoragePoolVolumeFromISO(pool string, args Storage
 		return nil, err
 	}
 
-	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(args.BackupFile), nil }
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("X-Incus-name", args.Name)
 	req.Header.Set("X-Incus-type", "iso")
@@ -1058,7 +1057,6 @@ func (r *ProtocolIncus) CreateStoragePoolVolumeFromBackup(pool string, args Stor
 		return nil, err
 	}
 
-	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(args.BackupFile), nil }
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	if args.Name != "" {


### PR DESCRIPTION
The recently added re-send logic works well for anything where we have a fixed buffer we can re-send but would hit issues when using files as source as those would typically be at the end of their content and need to be reset to 0 before reading again.

This PR removes any `GetBody` definition where the content isn't a fixed and where we can't just seek back to the beginning. For those where we can seek, we're now performing the expected Seek call and checking its error so that should the file not actually be seekable (e.g. a pipe), this will fail with the appropriate error.