### PR TITLE
incusd/storage/drivers/ceph: Rework parseParent

### DIFF
--- a/internal/server/storage/drivers/driver_ceph_utils_test.go
+++ b/internal/server/storage/drivers/driver_ceph_utils_test.go
@@ -9,7 +9,6 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 	type args struct {
 		vol          Volume
 		snapName     string
-		zombie       bool
 		withPoolName bool
 	}
 
@@ -23,7 +22,6 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 			args{
 				vol:          NewVolume(nil, "testpool", VolumeTypeContainer, ContentTypeFS, "testvol", nil, nil),
 				snapName:     "",
-				zombie:       false,
 				withPoolName: false,
 			},
 			"container_testvol",
@@ -33,7 +31,6 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 			args{
 				vol:          NewVolume(nil, "testpool", VolumeType("unknown"), ContentTypeFS, "testvol", nil, nil),
 				snapName:     "",
-				zombie:       false,
 				withPoolName: false,
 			},
 			"unknown_testvol",
@@ -41,9 +38,12 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 		{
 			"Volume without pool name in zombie mode",
 			args{
-				vol:          NewVolume(nil, "testpool", VolumeTypeContainer, ContentTypeFS, "testvol", nil, nil),
+				vol: func() Volume {
+					vol := NewVolume(nil, "testpool", VolumeTypeContainer, ContentTypeFS, "testvol", nil, nil)
+					vol.isDeleted = true
+					return vol
+				}(),
 				snapName:     "",
-				zombie:       true,
 				withPoolName: false,
 			},
 			"zombie_container_testvol",
@@ -51,9 +51,12 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 		{
 			"Volume with pool name in zombie mode",
 			args{
-				vol:          NewVolume(nil, "testpool", VolumeTypeContainer, ContentTypeFS, "testvol", nil, nil),
+				vol: func() Volume {
+					vol := NewVolume(nil, "testpool", VolumeTypeContainer, ContentTypeFS, "testvol", nil, nil)
+					vol.isDeleted = true
+					return vol
+				}(),
 				snapName:     "",
-				zombie:       true,
 				withPoolName: true,
 			},
 			"testosdpool/zombie_container_testvol",
@@ -63,7 +66,6 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 			args{
 				vol:          NewVolume(nil, "testpool", VolumeTypeContainer, ContentTypeFS, "testvol", nil, nil),
 				snapName:     "snapshot_testsnap",
-				zombie:       false,
 				withPoolName: false,
 			},
 			"container_testvol@snapshot_testsnap",
@@ -73,7 +75,6 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 			args{
 				vol:          NewVolume(nil, "testpool", VolumeTypeContainer, ContentTypeFS, "testvol", nil, nil),
 				snapName:     "snapshot_testsnap",
-				zombie:       false,
 				withPoolName: true,
 			},
 			"testosdpool/container_testvol@snapshot_testsnap",
@@ -83,7 +84,6 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 			args{
 				vol:          NewVolume(nil, "testpool", VolumeTypeContainer, ContentTypeFS, "testvol/testsnap", nil, nil),
 				snapName:     "",
-				zombie:       false,
 				withPoolName: true,
 			},
 			"testosdpool/container_testvol@snapshot_testsnap",
@@ -93,7 +93,6 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 			args{
 				vol:          NewVolume(nil, "testpool", VolumeTypeContainer, ContentTypeFS, "testvol/testsnap", nil, nil),
 				snapName:     "testsnap1",
-				zombie:       false,
 				withPoolName: true,
 			},
 			"testosdpool/container_testvol@testsnap1",
@@ -110,7 +109,7 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 				},
 			}
 
-			got := d.getRBDVolumeName(tt.args.vol, tt.args.snapName, tt.args.zombie, tt.args.withPoolName)
+			got := d.getRBDVolumeName(tt.args.vol, tt.args.snapName, tt.args.withPoolName)
 			if got != tt.want {
 				t.Errorf("ceph.getRBDVolumeName() = %v, want %v", got, tt.want)
 			}

--- a/internal/server/storage/drivers/driver_ceph_utils_test.go
+++ b/internal/server/storage/drivers/driver_ceph_utils_test.go
@@ -117,6 +117,7 @@ func Test_ceph_getRBDVolumeName(t *testing.T) {
 		})
 	}
 }
