### PR TITLE
incusd/network/ovn: LSP dynamic allocation can't be done per protocol

### DIFF
--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -1658,16 +1658,16 @@ func (o *NB) CreateLogicalSwitchPort(ctx context.Context, switchName OVNSwitch, 
 					address = append(address, opts.MAC.String())
 				}
 
-				if opts.IPV4 == "" || opts.IPV6 == "" {
+				if opts.IPV4 == "" && opts.IPV6 == "" {
 					address = append(address, "dynamic")
-				}
+				} else {
+					if opts.IPV4 != "" {
+						address = append(address, opts.IPV4)
+					}
 
-				if opts.IPV4 != "" {
-					address = append(address, opts.IPV4)
-				}
-
-				if opts.IPV6 != "" {
-					address = append(address, opts.IPV6)
+					if opts.IPV6 != "" {
+						address = append(address, opts.IPV6)
+					}
 				}
 
 				addresses = append(addresses, strings.Join(address, " "))


### PR DESCRIPTION
Despite the documentation mentioning that it can be done per-protocol, it apparently can only be done that way when the MAC isn't known.

Thankfully Incus will always compute an EUI64 address in the IPv6 case, so there should not be an actual need for partial dynamic allocation.


Sponsored-by: Luizalabs (https://luizalabs.com)