### PR TITLE
incusd/storage/lvm: Fix resize logic to conserve LV state

### DIFF
--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -458,9 +458,15 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 			}
 
 			// Activate volume if needed.
-			_, err := d.activateVolume(vol)
+			activated, err := d.activateVolume(vol)
 			if err != nil {
 				return err
+			}
+
+			if !activated {
+				defer func() {
+					_, _ = d.activateVolume(vol)
+				}()
 			}
 
 			// Shrink filesystem first.
@@ -475,7 +481,7 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 				return err
 			}
 
-			// Deactivate the volume if needed.
+			// Deactivate the volume for resizing.
 			_, err = d.deactivateVolume(vol)
 			if err != nil {
 				return err
@@ -495,15 +501,17 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 				return err
 			}
 
-			// Activate the volume if needed.
-			_, err := d.activateVolume(vol)
+			// Activate the volume for resizing.
+			activated, err := d.activateVolume(vol)
 			if err != nil {
 				return err
 			}
 
-			defer func() {
-				_, _ = d.deactivateVolume(vol)
-			}()
+			if activated {
+				defer func() {
+					_, _ = d.deactivateVolume(vol)
+				}()
+			}
 
 			// Grow the filesystem to fill block device.
 			err = growFileSystem(fsType, volDevPath, vol)
@@ -531,19 +539,21 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 			return err
 		}
 
-		// Activate the volume if needed.
-		_, err := d.activateVolume(vol)
-		if err != nil {
-			return err
-		}
-
-		defer func() {
-			_, _ = d.deactivateVolume(vol)
-		}()
-
 		// Move the VM GPT alt header to end of disk if needed (not needed in unsafe resize mode as it is
 		// expected the caller will do all necessary post resize actions themselves).
 		if vol.IsVMBlock() && !allowUnsafeResize {
+			// Activate the volume for resizing.
+			activated, err := d.activateVolume(vol)
+			if err != nil {
+				return err
+			}
+
+			if activated {
+				defer func() {
+					_, _ = d.deactivateVolume(vol)
+				}()
+			}
+
 			err = d.moveGPTAltHeader(volDevPath)
 			if err != nil {
 				return err


### PR DESCRIPTION
We want the activation state of the LV to be identical following a resize operation, otherwise we may end up having the caller assume it's still active and end up writing data to a file in /dev rather than to an actual device.

This was caught in our daily tests but took a little while to track down.