### PR TITLE
doc: Update Cloud-Init User Example

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -188,14 +188,14 @@ config:
 
 #### Add a user account
 
-To add a user account, use the `user` key.
+To add a user account, use the `users` key.
 See the {ref}`cloud-init:reference/examples:including users and groups` example in the `cloud-init` documentation for details about default users and which keys are supported.
 
 ```yaml
 config:
   cloud-init.user-data: |
     #cloud-config
-    user:
+    users:
       - name: documentation_example
 ```
 


### PR DESCRIPTION
The config shown in the documentation is not valid. I updated it to use the `users` key since that is what is shown on the linked cloud-init example.

Here is how I tested the new example:

```
[root@server ~]# cat users.txt
#cloud-config
user:
  - name: documentation_example
[root@server ~]# cloud-init schema --config-file users.txt
Invalid UNKNOWN_CONFIG_HEADER users.txt
Error: Cloud config schema errors: user: [{'name': 'documentation_example'}] is not of type 'string', user: [{'name': 'documentation_example'}] is valid under each of {'required': ['snapuser']}, {'required': ['name']}

Error: Invalid schema: UNKNOWN_CONFIG_HEADER

[root@server ~]# sed -i 's/user:/users:/' users.txt
[root@server ~]# cloud-init schema --config-file users.txt
Valid schema users.txt
```