+
 func Example_ceph_parseParent() {
 	d := &ceph{}
 
@@ -131,21 +132,98 @@ func Example_ceph_parseParent() {
 		"pool/container_bar@zombie_snapshot_ce77e971-6c1b-45c0-b193-dba9ec5e7d82",
 		"pool/container_test-project_c4.block",
 		"pool/zombie_container_test-project_c1_28e7a7ab-740a-490c-8118-7caf7810f83b@zombie_snapshot_1027f4ab-de11-4cee-8015-bd532a1fed76",
+		"pool/custom_default_foo.vol@zombie_snapshot_2e8112b2-91ca-4fc2-a546-c7723395fdbd",
 	}
 
 	for _, parent := range parents {
 		vol, snapName, err := d.parseParent(parent)
-		fmt.Println(vol.pool, vol.volType, vol.name, vol.config["block.filesystem"], vol.contentType, snapName, err)
+		fmt.Printf("%s: %v\n", parent, err)
+		if err == nil {
+			fmt.Printf("  pool: %s\n", vol.pool)
+			fmt.Printf("  name: %s\n", vol.name)
+
+			if snapName != "" {
+				fmt.Printf("  snapName: %s\n", snapName)
+			}
+
+			fmt.Printf("  volType: %s\n", vol.volType)
+			fmt.Printf("  contentType: %s\n", vol.contentType)
+			fmt.Printf("  config: %+v\n", vol.config)
+		}
 	}
 
-	// Output: pool zombie_image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 block readonly <nil>
-	// pool zombie_image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 block  <nil>
-	// pool image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 block readonly <nil>
-	// pool zombie_image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 filesystem readonly <nil>
-	// pool zombie_image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 filesystem  <nil>
-	// pool image 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb ext4 filesystem readonly <nil>
-	// pool zombie_image 2cfc5a5567b8d74c0986f3d8a77a2a78e58fe22ea9abd2693112031f85afa1a1 xfs filesystem zombie_snapshot_7f6d679b-ee25-419e-af49-bb805cb32088 <nil>
-	// pool container bar  filesystem zombie_snapshot_ce77e971-6c1b-45c0-b193-dba9ec5e7d82 <nil>
-	// pool container test-project_c4  block  <nil>
-	// pool zombie_container test-project_c1_28e7a7ab-740a-490c-8118-7caf7810f83b  filesystem zombie_snapshot_1027f4ab-de11-4cee-8015-bd532a1fed76 <nil>
+	// Output: pool/zombie_image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4.block@readonly: <nil>
+	//   pool: pool
+	//   name: 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb
+	//   snapName: readonly
+	//   volType: images
+	//   contentType: block
+	//   config: map[block.filesystem:ext4]
+	// pool/zombie_image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4.block: <nil>
+	//   pool: pool
+	//   name: 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb
+	//   volType: images
+	//   contentType: block
+	//   config: map[block.filesystem:ext4]
+	// pool/image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4.block@readonly: <nil>
+	//   pool: pool
+	//   name: 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb
+	//   snapName: readonly
+	//   volType: images
+	//   contentType: block
+	//   config: map[block.filesystem:ext4]
+	// pool/zombie_image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4@readonly: <nil>
+	//   pool: pool
+	//   name: 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb
+	//   snapName: readonly
+	//   volType: images
+	//   contentType: filesystem
+	//   config: map[block.filesystem:ext4]
+	// pool/zombie_image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4: <nil>
+	//   pool: pool
+	//   name: 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb
+	//   volType: images
+	//   contentType: filesystem
+	//   config: map[block.filesystem:ext4]
+	// pool/image_9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb_ext4@readonly: <nil>
+	//   pool: pool
+	//   name: 9e90b7b9ccdd7a671a987fadcf07ab92363be57e7f056d18d42af452cdaf95bb
+	//   snapName: readonly
+	//   volType: images
+	//   contentType: filesystem
+	//   config: map[block.filesystem:ext4]
+	// pool/zombie_image_2cfc5a5567b8d74c0986f3d8a77a2a78e58fe22ea9abd2693112031f85afa1a1_xfs@zombie_snapshot_7f6d679b-ee25-419e-af49-bb805cb32088: <nil>
+	//   pool: pool
+	//   name: 2cfc5a5567b8d74c0986f3d8a77a2a78e58fe22ea9abd2693112031f85afa1a1
+	//   snapName: zombie_snapshot_7f6d679b-ee25-419e-af49-bb805cb32088
+	//   volType: images
+	//   contentType: filesystem
+	//   config: map[block.filesystem:xfs]
+	// pool/container_bar@zombie_snapshot_ce77e971-6c1b-45c0-b193-dba9ec5e7d82: <nil>
+	//   pool: pool
+	//   name: bar
+	//   snapName: zombie_snapshot_ce77e971-6c1b-45c0-b193-dba9ec5e7d82
+	//   volType: containers
+	//   contentType: filesystem
+	//   config: map[]
+	// pool/container_test-project_c4.block: <nil>
+	//   pool: pool
+	//   name: test-project_c4
+	//   volType: containers
+	//   contentType: block
+	//   config: map[]
+	// pool/zombie_container_test-project_c1_28e7a7ab-740a-490c-8118-7caf7810f83b@zombie_snapshot_1027f4ab-de11-4cee-8015-bd532a1fed76: <nil>
+	//   pool: pool
+	//   name: test-project_c1_28e7a7ab-740a-490c-8118-7caf7810f83b
+	//   snapName: zombie_snapshot_1027f4ab-de11-4cee-8015-bd532a1fed76
+	//   volType: containers
+	//   contentType: filesystem
+	//   config: map[]
+	// pool/custom_default_foo.vol@zombie_snapshot_2e8112b2-91ca-4fc2-a546-c7723395fdbd: <nil>
+	//   pool: pool
+	//   name: default_foo.vol
+	//   snapName: zombie_snapshot_2e8112b2-91ca-4fc2-a546-c7723395fdbd
+	//   volType: custom
+	//   contentType: filesystem
+	//   config: map[]
 }

--- a/internal/server/storage/drivers/volume.go
+++ b/internal/server/storage/drivers/volume.go
@@ -105,6 +105,7 @@ type Volume struct {
 	mountCustomPath      string // Mount the filesystem volume at a custom location.
 	mountFilesystemProbe bool   // Probe filesystem type when mounting volume (when needed).
 	hasSource            bool   // Whether the volume is created from a source volume.
+	isDeleted            bool   // Whether we're dealing with a hidden volume (kept until all references are gone).
 }
 
 // NewVolume instantiates a new Volume struct.


### PR DESCRIPTION
The regexp logic was very hard to follow and also wasn't properly handling volume names that make use of special characters.

The new logic may be slower but is a lot easier to follow and reason about as well as being a lot easier to tweak in the future to handle more edge cases.

Also reworks the test to output something that's easier to check.


Sponsored-by: ActivePort (https://www.activeport.com.au)