### PR TITLE
doc: Fix limits.memory default value unit

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -829,7 +829,7 @@ See {ref}`instance-options-limits-hugepages` for more information.
 ```
 
 ```{config:option} limits.memory instance-resource-limits
-:defaultdesc: "`1Gib` (VMs)"
+:defaultdesc: "`1GiB` (VMs)"
 :liveupdate: "yes"
 :shortdesc: "Usage limit for the host's memory"
 :type: "string"


### PR DESCRIPTION
The documentation for `limits.memory` currently states `1Gib`, but this doesn't seem to be a valid unit.

https://linuxcontainers.org/incus/docs/main/reference/instance_units/

Today, I tried to configure settings based on this documentation, but I encountered an error stating that the unit was invalid, which made me realize the unit was misspelled.

Using my IDE's search function, I quickly searched for `Gib`, `Mib`, and `Tib`, but found no other occurrences.