### PR TITLE
Add startup scriptlets

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2582,3 +2582,7 @@ This introduces a new `oidc.scopes` server configuration key which can take a co
 ## `network_integrations_peer_name`
 
 This extends `ovn.transit.pattern` to allow `peerName` as a template variable.
+
+## `qemu_scriptlet`
+
+This adds the ability to run a scriptlet at various stages of startup: using the `raw.qemu.scriptlet` configuration key.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -705,6 +705,14 @@ See {ref}`instance-options-qemu` for more information.
 
 ```
 
+```{config:option} raw.qemu.scriptlet instance-raw
+:condition: "virtual machine"
+:liveupdate: "no"
+:shortdesc: "QEMU scriptlet to run at early, pre-start and post-start stages"
+:type: "string"
+
+```
+
 ```{config:option} raw.seccomp instance-raw
 :condition: "container"
 :liveupdate: "no"

--- a/internal/instance/config.go
+++ b/internal/instance/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	scriptletLoad "github.com/lxc/incus/v6/internal/server/scriptlet/load"
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/units"
 	"github.com/lxc/incus/v6/shared/validate"
@@ -961,6 +962,15 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	//  condition: virtual machine
 	//  shortdesc: QMP commands to run after Incus QEMU initialization and before the VM has started
 	"raw.qemu.qmp.pre-start": validate.IsAny,
