### PR TITLE
Revert "incusd/instance/agent-loader: Don't hardcode path"

### DIFF
--- a/internal/server/instance/drivers/agent-loader/install.sh
+++ b/internal/server/instance/drivers/agent-loader/install.sh
@@ -36,7 +36,7 @@ systemctl daemon-reload
 
 # SELinux handling.
 if getenforce >/dev/null 2>&1 && type semanage >/dev/null 2>&1; then
-    semanage fcontext -a -t bin_t "${PWD}/incus-agent"
+    semanage fcontext -a -t bin_t /var/run/incus_agent/incus-agent
 fi
 
 echo ""


### PR DESCRIPTION
This reverts commit 8dafa2a41772b22dd1bbb14bd51785eb5fac10ad.

On most Red Hat systems, you need to use /var/run/XYZ as there is an equivalency rule in SELinux that points /run to it.

Attempting to directly put a rule on /run/XYZ fails with an error.