### PR TITLE
incusd/instance/qemu: Always re-generate the nvram symlink

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -2141,14 +2141,13 @@ func (d *qemu) setupNvram() error {
 		return err
 	}
 
-	// Generate a symlink if needed.
+	// Generate a symlink.
 	// This is so qemu.nvram can always be assumed to be the EDK2 vars file.
 	// The real file name is then used to determine what firmware must be selected.
-	if !util.PathExists(d.nvramPath()) {
-		err = os.Symlink(efiVarsName, d.nvramPath())
-		if err != nil {
-			return err
-		}
+	_ = os.Remove(d.nvramPath())
+	err = os.Symlink(efiVarsName, d.nvramPath())
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
The NVRAM symlink was previously deleted thanks to a bug in the firmware lookup logic. That logic got recently corrected which in turn caused the symlink to no longer be deleted, causing it to occasionaly point to the incorrect target...