+
+	// gendoc:generate(entity=instance, group=raw, key=raw.qemu.scriptlet)
+	//
+	// ---
+	//  type: string
+	//  liveupdate: no
+	//  condition: virtual machine
+	//  shortdesc: QEMU scriptlet to run at early, pre-start and post-start stages
+	"raw.qemu.scriptlet": validate.Optional(scriptletLoad.QEMUValidate),
 
 	// gendoc:generate(entity=instance, group=security, key=security.agent.metrics)
 	//

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -57,6 +57,7 @@ import (
 	"github.com/lxc/incus/v6/internal/server/device/nictype"
 	"github.com/lxc/incus/v6/internal/server/instance"
 	"github.com/lxc/incus/v6/internal/server/instance/drivers/edk2"
+	"github.com/lxc/incus/v6/internal/server/instance/drivers/qemudefault"
 	"github.com/lxc/incus/v6/internal/server/instance/drivers/qmp"
 	"github.com/lxc/incus/v6/internal/server/instance/instancetype"
 	"github.com/lxc/incus/v6/internal/server/instance/operationlock"
@@ -91,12 +92,6 @@ import (
 //
 //go:embed agent-loader/*
 var incusAgentLoader embed.FS
-
-// QEMUDefaultCPUCores defines the default number of cores a VM will get if no limit specified.
-const QEMUDefaultCPUCores = 1
-
-// QEMUDefaultMemSize is the default memory size for VMs if no limit specified.
-const QEMUDefaultMemSize = "1GiB"
 
 // qemuSerialChardevName is used to communicate state with QEMU via QMP.
 const qemuSerialChardevName = "qemu_serial-chardev"
@@ -1088,7 +1083,7 @@ func (d *qemu) checkStateStorage() error {
 		return err
 	}
 
-	memoryLimitStr := QEMUDefaultMemSize
+	memoryLimitStr := qemudefault.MemSize
 	if d.expandedConfig["limits.memory"] != "" {
 		memoryLimitStr = d.expandedConfig["limits.memory"]
 	}
@@ -3747,7 +3742,7 @@ func (d *qemu) addCPUMemoryConfig(cfg *[]cfgSection, cpuInfo *cpuTopology) error
 	// Configure memory limit.
 	memSize := d.expandedConfig["limits.memory"]
 	if memSize == "" {
-		memSize = QEMUDefaultMemSize // Default if no memory limit specified.
+		memSize = qemudefault.MemSize // Default if no memory limit specified.
 	}
 
 	memSizeBytes, err := units.ParseByteSizeString(memSize)

--- a/internal/server/instance/drivers/driver_qemu_metrics.go
+++ b/internal/server/instance/drivers/driver_qemu_metrics.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/lxc/incus/v6/internal/server/instance/drivers/qemudefault"
 	"github.com/lxc/incus/v6/internal/server/instance/drivers/qmp"
 	"github.com/lxc/incus/v6/internal/server/instance/instancetype"
 	"github.com/lxc/incus/v6/internal/server/metrics"
@@ -146,7 +147,7 @@ func (d *qemu) getQemuMemoryMetrics(monitor *qmp.Monitor) (metrics.MemoryMetrics
 	// Get max memory usage.
 	memTotal := d.expandedConfig["limits.memory"]
 	if memTotal == "" {
-		memTotal = QEMUDefaultMemSize // Default if no memory limit specified.
+		memTotal = qemudefault.MemSize // Default if no memory limit specified.
 	}
 
 	memTotalBytes, err := units.ParseByteSizeString(memTotal)

--- a/internal/server/instance/drivers/qemudefault/default.go
+++ b/internal/server/instance/drivers/qemudefault/default.go
@@ -1,0 +1,7 @@
+package qemudefault
+
+// CPUCores defines the default number of cores a VM will get if no limit specified.
+const CPUCores = 1
+
+// MemSize is the default memory size for VMs if no limit specified.
+const MemSize = "1GiB"

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -780,6 +780,15 @@
 						}
 					},
 					{
+						"raw.qemu.scriptlet": {
+							"condition": "virtual machine",
+							"liveupdate": "no",
+							"longdesc": "",
+							"shortdesc": "QEMU scriptlet to run at early, pre-start and post-start stages",
+							"type": "string"
+						}
+					},
+					{
 						"raw.seccomp": {
 							"condition": "container",
 							"liveupdate": "no",

--- a/internal/server/project/permissions.go
+++ b/internal/server/project/permissions.go
@@ -909,6 +909,7 @@ func isVMLowLevelOptionForbidden(key string) bool {
 		"raw.qemu.qmp.early",
 		"raw.qemu.qmp.post-start",
 		"raw.qemu.qmp.pre-start",
+		"raw.qemu.scriptlet",
 	},
 		key)
 }

--- a/internal/server/scriptlet/instance_placement.go
+++ b/internal/server/scriptlet/instance_placement.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"go.starlark.net/starlark"
 
@@ -28,28 +27,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	logFunc := func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-		var sb strings.Builder
-		for _, arg := range args {
-			s, err := strconv.Unquote(arg.String())
-			if err != nil {
-				s = arg.String()
-			}
-
-			sb.WriteString(s)
-		}
-
-		switch b.Name() {
-		case "log_info":
-			l.Info(fmt.Sprintf("Instance placement scriptlet: %s", sb.String()))
-		case "log_warn":
-			l.Warn(fmt.Sprintf("Instance placement scriptlet: %s", sb.String()))
-		default:
-			l.Error(fmt.Sprintf("Instance placement scriptlet: %s", sb.String()))
-		}
-
-		return starlark.None, nil
-	}
+	logFunc := createLogger(l, "Instance placement scriptlet")
 
 	var targetMember *db.NodeInfo
 

--- a/internal/server/scriptlet/instance_placement.go
+++ b/internal/server/scriptlet/instance_placement.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lxc/incus/v6/internal/server/cluster"
 	"github.com/lxc/incus/v6/internal/server/db"
 	dbCluster "github.com/lxc/incus/v6/internal/server/db/cluster"
-	instanceDrivers "github.com/lxc/incus/v6/internal/server/instance/drivers"
+	"github.com/lxc/incus/v6/internal/server/instance/drivers/qemudefault"
 	"github.com/lxc/incus/v6/internal/server/resources"
 	scriptletLoad "github.com/lxc/incus/v6/internal/server/scriptlet/load"
 	"github.com/lxc/incus/v6/internal/server/state"
@@ -195,7 +195,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 			}
 		} else if req.Type == api.InstanceTypeVM {
 			// Apply VM CPU cores defaults if not specified.
-			res.CPUCores = instanceDrivers.QEMUDefaultCPUCores
+			res.CPUCores = qemudefault.CPUCores
 		}
 
 		// Parse limits.memory.
