### PR TITLE
[wip] Add Void Linux x86_64 paths

### DIFF
--- a/internal/server/instance/drivers/edk2/driver_edk2.go
+++ b/internal/server/instance/drivers/edk2/driver_edk2.go
@@ -81,6 +81,18 @@ var architectureInstallations = map[int][]Installation{
 			},
 		},
 	}, {
+		Path: "/usr/share/edk2/x64",
+		Usage: map[FirmwareUsage][]FirmwarePair{
+			GENERIC: {
+				{Code: "OVMF_CODE.4m.fd", Vars: "OVMF_VARS.4m.fd"},
+				{Code: "OVMF_CODE.fd", Vars: "OVMF_VARS.fd"},
+			},
+			SECUREBOOT: {
+				{Code: "OVMF_CODE.secure.4m.fd", Vars: "OVMF_VARS.4m.fd"},
+				{Code: "OVMF_CODE.secure.fd", Vars: "OVMF_VARS.fd"},
+			},
+		},
+	}, {
 		Path: "/usr/share/OVMF/x64",
 		Usage: map[FirmwareUsage][]FirmwarePair{
 			GENERIC: {


### PR DESCRIPTION
I can start a vm without exporting any variables in the service, but secure boot is still not working. I get

`qemu-system-x86_64:/run/incus/user-1000_v2/qemu.conf:46: Could not open '/usr/share/OVMF/OVMF_CODE.secboot.4m.fd': No such file or directory
`

@stgraber is there another place that needs patched?