### PR TITLE
Fix handling of long running connections

### DIFF
--- a/cmd/incusd/api.go
+++ b/cmd/incusd/api.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -164,6 +165,7 @@ func restServer(d *Daemon) *http.Server {
 	return &http.Server{
 		Handler:     &httpServer{r: mux, d: d},
 		ConnContext: request.SaveConnectionInContext,
+		IdleTimeout: 30 * time.Second,
 	}
 }
 

--- a/internal/server/auth/oidc/oidc.go
+++ b/internal/server/auth/oidc/oidc.go
@@ -103,30 +103,33 @@ func (o *Verifier) Auth(ctx context.Context, w http.ResponseWriter, r *http.Requ
 			return "", &AuthError{err}
 		}
 
-		// Update the access token cookie.
-		accessCookie := http.Cookie{
-			Name:     "oidc_access",
-			Value:    tokens.AccessToken,
-			Path:     "/",
-			Secure:   true,
-			HttpOnly: false,
-			SameSite: http.SameSiteStrictMode,
-		}
-
-		http.SetCookie(w, &accessCookie)
-
-		// Update the refresh token cookie.
-		if tokens.RefreshToken != "" {
-			refreshCookie := http.Cookie{
-				Name:     "oidc_refresh",
-				Value:    tokens.RefreshToken,
+		// If we have a ResponseWriter, refresh the cookies.
+		if w != nil {
+			// Update the access token cookie.
+			accessCookie := http.Cookie{
+				Name:     "oidc_access",
+				Value:    tokens.AccessToken,
 				Path:     "/",
 				Secure:   true,
 				HttpOnly: false,
 				SameSite: http.SameSiteStrictMode,
 			}
 
-			http.SetCookie(w, &refreshCookie)
+			http.SetCookie(w, &accessCookie)
+
+			// Update the refresh token cookie.
+			if tokens.RefreshToken != "" {
+				refreshCookie := http.Cookie{
+					Name:     "oidc_refresh",
+					Value:    tokens.RefreshToken,
+					Path:     "/",
+					Secure:   true,
+					HttpOnly: false,
+					SameSite: http.SameSiteStrictMode,
+				}
+
+				http.SetCookie(w, &refreshCookie)
+			}
 		}
 	}
 


### PR DESCRIPTION
This attempts to fix a common issue with HTTP/2 clients which keep a long lasting session with Incus but don't send any traffic over it.

When going through a load-balancer, this will typically lead to the connection getting closed due to timeout. On HTTP/1 this isn't a huge deal as it causes the request to fail and the client can just retry it. But on HTTP/2 such an abrupt disconnection is treated as a full network error and causes all current and subsequent requests to the server to fail, short of reloading the entire page.

On top of that, we had an issue with OIDC authentication expiring after 1 minute and the internal refresh failing to update the cookies in some code paths which would then cause the request to fail with an error. The updated logic will now validate the renewed token and move on, letting the request succeed knowing that a follow up request will pick up the new cookies.