### PR TITLE
doc: add colima instructions

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -43,6 +43,7 @@ Chocolatey
 CIDR
 CLI
 COPR
+Colima
 Cowsql
 CPUs
 CRIU

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -213,11 +213,27 @@ The builds for other operating systems include only the client, not the server.
 
 ```{group-tab} macOS
 
+**Homebrew**
+
 Incus publishes builds of the Incus client for macOS through [Homebrew](https://brew.sh/).
 
 To install the feature branch of Incus, run:
 
     brew install incus
+
+**Colima**
+
+Incus is supported as a runtime on [Colima](https://github.com/abiosoft/colima).
+
+Install Colima with:
+
+    brew install colima
+
+Start Colima with Incus as runtime with:
+
+    colima start --runtime incus
+
+For any Colima related issues, please [file an issue](https://github.com/abiosoft/colima/issues/new/choose) in the project repository.
 ```
 
 ```{group-tab} Windows


### PR DESCRIPTION
Colima [v0.7.0](https://github.com/abiosoft/colima/releases/tag/v0.7.0) has been released with support for Incus.

This PR adds the instructions for running Incus on macOS with Colima.