### PR TITLE
Allow VMs to pull console history similar to containers

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -3333,7 +3333,7 @@ func (d *qemu) generateQemuConfigFile(cpuInfo *cpuTopology, mountInfo *storagePo
 	cfg = append(cfg, qemuControlSocket(&qemuControlSocketOpts{d.monitorPath()})...)
 
 	// Console output.
-	cfg = append(cfg, qemuConsole(&qemuConsoleOpts{d.consolePath()})...)
+	cfg = append(cfg, qemuConsole()...)
 
 	// Setup the bus allocator.
 	bus := qemuNewBus(busName, &cfg)

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -621,6 +621,7 @@ func (d *qemu) onStop(target string) error {
 	d.cleanupDevices() // Must be called before unmount.
 	_ = os.Remove(d.pidFilePath())
 	_ = os.Remove(d.monitorPath())
+	_ = os.Remove(d.spicePath())
 
 	// Stop the storage for the instance.
 	err = d.unmount()

--- a/internal/server/instance/drivers/driver_qemu_config_test.go
+++ b/internal/server/instance/drivers/driver_qemu_config_test.go
@@ -701,19 +701,15 @@ func TestQemuConfigTemplates(t *testing.T) {
 
 	t.Run("qemu_console", func(t *testing.T) {
 		testCases := []struct {
-			opts     qemuConsoleOpts
 			expected string
 		}{{
-			qemuConsoleOpts{"/dev/shm/console-socket"},
 			`# Console
 			[chardev "console"]
-			backend = "socket"
-			path = "/dev/shm/console-socket"
-			server = "on"
-			wait = "off"`,
+			backend = "ringbuf"
+			size = "1048576"`,
 		}}
 		for _, tc := range testCases {
-			runTest(tc.expected, qemuConsole(&tc.opts))
+			runTest(tc.expected, qemuConsole())
 		}
 	})
 

--- a/internal/server/instance/drivers/driver_qemu_templates.go
+++ b/internal/server/instance/drivers/driver_qemu_templates.go
@@ -606,19 +606,13 @@ func qemuControlSocket(opts *qemuControlSocketOpts) []cfgSection {
 	}}
 }
 
-type qemuConsoleOpts struct {
-	path string
-}
-
-func qemuConsole(opts *qemuConsoleOpts) []cfgSection {
+func qemuConsole() []cfgSection {
 	return []cfgSection{{
 		name:    `chardev "console"`,
 		comment: "Console",
 		entries: []cfgEntry{
-			{key: "backend", value: "socket"},
-			{key: "path", value: opts.path},
-			{key: "server", value: "on"},
-			{key: "wait", value: "off"},
+			{key: "backend", value: "ringbuf"},
+			{key: "size", value: "1048576"},
 		},
 	}}
 }

--- a/internal/server/instance/instance_interface.go
+++ b/internal/server/instance/instance_interface.go
@@ -190,6 +190,7 @@ type VM interface {
 	Instance
 
 	AgentCertificate() *x509.Certificate
+	ConsoleLog() (string, error)
 }
 
 // CriuMigrationArgs arguments for CRIU migration.

--- a/internal/server/instance/instance_interface.go
+++ b/internal/server/instance/instance_interface.go
@@ -191,6 +191,9 @@ type VM interface {
 
 	AgentCertificate() *x509.Certificate
 	ConsoleLog() (string, error)
+
+	SwapConsoleRBWithSocket() error
+	SwapConsoleSocketWithRB() error
 }
 
 // CriuMigrationArgs arguments for CRIU migration.

--- a/internal/server/instance/operationlock/operationlock.go
+++ b/internal/server/instance/operationlock/operationlock.go
@@ -37,6 +37,9 @@ const ActionDelete Action = "delete"
 // ActionMigrate for migrating an instance.
 const ActionMigrate Action = "migrate"
 
+// ActionConsoleRetrieve for retrieving and saving a VM's console history.
+const ActionConsoleRetrieve Action = "console_retrieve"
+
 // ErrNonReusuableSucceeded is returned when no operation is created due to having to wait for a matching
 // non-reusuable operation that has now completed successfully.
 var ErrNonReusuableSucceeded error = fmt.Errorf("A matching non-reusable operation has now succeeded")


### PR DESCRIPTION
This adds the capability for VMs to fetch console history in a similar manner to containers (`incus console --show-log <instance>`).

The console backend device is changed to be a ring buffer by default, which we can query for history since the VM started up. When an interactive console is needed (ie, running `incus console <instance>`) the ring buffer is swapped out for a socket, and when done is replaced again by the ring buffer.