@@ -203,7 +203,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 
 		// Apply VM memory limit defaults if not specified.
 		if req.Type == api.InstanceTypeVM && memoryLimitStr == "" {
-			memoryLimitStr = instanceDrivers.QEMUDefaultMemSize
+			memoryLimitStr = qemudefault.MemSize
 		}
 
 		if memoryLimitStr != "" {

--- a/internal/server/scriptlet/load/load.go
+++ b/internal/server/scriptlet/load/load.go
@@ -11,26 +11,14 @@ import (
 // nameInstancePlacement is the name used in Starlark for the instance placement scriptlet.
 const nameInstancePlacement = "instance_placement"
 
-// InstancePlacementCompile compiles the instance placement scriptlet.
-func InstancePlacementCompile(src string) (*starlark.Program, error) {
+// compile compiles a scriptlet.
+func compile(programName string, src string, preDeclared []string) (*starlark.Program, error) {
 	isPreDeclared := func(name string) bool {
-		return slices.Contains([]string{
-			"log_info",
-			"log_warn",
-			"log_error",
-			"set_target",
-			"get_cluster_member_resources",
-			"get_cluster_member_state",
-			"get_instance_resources",
-			"get_instances",
-			"get_cluster_members",
-			"get_project",
-		},
-			name)
+		return slices.Contains(preDeclared, name)
 	}
 
 	// Parse, resolve, and compile a Starlark source file.
-	_, mod, err := starlark.SourceProgram(nameInstancePlacement, src, isPreDeclared)
+	_, mod, err := starlark.SourceProgram(programName, src, isPreDeclared)
 	if err != nil {
 		return nil, err
 	}
@@ -38,46 +26,72 @@ func InstancePlacementCompile(src string) (*starlark.Program, error) {
 	return mod, nil
 }
 
-// InstancePlacementValidate validates the instance placement scriptlet.
-func InstancePlacementValidate(src string) error {
-	_, err := InstancePlacementCompile(src)
-	return err
-}
-
 var programsMu sync.Mutex
 var programs = make(map[string]*starlark.Program)
 
-// InstancePlacementSet compiles the instance placement scriptlet into memory for use with InstancePlacementRun.
-// If empty src is provided the current program is deleted.
-func InstancePlacementSet(src string) error {
+// set compiles a scriptlet into memory. If empty src is provided the current program is deleted.
+func set(compiler func(string, string) (*starlark.Program, error), programName string, src string) error {
 	if src == "" {
 		programsMu.Lock()
-		delete(programs, nameInstancePlacement)
+		delete(programs, programName)
 		programsMu.Unlock()
 	} else {
-		prog, err := InstancePlacementCompile(src)
+		prog, err := compiler(programName, src)
 		if err != nil {
 			return err
 		}
 
 		programsMu.Lock()
-		programs[nameInstancePlacement] = prog
+		programs[programName] = prog
 		programsMu.Unlock()
 	}
 
 	return nil
 }
 
-// InstancePlacementProgram returns the precompiled instance placement scriptlet program.
-func InstancePlacementProgram() (*starlark.Program, *starlark.Thread, error) {
+// program returns a precompiled scriptlet program.
+func program(name string, programName string) (*starlark.Program, *starlark.Thread, error) {
 	programsMu.Lock()
-	prog, found := programs[nameInstancePlacement]
+	prog, found := programs[programName]
 	programsMu.Unlock()
 	if !found {
-		return nil, nil, fmt.Errorf("Instance placement scriptlet not loaded")
+		return nil, nil, fmt.Errorf("%s scriptlet not loaded", name)
 	}
 
-	thread := &starlark.Thread{Name: nameInstancePlacement}
+	thread := &starlark.Thread{Name: programName}
 
 	return prog, thread, nil
+}
+
+// InstancePlacementCompile compiles the instance placement scriptlet.
+func InstancePlacementCompile(name string, src string) (*starlark.Program, error) {
+	return compile(name, src, []string{
+		"log_info",
+		"log_warn",
+		"log_error",
+		"set_target",
+		"get_cluster_member_resources",
+		"get_cluster_member_state",
+		"get_instance_resources",
+		"get_instances",
+		"get_cluster_members",
+		"get_project",
+	})
+}
+
+// InstancePlacementValidate validates the instance placement scriptlet.
+func InstancePlacementValidate(src string) error {
+	_, err := InstancePlacementCompile(nameInstancePlacement, src)
+	return err
+}
+
+// InstancePlacementSet compiles the instance placement scriptlet into memory for use with InstancePlacementRun.
+// If empty src is provided the current program is deleted.
+func InstancePlacementSet(src string) error {
+	return set(InstancePlacementCompile, nameInstancePlacement, src)
+}
+
+// InstancePlacementProgram returns the precompiled instance placement scriptlet program.
+func InstancePlacementProgram() (*starlark.Program, *starlark.Thread, error) {
+	return program("Instance placement", nameInstancePlacement)
 }

--- a/internal/server/scriptlet/load/load.go
+++ b/internal/server/scriptlet/load/load.go
@@ -11,6 +11,9 @@ import (
 // nameInstancePlacement is the name used in Starlark for the instance placement scriptlet.
 const nameInstancePlacement = "instance_placement"
 
+// prefixQEMU is the prefix used in Starlark for the QEMU scriptlet.
+const prefixQEMU = "qemu"
+
 // compile compiles a scriptlet.
 func compile(programName string, src string, preDeclared []string) (*starlark.Program, error) {
 	isPreDeclared := func(name string) bool {
@@ -94,4 +97,31 @@ func InstancePlacementSet(src string) error {
 // InstancePlacementProgram returns the precompiled instance placement scriptlet program.
 func InstancePlacementProgram() (*starlark.Program, *starlark.Thread, error) {
 	return program("Instance placement", nameInstancePlacement)
+}
+
+// QEMUCompile compiles the QEMU scriptlet.
+func QEMUCompile(name string, src string) (*starlark.Program, error) {
+	return compile(name, src, []string{
+		"log_info",
+		"log_warn",
+		"log_error",
+		"run_qmp",
+	})
+}
+
+// QEMUValidate validates the instance placement scriptlet.
+func QEMUValidate(src string) error {
+	_, err := QEMUCompile(prefixQEMU, src)
+	return err
+}
+
+// QEMUSet compiles the QEMU scriptlet into memory for use with QEMURun.
+// If empty src is provided the current program is deleted.
+func QEMUSet(src string, instance string) error {
+	return set(QEMUCompile, prefixQEMU+"/"+instance, src)
+}
+
+// QEMUProgram returns the precompiled QEMU scriptlet program.
+func QEMUProgram(instance string) (*starlark.Program, *starlark.Thread, error) {
+	return program("QEMU", prefixQEMU+"/"+instance)
 }

--- a/internal/server/scriptlet/load/load.go
+++ b/internal/server/scriptlet/load/load.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 )
 
 // nameInstancePlacement is the name used in Starlark for the instance placement scriptlet.
@@ -21,7 +22,7 @@ func compile(programName string, src string, preDeclared []string) (*starlark.Pr
 	}
 
 	// Parse, resolve, and compile a Starlark source file.
-	_, mod, err := starlark.SourceProgram(programName, src, isPreDeclared)
+	_, mod, err := starlark.SourceProgramOptions(syntax.LegacyFileOptions(), programName, src, isPreDeclared)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/scriptlet/logger.go
+++ b/internal/server/scriptlet/logger.go
@@ -1,0 +1,37 @@
+package scriptlet
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.starlark.net/starlark"
+
+	"github.com/lxc/incus/v6/shared/logger"
+)
+
+// createLogger creates a logger for scriptlets.
+func createLogger(l logger.Logger, name string) func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+	return func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var sb strings.Builder
+		for _, arg := range args {
+			s, err := strconv.Unquote(arg.String())
+			if err != nil {
+				s = arg.String()
+			}
+
+			sb.WriteString(s)
+		}
+
+		switch b.Name() {
+		case "log_info":
+			l.Info(fmt.Sprintf("%s: %s", name, sb.String()))
+		case "log_warn":
+			l.Warn(fmt.Sprintf("%s: %s", name, sb.String()))
+		default:
+			l.Error(fmt.Sprintf("%s: %s", name, sb.String()))
+		}
+
+		return starlark.None, nil
+	}
+}

--- a/internal/server/scriptlet/qemu.go
+++ b/internal/server/scriptlet/qemu.go
@@ -1,0 +1,92 @@
+package scriptlet
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/lxc/incus/v6/internal/server/instance/drivers/qmp"
+	scriptletLoad "github.com/lxc/incus/v6/internal/server/scriptlet/load"
+	"github.com/lxc/incus/v6/shared/logger"
+)
+
+// QEMURun runs the QEMU scriptlet.
+func QEMURun(l logger.Logger, m *qmp.Monitor, instance string, stage string) error {
+	logFunc := createLogger(l, "QEMU scriptlet ("+stage+")")
+	runQMPFunc := func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var command *starlark.Dict
+
+		err := starlark.UnpackArgs(b.Name(), args, kwargs, "command", &command)
+		if err != nil {
+			return nil, err
+		}
+
+		value, err := StarlarkUnmarshal(command)
+		if err != nil {
+			return nil, err
+		}
+
+		request, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+
+		var resp map[string]any
+		err = m.RunJSON(request, &resp)
+		if err != nil {
+			return nil, err
+		}
+
+		rv, err := StarlarkMarshal(resp)
+		if err != nil {
+			return nil, fmt.Errorf("Marshalling QMP response failed: %w", err)
+		}
+
+		return rv, nil
+	}
+
+	// Remember to match the entries in scriptletLoad.QEMUCompile() with this list so Starlark can
+	// perform compile time validation of functions used.
+	env := starlark.StringDict{
+		"log_info":  starlark.NewBuiltin("log_info", logFunc),
+		"log_warn":  starlark.NewBuiltin("log_warn", logFunc),
+		"log_error": starlark.NewBuiltin("log_error", logFunc),
+		"run_qmp":   starlark.NewBuiltin("run_qmp", runQMPFunc),
+	}
+
+	prog, thread, err := scriptletLoad.QEMUProgram(instance)
+	if err != nil {
+		return err
+	}
+
+	globals, err := prog.Init(thread, env)
+	if err != nil {
+		return fmt.Errorf("Failed initializing: %w", err)
+	}
+
+	globals.Freeze()
+
+	// Retrieve a global variable from starlark environment.
+	qemuHook := globals["qemu_hook"]
+	if qemuHook == nil {
+		return fmt.Errorf("Scriptlet missing qemu_hook function")
+	}
+
+	// Call starlark function from Go.
+	v, err := starlark.Call(thread, qemuHook, nil, []starlark.Tuple{
+		{
+			starlark.String("stage"),
+			starlark.String(stage),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to run: %w", err)
+	}
+
+	if v.Type() != "NoneType" {
+		return fmt.Errorf("Failed with unexpected return value: %v", v)
+	}
+
+	return nil
+}

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -437,6 +437,7 @@ var APIExtensions = []string{
 	"network_load_balancer_health_check",
 	"oidc_scopes",
 	"network_integrations_peer_name",
+	"qemu_scriptlet",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds the ability to call scriptlets at various stages of a VM initialization.
Several modifications to the codebase are proposed:
* A `qemudefault` subpackage has been created to avoid a dependency cycle when allowing the QEMU driver to call scriptlets;
* The scriptlet logger has been moved to a dedicated file, to be reused by other scriptlets;
* The scriptlet creation functions have been transformed to helper functions, to make writing new scriptlets easy;
* A Starlark value unmarshaller has been written
* And finally, the startup scriptlet has been written

For now, the scriptlet only allows running QMP queries, but feel free to add anything you want there!