### PR TITLE
incus: Add support for environment file (.env)

### DIFF
--- a/cmd/incus/utils.go
+++ b/cmd/incus/utils.go
@@ -244,6 +244,36 @@ func getConfig(args ...string) (map[string]string, error) {
 	return values, nil
 }
 
+func readEnvironmentFile(path string) (map[string]string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf(i18n.G("Can't read from environment file: %w"), err)
+	}
+
+	// Split the file into lines.
+	lines := strings.Split(string(content), "\n")
+
+	// Create a map to store the key value pairs.
+	envMap := make(map[string]string)
+
+	// Iterate over the lines.
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		pieces := strings.SplitN(line, "=", 2)
+		value := ""
+		if len(pieces) > 1 {
+			value = pieces[1]
+		}
+
+		envMap[pieces[0]] = value
+	}
+
+	return envMap, nil
+}
+
 func usage(name string, args ...string) string {
 	if len(args) == 0 {
 		return name

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-08-01 01:00-0400\n"
+"POT-Creation-Date: 2024-08-07 14:26-0400\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: Tobias Gerold <tobias@g3ro.eu>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -680,7 +680,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1071,7 +1071,7 @@ msgstr ""
 "Da keines der genannten Programme gefunden werden konnte, finden Sie hier "
 "den SPICE Socket zum manuellen verbinden:"
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 #, fuzzy
 msgid "Asked for a VM but image is of type container"
 msgstr ""
@@ -1195,15 +1195,15 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308
+#: cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1341,6 +1341,11 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
+#: cmd/incus/utils.go:250
+#, c-format
+msgid "Can't read from environment file: %w"
+msgstr ""
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, c-format
 msgid "Can't read from stdin: %w"
@@ -1396,7 +1401,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1532,13 +1537,13 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1386 cmd/incus/network.go:1479
-#: cmd/incus/network.go:1551 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
-#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
-#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598
+#: cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841
+#: cmd/incus/network_forward.go:923 cmd/incus/network.go:347
+#: cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386
+#: cmd/incus/network.go:1479 cmd/incus/network.go:1551
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:261
 #: cmd/incus/network_load_balancer.go:432
@@ -1547,16 +1552,16 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: cmd/incus/network_load_balancer.go:820
 #: cmd/incus/network_load_balancer.go:896
 #: cmd/incus/network_load_balancer.go:1009
-#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108
+#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103
+#: cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266
+#: cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573
+#: cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732
+#: cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058
+#: cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268
+#: cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108
 #: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
 #: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807
-#: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
-#: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
-#: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
 #: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
 #: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
 #: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
@@ -1604,7 +1609,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1631,12 +1636,13 @@ msgstr ""
 #: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729
-#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/image.go:477 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:716 cmd/incus/network.go:802
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696
+#: cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637
+#: cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600
+#: cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361
+#: cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
@@ -1819,7 +1825,7 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1828,7 +1834,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1865,7 +1871,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 #, fuzzy
 msgid "Create instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1944,7 +1950,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1955,7 +1961,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
@@ -1965,7 +1971,7 @@ msgstr "Erstelle %s"
 msgid "Creating %s: %%s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 #, fuzzy
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1980,15 +1986,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098
-#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152
+#: cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237
+#: cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169
+#: cmd/incus/network_forward.go:152 cmd/incus/network.go:1098
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -2150,62 +2156,57 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
-#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
-#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
-#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
-#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
-#: cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176
-#: cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388
-#: cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30
-#: cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181
-#: cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327
-#: cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533
-#: cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674
-#: cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812
-#: cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584
-#: cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732
-#: cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40
-#: cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
-#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
-#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
-#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
-#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375
+#: cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587
+#: cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780
+#: cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066
+#: cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264
+#: cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417
+#: cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96
+#: cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267
+#: cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451
+#: cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618
+#: cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686
+#: cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803
+#: cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43
+#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
+#: cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310
+#: cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648
+#: cmd/incus/file.go:1153 cmd/incus/image_alias.go:24
+#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
+#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
+#: cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321
+#: cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679
+#: cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417
+#: cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633
+#: cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35
 #: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
-#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241
-#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
-#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
 #: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
@@ -2219,13 +2220,20 @@ msgstr ""
 #: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
 #: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
 #: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
-#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347
-#: cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478
-#: cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613
-#: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
+#: cmd/incus/network_forward.go:919 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337
+#: cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603
+#: cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917
+#: cmd/incus/network.go:1053 cmd/incus/network.go:1241
+#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
+#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410
+#: cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90
+#: cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
 #: cmd/incus/network_load_balancer.go:356
 #: cmd/incus/network_load_balancer.go:424
@@ -2270,10 +2278,7 @@ msgstr ""
 #: cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
 #: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
 #: cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385
-#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473
@@ -2282,23 +2287,27 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884
 #: cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054
 #: cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261
-#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755
-#: cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922
-#: cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475
+#: cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088
+#: cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29
+#: cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304
+#: cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2397,7 +2406,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr ""
@@ -2716,7 +2725,7 @@ msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 "Festzulegende Umgebungsvariable (Environment variable) (z.B. HOME=/home/foo)"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Kurzlebiger Container"
@@ -2742,13 +2751,13 @@ msgid "Error retrieving aliases: %w"
 msgstr "Fehler beim Abrufen des Aliase/Namen: %w"
 
 #: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540
+#: cmd/incus/network_forward.go:521 cmd/incus/network.go:1454
 #: cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507
 #: cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475
 #: cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634
+#: cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2765,13 +2774,13 @@ msgid "Error unsetting properties: %v"
 msgstr "Fehler beim Löschen der Parameter: %v"
 
 #: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937
-#: cmd/incus/network.go:1448 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581
+#: cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515
+#: cmd/incus/network.go:1448 cmd/incus/network_integration.go:581
 #: cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547
 #: cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890
+#: cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Fehler beim Löschen des Parameters: %v"
@@ -2984,8 +2993,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr "DATEINAME"
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235
+#: cmd/incus/image.go:1117 cmd/incus/image.go:1118
 #, fuzzy
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -3005,12 +3014,12 @@ msgstr "SSH handshake mit Client %q gescheitert: %v"
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Check ob Instanz existiert fehlgeschlagen \"%s:%s\": %w"
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3075,17 +3084,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3341,7 +3350,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187
 #: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -3418,16 +3427,16 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067
 #: cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135
-#: cmd/incus/network.go:1073 cmd/incus/network.go:1243
+#: cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57
-#: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:1073
+#: cmd/incus/network.go:1243 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806
+#: cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575
 #: cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3912,6 +3921,10 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Importing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
+#: cmd/incus/create.go:55
+msgid "Include environment variables from file"
+msgstr ""
+
 #: cmd/incus/manpage.go:26
 msgid "Include less common commands"
 msgstr ""
@@ -3946,7 +3959,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3965,7 +3978,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid "Instance type"
 msgstr ""
 
@@ -4166,8 +4179,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303
-#: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158
+#: cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
 #: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
@@ -4187,12 +4200,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 #, fuzzy
 msgid "Launching the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5030,8 +5043,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:38 cmd/incus/remote.go:39
@@ -5212,15 +5225,15 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing network integration name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274
-#: cmd/incus/network.go:1352 cmd/incus/network.go:1418
-#: cmd/incus/network.go:1510 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
-#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
-#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
-#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210
+#: cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654
+#: cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878
+#: cmd/incus/network_forward.go:960 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542
+#: cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875
+#: cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352
+#: cmd/incus/network.go:1418 cmd/incus/network.go:1510
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:282
@@ -5261,24 +5274,24 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing peer name"
 msgstr "Fehlende Zusammenfassung."
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
 #: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
 #: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
 #: cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596
 #: cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
-#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244
+#: cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518
+#: cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722
+#: cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897
+#: cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231
+#: cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904
+#: cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160
+#: cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495
+#: cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5425,12 +5438,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158
 #: cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:583
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_acl.go:168 cmd/incus/network.go:1093
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780
-#: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863
+#: cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5642,7 +5655,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Network load balancer %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid "Network name"
 msgstr ""
 
@@ -5695,7 +5708,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5749,7 +5762,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
@@ -5871,8 +5884,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
-#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174
+#: cmd/incus/network.go:1092 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
 #: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
 #: cmd/incus/warning.go:213
@@ -5995,13 +6008,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717
+#: cmd/incus/network.go:803 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112
+#: cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6086,7 +6100,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Profile to apply to the new image"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6546,7 +6560,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Retrieve the instance's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -7484,7 +7498,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 #, fuzzy
 msgid "Storage pool name"
@@ -7572,12 +7586,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094
-#: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
-#: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
-#: cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236
+#: cmd/incus/image.go:1123 cmd/incus/list.go:589
+#: cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1299 cmd/incus/network_integration.go:459
+#: cmd/incus/network_peer.go:157 cmd/incus/operation.go:172
+#: cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -7679,7 +7693,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7697,12 +7711,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The key %q does not exist on cluster member %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7900,11 +7914,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -8040,8 +8054,8 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "USB devices:"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
-#: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24
+#: cmd/incus/network.go:1099 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
@@ -8638,7 +8652,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064
 #: cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1050
 #: cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505
 #: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
@@ -8902,7 +8916,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -9243,9 +9257,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1239 cmd/incus/network.go:1474
-#: cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445
+#: cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239
+#: cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87
 #: cmd/incus/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -9447,8 +9461,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209
+#: cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -10024,7 +10038,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-08-01 01:00-0400\n"
+"POT-Creation-Date: 2024-08-07 14:26-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -666,7 +666,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -778,7 +778,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1030,7 +1030,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1142,15 +1142,15 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308
+#: cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1282,6 +1282,11 @@ msgstr "No se puede proporcionar un nombre para la imagen de destino"
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
+#: cmd/incus/utils.go:250
+#, fuzzy, c-format
+msgid "Can't read from environment file: %w"
+msgstr "No se peude leer desde stdin: %s"
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
@@ -1338,7 +1343,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1470,13 +1475,13 @@ msgstr "Perfil %s eliminado de %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1386 cmd/incus/network.go:1479
-#: cmd/incus/network.go:1551 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
-#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
-#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598
+#: cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841
+#: cmd/incus/network_forward.go:923 cmd/incus/network.go:347
+#: cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386
+#: cmd/incus/network.go:1479 cmd/incus/network.go:1551
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:261
 #: cmd/incus/network_load_balancer.go:432
@@ -1485,16 +1490,16 @@ msgstr "Perfil %s eliminado de %s"
 #: cmd/incus/network_load_balancer.go:820
 #: cmd/incus/network_load_balancer.go:896
 #: cmd/incus/network_load_balancer.go:1009
-#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108
+#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103
+#: cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266
+#: cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573
+#: cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732
+#: cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058
+#: cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268
+#: cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108
 #: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
 #: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807
-#: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
-#: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
-#: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
 #: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
 #: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
 #: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
@@ -1543,7 +1548,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1569,12 +1574,13 @@ msgstr ""
 #: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729
-#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/image.go:477 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:716 cmd/incus/network.go:802
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696
+#: cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637
+#: cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600
+#: cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361
+#: cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
@@ -1755,7 +1761,7 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Copiando la imagen: %s"
@@ -1764,7 +1770,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Creando el contenedor"
@@ -1800,7 +1806,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 msgid "Create instances from images"
 msgstr ""
 
@@ -1869,7 +1875,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1879,7 +1885,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
@@ -1889,7 +1895,7 @@ msgstr "Creando %s"
 msgid "Creating %s: %%s"
 msgstr "Creando %s"
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
@@ -1904,15 +1910,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098
-#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152
+#: cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237
+#: cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169
+#: cmd/incus/network_forward.go:152 cmd/incus/network.go:1098
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -2070,62 +2076,57 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
-#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
-#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
-#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
-#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
-#: cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176
-#: cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388
-#: cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30
-#: cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181
-#: cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327
-#: cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533
-#: cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674
-#: cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812
-#: cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584
-#: cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732
-#: cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40
-#: cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
-#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
-#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
-#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
-#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375
+#: cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587
+#: cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780
+#: cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066
+#: cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264
+#: cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417
+#: cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96
+#: cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267
+#: cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451
+#: cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618
+#: cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686
+#: cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803
+#: cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43
+#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
+#: cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310
+#: cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648
+#: cmd/incus/file.go:1153 cmd/incus/image_alias.go:24
+#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
+#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
+#: cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321
+#: cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679
+#: cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417
+#: cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633
+#: cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35
 #: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
-#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241
-#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
-#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
 #: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
@@ -2139,13 +2140,20 @@ msgstr ""
 #: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
 #: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
 #: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
-#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347
-#: cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478
-#: cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613
-#: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
+#: cmd/incus/network_forward.go:919 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337
+#: cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603
+#: cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917
+#: cmd/incus/network.go:1053 cmd/incus/network.go:1241
+#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
+#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410
+#: cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90
+#: cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
 #: cmd/incus/network_load_balancer.go:356
 #: cmd/incus/network_load_balancer.go:424
@@ -2190,10 +2198,7 @@ msgstr ""
 #: cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
 #: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
 #: cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385
-#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473
@@ -2202,23 +2207,27 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884
 #: cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054
 #: cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261
-#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755
-#: cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922
-#: cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475
+#: cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088
+#: cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29
+#: cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304
+#: cmd/incus/warning.go:358
 msgid "Description"
 msgstr "Descripción"
 
@@ -2308,7 +2317,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2631,13 +2640,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540
+#: cmd/incus/network_forward.go:521 cmd/incus/network.go:1454
 #: cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507
 #: cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475
 #: cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634
+#: cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2654,13 +2663,13 @@ msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
 #: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937
-#: cmd/incus/network.go:1448 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581
+#: cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515
+#: cmd/incus/network.go:1448 cmd/incus/network_integration.go:581
 #: cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547
 #: cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890
+#: cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2819,8 +2828,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235
+#: cmd/incus/image.go:1117 cmd/incus/image.go:1118
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
@@ -2838,12 +2847,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2908,17 +2917,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Acepta certificado"
@@ -3174,7 +3183,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187
 #: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
@@ -3248,16 +3257,16 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067
 #: cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135
-#: cmd/incus/network.go:1073 cmd/incus/network.go:1243
+#: cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57
-#: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:1073
+#: cmd/incus/network.go:1243 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806
+#: cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575
 #: cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3731,6 +3740,10 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Importing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
+#: cmd/incus/create.go:55
+msgid "Include environment variables from file"
+msgstr ""
+
 #: cmd/incus/manpage.go:26
 msgid "Include less common commands"
 msgstr ""
@@ -3767,7 +3780,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3786,7 +3799,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid "Instance type"
 msgstr ""
 
@@ -3980,8 +3993,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303
-#: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158
+#: cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
 #: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
@@ -4001,12 +4014,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creando %s"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creando el contenedor"
@@ -4801,8 +4814,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:38 cmd/incus/remote.go:39
@@ -4981,15 +4994,15 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing network integration name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274
-#: cmd/incus/network.go:1352 cmd/incus/network.go:1418
-#: cmd/incus/network.go:1510 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
-#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
-#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
-#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210
+#: cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654
+#: cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878
+#: cmd/incus/network_forward.go:960 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542
+#: cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875
+#: cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352
+#: cmd/incus/network.go:1418 cmd/incus/network.go:1510
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:282
@@ -5030,24 +5043,24 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing peer name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
 #: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
 #: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
 #: cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596
 #: cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
-#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244
+#: cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518
+#: cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722
+#: cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897
+#: cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231
+#: cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904
+#: cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160
+#: cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495
+#: cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 msgid "Missing pool name"
 msgstr ""
 
@@ -5188,12 +5201,12 @@ msgstr ""
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158
 #: cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:583
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_acl.go:168 cmd/incus/network.go:1093
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780
-#: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863
+#: cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5401,7 +5414,7 @@ msgstr "Perfil %s creado"
 msgid "Network load balancer %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid "Network name"
 msgstr ""
 
@@ -5452,7 +5465,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5503,7 +5516,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
@@ -5623,8 +5636,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
-#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174
+#: cmd/incus/network.go:1092 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
 #: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
 #: cmd/incus/warning.go:213
@@ -5745,13 +5758,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717
+#: cmd/incus/network.go:803 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112
+#: cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5836,7 +5850,7 @@ msgstr "Perfil %s renombrado a %s"
 msgid "Profile to apply to the new image"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -6280,7 +6294,7 @@ msgstr "Aliases:"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -7179,7 +7193,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7263,12 +7277,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094
-#: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
-#: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
-#: cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236
+#: cmd/incus/image.go:1123 cmd/incus/list.go:589
+#: cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1299 cmd/incus/network_integration.go:459
+#: cmd/incus/network_peer.go:157 cmd/incus/operation.go:172
+#: cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -7368,7 +7382,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7386,12 +7400,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7584,11 +7598,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7723,8 +7737,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
-#: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24
+#: cmd/incus/network.go:1099 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
@@ -8291,7 +8305,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064
 #: cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1050
 #: cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505
 #: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
@@ -8453,7 +8467,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8657,9 +8671,9 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1239 cmd/incus/network.go:1474
-#: cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445
+#: cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239
+#: cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87
 #: cmd/incus/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -8792,8 +8806,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<operation>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209
+#: cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9184,7 +9198,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-08-01 01:00-0400\n"
+"POT-Creation-Date: 2024-08-07 14:26-0400\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -676,7 +676,7 @@ msgstr "--console ne peut être utilisé avec --all"
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
@@ -783,7 +783,7 @@ msgstr "Vous devez fournir le nom d'un membre appartenant à un cluster"
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1052,7 +1052,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "Aucun n'a pu être trouvé, la socket SPICE peut être trouvé à:"
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr "Machine virtuelle a été demandé mais l'image est de type conteneur"
 
@@ -1172,15 +1172,15 @@ msgstr ""
 "Mauvais appareil remplacez la syntaxe, syntaxe attendue <appareil>,"
 "<clé>=<valeur>: %s"
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308
+#: cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1312,6 +1312,11 @@ msgstr "Impossible de fournir un nom à l'image cible"
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossible de récupérer un répertoire sans --recursive"
 
+#: cmd/incus/utils.go:250
+#, fuzzy, c-format
+msgid "Can't read from environment file: %w"
+msgstr "Impossible de lire depuis stdin : %w"
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, c-format
 msgid "Can't read from stdin: %w"
@@ -1370,7 +1375,7 @@ msgstr "Impossible d'utiliser --minimal et --preseed ensemble"
 msgid "Can't use an image with --empty"
 msgstr "Impossible d'utiliser une image avec --empty"
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1510,13 +1515,13 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1386 cmd/incus/network.go:1479
-#: cmd/incus/network.go:1551 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
-#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
-#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598
+#: cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841
+#: cmd/incus/network_forward.go:923 cmd/incus/network.go:347
+#: cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386
+#: cmd/incus/network.go:1479 cmd/incus/network.go:1551
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:261
 #: cmd/incus/network_load_balancer.go:432
@@ -1525,16 +1530,16 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 #: cmd/incus/network_load_balancer.go:820
 #: cmd/incus/network_load_balancer.go:896
 #: cmd/incus/network_load_balancer.go:1009
-#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108
+#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103
+#: cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266
+#: cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573
+#: cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732
+#: cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058
+#: cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268
+#: cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108
 #: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
 #: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807
-#: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
-#: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
-#: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
 #: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
 #: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
 #: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
@@ -1591,7 +1596,7 @@ msgstr "Algorithme de compression à utiliser (`none` pour ne pas compresser)"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Algorithme de compression à utiliser (`none` pour ne pas compresser)"
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuration clef/valeur à associer à la nouvelle instance"
@@ -1616,12 +1621,13 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729
-#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/image.go:477 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:716 cmd/incus/network.go:802
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696
+#: cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637
+#: cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600
+#: cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361
+#: cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
@@ -1820,7 +1826,7 @@ msgstr "Créer un groupe de serveurs"
 msgid "Create a new %s pool?"
 msgstr "Créer un nouvel agrégat de stockage %s ?"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Create a virtual machine"
 msgstr "Créer une nouvelle machine virtuelle"
 
@@ -1828,7 +1834,7 @@ msgstr "Créer une nouvelle machine virtuelle"
 msgid "Create aliases for existing images"
 msgstr "Crée des alias pour les images existantes"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Create an empty instance"
 msgstr "Créer une instance vide"
 
@@ -1883,7 +1889,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Création d'instances à partir d'images"
@@ -1963,7 +1969,7 @@ msgstr "Créé : %s"
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -1974,7 +1980,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
@@ -1984,7 +1990,7 @@ msgstr "Création de %s"
 msgid "Creating %s: %%s"
 msgstr "Création de %s"
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Création du conteneur"
@@ -1999,15 +2005,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "ADRESSE CIBLE PAR DÉFAUT"
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098
-#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152
+#: cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237
+#: cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169
+#: cmd/incus/network_forward.go:152 cmd/incus/network.go:1098
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -2175,62 +2181,57 @@ msgid "Delete warning"
 msgstr "Récupération de l'image : %s"
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
-#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
-#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
-#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
-#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
-#: cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176
-#: cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388
-#: cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30
-#: cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181
-#: cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327
-#: cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533
-#: cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674
-#: cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812
-#: cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584
-#: cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732
-#: cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40
-#: cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
-#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
-#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
-#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
-#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375
+#: cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587
+#: cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780
+#: cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066
+#: cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264
+#: cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417
+#: cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96
+#: cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267
+#: cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451
+#: cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618
+#: cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686
+#: cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803
+#: cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43
+#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
+#: cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310
+#: cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648
+#: cmd/incus/file.go:1153 cmd/incus/image_alias.go:24
+#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
+#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
+#: cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321
+#: cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679
+#: cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417
+#: cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633
+#: cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35
 #: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
-#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241
-#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
-#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
 #: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
@@ -2244,13 +2245,20 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
 #: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
 #: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
-#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347
-#: cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478
-#: cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613
-#: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
+#: cmd/incus/network_forward.go:919 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337
+#: cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603
+#: cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917
+#: cmd/incus/network.go:1053 cmd/incus/network.go:1241
+#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
+#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410
+#: cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90
+#: cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
 #: cmd/incus/network_load_balancer.go:356
 #: cmd/incus/network_load_balancer.go:424
@@ -2295,10 +2303,7 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
 #: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
 #: cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385
-#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473
@@ -2307,23 +2312,27 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884
 #: cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054
 #: cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261
-#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755
-#: cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922
-#: cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475
+#: cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088
+#: cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29
+#: cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304
+#: cmd/incus/warning.go:358
 msgid "Description"
 msgstr "Description"
 
@@ -2418,7 +2427,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
@@ -2743,7 +2752,7 @@ msgstr "Entrée TTL"
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Conteneur éphémère"
@@ -2769,13 +2778,13 @@ msgid "Error retrieving aliases: %w"
 msgstr "Erreur lors de la récupération des alias : %w"
 
 #: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540
+#: cmd/incus/network_forward.go:521 cmd/incus/network.go:1454
 #: cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507
 #: cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475
 #: cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634
+#: cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
@@ -2792,13 +2801,13 @@ msgid "Error unsetting properties: %v"
 msgstr "Erreur lors du déparamétrage des propriétés: %v"
 
 #: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937
-#: cmd/incus/network.go:1448 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581
+#: cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515
+#: cmd/incus/network.go:1448 cmd/incus/network_integration.go:581
 #: cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547
 #: cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890
+#: cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Erreur dans le déparamétrage de la propriété: %v"
@@ -3021,8 +3030,8 @@ msgstr "DOMAINE D'ÉCHEC"
 msgid "FILENAME"
 msgstr "NOM"
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235
+#: cmd/incus/image.go:1117 cmd/incus/image.go:1118
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
@@ -3040,12 +3049,12 @@ msgstr "Échec de l'authentification SSH avec le client %q : %v"
 msgid "Failed accepting channel client %q: %v"
 msgstr "Échec de l'acceptation du canal client %q : %v"
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Échec de la vérification de l'existence de l'instance \"%s:%s\" : %w"
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -3115,18 +3124,18 @@ msgstr "Échec de la récupération du status du pair : %w"
 msgid "Failed import request: %w"
 msgstr "Échec de la demande d'importation : %w"
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Échec du chargement du réseau %q : %w"
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 "Échec du chargement du profil %q pour la modification du périphérique : %w"
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Échec du chargement du pool de stockage %q : %w"
@@ -3389,7 +3398,7 @@ msgstr "Mode rapide (identique à --columns=nsacPt"
 msgid "Fetch instance backup file: %w"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187
 #: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "Le filtrage n'est pas encore pris en charge"
@@ -3486,16 +3495,16 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067
 #: cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135
-#: cmd/incus/network.go:1073 cmd/incus/network.go:1243
+#: cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57
-#: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:1073
+#: cmd/incus/network.go:1243 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806
+#: cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575
 #: cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 #, fuzzy
 msgid "Format (csv|json|table|yaml|compact)"
@@ -4006,6 +4015,10 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Importing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
+#: cmd/incus/create.go:55
+msgid "Include environment variables from file"
+msgstr ""
+
 #: cmd/incus/manpage.go:26
 #, fuzzy
 msgid "Include less common commands"
@@ -4043,7 +4056,7 @@ msgstr "Instance déconnectée pour le client %q"
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -4065,7 +4078,7 @@ msgstr "Conteneur publié avec l'empreinte : %s"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid "Instance type"
 msgstr "Type d'instance"
 
@@ -4267,8 +4280,8 @@ msgstr "LIMITE"
 msgid "LISTEN ADDRESS"
 msgstr "ADRESSE D’ÉCOUTE"
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303
-#: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158
+#: cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
 #: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
@@ -4288,12 +4301,12 @@ msgstr "Dernière utilisation : %s"
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Création de %s"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Création du conteneur"
@@ -5171,8 +5184,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:38 cmd/incus/remote.go:39
@@ -5353,15 +5366,15 @@ msgstr "Nom du réseau"
 msgid "Missing network integration name"
 msgstr "Nom du réseau"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274
-#: cmd/incus/network.go:1352 cmd/incus/network.go:1418
-#: cmd/incus/network.go:1510 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
-#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
-#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
-#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210
+#: cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654
+#: cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878
+#: cmd/incus/network_forward.go:960 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542
+#: cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875
+#: cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352
+#: cmd/incus/network.go:1418 cmd/incus/network.go:1510
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:282
@@ -5403,24 +5416,24 @@ msgstr "Nom du réseau"
 msgid "Missing peer name"
 msgstr "Résumé manquant."
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
 #: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
 #: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
 #: cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596
 #: cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
-#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244
+#: cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518
+#: cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722
+#: cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897
+#: cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231
+#: cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904
+#: cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160
+#: cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495
+#: cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5570,12 +5583,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158
 #: cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:583
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_acl.go:168 cmd/incus/network.go:1093
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780
-#: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863
+#: cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr "NOM"
 
@@ -5788,7 +5801,7 @@ msgstr "Le réseau %s a été créé"
 msgid "Network load balancer %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid "Network name"
 msgstr "Nom du réseau"
 
@@ -5841,7 +5854,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -5894,7 +5907,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
@@ -6028,8 +6041,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
-#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174
+#: cmd/incus/network.go:1092 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
 #: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
 #: cmd/incus/warning.go:213
@@ -6152,13 +6165,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717
+#: cmd/incus/network.go:803 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112
+#: cmd/incus/storage_volume.go:1144
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -6244,7 +6258,7 @@ msgstr "Profil %s ajouté à %s"
 msgid "Profile to apply to the new image"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -6723,7 +6737,7 @@ msgstr "Création du conteneur"
 msgid "Retrieve the instance's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -7663,7 +7677,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -7752,12 +7766,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094
-#: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
-#: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
-#: cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236
+#: cmd/incus/image.go:1123 cmd/incus/list.go:589
+#: cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1299 cmd/incus/network_integration.go:459
+#: cmd/incus/network_peer.go:157 cmd/incus/operation.go:172
+#: cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -7864,7 +7878,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
@@ -7884,12 +7898,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
@@ -8087,12 +8101,12 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 #, fuzzy
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 #, fuzzy
 msgid "To create a new network, use: incus network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
@@ -8232,8 +8246,8 @@ msgstr "Création du conteneur"
 msgid "USB devices:"
 msgstr "Création du conteneur"
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
-#: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24
+#: cmd/incus/network.go:1099 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
@@ -8828,7 +8842,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064
 #: cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1050
 #: cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505
 #: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
@@ -9071,7 +9085,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -9466,9 +9480,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1239 cmd/incus/network.go:1474
-#: cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445
+#: cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239
+#: cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87
 #: cmd/incus/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -9670,8 +9684,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209
+#: cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -10278,7 +10292,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-08-01 01:00-0400\n"
+        "POT-Creation-Date: 2024-08-07 14:26-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -401,7 +401,7 @@ msgstr  ""
 msgid   "--console only works with a single instance"
 msgstr  ""
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
@@ -502,7 +502,7 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid   "ALIAS"
 msgstr  ""
 
@@ -738,7 +738,7 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
@@ -845,12 +845,12 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311 cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382 cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308 cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311 cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382 cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302 cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302 cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -974,6 +974,11 @@ msgstr  ""
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
+#: cmd/incus/utils.go:250
+#, c-format
+msgid   "Can't read from environment file: %w"
+msgstr  ""
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, c-format
 msgid   "Can't read from stdin: %w"
@@ -1028,7 +1033,7 @@ msgstr  ""
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid   "Cannot override config for device %q: Device not found in profile devices"
 msgstr  ""
@@ -1153,7 +1158,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64 cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386 cmd/incus/network.go:1479 cmd/incus/network.go:1551 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:432 cmd/incus/network_load_balancer.go:567 cmd/incus/network_load_balancer.go:732 cmd/incus/network_load_balancer.go:820 cmd/incus/network_load_balancer.go:896 cmd/incus/network_load_balancer.go:1009 cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108 cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832 cmd/incus/storage.go:934 cmd/incus/storage.go:1027 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417 cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966 cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325 cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126 cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2671 cmd/incus/storage_volume.go:2757 cmd/incus/storage_volume.go:2837 cmd/incus/storage_volume.go:2929 cmd/incus/storage_volume.go:3095
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64 cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923 cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386 cmd/incus/network.go:1479 cmd/incus/network.go:1551 cmd/incus/network_load_balancer.go:180 cmd/incus/network_load_balancer.go:261 cmd/incus/network_load_balancer.go:432 cmd/incus/network_load_balancer.go:567 cmd/incus/network_load_balancer.go:732 cmd/incus/network_load_balancer.go:820 cmd/incus/network_load_balancer.go:896 cmd/incus/network_load_balancer.go:1009 cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108 cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832 cmd/incus/storage.go:934 cmd/incus/storage.go:1027 cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966 cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325 cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126 cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2671 cmd/incus/storage_volume.go:2757 cmd/incus/storage_volume.go:2837 cmd/incus/storage_volume.go:2929 cmd/incus/storage_volume.go:3095
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1186,7 +1191,7 @@ msgstr  ""
 msgid   "Compression algorithm to use (none for uncompressed)"
 msgstr  ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
@@ -1206,7 +1211,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714 cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157 cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:477 cmd/incus/network_acl.go:714 cmd/incus/network_forward.go:716 cmd/incus/network.go:802 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368 cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1376,7 +1381,7 @@ msgstr  ""
 msgid   "Create a new %s pool?"
 msgstr  ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid   "Create a virtual machine"
 msgstr  ""
 
@@ -1384,7 +1389,7 @@ msgstr  ""
 msgid   "Create aliases for existing images"
 msgstr  ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid   "Create an empty instance"
 msgstr  ""
 
@@ -1416,7 +1421,7 @@ msgid   "Create instance snapshots\n"
         "running state, including process memory state, TCP connections, ..."
 msgstr  ""
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 msgid   "Create instances from images"
 msgstr  ""
 
@@ -1480,7 +1485,7 @@ msgstr  ""
 msgid   "Create storage pools"
 msgstr  ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
@@ -1489,7 +1494,7 @@ msgstr  ""
 msgid   "Created: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
@@ -1499,7 +1504,7 @@ msgstr  ""
 msgid   "Creating %s: %%s"
 msgstr  ""
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 msgid   "Creating the instance"
 msgstr  ""
 
@@ -1512,7 +1517,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:435 cmd/incus/image.go:1115 cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152 cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:844 cmd/incus/operation.go:173 cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864 cmd/incus/storage_volume.go:1672
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515 cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237 cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152 cmd/incus/network.go:1098 cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160 cmd/incus/network_zone.go:844 cmd/incus/operation.go:173 cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864 cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1659,7 +1664,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241 cmd/incus/network.go:1320 cmd/incus/network.go:1380 cmd/incus/network.go:1476 cmd/incus/network.go:1548 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:729 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:817 cmd/incus/network_load_balancer.go:893 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1006 cmd/incus/network_load_balancer.go:1079 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391 cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578 cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412 cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543 cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726 cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861 cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001 cmd/incus/network_zone.go:1099 cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1235 cmd/incus/network_zone.go:1365 cmd/incus/network_zone.go:1426 cmd/incus/network_zone.go:1441 cmd/incus/network_zone.go:1499 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:39 cmd/incus/remote.go:104 cmd/incus/remote.go:633 cmd/incus/remote.go:680 cmd/incus/remote.go:718 cmd/incus/remote.go:804 cmd/incus/remote.go:885 cmd/incus/remote.go:950 cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473 cmd/incus/storage_bucket.go:567 cmd/incus/storage_bucket.go:661 cmd/incus/storage_bucket.go:730 cmd/incus/storage_bucket.go:764 cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884 cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261 cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:51 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:85 cmd/incus/network_forward.go:174 cmd/incus/network_forward.go:250 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548 cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838 cmd/incus/network_forward.go:919 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241 cmd/incus/network.go:1320 cmd/incus/network.go:1380 cmd/incus/network.go:1476 cmd/incus/network.go:1548 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177 cmd/incus/network_load_balancer.go:253 cmd/incus/network_load_balancer.go:356 cmd/incus/network_load_balancer.go:424 cmd/incus/network_load_balancer.go:534 cmd/incus/network_load_balancer.go:564 cmd/incus/network_load_balancer.go:729 cmd/incus/network_load_balancer.go:802 cmd/incus/network_load_balancer.go:817 cmd/incus/network_load_balancer.go:893 cmd/incus/network_load_balancer.go:991 cmd/incus/network_load_balancer.go:1006 cmd/incus/network_load_balancer.go:1079 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:81 cmd/incus/network_peer.go:174 cmd/incus/network_peer.go:245 cmd/incus/network_peer.go:391 cmd/incus/network_peer.go:476 cmd/incus/network_peer.go:578 cmd/incus/network_peer.go:625 cmd/incus/network_peer.go:762 cmd/incus/network_zone.go:27 cmd/incus/network_zone.go:85 cmd/incus/network_zone.go:181 cmd/incus/network_zone.go:244 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:412 cmd/incus/network_zone.go:500 cmd/incus/network_zone.go:543 cmd/incus/network_zone.go:670 cmd/incus/network_zone.go:726 cmd/incus/network_zone.go:783 cmd/incus/network_zone.go:861 cmd/incus/network_zone.go:925 cmd/incus/network_zone.go:1001 cmd/incus/network_zone.go:1099 cmd/incus/network_zone.go:1188 cmd/incus/network_zone.go:1235 cmd/incus/network_zone.go:1365 cmd/incus/network_zone.go:1426 cmd/incus/network_zone.go:1441 cmd/incus/network_zone.go:1499 cmd/incus/operation.go:24 cmd/incus/operation.go:57 cmd/incus/operation.go:107 cmd/incus/operation.go:194 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:39 cmd/incus/remote.go:104 cmd/incus/remote.go:633 cmd/incus/remote.go:680 cmd/incus/remote.go:718 cmd/incus/remote.go:804 cmd/incus/remote.go:885 cmd/incus/remote.go:950 cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385 cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473 cmd/incus/storage_bucket.go:567 cmd/incus/storage_bucket.go:661 cmd/incus/storage_bucket.go:730 cmd/incus/storage_bucket.go:764 cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884 cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054 cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261 cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1739,7 +1744,7 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 msgid   "Didn't get name of new instance from the server"
 msgstr  ""
 
@@ -2010,7 +2015,7 @@ msgstr  ""
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 msgid   "Ephemeral instance"
 msgstr  ""
 
@@ -2034,7 +2039,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454 cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896 cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038 cmd/incus/storage_volume.go:2081
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521 cmd/incus/network.go:1454 cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507 cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475 cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634 cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038 cmd/incus/storage_volume.go:2081
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -2049,7 +2054,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937 cmd/incus/network.go:1448 cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937 cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515 cmd/incus/network.go:1448 cmd/incus/network_integration.go:581 cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547 cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157 cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890 cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2195,7 +2200,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117 cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235 cmd/incus/image.go:1117 cmd/incus/image.go:1118
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -2213,12 +2218,12 @@ msgstr  ""
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, c-format
 msgid   "Failed checking instance exists \"%s:%s\": %w"
 msgstr  ""
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, c-format
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
@@ -2283,17 +2288,17 @@ msgstr  ""
 msgid   "Failed import request: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, c-format
 msgid   "Failed loading network %q: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid   "Failed loading profile %q for device override: %w"
 msgstr  ""
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, c-format
 msgid   "Failed loading storage pool %q: %w"
 msgstr  ""
@@ -2546,7 +2551,7 @@ msgstr  ""
 msgid   "Fetch instance backup file: %w"
 msgstr  ""
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133 cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187 cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -2610,7 +2615,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067 cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586 cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135 cmd/incus/network.go:1073 cmd/incus/network.go:1243 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84 cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786 cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
+#: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067 cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586 cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57 cmd/incus/network_forward.go:88 cmd/incus/network.go:1073 cmd/incus/network.go:1243 cmd/incus/network_integration.go:412 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84 cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786 cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291 cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806 cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -3050,6 +3055,10 @@ msgstr  ""
 msgid   "Importing instance: %s"
 msgstr  ""
 
+#: cmd/incus/create.go:55
+msgid   "Include environment variables from file"
+msgstr  ""
+
 #: cmd/incus/manpage.go:26
 msgid   "Include less common commands"
 msgstr  ""
@@ -3083,7 +3092,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -3102,7 +3111,7 @@ msgstr  ""
 msgid   "Instance snapshots cannot be rebuilt: %s"
 msgstr  ""
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid   "Instance type"
 msgstr  ""
 
@@ -3285,7 +3294,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303 cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161 cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544 cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158 cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161 cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544 cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -3303,12 +3312,12 @@ msgstr  ""
 msgid   "Last used: never"
 msgstr  ""
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, c-format
 msgid   "Launching %s"
 msgstr  ""
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 msgid   "Launching the instance"
 msgstr  ""
 
@@ -4176,7 +4185,7 @@ msgstr  ""
 msgid   "Missing network integration name"
 msgstr  ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352 cmd/incus/network.go:1418 cmd/incus/network.go:1510 cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960 cmd/incus/network_load_balancer.go:127 cmd/incus/network_load_balancer.go:213 cmd/incus/network_load_balancer.go:282 cmd/incus/network_load_balancer.go:380 cmd/incus/network_load_balancer.go:465 cmd/incus/network_load_balancer.go:633 cmd/incus/network_load_balancer.go:765 cmd/incus/network_load_balancer.go:853 cmd/incus/network_load_balancer.go:929 cmd/incus/network_load_balancer.go:1042 cmd/incus/network_load_balancer.go:1116 cmd/incus/network_peer.go:118 cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516 cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960 cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352 cmd/incus/network.go:1418 cmd/incus/network.go:1510 cmd/incus/network_load_balancer.go:127 cmd/incus/network_load_balancer.go:213 cmd/incus/network_load_balancer.go:282 cmd/incus/network_load_balancer.go:380 cmd/incus/network_load_balancer.go:465 cmd/incus/network_load_balancer.go:633 cmd/incus/network_load_balancer.go:765 cmd/incus/network_load_balancer.go:853 cmd/incus/network_load_balancer.go:929 cmd/incus/network_load_balancer.go:1042 cmd/incus/network_load_balancer.go:1116 cmd/incus/network_peer.go:118 cmd/incus/network_peer.go:208 cmd/incus/network_peer.go:291 cmd/incus/network_peer.go:432 cmd/incus/network_peer.go:516 cmd/incus/network_peer.go:675 cmd/incus/network_peer.go:796
 msgid   "Missing network name"
 msgstr  ""
 
@@ -4192,7 +4201,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970 cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596 cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014 cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596 cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830 cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014 cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216 cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -4312,7 +4321,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158 cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:666 cmd/incus/list.go:583 cmd/incus/network.go:1093 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154 cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843 cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158 cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:666 cmd/incus/list.go:583 cmd/incus/network_acl.go:168 cmd/incus/network.go:1093 cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154 cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843 cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780 cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863 cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid   "NAME"
 msgstr  ""
 
@@ -4512,7 +4521,7 @@ msgstr  ""
 msgid   "Network load balancer %s deleted"
 msgstr  ""
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid   "Network name"
 msgstr  ""
 
@@ -4562,7 +4571,7 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
@@ -4613,7 +4622,7 @@ msgstr  ""
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid   "No text editor found, please set the EDITOR environment variable"
 msgstr  ""
 
@@ -4730,7 +4739,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092 cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165 cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548 cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352 cmd/incus/warning.go:213
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174 cmd/incus/network.go:1092 cmd/incus/network_zone.go:165 cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548 cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352 cmd/incus/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4843,7 +4852,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:409 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:478 cmd/incus/network.go:803 cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730 cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333 cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158 cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:409 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:478 cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717 cmd/incus/network.go:803 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730 cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333 cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158 cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4927,7 +4936,7 @@ msgstr  ""
 msgid   "Profile to apply to the new image"
 msgstr  ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
@@ -5339,7 +5348,7 @@ msgstr  ""
 msgid   "Retrieve the instance's console log"
 msgstr  ""
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -6157,7 +6166,7 @@ msgstr  ""
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34 cmd/incus/move.go:63
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34 cmd/incus/move.go:63
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -6238,7 +6247,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123 cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094 cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26 cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157 cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236 cmd/incus/image.go:1123 cmd/incus/list.go:589 cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094 cmd/incus/network.go:1299 cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157 cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -6325,7 +6334,7 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -6343,12 +6352,12 @@ msgstr  ""
 msgid   "The key %q does not exist on cluster member %q"
 msgstr  ""
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, c-format
 msgid   "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr  ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, c-format
 msgid   "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr  ""
@@ -6531,11 +6540,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 msgid   "To attach a network to an instance, use: incus network attach"
 msgstr  ""
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 msgid   "To create a new network, use: incus network create"
 msgstr  ""
 
@@ -6660,7 +6669,7 @@ msgstr  ""
 msgid   "USB devices:"
 msgstr  ""
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460 cmd/incus/network_zone.go:161 cmd/incus/profile.go:748 cmd/incus/project.go:556 cmd/incus/storage.go:712 cmd/incus/storage_volume.go:1674
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24 cmd/incus/network.go:1099 cmd/incus/network_integration.go:460 cmd/incus/network_zone.go:161 cmd/incus/profile.go:748 cmd/incus/project.go:556 cmd/incus/storage.go:712 cmd/incus/storage_volume.go:1674
 msgid   "USED BY"
 msgstr  ""
 
@@ -7170,7 +7179,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064 cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31 cmd/incus/network.go:1050 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82 cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505 cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064 cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31 cmd/incus/network_acl.go:91 cmd/incus/network.go:1050 cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82 cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505 cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -7294,7 +7303,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<remote>:]<instance>"
 msgstr  ""
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 msgid   "[<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
@@ -7450,7 +7459,7 @@ msgstr  ""
 msgid   "[<remote>:]<network integration> <type>"
 msgstr  ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239 cmd/incus/network.go:1474 cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87 cmd/incus/network_peer.go:78
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239 cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87 cmd/incus/network_peer.go:78
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
@@ -7546,7 +7555,7 @@ msgstr  ""
 msgid   "[<remote>:]<operation>"
 msgstr  ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
@@ -7862,7 +7871,7 @@ msgid   "incus config template create u1 t1\n"
         "    Create template t1 for instance u1 from config.tpl"
 msgstr  ""
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 msgid   "incus create images:ubuntu/22.04 u1\n"
         "\n"
         "incus create images:ubuntu/22.04 u1 < config.yaml\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-08-01 01:00-0400\n"
+"POT-Creation-Date: 2024-08-07 14:26-0400\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -669,7 +669,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgstr "Il nome del container è: %s"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1141,15 +1141,15 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308
+#: cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1278,6 +1278,11 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
+#: cmd/incus/utils.go:250
+#, fuzzy, c-format
+msgid "Can't read from environment file: %w"
+msgstr "Impossible leggere da stdin: %s"
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
@@ -1333,7 +1338,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1465,13 +1470,13 @@ msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1386 cmd/incus/network.go:1479
-#: cmd/incus/network.go:1551 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
-#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
-#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598
+#: cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841
+#: cmd/incus/network_forward.go:923 cmd/incus/network.go:347
+#: cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386
+#: cmd/incus/network.go:1479 cmd/incus/network.go:1551
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:261
 #: cmd/incus/network_load_balancer.go:432
@@ -1480,16 +1485,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:820
 #: cmd/incus/network_load_balancer.go:896
 #: cmd/incus/network_load_balancer.go:1009
-#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108
+#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103
+#: cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266
+#: cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573
+#: cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732
+#: cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058
+#: cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268
+#: cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108
 #: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
 #: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807
-#: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
-#: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
-#: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
 #: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
 #: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
 #: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
@@ -1537,7 +1542,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1561,12 +1566,13 @@ msgstr ""
 #: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729
-#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/image.go:477 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:716 cmd/incus/network.go:802
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696
+#: cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637
+#: cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600
+#: cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361
+#: cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
@@ -1745,7 +1751,7 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Creazione del container in corso"
@@ -1754,7 +1760,7 @@ msgstr "Creazione del container in corso"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Creazione del container in corso"
@@ -1791,7 +1797,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Creazione del container in corso"
@@ -1862,7 +1868,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1872,7 +1878,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
@@ -1882,7 +1888,7 @@ msgstr "Creazione di %s in corso"
 msgid "Creating %s: %%s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
@@ -1897,15 +1903,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098
-#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152
+#: cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237
+#: cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169
+#: cmd/incus/network_forward.go:152 cmd/incus/network.go:1098
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -2063,62 +2069,57 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
-#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
-#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
-#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
-#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
-#: cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176
-#: cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388
-#: cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30
-#: cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181
-#: cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327
-#: cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533
-#: cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674
-#: cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812
-#: cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584
-#: cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732
-#: cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40
-#: cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
-#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
-#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
-#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
-#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375
+#: cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587
+#: cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780
+#: cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066
+#: cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264
+#: cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417
+#: cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96
+#: cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267
+#: cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451
+#: cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618
+#: cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686
+#: cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803
+#: cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43
+#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
+#: cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310
+#: cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648
+#: cmd/incus/file.go:1153 cmd/incus/image_alias.go:24
+#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
+#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
+#: cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321
+#: cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679
+#: cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417
+#: cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633
+#: cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35
 #: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
-#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241
-#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
-#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
 #: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
@@ -2132,13 +2133,20 @@ msgstr ""
 #: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
 #: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
 #: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
-#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347
-#: cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478
-#: cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613
-#: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
+#: cmd/incus/network_forward.go:919 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337
+#: cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603
+#: cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917
+#: cmd/incus/network.go:1053 cmd/incus/network.go:1241
+#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
+#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410
+#: cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90
+#: cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
 #: cmd/incus/network_load_balancer.go:356
 #: cmd/incus/network_load_balancer.go:424
@@ -2183,10 +2191,7 @@ msgstr ""
 #: cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
 #: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
 #: cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385
-#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473
@@ -2195,23 +2200,27 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884
 #: cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054
 #: cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261
-#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755
-#: cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922
-#: cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475
+#: cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088
+#: cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29
+#: cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304
+#: cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2301,7 +2310,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2600,7 +2609,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2625,13 +2634,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540
+#: cmd/incus/network_forward.go:521 cmd/incus/network.go:1454
 #: cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507
 #: cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475
 #: cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634
+#: cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
@@ -2648,13 +2657,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937
-#: cmd/incus/network.go:1448 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581
+#: cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515
+#: cmd/incus/network.go:1448 cmd/incus/network_integration.go:581
 #: cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547
 #: cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890
+#: cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2812,8 +2821,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235
+#: cmd/incus/image.go:1117 cmd/incus/image.go:1118
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2831,12 +2840,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
@@ -2901,17 +2910,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Accetta certificato"
@@ -3167,7 +3176,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187
 #: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -3242,16 +3251,16 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067
 #: cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135
-#: cmd/incus/network.go:1073 cmd/incus/network.go:1243
+#: cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57
-#: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:1073
+#: cmd/incus/network.go:1243 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806
+#: cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575
 #: cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3721,6 +3730,10 @@ msgstr "Creazione del container in corso"
 msgid "Importing instance: %s"
 msgstr "Creazione del container in corso"
 
+#: cmd/incus/create.go:55
+msgid "Include environment variables from file"
+msgstr ""
+
 #: cmd/incus/manpage.go:26
 msgid "Include less common commands"
 msgstr ""
@@ -3755,7 +3768,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -3774,7 +3787,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid "Instance type"
 msgstr ""
 
@@ -3969,8 +3982,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303
-#: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158
+#: cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
 #: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
@@ -3990,12 +4003,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creazione del container in corso"
@@ -4796,8 +4809,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:38 cmd/incus/remote.go:39
@@ -4975,15 +4988,15 @@ msgstr "Il nome del container è: %s"
 msgid "Missing network integration name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274
-#: cmd/incus/network.go:1352 cmd/incus/network.go:1418
-#: cmd/incus/network.go:1510 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
-#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
-#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
-#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210
+#: cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654
+#: cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878
+#: cmd/incus/network_forward.go:960 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542
+#: cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875
+#: cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352
+#: cmd/incus/network.go:1418 cmd/incus/network.go:1510
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:282
@@ -5024,24 +5037,24 @@ msgstr "Il nome del container è: %s"
 msgid "Missing peer name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
 #: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
 #: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
 #: cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596
 #: cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
-#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244
+#: cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518
+#: cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722
+#: cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897
+#: cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231
+#: cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904
+#: cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160
+#: cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495
+#: cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 msgid "Missing pool name"
 msgstr ""
 
@@ -5182,12 +5195,12 @@ msgstr ""
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158
 #: cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:583
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_acl.go:168 cmd/incus/network.go:1093
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780
-#: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863
+#: cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5395,7 +5408,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid "Network name"
 msgstr ""
 
@@ -5446,7 +5459,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5497,7 +5510,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
@@ -5619,8 +5632,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
-#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174
+#: cmd/incus/network.go:1092 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
 #: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
 #: cmd/incus/warning.go:213
@@ -5742,13 +5755,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717
+#: cmd/incus/network.go:803 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112
+#: cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5833,7 +5847,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6277,7 +6291,7 @@ msgstr "Creazione del container in corso"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -7174,7 +7188,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7258,12 +7272,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094
-#: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
-#: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
-#: cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236
+#: cmd/incus/image.go:1123 cmd/incus/list.go:589
+#: cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1299 cmd/incus/network_integration.go:459
+#: cmd/incus/network_peer.go:157 cmd/incus/operation.go:172
+#: cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -7364,7 +7378,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7382,12 +7396,12 @@ msgstr "Il nome del container è: %s"
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7581,11 +7595,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7721,8 +7735,8 @@ msgstr "Creazione del container in corso"
 msgid "USB devices:"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
-#: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24
+#: cmd/incus/network.go:1099 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
@@ -8289,7 +8303,7 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064
 #: cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1050
 #: cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505
 #: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
@@ -8451,7 +8465,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "Creazione del container in corso"
@@ -8655,9 +8669,9 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1239 cmd/incus/network.go:1474
-#: cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445
+#: cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239
+#: cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87
 #: cmd/incus/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -8790,8 +8804,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<operation>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209
+#: cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
@@ -9182,7 +9196,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-08-01 01:00-0400\n"
+"POT-Creation-Date: 2024-08-07 14:26-0400\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -661,7 +661,7 @@ msgstr "--console と --all は同時に指定できません"
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
@@ -767,7 +767,7 @@ msgstr "クラスターメンバー名が必要です"
 msgid "ADDRESS"
 msgstr "ADDRESS"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1030,7 +1030,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
@@ -1147,15 +1147,15 @@ msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308
+#: cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1285,6 +1285,11 @@ msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
 
+#: cmd/incus/utils.go:250
+#, fuzzy, c-format
+msgid "Can't read from environment file: %w"
+msgstr "標準入力から読み込めません: %w"
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, c-format
 msgid "Can't read from stdin: %w"
@@ -1340,7 +1345,7 @@ msgstr "--minimal と --preseed を同時に使えません"
 msgid "Can't use an image with --empty"
 msgstr "イメージに --empty は使えません"
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1479,13 +1484,13 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1386 cmd/incus/network.go:1479
-#: cmd/incus/network.go:1551 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
-#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
-#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598
+#: cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841
+#: cmd/incus/network_forward.go:923 cmd/incus/network.go:347
+#: cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386
+#: cmd/incus/network.go:1479 cmd/incus/network.go:1551
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:261
 #: cmd/incus/network_load_balancer.go:432
@@ -1494,16 +1499,16 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: cmd/incus/network_load_balancer.go:820
 #: cmd/incus/network_load_balancer.go:896
 #: cmd/incus/network_load_balancer.go:1009
-#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108
+#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103
+#: cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266
+#: cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573
+#: cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732
+#: cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058
+#: cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268
+#: cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108
 #: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
 #: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807
-#: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
-#: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
-#: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
 #: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
 #: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
 #: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
@@ -1558,7 +1563,7 @@ msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `n
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない場合は none)"
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
@@ -1582,12 +1587,13 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729
-#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/image.go:477 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:716 cmd/incus/network.go:802
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696
+#: cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637
+#: cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600
+#: cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361
+#: cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
@@ -1782,7 +1788,7 @@ msgstr "クラスターグループを作成します"
 msgid "Create a new %s pool?"
 msgstr "新たに %s プールを作成しますか?"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Create a virtual machine"
 msgstr "仮想マシンを作成します"
 
@@ -1790,7 +1796,7 @@ msgstr "仮想マシンを作成します"
 msgid "Create aliases for existing images"
 msgstr "既存のイメージに対するエイリアスを作成します"
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Create an empty instance"
 msgstr "空のインスタンスを作成"
 
@@ -1827,7 +1833,7 @@ msgstr ""
 "--stateful を指定すると、インスタンスの実行状態（プロセスのメモリ状態、TCPコ"
 "ネクション、など…を含む）を保存しようとします。"
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 msgid "Create instances from images"
 msgstr "イメージからインスタンスを作成します"
 
@@ -1893,7 +1899,7 @@ msgstr "プロジェクトを作成します"
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
@@ -1903,7 +1909,7 @@ msgstr "プロファイルを適用しないインスタンスを作成します
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
@@ -1913,7 +1919,7 @@ msgstr "%s を作成中"
 msgid "Creating %s: %%s"
 msgstr "%s: %%s を作成中"
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
@@ -1927,15 +1933,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098
-#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152
+#: cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237
+#: cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169
+#: cmd/incus/network_forward.go:152 cmd/incus/network.go:1098
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -2088,62 +2094,57 @@ msgid "Delete warning"
 msgstr "警告を削除します"
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
-#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
-#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
-#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
-#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
-#: cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176
-#: cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388
-#: cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30
-#: cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181
-#: cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327
-#: cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533
-#: cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674
-#: cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812
-#: cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584
-#: cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732
-#: cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40
-#: cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
-#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
-#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
-#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
-#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375
+#: cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587
+#: cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780
+#: cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066
+#: cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264
+#: cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417
+#: cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96
+#: cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267
+#: cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451
+#: cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618
+#: cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686
+#: cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803
+#: cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43
+#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
+#: cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310
+#: cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648
+#: cmd/incus/file.go:1153 cmd/incus/image_alias.go:24
+#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
+#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
+#: cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321
+#: cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679
+#: cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417
+#: cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633
+#: cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35
 #: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
-#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241
-#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
-#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
 #: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
@@ -2157,13 +2158,20 @@ msgstr "警告を削除します"
 #: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
 #: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
 #: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
-#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347
-#: cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478
-#: cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613
-#: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
+#: cmd/incus/network_forward.go:919 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337
+#: cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603
+#: cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917
+#: cmd/incus/network.go:1053 cmd/incus/network.go:1241
+#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
+#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410
+#: cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90
+#: cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
 #: cmd/incus/network_load_balancer.go:356
 #: cmd/incus/network_load_balancer.go:424
@@ -2208,10 +2216,7 @@ msgstr "警告を削除します"
 #: cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
 #: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
 #: cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385
-#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473
@@ -2220,23 +2225,27 @@ msgstr "警告を削除します"
 #: cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884
 #: cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054
 #: cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261
-#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755
-#: cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922
-#: cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475
+#: cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088
+#: cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29
+#: cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304
+#: cmd/incus/warning.go:358
 msgid "Description"
 msgstr "説明"
 
@@ -2328,7 +2337,7 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 #, fuzzy
 msgid "Didn't get name of new instance from the server"
 msgstr ""
@@ -2632,7 +2641,7 @@ msgstr "TTLを指定します"
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr "Ephemeral インスタンス"
 
@@ -2657,13 +2666,13 @@ msgid "Error retrieving aliases: %w"
 msgstr "エイリアスの取得に失敗しました: %w"
 
 #: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540
+#: cmd/incus/network_forward.go:521 cmd/incus/network.go:1454
 #: cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507
 #: cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475
 #: cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634
+#: cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
@@ -2680,13 +2689,13 @@ msgid "Error unsetting properties: %v"
 msgstr "プロパティの削除でエラーが発生しました: %v"
 
 #: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937
-#: cmd/incus/network.go:1448 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581
+#: cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515
+#: cmd/incus/network.go:1448 cmd/incus/network_integration.go:581
 #: cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547
 #: cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890
+#: cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "プロパティの設定解除エラー: %v"
@@ -2883,8 +2892,8 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235
+#: cmd/incus/image.go:1117 cmd/incus/image.go:1118
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
@@ -2902,12 +2911,12 @@ msgstr "クライアント %q との SSH ハンドシェイクに失敗しまし
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
@@ -2972,17 +2981,17 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed import request: %w"
 msgstr "インポート要求が失敗しました: %w"
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr "ネットワーク %q の取得に失敗しました: %w"
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "ストレージプール %q の取得に失敗しました: %w"
@@ -3238,7 +3247,7 @@ msgstr "Fast モード (--columns=nsacPt と同じ)"
 msgid "Fetch instance backup file: %w"
 msgstr "インスタンスのバックアップをエクスポートします"
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187
 #: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
@@ -3326,16 +3335,16 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067
 #: cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135
-#: cmd/incus/network.go:1073 cmd/incus/network.go:1243
+#: cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57
-#: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:1073
+#: cmd/incus/network.go:1243 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806
+#: cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575
 #: cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
@@ -3817,6 +3826,10 @@ msgstr "カスタムボリュームのインポート中: %s"
 msgid "Importing instance: %s"
 msgstr "インスタンスのインポート中: %s"
 
+#: cmd/incus/create.go:55
+msgid "Include environment variables from file"
+msgstr ""
+
 #: cmd/incus/manpage.go:26
 #, fuzzy
 msgid "Include less common commands"
@@ -3852,7 +3865,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -3871,7 +3884,7 @@ msgstr "インスタンスは以下のフィンガープリントで publish さ
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "インスタンス名: %s"
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
@@ -4069,8 +4082,8 @@ msgstr "LIMIT"
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303
-#: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158
+#: cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
 #: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
@@ -4090,12 +4103,12 @@ msgstr "最終使用: %s"
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "%s を作成中"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 #, fuzzy
 msgid "Launching the instance"
 msgstr "インスタンスを作成中"
@@ -5157,8 +5170,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -5332,15 +5345,15 @@ msgstr "ネットワーク ACL 名を指定する必要があります"
 msgid "Missing network integration name"
 msgstr "ネットワークゾーン名を指定する必要があります"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274
-#: cmd/incus/network.go:1352 cmd/incus/network.go:1418
-#: cmd/incus/network.go:1510 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
-#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
-#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
-#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210
+#: cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654
+#: cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878
+#: cmd/incus/network_forward.go:960 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542
+#: cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875
+#: cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352
+#: cmd/incus/network.go:1418 cmd/incus/network.go:1510
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:282
@@ -5378,24 +5391,24 @@ msgstr "ネットワークゾーンレコード名を指定する必要があり
 msgid "Missing peer name"
 msgstr "ピア名を指定する必要があります"
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
 #: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
 #: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
 #: cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596
 #: cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
-#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244
+#: cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518
+#: cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722
+#: cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897
+#: cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231
+#: cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904
+#: cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160
+#: cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495
+#: cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -5554,12 +5567,12 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158
 #: cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:583
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_acl.go:168 cmd/incus/network.go:1093
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780
-#: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863
+#: cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr "NAME"
 
@@ -5771,7 +5784,7 @@ msgstr "ネットワークロードバランサー %s を作成しました"
 msgid "Network load balancer %s deleted"
 msgstr "ネットワークロードバランサー %s を削除しました"
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid "Network name"
 msgstr "ネットワーク名:"
 
@@ -5824,7 +5837,7 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
@@ -5876,7 +5889,7 @@ msgstr "コピー元のボリュームに対するストレージプールが指
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr "テキストエディターが見つかりません。環境変数 EDITOR を設定してください"
 
@@ -6005,8 +6018,8 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
-#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174
+#: cmd/incus/network.go:1092 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
 #: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
 #: cmd/incus/warning.go:213
@@ -6128,13 +6141,14 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717
+#: cmd/incus/network.go:803 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112
+#: cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -6220,7 +6234,7 @@ msgstr "プロファイル名 %s を %s に変更しました"
 msgid "Profile to apply to the new image"
 msgstr "新しいイメージに適用するプロファイル"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
@@ -6666,7 +6680,7 @@ msgstr "インスタンスを再起動します"
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -7637,7 +7651,7 @@ msgstr "ストレージプール %s を削除しました"
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr "ストレージプール名"
@@ -7721,12 +7735,12 @@ msgstr "TARGET"
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094
-#: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
-#: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
-#: cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236
+#: cmd/incus/image.go:1123 cmd/incus/list.go:589
+#: cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1299 cmd/incus/network_integration.go:459
+#: cmd/incus/network_peer.go:157 cmd/incus/operation.go:172
+#: cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -7856,7 +7870,7 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
@@ -7874,14 +7888,14 @@ msgstr "設定 %q はクラスターメンバー %q には存在しません"
 msgid "The key %q does not exist on cluster member %q"
 msgstr "設定 %q はクラスターメンバー %q には存在しません"
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:%s' を試してみてくださ"
 "い。"
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -8098,14 +8112,14 @@ msgstr "インスタンスがクリーンにシャットダウンするまで待
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 #, fuzzy
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 #, fuzzy
 msgid "To create a new network, use: incus network create"
 msgstr ""
@@ -8250,8 +8264,8 @@ msgstr "device"
 msgid "USB devices:"
 msgstr "上位デバイス"
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
-#: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24
+#: cmd/incus/network.go:1099 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
@@ -8836,7 +8850,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064
 #: cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1050
 #: cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505
 #: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
@@ -8971,7 +8985,7 @@ msgstr "[<remote>:]<image> <remote>:"
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
@@ -9151,9 +9165,9 @@ msgstr "[<remote>:]<network> <new-name>"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "[<remote>:]<network> <key>"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1239 cmd/incus/network.go:1474
-#: cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445
+#: cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239
+#: cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87
 #: cmd/incus/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
@@ -9272,8 +9286,8 @@ msgstr "[<remote>:]<network> [key=value...]"
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operation>"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209
+#: cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
@@ -9670,7 +9684,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 #, fuzzy
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-08-01 01:00-0400\n"
+"POT-Creation-Date: 2024-08-07 14:26-0400\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -679,7 +679,7 @@ msgstr "--console kan niet gebruikt worden samen met --all"
 msgid "--console only works with a single instance"
 msgstr "--console werkt alleen als het een enkele instantie (instance) betreft"
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 "--empty kan niet gebruikt worden in combinatie met een virtuele disk (image) "
@@ -786,7 +786,7 @@ msgstr "Een clusterlid (cluster member) naam (name) moet worden meegegeven"
 msgid "ADDRESS"
 msgstr "ADRES"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1049,7 +1049,7 @@ msgstr ""
 "Beide konden niet worden gevonden, de directe SPICE plug (raw SPICE socket) "
 "kan hier gevonden worden:"
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 "Gevraagd naar een virtueel machine (VM), maar het bestand (image) is van het "
@@ -1164,15 +1164,15 @@ msgstr "Backups:"
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308
+#: cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1303,6 +1303,11 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
+#: cmd/incus/utils.go:250
+#, c-format
+msgid "Can't read from environment file: %w"
+msgstr ""
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, c-format
 msgid "Can't read from stdin: %w"
@@ -1358,7 +1363,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1489,13 +1494,13 @@ msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1386 cmd/incus/network.go:1479
-#: cmd/incus/network.go:1551 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
-#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
-#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598
+#: cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841
+#: cmd/incus/network_forward.go:923 cmd/incus/network.go:347
+#: cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386
+#: cmd/incus/network.go:1479 cmd/incus/network.go:1551
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:261
 #: cmd/incus/network_load_balancer.go:432
@@ -1504,16 +1509,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:820
 #: cmd/incus/network_load_balancer.go:896
 #: cmd/incus/network_load_balancer.go:1009
-#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108
+#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103
+#: cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266
+#: cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573
+#: cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732
+#: cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058
+#: cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268
+#: cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108
 #: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
 #: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807
-#: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
-#: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
-#: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
 #: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
 #: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
 #: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
@@ -1561,7 +1566,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1584,12 +1589,13 @@ msgstr ""
 #: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729
-#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/image.go:477 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:716 cmd/incus/network.go:802
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696
+#: cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637
+#: cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600
+#: cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361
+#: cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
@@ -1768,7 +1774,7 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1776,7 +1782,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1809,7 +1815,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 msgid "Create instances from images"
 msgstr ""
 
@@ -1875,7 +1881,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1885,7 +1891,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1895,7 +1901,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 msgid "Creating the instance"
 msgstr ""
 
@@ -1909,15 +1915,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098
-#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152
+#: cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237
+#: cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169
+#: cmd/incus/network_forward.go:152 cmd/incus/network.go:1098
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -2068,62 +2074,57 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
-#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
-#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
-#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
-#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
-#: cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176
-#: cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388
-#: cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30
-#: cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181
-#: cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327
-#: cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533
-#: cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674
-#: cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812
-#: cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584
-#: cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732
-#: cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40
-#: cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
-#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
-#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
-#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
-#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375
+#: cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587
+#: cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780
+#: cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066
+#: cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264
+#: cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417
+#: cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96
+#: cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267
+#: cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451
+#: cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618
+#: cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686
+#: cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803
+#: cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43
+#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
+#: cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310
+#: cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648
+#: cmd/incus/file.go:1153 cmd/incus/image_alias.go:24
+#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
+#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
+#: cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321
+#: cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679
+#: cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417
+#: cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633
+#: cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35
 #: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
-#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241
-#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
-#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
 #: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
@@ -2137,13 +2138,20 @@ msgstr ""
 #: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
 #: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
 #: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
-#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347
-#: cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478
-#: cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613
-#: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
+#: cmd/incus/network_forward.go:919 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337
+#: cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603
+#: cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917
+#: cmd/incus/network.go:1053 cmd/incus/network.go:1241
+#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
+#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410
+#: cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90
+#: cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
 #: cmd/incus/network_load_balancer.go:356
 #: cmd/incus/network_load_balancer.go:424
@@ -2188,10 +2196,7 @@ msgstr ""
 #: cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
 #: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
 #: cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385
-#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473
@@ -2200,23 +2205,27 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884
 #: cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054
 #: cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261
-#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755
-#: cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922
-#: cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475
+#: cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088
+#: cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29
+#: cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304
+#: cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2304,7 +2313,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2588,7 +2597,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2613,13 +2622,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540
+#: cmd/incus/network_forward.go:521 cmd/incus/network.go:1454
 #: cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507
 #: cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475
 #: cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634
+#: cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
@@ -2636,13 +2645,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937
-#: cmd/incus/network.go:1448 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581
+#: cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515
+#: cmd/incus/network.go:1448 cmd/incus/network_integration.go:581
 #: cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547
 #: cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890
+#: cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2795,8 +2804,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235
+#: cmd/incus/image.go:1117 cmd/incus/image.go:1118
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2814,12 +2823,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2884,17 +2893,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187
 #: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3223,16 +3232,16 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067
 #: cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135
-#: cmd/incus/network.go:1073 cmd/incus/network.go:1243
+#: cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57
-#: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:1073
+#: cmd/incus/network.go:1243 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806
+#: cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575
 #: cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3686,6 +3695,10 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
+#: cmd/incus/create.go:55
+msgid "Include environment variables from file"
+msgstr ""
+
 #: cmd/incus/manpage.go:26
 msgid "Include less common commands"
 msgstr ""
@@ -3719,7 +3732,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3738,7 +3751,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid "Instance type"
 msgstr ""
 
@@ -3926,8 +3939,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303
-#: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158
+#: cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
 #: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
@@ -3947,12 +3960,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 msgid "Launching the instance"
 msgstr ""
 
@@ -4718,8 +4731,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:38 cmd/incus/remote.go:39
@@ -4889,15 +4902,15 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr "Toekennen van netwerk interfaces aan instanties (instances)"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274
-#: cmd/incus/network.go:1352 cmd/incus/network.go:1418
-#: cmd/incus/network.go:1510 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
-#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
-#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
-#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210
+#: cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654
+#: cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878
+#: cmd/incus/network_forward.go:960 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542
+#: cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875
+#: cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352
+#: cmd/incus/network.go:1418 cmd/incus/network.go:1510
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:282
@@ -4935,24 +4948,24 @@ msgstr ""
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
 #: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
 #: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
 #: cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596
 #: cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
-#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244
+#: cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518
+#: cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722
+#: cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897
+#: cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231
+#: cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904
+#: cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160
+#: cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495
+#: cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 msgid "Missing pool name"
 msgstr ""
 
@@ -5086,12 +5099,12 @@ msgstr ""
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158
 #: cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:583
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_acl.go:168 cmd/incus/network.go:1093
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780
-#: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863
+#: cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5299,7 +5312,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid "Network name"
 msgstr ""
 
@@ -5350,7 +5363,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5401,7 +5414,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
@@ -5521,8 +5534,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
-#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174
+#: cmd/incus/network.go:1092 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
 #: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
 #: cmd/incus/warning.go:213
@@ -5642,13 +5655,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717
+#: cmd/incus/network.go:803 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112
+#: cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5732,7 +5746,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6158,7 +6172,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -7026,7 +7040,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7108,12 +7122,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094
-#: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
-#: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
-#: cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236
+#: cmd/incus/image.go:1123 cmd/incus/list.go:589
+#: cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1299 cmd/incus/network_integration.go:459
+#: cmd/incus/network_peer.go:157 cmd/incus/operation.go:172
+#: cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -7213,7 +7227,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7231,12 +7245,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7428,11 +7442,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7565,8 +7579,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
-#: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24
+#: cmd/incus/network.go:1099 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
@@ -8108,7 +8122,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064
 #: cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1050
 #: cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505
 #: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
@@ -8239,7 +8253,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
@@ -8405,9 +8419,9 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1239 cmd/incus/network.go:1474
-#: cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445
+#: cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239
+#: cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87
 #: cmd/incus/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8517,8 +8531,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209
+#: cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -8854,7 +8868,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-08-01 01:00-0400\n"
+"POT-Creation-Date: 2024-08-07 14:26-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid "ALIAS"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -882,15 +882,15 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308
+#: cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1017,6 +1017,11 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
+#: cmd/incus/utils.go:250
+#, c-format
+msgid "Can't read from environment file: %w"
+msgstr ""
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, c-format
 msgid "Can't read from stdin: %w"
@@ -1072,7 +1077,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1203,13 +1208,13 @@ msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1386 cmd/incus/network.go:1479
-#: cmd/incus/network.go:1551 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
-#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
-#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598
+#: cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841
+#: cmd/incus/network_forward.go:923 cmd/incus/network.go:347
+#: cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386
+#: cmd/incus/network.go:1479 cmd/incus/network.go:1551
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:261
 #: cmd/incus/network_load_balancer.go:432
@@ -1218,16 +1223,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:820
 #: cmd/incus/network_load_balancer.go:896
 #: cmd/incus/network_load_balancer.go:1009
-#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108
+#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103
+#: cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266
+#: cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573
+#: cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732
+#: cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058
+#: cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268
+#: cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108
 #: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
 #: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807
-#: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
-#: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
-#: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
 #: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
 #: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
 #: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
@@ -1275,7 +1280,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1298,12 +1303,13 @@ msgstr ""
 #: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729
-#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/image.go:477 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:716 cmd/incus/network.go:802
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696
+#: cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637
+#: cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600
+#: cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361
+#: cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
@@ -1481,7 +1487,7 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1489,7 +1495,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1522,7 +1528,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 msgid "Create instances from images"
 msgstr ""
 
@@ -1587,7 +1593,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1597,7 +1603,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1607,7 +1613,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 msgid "Creating the instance"
 msgstr ""
 
@@ -1621,15 +1627,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098
-#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152
+#: cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237
+#: cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169
+#: cmd/incus/network_forward.go:152 cmd/incus/network.go:1098
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1778,62 +1784,57 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
-#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
-#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
-#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
-#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
-#: cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176
-#: cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388
-#: cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30
-#: cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181
-#: cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327
-#: cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533
-#: cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674
-#: cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812
-#: cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584
-#: cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732
-#: cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40
-#: cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
-#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
-#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
-#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
-#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375
+#: cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587
+#: cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780
+#: cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066
+#: cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264
+#: cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417
+#: cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96
+#: cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267
+#: cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451
+#: cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618
+#: cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686
+#: cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803
+#: cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43
+#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
+#: cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310
+#: cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648
+#: cmd/incus/file.go:1153 cmd/incus/image_alias.go:24
+#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
+#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
+#: cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321
+#: cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679
+#: cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417
+#: cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633
+#: cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35
 #: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
-#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241
-#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
-#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
 #: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
@@ -1847,13 +1848,20 @@ msgstr ""
 #: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
 #: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
 #: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
-#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347
-#: cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478
-#: cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613
-#: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
+#: cmd/incus/network_forward.go:919 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337
+#: cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603
+#: cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917
+#: cmd/incus/network.go:1053 cmd/incus/network.go:1241
+#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
+#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410
+#: cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90
+#: cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
 #: cmd/incus/network_load_balancer.go:356
 #: cmd/incus/network_load_balancer.go:424
@@ -1898,10 +1906,7 @@ msgstr ""
 #: cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
 #: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
 #: cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385
-#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473
@@ -1910,23 +1915,27 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884
 #: cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054
 #: cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261
-#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755
-#: cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922
-#: cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475
+#: cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088
+#: cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29
+#: cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304
+#: cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2012,7 +2021,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2296,7 +2305,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2321,13 +2330,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540
+#: cmd/incus/network_forward.go:521 cmd/incus/network.go:1454
 #: cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507
 #: cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475
 #: cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634
+#: cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
@@ -2344,13 +2353,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937
-#: cmd/incus/network.go:1448 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581
+#: cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515
+#: cmd/incus/network.go:1448 cmd/incus/network_integration.go:581
 #: cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547
 #: cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890
+#: cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2503,8 +2512,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235
+#: cmd/incus/image.go:1117 cmd/incus/image.go:1118
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2522,12 +2531,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2592,17 +2601,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
@@ -2858,7 +2867,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187
 #: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2931,16 +2940,16 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067
 #: cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135
-#: cmd/incus/network.go:1073 cmd/incus/network.go:1243
+#: cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57
-#: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:1073
+#: cmd/incus/network.go:1243 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806
+#: cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575
 #: cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3389,6 +3398,10 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
+#: cmd/incus/create.go:55
+msgid "Include environment variables from file"
+msgstr ""
+
 #: cmd/incus/manpage.go:26
 msgid "Include less common commands"
 msgstr ""
@@ -3422,7 +3435,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3441,7 +3454,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid "Instance type"
 msgstr ""
 
@@ -3629,8 +3642,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303
-#: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158
+#: cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
 #: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
@@ -3650,12 +3663,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 msgid "Launching the instance"
 msgstr ""
 
@@ -4418,8 +4431,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:38 cmd/incus/remote.go:39
@@ -4588,15 +4601,15 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274
-#: cmd/incus/network.go:1352 cmd/incus/network.go:1418
-#: cmd/incus/network.go:1510 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
-#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
-#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
-#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210
+#: cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654
+#: cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878
+#: cmd/incus/network_forward.go:960 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542
+#: cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875
+#: cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352
+#: cmd/incus/network.go:1418 cmd/incus/network.go:1510
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:282
@@ -4634,24 +4647,24 @@ msgstr ""
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
 #: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
 #: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
 #: cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596
 #: cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
-#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244
+#: cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518
+#: cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722
+#: cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897
+#: cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231
+#: cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904
+#: cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160
+#: cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495
+#: cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 msgid "Missing pool name"
 msgstr ""
 
@@ -4785,12 +4798,12 @@ msgstr ""
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158
 #: cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:583
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_acl.go:168 cmd/incus/network.go:1093
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780
-#: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863
+#: cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -4998,7 +5011,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid "Network name"
 msgstr ""
 
@@ -5049,7 +5062,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5100,7 +5113,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
@@ -5220,8 +5233,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
-#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174
+#: cmd/incus/network.go:1092 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
 #: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
 #: cmd/incus/warning.go:213
@@ -5341,13 +5354,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717
+#: cmd/incus/network.go:803 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112
+#: cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5431,7 +5445,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -5855,7 +5869,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6717,7 +6731,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -6799,12 +6813,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094
-#: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
-#: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
-#: cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236
+#: cmd/incus/image.go:1123 cmd/incus/list.go:589
+#: cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1299 cmd/incus/network_integration.go:459
+#: cmd/incus/network_peer.go:157 cmd/incus/operation.go:172
+#: cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -6904,7 +6918,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6922,12 +6936,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7119,11 +7133,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7256,8 +7270,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
-#: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24
+#: cmd/incus/network.go:1099 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
@@ -7797,7 +7811,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064
 #: cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1050
 #: cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505
 #: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
@@ -7928,7 +7942,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
@@ -8094,9 +8108,9 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1239 cmd/incus/network.go:1474
-#: cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445
+#: cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239
+#: cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87
 #: cmd/incus/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8206,8 +8220,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209
+#: cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -8543,7 +8557,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-08-01 01:00-0400\n"
+"POT-Creation-Date: 2024-08-07 14:26-0400\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -662,7 +662,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
@@ -778,7 +778,7 @@ msgstr "Nome de membro do cluster"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1152,15 +1152,15 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308
+#: cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1290,6 +1290,11 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
+#: cmd/incus/utils.go:250
+#, fuzzy, c-format
+msgid "Can't read from environment file: %w"
+msgstr "Não é possível ler stdin: %s"
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
@@ -1346,7 +1351,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1478,13 +1483,13 @@ msgstr "Dispositivo %s removido de %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1386 cmd/incus/network.go:1479
-#: cmd/incus/network.go:1551 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
-#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
-#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598
+#: cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841
+#: cmd/incus/network_forward.go:923 cmd/incus/network.go:347
+#: cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386
+#: cmd/incus/network.go:1479 cmd/incus/network.go:1551
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:261
 #: cmd/incus/network_load_balancer.go:432
@@ -1493,16 +1498,16 @@ msgstr "Dispositivo %s removido de %s"
 #: cmd/incus/network_load_balancer.go:820
 #: cmd/incus/network_load_balancer.go:896
 #: cmd/incus/network_load_balancer.go:1009
-#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108
+#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103
+#: cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266
+#: cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573
+#: cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732
+#: cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058
+#: cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268
+#: cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108
 #: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
 #: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807
-#: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
-#: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
-#: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
 #: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
 #: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
 #: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
@@ -1559,7 +1564,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1585,12 +1590,13 @@ msgstr ""
 #: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729
-#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/image.go:477 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:716 cmd/incus/network.go:802
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696
+#: cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637
+#: cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600
+#: cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361
+#: cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
@@ -1771,7 +1777,7 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr "Criar novas redes"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Copiar a imagem: %s"
@@ -1780,7 +1786,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1820,7 +1826,7 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 msgid "Create instances from images"
 msgstr ""
 
@@ -1894,7 +1900,7 @@ msgstr "Criar projetos"
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1904,7 +1910,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
@@ -1914,7 +1920,7 @@ msgstr "Criando %s"
 msgid "Creating %s: %%s"
 msgstr "Criando %s"
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Criando %s"
@@ -1929,15 +1935,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098
-#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152
+#: cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237
+#: cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169
+#: cmd/incus/network_forward.go:152 cmd/incus/network.go:1098
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -2102,62 +2108,57 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
-#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
-#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
-#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
-#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
-#: cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176
-#: cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388
-#: cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30
-#: cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181
-#: cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327
-#: cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533
-#: cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674
-#: cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812
-#: cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584
-#: cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732
-#: cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40
-#: cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
-#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
-#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
-#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
-#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375
+#: cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587
+#: cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780
+#: cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066
+#: cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264
+#: cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417
+#: cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96
+#: cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267
+#: cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451
+#: cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618
+#: cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686
+#: cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803
+#: cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43
+#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
+#: cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310
+#: cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648
+#: cmd/incus/file.go:1153 cmd/incus/image_alias.go:24
+#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
+#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
+#: cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321
+#: cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679
+#: cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417
+#: cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633
+#: cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35
 #: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
-#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241
-#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
-#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
 #: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
@@ -2171,13 +2172,20 @@ msgstr ""
 #: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
 #: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
 #: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
-#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347
-#: cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478
-#: cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613
-#: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
+#: cmd/incus/network_forward.go:919 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337
+#: cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603
+#: cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917
+#: cmd/incus/network.go:1053 cmd/incus/network.go:1241
+#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
+#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410
+#: cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90
+#: cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
 #: cmd/incus/network_load_balancer.go:356
 #: cmd/incus/network_load_balancer.go:424
@@ -2222,10 +2230,7 @@ msgstr ""
 #: cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
 #: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
 #: cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385
-#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473
@@ -2234,23 +2239,27 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884
 #: cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054
 #: cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261
-#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755
-#: cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922
-#: cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475
+#: cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088
+#: cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29
+#: cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304
+#: cmd/incus/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
@@ -2341,7 +2350,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2648,7 +2657,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2673,13 +2682,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540
+#: cmd/incus/network_forward.go:521 cmd/incus/network.go:1454
 #: cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507
 #: cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475
 #: cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634
+#: cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2696,13 +2705,13 @@ msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
 #: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937
-#: cmd/incus/network.go:1448 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581
+#: cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515
+#: cmd/incus/network.go:1448 cmd/incus/network_integration.go:581
 #: cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547
 #: cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890
+#: cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2858,8 +2867,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235
+#: cmd/incus/image.go:1117 cmd/incus/image.go:1118
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2877,12 +2886,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
@@ -2947,17 +2956,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Aceitar certificado"
@@ -3213,7 +3222,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187
 #: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3287,16 +3296,16 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067
 #: cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135
-#: cmd/incus/network.go:1073 cmd/incus/network.go:1243
+#: cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57
-#: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:1073
+#: cmd/incus/network.go:1243 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806
+#: cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575
 #: cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3774,6 +3783,10 @@ msgstr "Editar arquivos no container"
 msgid "Importing instance: %s"
 msgstr "Editar arquivos no container"
 
+#: cmd/incus/create.go:55
+msgid "Include environment variables from file"
+msgstr ""
+
 #: cmd/incus/manpage.go:26
 msgid "Include less common commands"
 msgstr ""
@@ -3808,7 +3821,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3827,7 +3840,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid "Instance type"
 msgstr ""
 
@@ -4021,8 +4034,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303
-#: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158
+#: cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
 #: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
@@ -4042,12 +4055,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Criando %s"
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Criando %s"
@@ -4849,8 +4862,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:38 cmd/incus/remote.go:39
@@ -5029,15 +5042,15 @@ msgstr "Nome de membro do cluster"
 msgid "Missing network integration name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274
-#: cmd/incus/network.go:1352 cmd/incus/network.go:1418
-#: cmd/incus/network.go:1510 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
-#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
-#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
-#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210
+#: cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654
+#: cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878
+#: cmd/incus/network_forward.go:960 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542
+#: cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875
+#: cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352
+#: cmd/incus/network.go:1418 cmd/incus/network.go:1510
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:282
@@ -5078,24 +5091,24 @@ msgstr "Nome de membro do cluster"
 msgid "Missing peer name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
 #: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
 #: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
 #: cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596
 #: cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
-#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244
+#: cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518
+#: cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722
+#: cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897
+#: cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231
+#: cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904
+#: cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160
+#: cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495
+#: cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 msgid "Missing pool name"
 msgstr ""
 
@@ -5236,12 +5249,12 @@ msgstr ""
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158
 #: cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:583
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_acl.go:168 cmd/incus/network.go:1093
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780
-#: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863
+#: cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5449,7 +5462,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid "Network name"
 msgstr ""
 
@@ -5500,7 +5513,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5551,7 +5564,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
@@ -5673,8 +5686,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
-#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174
+#: cmd/incus/network.go:1092 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
 #: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
 #: cmd/incus/warning.go:213
@@ -5795,13 +5808,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717
+#: cmd/incus/network.go:803 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112
+#: cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5886,7 +5900,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -6344,7 +6358,7 @@ msgstr "Editar arquivos no container"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -7258,7 +7272,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7343,12 +7357,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094
-#: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
-#: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
-#: cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236
+#: cmd/incus/image.go:1123 cmd/incus/list.go:589
+#: cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1299 cmd/incus/network_integration.go:459
+#: cmd/incus/network_peer.go:157 cmd/incus/operation.go:172
+#: cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -7449,7 +7463,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7467,12 +7481,12 @@ msgstr "Nome de membro do cluster"
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7665,11 +7679,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7805,8 +7819,8 @@ msgstr "Editar arquivos no container"
 msgid "USB devices:"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
-#: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24
+#: cmd/incus/network.go:1099 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
@@ -8380,7 +8394,7 @@ msgstr "Criar perfis"
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064
 #: cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1050
 #: cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505
 #: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
@@ -8532,7 +8546,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
@@ -8716,9 +8730,9 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<network integration> <type>"
 msgstr "Criar perfis"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1239 cmd/incus/network.go:1474
-#: cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445
+#: cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239
+#: cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87
 #: cmd/incus/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8840,8 +8854,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209
+#: cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -9208,7 +9222,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-08-01 01:00-0400\n"
+"POT-Creation-Date: 2024-08-07 14:26-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -684,7 +684,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr "Копирование образа: %s"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1166,15 +1166,15 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308
+#: cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
@@ -1304,6 +1304,11 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
+#: cmd/incus/utils.go:250
+#, fuzzy, c-format
+msgid "Can't read from environment file: %w"
+msgstr "Невозможно прочитать из стандартного ввода: %s"
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
@@ -1359,7 +1364,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1491,13 +1496,13 @@ msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1386 cmd/incus/network.go:1479
-#: cmd/incus/network.go:1551 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
-#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
-#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598
+#: cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841
+#: cmd/incus/network_forward.go:923 cmd/incus/network.go:347
+#: cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386
+#: cmd/incus/network.go:1479 cmd/incus/network.go:1551
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:261
 #: cmd/incus/network_load_balancer.go:432
@@ -1506,16 +1511,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:820
 #: cmd/incus/network_load_balancer.go:896
 #: cmd/incus/network_load_balancer.go:1009
-#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108
+#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103
+#: cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266
+#: cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573
+#: cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732
+#: cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058
+#: cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268
+#: cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108
 #: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
 #: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807
-#: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
-#: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
-#: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
 #: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
 #: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
 #: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
@@ -1563,7 +1568,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1586,12 +1591,13 @@ msgstr ""
 #: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729
-#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/image.go:477 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:716 cmd/incus/network.go:802
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696
+#: cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637
+#: cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600
+#: cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361
+#: cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
@@ -1771,7 +1777,7 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 #, fuzzy
 msgid "Create a virtual machine"
 msgstr "Копирование образа: %s"
@@ -1780,7 +1786,7 @@ msgstr "Копирование образа: %s"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 #, fuzzy
 msgid "Create an empty instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1816,7 +1822,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 #, fuzzy
 msgid "Create instances from images"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1893,7 +1899,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1904,7 +1910,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1914,7 +1920,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1929,15 +1935,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098
-#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152
+#: cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237
+#: cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169
+#: cmd/incus/network_forward.go:152 cmd/incus/network.go:1098
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -2098,62 +2104,57 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
-#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
-#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
-#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
-#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
-#: cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176
-#: cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388
-#: cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30
-#: cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181
-#: cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327
-#: cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533
-#: cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674
-#: cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812
-#: cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584
-#: cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732
-#: cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40
-#: cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
-#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
-#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
-#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
-#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375
+#: cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587
+#: cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780
+#: cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066
+#: cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264
+#: cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417
+#: cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96
+#: cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267
+#: cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451
+#: cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618
+#: cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686
+#: cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803
+#: cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43
+#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
+#: cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310
+#: cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648
+#: cmd/incus/file.go:1153 cmd/incus/image_alias.go:24
+#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
+#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
+#: cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321
+#: cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679
+#: cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417
+#: cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633
+#: cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35
 #: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
-#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241
-#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
-#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
 #: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
@@ -2167,13 +2168,20 @@ msgstr ""
 #: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
 #: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
 #: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
-#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347
-#: cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478
-#: cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613
-#: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
+#: cmd/incus/network_forward.go:919 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337
+#: cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603
+#: cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917
+#: cmd/incus/network.go:1053 cmd/incus/network.go:1241
+#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
+#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410
+#: cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90
+#: cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
 #: cmd/incus/network_load_balancer.go:356
 #: cmd/incus/network_load_balancer.go:424
@@ -2218,10 +2226,7 @@ msgstr ""
 #: cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
 #: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
 #: cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385
-#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473
@@ -2230,23 +2235,27 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884
 #: cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054
 #: cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261
-#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755
-#: cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922
-#: cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475
+#: cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088
+#: cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29
+#: cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304
+#: cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2335,7 +2344,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2636,7 +2645,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2661,13 +2670,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540
+#: cmd/incus/network_forward.go:521 cmd/incus/network.go:1454
 #: cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507
 #: cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475
 #: cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634
+#: cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2684,13 +2693,13 @@ msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937
-#: cmd/incus/network.go:1448 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581
+#: cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515
+#: cmd/incus/network.go:1448 cmd/incus/network_integration.go:581
 #: cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547
 #: cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890
+#: cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2854,8 +2863,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235
+#: cmd/incus/image.go:1117 cmd/incus/image.go:1118
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2873,12 +2882,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
@@ -2943,17 +2952,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, fuzzy, c-format
 msgid "Failed loading network %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, fuzzy, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr "Принять сертификат"
@@ -3209,7 +3218,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187
 #: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -3283,16 +3292,16 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067
 #: cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135
-#: cmd/incus/network.go:1073 cmd/incus/network.go:1243
+#: cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57
-#: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:1073
+#: cmd/incus/network.go:1243 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806
+#: cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575
 #: cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3769,6 +3778,10 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Importing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
+#: cmd/incus/create.go:55
+msgid "Include environment variables from file"
+msgstr ""
+
 #: cmd/incus/manpage.go:26
 msgid "Include less common commands"
 msgstr ""
@@ -3804,7 +3817,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -3823,7 +3836,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid "Instance type"
 msgstr ""
 
@@ -4017,8 +4030,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303
-#: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158
+#: cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
 #: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
@@ -4038,12 +4051,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4854,8 +4867,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:38 cmd/incus/remote.go:39
@@ -5035,15 +5048,15 @@ msgstr "Имя контейнера: %s"
 msgid "Missing network integration name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274
-#: cmd/incus/network.go:1352 cmd/incus/network.go:1418
-#: cmd/incus/network.go:1510 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
-#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
-#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
-#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210
+#: cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654
+#: cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878
+#: cmd/incus/network_forward.go:960 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542
+#: cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875
+#: cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352
+#: cmd/incus/network.go:1418 cmd/incus/network.go:1510
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:282
@@ -5084,24 +5097,24 @@ msgstr "Имя контейнера: %s"
 msgid "Missing peer name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
 #: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
 #: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
 #: cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596
 #: cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
-#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244
+#: cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518
+#: cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722
+#: cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897
+#: cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231
+#: cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904
+#: cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160
+#: cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495
+#: cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 msgid "Missing pool name"
 msgstr ""
 
@@ -5242,12 +5255,12 @@ msgstr ""
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158
 #: cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:583
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_acl.go:168 cmd/incus/network.go:1093
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780
-#: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863
+#: cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5459,7 +5472,7 @@ msgstr " Использование сети:"
 msgid "Network load balancer %s deleted"
 msgstr " Использование сети:"
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid "Network name"
 msgstr ""
 
@@ -5512,7 +5525,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5564,7 +5577,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
@@ -5686,8 +5699,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
-#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174
+#: cmd/incus/network.go:1092 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
 #: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
 #: cmd/incus/warning.go:213
@@ -5808,13 +5821,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717
+#: cmd/incus/network.go:803 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112
+#: cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5898,7 +5912,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6343,7 +6357,7 @@ msgstr "Псевдонимы:"
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -7253,7 +7267,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7338,12 +7352,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094
-#: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
-#: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
-#: cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236
+#: cmd/incus/image.go:1123 cmd/incus/list.go:589
+#: cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1299 cmd/incus/network_integration.go:459
+#: cmd/incus/network_peer.go:157 cmd/incus/operation.go:172
+#: cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -7443,7 +7457,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -7461,12 +7475,12 @@ msgstr "Копирование образа: %s"
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7659,11 +7673,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7799,8 +7813,8 @@ msgstr "Копирование образа: %s"
 msgid "USB devices:"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
-#: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24
+#: cmd/incus/network.go:1099 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
@@ -8376,7 +8390,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064
 #: cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1050
 #: cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505
 #: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
@@ -8631,7 +8645,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
@@ -8953,9 +8967,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1239 cmd/incus/network.go:1474
-#: cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445
+#: cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239
+#: cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87
 #: cmd/incus/network_peer.go:78
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -9157,8 +9171,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209
+#: cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -9714,7 +9728,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-08-01 01:00-0400\n"
+"POT-Creation-Date: 2024-08-07 14:26-0400\n"
 "PO-Revision-Date: 2024-08-07 12:18+0000\n"
 "Last-Translator: Kwok Guy <kwokjuy@163.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -459,7 +459,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: cmd/incus/create.go:134 cmd/incus/rebuild.go:64
+#: cmd/incus/create.go:136 cmd/incus/rebuild.go:64
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -562,7 +562,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:234
+#: cmd/incus/alias.go:148 cmd/incus/image_alias.go:234 cmd/incus/image.go:1119
 msgid "ALIAS"
 msgstr ""
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: cmd/incus/create.go:365 cmd/incus/rebuild.go:131
+#: cmd/incus/create.go:379 cmd/incus/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -917,15 +917,15 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
-#: cmd/incus/network_forward.go:308 cmd/incus/network_load_balancer.go:311
+#: cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:308
+#: cmd/incus/network.go:409 cmd/incus/network_load_balancer.go:311
 #: cmd/incus/network_peer.go:334 cmd/incus/network_zone.go:382
 #: cmd/incus/network_zone.go:1069 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:229 cmd/incus/move.go:302
+#: cmd/incus/copy.go:150 cmd/incus/create.go:243 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
@@ -1052,6 +1052,11 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
+#: cmd/incus/utils.go:250
+#, c-format
+msgid "Can't read from environment file: %w"
+msgstr ""
+
 #: cmd/incus/utils.go:215 cmd/incus/utils.go:235
 #, c-format
 msgid "Can't read from stdin: %w"
@@ -1107,7 +1112,7 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: cmd/incus/create.go:334
+#: cmd/incus/create.go:348
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
@@ -1238,13 +1243,13 @@ msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
 #: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
-#: cmd/incus/create.go:57 cmd/incus/info.go:48 cmd/incus/move.go:64
-#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
-#: cmd/incus/network.go:1386 cmd/incus/network.go:1479
-#: cmd/incus/network.go:1551 cmd/incus/network_forward.go:177
-#: cmd/incus/network_forward.go:258 cmd/incus/network_forward.go:446
-#: cmd/incus/network_forward.go:598 cmd/incus/network_forward.go:752
-#: cmd/incus/network_forward.go:841 cmd/incus/network_forward.go:923
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network_forward.go:177 cmd/incus/network_forward.go:258
+#: cmd/incus/network_forward.go:446 cmd/incus/network_forward.go:598
+#: cmd/incus/network_forward.go:752 cmd/incus/network_forward.go:841
+#: cmd/incus/network_forward.go:923 cmd/incus/network.go:347
+#: cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1386
+#: cmd/incus/network.go:1479 cmd/incus/network.go:1551
 #: cmd/incus/network_load_balancer.go:180
 #: cmd/incus/network_load_balancer.go:261
 #: cmd/incus/network_load_balancer.go:432
@@ -1253,16 +1258,16 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:820
 #: cmd/incus/network_load_balancer.go:896
 #: cmd/incus/network_load_balancer.go:1009
-#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage.go:108
+#: cmd/incus/network_load_balancer.go:1083 cmd/incus/storage_bucket.go:103
+#: cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266
+#: cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:573
+#: cmd/incus/storage_bucket.go:666 cmd/incus/storage_bucket.go:732
+#: cmd/incus/storage_bucket.go:807 cmd/incus/storage_bucket.go:893
+#: cmd/incus/storage_bucket.go:993 cmd/incus/storage_bucket.go:1058
+#: cmd/incus/storage_bucket.go:1194 cmd/incus/storage_bucket.go:1268
+#: cmd/incus/storage_bucket.go:1417 cmd/incus/storage.go:108
 #: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
 #: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
-#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
-#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
-#: cmd/incus/storage_bucket.go:573 cmd/incus/storage_bucket.go:666
-#: cmd/incus/storage_bucket.go:732 cmd/incus/storage_bucket.go:807
-#: cmd/incus/storage_bucket.go:893 cmd/incus/storage_bucket.go:993
-#: cmd/incus/storage_bucket.go:1058 cmd/incus/storage_bucket.go:1194
-#: cmd/incus/storage_bucket.go:1268 cmd/incus/storage_bucket.go:1417
 #: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
 #: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
 #: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
@@ -1310,7 +1315,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:50
+#: cmd/incus/copy.go:52 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1333,12 +1338,13 @@ msgstr ""
 #: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:408
 #: cmd/incus/config.go:276 cmd/incus/config.go:351
 #: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
-#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
-#: cmd/incus/network_forward.go:716 cmd/incus/network_integration.go:312
-#: cmd/incus/network_load_balancer.go:696 cmd/incus/network_peer.go:729
-#: cmd/incus/network_zone.go:637 cmd/incus/network_zone.go:1332
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
-#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/image.go:477 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:716 cmd/incus/network.go:802
+#: cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:696
+#: cmd/incus/network_peer.go:729 cmd/incus/network_zone.go:637
+#: cmd/incus/network_zone.go:1332 cmd/incus/profile.go:600
+#: cmd/incus/project.go:399 cmd/incus/storage_bucket.go:361
+#: cmd/incus/storage_bucket.go:1157 cmd/incus/storage.go:368
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
@@ -1516,7 +1522,7 @@ msgstr ""
 msgid "Create a new %s pool?"
 msgstr ""
 
-#: cmd/incus/create.go:60
+#: cmd/incus/create.go:62
 msgid "Create a virtual machine"
 msgstr ""
 
@@ -1524,7 +1530,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: cmd/incus/create.go:59
+#: cmd/incus/create.go:61
 msgid "Create an empty instance"
 msgstr ""
 
@@ -1557,7 +1563,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: cmd/incus/create.go:41 cmd/incus/create.go:42
+#: cmd/incus/create.go:42 cmd/incus/create.go:43
 msgid "Create instances from images"
 msgstr ""
 
@@ -1622,7 +1628,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:58
+#: cmd/incus/copy.go:62 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
@@ -1632,7 +1638,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: cmd/incus/create.go:174
+#: cmd/incus/create.go:176
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1642,7 +1648,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: cmd/incus/create.go:172
+#: cmd/incus/create.go:174
 msgid "Creating the instance"
 msgstr ""
 
@@ -1656,15 +1662,15 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:515
-#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:237 cmd/incus/list.go:575 cmd/incus/network.go:1098
-#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:152
+#: cmd/incus/config_trust.go:435 cmd/incus/image_alias.go:237
+#: cmd/incus/image.go:1115 cmd/incus/list.go:575 cmd/incus/network_acl.go:169
+#: cmd/incus/network_forward.go:152 cmd/incus/network.go:1098
 #: cmd/incus/network_integration.go:458 cmd/incus/network_load_balancer.go:156
 #: cmd/incus/network_peer.go:155 cmd/incus/network_zone.go:160
 #: cmd/incus/network_zone.go:844 cmd/incus/operation.go:173
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555
 #: cmd/incus/storage_bucket.go:540 cmd/incus/storage_bucket.go:864
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage.go:710 cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1813,62 +1819,57 @@ msgid "Delete warning"
 msgstr ""
 
 #: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
-#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
-#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
-#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
-#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
-#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
-#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
-#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
-#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
-#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
-#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
-#: cmd/incus/cluster.go:1066 cmd/incus/cluster.go:1176
-#: cmd/incus/cluster.go:1264 cmd/incus/cluster.go:1388
-#: cmd/incus/cluster.go:1417 cmd/incus/cluster_group.go:30
-#: cmd/incus/cluster_group.go:96 cmd/incus/cluster_group.go:181
-#: cmd/incus/cluster_group.go:267 cmd/incus/cluster_group.go:327
-#: cmd/incus/cluster_group.go:451 cmd/incus/cluster_group.go:533
-#: cmd/incus/cluster_group.go:618 cmd/incus/cluster_group.go:674
-#: cmd/incus/cluster_group.go:736 cmd/incus/cluster_group.go:812
-#: cmd/incus/cluster_group.go:887 cmd/incus/cluster_group.go:969
-#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
-#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
-#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
-#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
-#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
-#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
-#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
-#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
-#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
-#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
-#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
-#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
-#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
-#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
-#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
-#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:584
-#: cmd/incus/config_trust.go:686 cmd/incus/config_trust.go:732
-#: cmd/incus/config_trust.go:803 cmd/incus/console.go:37 cmd/incus/copy.go:40
-#: cmd/incus/create.go:42 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
-#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
-#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
-#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
-#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
-#: cmd/incus/image_alias.go:24 cmd/incus/image_alias.go:60
-#: cmd/incus/image_alias.go:107 cmd/incus/image_alias.go:152
-#: cmd/incus/image_alias.go:255 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/action.go:109 cmd/incus/action.go:134
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin.go:20
+#: cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20
+#: cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30
+#: cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27
+#: cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111
+#: cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35
+#: cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375
+#: cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587
+#: cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780
+#: cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1066
+#: cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1264
+#: cmd/incus/cluster.go:1388 cmd/incus/cluster.go:1417
+#: cmd/incus/cluster_group.go:30 cmd/incus/cluster_group.go:96
+#: cmd/incus/cluster_group.go:181 cmd/incus/cluster_group.go:267
+#: cmd/incus/cluster_group.go:327 cmd/incus/cluster_group.go:451
+#: cmd/incus/cluster_group.go:533 cmd/incus/cluster_group.go:618
+#: cmd/incus/cluster_group.go:674 cmd/incus/cluster_group.go:736
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:887
+#: cmd/incus/cluster_group.go:969 cmd/incus/cluster_role.go:24
+#: cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115
+#: cmd/incus/config_device.go:24 cmd/incus/config_device.go:78
+#: cmd/incus/config_device.go:220 cmd/incus/config_device.go:317
+#: cmd/incus/config_device.go:400 cmd/incus/config_device.go:502
+#: cmd/incus/config_device.go:618 cmd/incus/config_device.go:625
+#: cmd/incus/config_device.go:758 cmd/incus/config_device.go:843
+#: cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388
+#: cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883
+#: cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54
+#: cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26
+#: cmd/incus/config_template.go:66 cmd/incus/config_template.go:134
+#: cmd/incus/config_template.go:188 cmd/incus/config_template.go:288
+#: cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36
+#: cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171
+#: cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400
+#: cmd/incus/config_trust.go:584 cmd/incus/config_trust.go:686
+#: cmd/incus/config_trust.go:732 cmd/incus/config_trust.go:803
+#: cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43
+#: cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32
+#: cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310
+#: cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648
+#: cmd/incus/file.go:1153 cmd/incus/image_alias.go:24
+#: cmd/incus/image_alias.go:60 cmd/incus/image_alias.go:107
+#: cmd/incus/image_alias.go:152 cmd/incus/image_alias.go:255
+#: cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321
+#: cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679
+#: cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417
+#: cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633
+#: cmd/incus/image.go:1697 cmd/incus/import.go:27 cmd/incus/info.go:35
 #: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
-#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
-#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
-#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
-#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1241
-#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
-#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
 #: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
 #: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
 #: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
@@ -1882,13 +1883,20 @@ msgstr ""
 #: cmd/incus/network_forward.go:438 cmd/incus/network_forward.go:548
 #: cmd/incus/network_forward.go:595 cmd/incus/network_forward.go:749
 #: cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:838
-#: cmd/incus/network_forward.go:919 cmd/incus/network_integration.go:28
-#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
-#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:347
-#: cmd/incus/network_integration.go:410 cmd/incus/network_integration.go:478
-#: cmd/incus/network_integration.go:532 cmd/incus/network_integration.go:613
-#: cmd/incus/network_integration.go:646 cmd/incus/network_load_balancer.go:29
-#: cmd/incus/network_load_balancer.go:90 cmd/incus/network_load_balancer.go:177
+#: cmd/incus/network_forward.go:919 cmd/incus/network.go:36
+#: cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337
+#: cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603
+#: cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917
+#: cmd/incus/network.go:1053 cmd/incus/network.go:1241
+#: cmd/incus/network.go:1320 cmd/incus/network.go:1380
+#: cmd/incus/network.go:1476 cmd/incus/network.go:1548
+#: cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85
+#: cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230
+#: cmd/incus/network_integration.go:347 cmd/incus/network_integration.go:410
+#: cmd/incus/network_integration.go:478 cmd/incus/network_integration.go:532
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:646
+#: cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:90
+#: cmd/incus/network_load_balancer.go:177
 #: cmd/incus/network_load_balancer.go:253
 #: cmd/incus/network_load_balancer.go:356
 #: cmd/incus/network_load_balancer.go:424
@@ -1933,10 +1941,7 @@ msgstr ""
 #: cmd/incus/remote.go:998 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
 #: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
 #: cmd/incus/snapshot.go:288 cmd/incus/snapshot.go:385
-#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/snapshot.go:446 cmd/incus/snapshot.go:525
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:473
@@ -1945,23 +1950,27 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:805 cmd/incus/storage_bucket.go:884
 #: cmd/incus/storage_bucket.go:990 cmd/incus/storage_bucket.go:1054
 #: cmd/incus/storage_bucket.go:1189 cmd/incus/storage_bucket.go:1261
-#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage_volume.go:56
-#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755
-#: cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922
-#: cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22
-#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/storage_bucket.go:1412 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163
+#: cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475
+#: cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088
+#: cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29
+#: cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304
+#: cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2047,7 +2056,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: cmd/incus/create.go:422
+#: cmd/incus/create.go:436
 msgid "Didn't get name of new instance from the server"
 msgstr ""
 
@@ -2331,7 +2340,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:53
+#: cmd/incus/copy.go:55 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2356,13 +2365,13 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:943
-#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1454
-#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:521
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network_acl.go:540
+#: cmd/incus/network_forward.go:521 cmd/incus/network.go:1454
 #: cmd/incus/network_integration.go:587 cmd/incus/network_load_balancer.go:507
 #: cmd/incus/network_peer.go:553 cmd/incus/network_zone.go:475
 #: cmd/incus/network_zone.go:1163 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:634 cmd/incus/storage_volume.go:2038
+#: cmd/incus/project.go:851 cmd/incus/storage_bucket.go:634
+#: cmd/incus/storage.go:896 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
@@ -2379,13 +2388,13 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:937
-#: cmd/incus/network.go:1448 cmd/incus/network_acl.go:534
-#: cmd/incus/network_forward.go:515 cmd/incus/network_integration.go:581
+#: cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:515
+#: cmd/incus/network.go:1448 cmd/incus/network_integration.go:581
 #: cmd/incus/network_load_balancer.go:501 cmd/incus/network_peer.go:547
 #: cmd/incus/network_zone.go:469 cmd/incus/network_zone.go:1157
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:628 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845
+#: cmd/incus/storage_bucket.go:628 cmd/incus/storage.go:890
+#: cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2538,8 +2547,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:235
+#: cmd/incus/config_trust.go:434 cmd/incus/image_alias.go:235
+#: cmd/incus/image.go:1117 cmd/incus/image.go:1118
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2557,12 +2566,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: cmd/incus/utils.go:272
+#: cmd/incus/utils.go:296
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/utils.go:264
+#: cmd/incus/utils.go:288
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2627,17 +2636,17 @@ msgstr ""
 msgid "Failed import request: %w"
 msgstr ""
 
-#: cmd/incus/create.go:188
+#: cmd/incus/create.go:190
 #, c-format
 msgid "Failed loading network %q: %w"
 msgstr ""
 
-#: cmd/incus/create.go:313
+#: cmd/incus/create.go:327
 #, c-format
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: cmd/incus/create.go:239
+#: cmd/incus/create.go:253
 #, c-format
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
@@ -2893,7 +2902,7 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1187 cmd/incus/network_acl.go:133
+#: cmd/incus/network_acl.go:133 cmd/incus/network.go:1187
 #: cmd/incus/network_zone.go:124 cmd/incus/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2966,16 +2975,16 @@ msgstr ""
 #: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1067
 #: cmd/incus/cluster_group.go:453 cmd/incus/config_template.go:290
 #: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:586
-#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:157 cmd/incus/list.go:135
-#: cmd/incus/network.go:1073 cmd/incus/network.go:1243
+#: cmd/incus/image_alias.go:157 cmd/incus/image.go:1094 cmd/incus/list.go:135
 #: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:57
-#: cmd/incus/network_forward.go:88 cmd/incus/network_integration.go:412
+#: cmd/incus/network_forward.go:88 cmd/incus/network.go:1073
+#: cmd/incus/network.go:1243 cmd/incus/network_integration.go:412
 #: cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
 #: cmd/incus/network_zone.go:88 cmd/incus/network_zone.go:786
 #: cmd/incus/operation.go:109 cmd/incus/profile.go:726 cmd/incus/project.go:529
 #: cmd/incus/project.go:1052 cmd/incus/remote.go:722 cmd/incus/snapshot.go:291
-#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:474
-#: cmd/incus/storage_bucket.go:806 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_bucket.go:474 cmd/incus/storage_bucket.go:806
+#: cmd/incus/storage.go:689 cmd/incus/storage_volume.go:1575
 #: cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3424,6 +3433,10 @@ msgstr ""
 msgid "Importing instance: %s"
 msgstr ""
 
+#: cmd/incus/create.go:55
+msgid "Include environment variables from file"
+msgstr ""
+
 #: cmd/incus/manpage.go:26
 msgid "Include less common commands"
 msgstr ""
@@ -3457,7 +3470,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: cmd/incus/create.go:432
+#: cmd/incus/create.go:446
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3476,7 +3489,7 @@ msgstr ""
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
 
-#: cmd/incus/create.go:56
+#: cmd/incus/create.go:58
 msgid "Instance type"
 msgstr ""
 
@@ -3664,8 +3677,8 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1303
-#: cmd/incus/network_forward.go:158 cmd/incus/network_load_balancer.go:161
+#: cmd/incus/list.go:617 cmd/incus/network_forward.go:158
+#: cmd/incus/network.go:1303 cmd/incus/network_load_balancer.go:161
 #: cmd/incus/operation.go:178 cmd/incus/storage_bucket.go:544
 #: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
@@ -3685,12 +3698,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: cmd/incus/create.go:168
+#: cmd/incus/create.go:170
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: cmd/incus/create.go:166
+#: cmd/incus/create.go:168
 msgid "Launching the instance"
 msgstr ""
 
@@ -4453,8 +4466,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:38 cmd/incus/remote.go:39
@@ -4623,15 +4636,15 @@ msgstr ""
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
-#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
-#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1274
-#: cmd/incus/network.go:1352 cmd/incus/network.go:1418
-#: cmd/incus/network.go:1510 cmd/incus/network_forward.go:122
-#: cmd/incus/network_forward.go:210 cmd/incus/network_forward.go:279
-#: cmd/incus/network_forward.go:394 cmd/incus/network_forward.go:479
-#: cmd/incus/network_forward.go:654 cmd/incus/network_forward.go:785
-#: cmd/incus/network_forward.go:878 cmd/incus/network_forward.go:960
+#: cmd/incus/network_forward.go:122 cmd/incus/network_forward.go:210
+#: cmd/incus/network_forward.go:279 cmd/incus/network_forward.go:394
+#: cmd/incus/network_forward.go:479 cmd/incus/network_forward.go:654
+#: cmd/incus/network_forward.go:785 cmd/incus/network_forward.go:878
+#: cmd/incus/network_forward.go:960 cmd/incus/network.go:179
+#: cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542
+#: cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875
+#: cmd/incus/network.go:951 cmd/incus/network.go:1274 cmd/incus/network.go:1352
+#: cmd/incus/network.go:1418 cmd/incus/network.go:1510
 #: cmd/incus/network_load_balancer.go:127
 #: cmd/incus/network_load_balancer.go:213
 #: cmd/incus/network_load_balancer.go:282
@@ -4669,24 +4682,24 @@ msgstr ""
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
-#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
 #: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
 #: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
 #: cmd/incus/storage_bucket.go:498 cmd/incus/storage_bucket.go:596
 #: cmd/incus/storage_bucket.go:688 cmd/incus/storage_bucket.go:830
 #: cmd/incus/storage_bucket.go:917 cmd/incus/storage_bucket.go:1014
 #: cmd/incus/storage_bucket.go:1093 cmd/incus/storage_bucket.go:1216
-#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600
-#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_bucket.go:1291 cmd/incus/storage.go:244
+#: cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518
+#: cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294
+#: cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722
+#: cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897
+#: cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231
+#: cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904
+#: cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160
+#: cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495
+#: cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
 msgid "Missing pool name"
 msgstr ""
 
@@ -4820,12 +4833,12 @@ msgstr ""
 #: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1158
 #: cmd/incus/cluster_group.go:514 cmd/incus/config_trust.go:431
 #: cmd/incus/config_trust.go:666 cmd/incus/list.go:583
-#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_acl.go:168 cmd/incus/network.go:1093
 #: cmd/incus/network_integration.go:457 cmd/incus/network_peer.go:154
 #: cmd/incus/network_zone.go:159 cmd/incus/network_zone.go:843
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:780
-#: cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:539
-#: cmd/incus/storage_bucket.go:863 cmd/incus/storage_volume.go:1671
+#: cmd/incus/storage_bucket.go:539 cmd/incus/storage_bucket.go:863
+#: cmd/incus/storage.go:708 cmd/incus/storage_volume.go:1671
 msgid "NAME"
 msgstr ""
 
@@ -5033,7 +5046,7 @@ msgstr ""
 msgid "Network load balancer %s deleted"
 msgstr ""
 
-#: cmd/incus/create.go:54
+#: cmd/incus/create.go:56
 msgid "Network name"
 msgstr ""
 
@@ -5084,7 +5097,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:52 cmd/incus/move.go:57
+#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5135,7 +5148,7 @@ msgstr ""
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: cmd/incus/utils.go:416
+#: cmd/incus/utils.go:440
 msgid "No text editor found, please set the EDITOR environment variable"
 msgstr ""
 
@@ -5255,8 +5268,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
-#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:165
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network_acl.go:174
+#: cmd/incus/network.go:1092 cmd/incus/network_zone.go:165
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:548
 #: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
 #: cmd/incus/warning.go:213
@@ -5376,13 +5389,14 @@ msgstr ""
 #: cmd/incus/config.go:277 cmd/incus/config.go:352
 #: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
 #: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
-#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
-#: cmd/incus/network_forward.go:717 cmd/incus/network_integration.go:313
+#: cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:717
+#: cmd/incus/network.go:803 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:697 cmd/incus/network_peer.go:730
 #: cmd/incus/network_zone.go:638 cmd/incus/network_zone.go:1333
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1158
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage.go:369 cmd/incus/storage_volume.go:1112
+#: cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5466,7 +5480,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:51
+#: cmd/incus/copy.go:54 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -5890,7 +5904,7 @@ msgstr ""
 msgid "Retrieve the instance's console log"
 msgstr ""
 
-#: cmd/incus/create.go:379
+#: cmd/incus/create.go:393
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6752,7 +6766,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:55 cmd/incus/import.go:34
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -6834,12 +6848,12 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:236 cmd/incus/list.go:589 cmd/incus/network.go:1094
-#: cmd/incus/network.go:1299 cmd/incus/network_allocations.go:26
-#: cmd/incus/network_integration.go:459 cmd/incus/network_peer.go:157
-#: cmd/incus/operation.go:172 cmd/incus/storage_volume.go:1670
-#: cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image_alias.go:236
+#: cmd/incus/image.go:1123 cmd/incus/list.go:589
+#: cmd/incus/network_allocations.go:26 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1299 cmd/incus/network_integration.go:459
+#: cmd/incus/network_peer.go:157 cmd/incus/operation.go:172
+#: cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -6939,7 +6953,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: cmd/incus/create.go:453
+#: cmd/incus/create.go:467
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6957,12 +6971,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: cmd/incus/utils.go:352
+#: cmd/incus/utils.go:376
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: cmd/incus/utils.go:348
+#: cmd/incus/utils.go:372
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -7154,11 +7168,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: cmd/incus/create.go:455
+#: cmd/incus/create.go:469
 msgid "To attach a network to an instance, use: incus network attach"
 msgstr ""
 
-#: cmd/incus/create.go:454
+#: cmd/incus/create.go:468
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
@@ -7291,8 +7305,8 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
-#: cmd/incus/network_allocations.go:24 cmd/incus/network_integration.go:460
+#: cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:24
+#: cmd/incus/network.go:1099 cmd/incus/network_integration.go:460
 #: cmd/incus/network_zone.go:161 cmd/incus/profile.go:748
 #: cmd/incus/project.go:556 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
@@ -7832,7 +7846,7 @@ msgstr ""
 #: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1064
 #: cmd/incus/cluster_group.go:448 cmd/incus/config_trust.go:397
 #: cmd/incus/config_trust.go:582 cmd/incus/monitor.go:31
-#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_acl.go:91 cmd/incus/network.go:1050
 #: cmd/incus/network_integration.go:407 cmd/incus/network_zone.go:82
 #: cmd/incus/operation.go:104 cmd/incus/profile.go:707 cmd/incus/project.go:505
 #: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
@@ -7963,7 +7977,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
-#: cmd/incus/create.go:40 cmd/incus/launch.go:22
+#: cmd/incus/create.go:41 cmd/incus/launch.go:22
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
@@ -8129,9 +8143,9 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
-#: cmd/incus/network.go:1239 cmd/incus/network.go:1474
-#: cmd/incus/network_forward.go:82 cmd/incus/network_load_balancer.go:87
+#: cmd/incus/network_forward.go:82 cmd/incus/network.go:445
+#: cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1239
+#: cmd/incus/network.go:1474 cmd/incus/network_load_balancer.go:87
 #: cmd/incus/network_peer.go:78
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -8241,8 +8255,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
-#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:469
+#: cmd/incus/storage_bucket.go:469 cmd/incus/storage.go:209
+#: cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -8578,7 +8592,7 @@ msgid ""
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
-#: cmd/incus/create.go:43
+#: cmd/incus/create.go:44
 msgid ""
 "incus create images:ubuntu/22.04 u1\n"
 "\n"


### PR DESCRIPTION
This change adds `--environment-file` to `init/create/launch` commands and reads environment value key pairs from the referenced file, adding them to the config map for the container.