### PR TITLE
client: docs improvements

### DIFF
--- a/client/doc.go
+++ b/client/doc.go
@@ -30,7 +30,9 @@
 //	  Name: name,
 //	  Source: api.InstanceSource{
 //	    Type:  "image",
-//	    Alias: "my-image",
+//	    Alias: "my-image", # e.g. alpine/3.20
+//	    Server: "https://images.linuxcontainers.org",
+//	    Protocol: "simplestreams",
 //	  },
 //	  Type: "container"
 //	}

--- a/client/doc.go
+++ b/client/doc.go
@@ -25,8 +25,9 @@
 //	}
 //
 //	// Instance creation request
+//	name := "my-container"
 //	req := api.InstancesPost{
-//	  Name: "my-container",
+//	  Name: name,
 //	  Source: api.InstanceSource{
 //	    Type:  "image",
 //	    Alias: "my-image",
@@ -101,7 +102,7 @@
 //	}
 //
 //	// Get the current state
-//	op, err := c.ExecInstance("c1", req, &args)
+//	op, err := c.ExecInstance(name, req, &args)
 //	if err != nil {
 //	  return err
 //	}

--- a/client/doc.go
+++ b/client/doc.go
@@ -6,6 +6,14 @@
 // servers over a Unix socket or HTTPs. You can then interact with those
 // remote servers, creating instances, images, moving them around, ...
 //
+// The following examples make use of serveral imports:
+//
+//	import (
+//		"github.com/lxc/incus/client"
+//		"github.com/lxc/incus/shared/api"
+//		"github.com/lxc/incus/shared/termios"
+//	)
+//
 // # Example - instance creation
 //
 // This creates a container on a local Incus daemon and then starts it.


### PR DESCRIPTION
Follows https://discuss.linuxcontainers.org/t/getting-starting-with-client-api-incus-golang-api/21332

Unsure re: explanation on using `incus` because my `vim-go` auto converts `"github.com/lxc/incus/client"` into `incus "github.com/lxc/incus/client"` 🤔 Maybe you have a wording here that will clarify? Can update the PR...