### PR TITLE
Storage related fixes

### DIFF
--- a/cmd/incusd/api_internal.go
+++ b/cmd/incusd/api_internal.go
@@ -57,6 +57,7 @@ var apiInternal = []APIEndpoint{
 	internalContainerOnStartCmd,
 	internalContainerOnStopCmd,
 	internalContainerOnStopNSCmd,
+	internalVirtualMachineOnResizeCmd,
 	internalGarbageCollectorCmd,
 	internalImageOptimizeCmd,
 	internalImageRefreshCmd,
@@ -95,6 +96,12 @@ var internalContainerOnStopCmd = APIEndpoint{
 	Path: "containers/{instanceRef}/onstop",
 
 	Get: APIEndpointAction{Handler: internalContainerOnStop, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanEdit)},
+}
+
+var internalVirtualMachineOnResizeCmd = APIEndpoint{
+	Path: "virtual-machines/{instanceRef}/onresize",
+
+	Get: APIEndpointAction{Handler: internalVirtualMachineOnResize, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanEdit)},
 }
 
 var internalSQLCmd = APIEndpoint{
@@ -395,6 +402,56 @@ func internalContainerOnStop(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		logger.Error("The stop hook failed", logger.Ctx{"instance": inst.Name(), "err": err})
 		return response.SmartError(err)
+	}
+
+	return response.EmptySyncResponse
+}
+
+func internalVirtualMachineOnResize(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
+	// Get the instance ID.
+	instanceID, err := strconv.Atoi(mux.Vars(r)["instanceRef"])
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	// Get the devices list.
+	devices := request.QueryParam(r, "devices")
+	if devices == "" {
+		return response.BadRequest(fmt.Errorf("Resize hook requires a list of devices"))
+	}
+
+	// Load by ID.
+	inst, err := instance.LoadByID(s, instanceID)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Update the local instance.
+	for _, dev := range strings.Split(devices, ",") {
+		fields := strings.SplitN(dev, ":", 2)
+		if len(fields) != 2 {
+			return response.BadRequest(fmt.Errorf("Invalid device/size tuple: %s", dev))
+		}
+
+		size, err := strconv.ParseInt(fields[1], 16, 64)
+		if err != nil {
+			return response.BadRequest(err)
+		}
+
+		runConf := deviceConfig.RunConfig{}
+		runConf.Mounts = []deviceConfig.MountEntryItem{
+			{
+				DevName: fields[0],
+				Size:    size,
+			},
+		}
+
+		err = inst.DeviceEventHandler(&runConf)
+		if err != nil {
+			return response.InternalError(err)
+		}
 	}
 
 	return response.EmptySyncResponse

--- a/internal/server/cluster/connect.go
+++ b/internal/server/cluster/connect.go
@@ -22,6 +22,11 @@ import (
 	localtls "github.com/lxc/incus/v6/shared/tls"
 )
 
+// Set references.
+func init() {
+	storagePools.ConnectIfInstanceIsRemote = ConnectIfInstanceIsRemote
+}
+
 // Connect is a convenience around incus.ConnectIncus that configures the client
 // with the correct parameters for node-to-node communication.
 //

--- a/internal/server/cluster/connect.go
+++ b/internal/server/cluster/connect.go
@@ -152,11 +152,12 @@ func ConnectIfVolumeIsRemote(s *state.State, poolName string, projectName string
 		// Find if volume is attached to a remote instance.
 		var remoteInstance *db.InstanceArgs
 		err = storagePools.VolumeUsedByInstanceDevices(s, poolName, projectName, &dbVolume.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-			if dbInst.Node != s.ServerName {
-				remoteInstance = &dbInst
-				return db.ErrInstanceListStop // Stop the search, this volume is attached to a remote instance.
+			if dbInst.Node == s.ServerName {
+				remoteInstance = nil
+				return db.ErrInstanceListStop // Stop the search if the volume is attached to the local system.
 			}
 
+			remoteInstance = &dbInst
 			return nil
 		})
 		if err != nil && err != db.ErrInstanceListStop {

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -4244,7 +4244,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 		revert := revert.New()
 		defer revert.Fail()
 
-		nodeName := fmt.Sprintf("%s%s", qemuBlockDevIDPrefix, escapedDeviceName)
+		nodeName := d.blockNodeName(escapedDeviceName)
 
 		if isRBDImage {
 			secretID := fmt.Sprintf("pool_%s_%s", blockDev["pool"], blockDev["user"])

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -9058,15 +9058,15 @@ func (d *qemu) deviceDetachUSB(usbDev deviceConfig.USBDeviceItem) error {
 
 // Block node names may only be up to 31 characters long, so use a hash if longer.
 func (d *qemu) blockNodeName(name string) string {
-	if len(name) > 27 {
+	if len(name) > 25 {
 		// If the name is too long, hash it as SHA-256 (32 bytes).
-		// Then encode the SHA-256 binary hash as Base64 Raw URL format and trim down to 27 chars.
+		// Then encode the SHA-256 binary hash as Base64 Raw URL format and trim down to 25 chars.
 		// Raw URL avoids the use of "+" character and the padding "=" character which QEMU doesn't allow.
 		hash := sha256.New()
 		hash.Write([]byte(name))
 		binaryHash := hash.Sum(nil)
 		name = base64.RawURLEncoding.EncodeToString(binaryHash)
-		name = name[0:27]
+		name = name[0:25]
 	}
 
 	// Apply the prefix.


### PR DESCRIPTION
This fixes two issues:
 - Long device names (e.g. UUID) were causing QEMU errors due to the length exceeding the maximum
 - Resizing an external (non root) disk would not notify the VM