### PR TITLE
incusd: allow custom oidc scope

### DIFF
--- a/cmd/incusd/api_1.0.go
+++ b/cmd/incusd/api_1.0.go
@@ -224,7 +224,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	// Get the authentication methods.
 	authMethods := []string{api.AuthenticationMethodTLS}
 
-	oidcIssuer, oidcClientID, _, _ := s.GlobalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, _, _, _ := s.GlobalConfig.OIDCServer()
 	if oidcIssuer != "" && oidcClientID != "" {
 		authMethods = append(authMethods, api.AuthenticationMethodOIDC)
 	}
@@ -965,13 +965,13 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if oidcChanged {
-		oidcIssuer, oidcClientID, oidcAudience, oidcClaim := clusterConfig.OIDCServer()
+		oidcIssuer, oidcClientID, oidcScope, oidcAudience, oidcClaim := clusterConfig.OIDCServer()
 
 		if oidcIssuer == "" || oidcClientID == "" {
 			d.oidcVerifier = nil
 		} else {
 			var err error
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, oidcClaim)
+			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcScope, oidcAudience, oidcClaim)
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1416,7 +1416,7 @@ func (d *Daemon) init() error {
 
 	d.gateway.HeartbeatOfflineThreshold = d.globalConfig.OfflineThreshold()
 	lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiInstance, lokiLoglevel, lokiLabels, lokiTypes := d.globalConfig.LokiServer()
-	oidcIssuer, oidcClientID, oidcAudience, oidcClaim := d.globalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, oidcScope, oidcAudience, oidcClaim := d.globalConfig.OIDCServer()
 	syslogSocketEnabled := d.localConfig.SyslogSocket()
 	openfgaAPIURL, openfgaAPIToken, openfgaStoreID := d.globalConfig.OpenFGA()
 	instancePlacementScriptlet := d.globalConfig.InstancesPlacementScriptlet()
@@ -1442,7 +1442,7 @@ func (d *Daemon) init() error {
 
 	// Setup OIDC authentication.
 	if oidcIssuer != "" && oidcClientID != "" {
-		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, oidcClaim)
+		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcScope, oidcAudience, oidcClaim)
 		if err != nil {
 			return err
 		}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2574,3 +2574,7 @@ The following new configuration options are introduced:
 * `healthcheck.timeout`
 * `healthcheck.failure_count`
 * `healthcheck.success_count`
+
+## `oidc_scopes`
+
+This introduces a new `oidc.scopes` server configuration key which can take a comma separate list of OIDC scopes to request from the identity provider.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -2491,6 +2491,13 @@ This value is required by some providers.
 
 ```
 
+```{config:option} oidc.scopes server-oidc
+:scope: "global"
+:shortdesc: "Comma separated list of OpenID Connect scopes"
+:type: "string"
+
+```
+
 <!-- config group server-oidc end -->
 <!-- config group server-openfga start -->
 ```{config:option} openfga.api.token server-openfga

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -219,8 +219,8 @@ func (c *Config) RemoteTokenExpiry() string {
 }
 
 // OIDCServer returns all the OpenID Connect settings needed to connect to a server.
-func (c *Config) OIDCServer() (string, string, string, string) {
-	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.audience"), c.m.GetString("oidc.claim")
+func (c *Config) OIDCServer() (string, string, string, string, string) {
+	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.scopes"), c.m.GetString("oidc.audience"), c.m.GetString("oidc.claim")
 }
 
 // ClusterHealingThreshold returns the configured healing threshold, i.e. the
@@ -690,6 +690,14 @@ var ConfigSchema = config.Schema{
 	//  scope: global
 	//  shortdesc: OpenID Connect Discovery URL for the provider
 	"oidc.issuer": {},
+
+	// gendoc:generate(entity=server, group=oidc, key=oidc.scopes)
+	//
+	// ---
+	//  type: string
+	//  scope: global
+	//  shortdesc: Comma separated list of OpenID Connect scopes
+	"oidc.scopes": {Default: "openid, offline_access"},
 
 	// gendoc:generate(entity=server, group=oidc, key=oidc.audience)
 	// This value is required by some providers.

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -2755,6 +2755,14 @@
 							"shortdesc": "OpenID Connect Discovery URL for the provider",
 							"type": "string"
 						}
+					},
+					{
+						"oidc.scopes": {
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Comma separated list of OpenID Connect scopes",
+							"type": "string"
+						}
 					}
 				]
 			},

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -435,6 +435,7 @@ var APIExtensions = []string{
 	"network_ovn_isolated",
 	"qemu_raw_qmp",
 	"network_load_balancer_health_check",
+	"oidc_scopes",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This adds the option to customize the effective scope of authorizations via OpenID Connect 1.0.