### PR TITLE
Properly handle `--project` in CLI error messages

### DIFF
--- a/cmd/incus/action.go
+++ b/cmd/incus/action.go
@@ -331,7 +331,12 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 	err = cli.CancelableWait(op, &progress)
 	if err != nil {
 		progress.Done("")
-		return fmt.Errorf("%s\n"+i18n.G("Try `incus info --show-log %s` for more info"), err, nameArg)
+		projectArg := ""
+		if conf.ProjectOverride != "" && conf.ProjectOverride != api.ProjectDefaultName {
+			projectArg = " --project " + conf.ProjectOverride
+		}
+
+		return fmt.Errorf("%s\n"+i18n.G("Try `incus info --show-log %s%s` for more info"), err, nameArg, projectArg)
 	}
 
 	progress.Done("")

--- a/cmd/incus/launch.go
+++ b/cmd/incus/launch.go
@@ -143,7 +143,12 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 			prettyName = fmt.Sprintf("%s:%s", remote, name)
 		}
 
-		return fmt.Errorf("%s\n"+i18n.G("Try `incus info --show-log %s` for more info"), err, prettyName)
+		projectArg := ""
+		if conf.ProjectOverride != "" && conf.ProjectOverride != api.ProjectDefaultName {
+			projectArg = " --project " + conf.ProjectOverride
+		}
+
+		return fmt.Errorf("%s\n"+i18n.G("Try `incus info --show-log %s%s` for more info"), err, prettyName, projectArg)
 	}
 
 	progress.Done("")

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: Tobias Gerold <tobias@g3ro.eu>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -670,12 +670,12 @@ msgstr "- Port %d (%s)"
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1175,13 +1175,13 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Backing up storage bucket: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
@@ -1224,7 +1224,7 @@ msgstr "Ungültige Abbild Eigenschaft: %s\n"
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1568,9 +1568,9 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr ""
 
@@ -2040,7 +2040,7 @@ msgstr "Erstellt: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2307,9 +2307,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2554,7 +2554,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "ABLAUFDATUM"
@@ -2693,7 +2693,7 @@ msgstr "Alternatives config Verzeichnis."
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2957,7 +2957,7 @@ msgstr ""
 "angegeben wird, wird die resultierende Datei im derzeit aktiven Ordner/Pfad "
 "gespeichert."
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid "Export custom storage volume"
 msgstr "Storage Volume exportieren"
 
@@ -2979,7 +2979,7 @@ msgstr "Storage Buckets exportieren"
 msgid "Export storage buckets as tarball."
 msgstr "Storage Buckets als Dateien (.tar) exportieren."
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 msgid "Export the volume without its snapshots"
 msgstr "Storage Volume ohne Snapshots exportieren"
 
@@ -2988,7 +2988,7 @@ msgstr "Storage Volume ohne Snapshots exportieren"
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Backup des Storage Bucket %s wird exportiert"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Backup %s wird exportiert"
@@ -3206,7 +3206,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3221,7 +3221,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3872,12 +3872,12 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3903,15 +3903,15 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Import storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3920,7 +3920,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3997,7 +3997,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Ungültige Quelle %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Ungültiges Ziel %s"
@@ -4018,7 +4018,7 @@ msgid "Invalid arguments"
 msgstr "Ungültiges Ziel %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -4125,7 +4125,7 @@ msgstr "Ungültiges Ziel %s"
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -5411,8 +5411,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5658,8 +5658,8 @@ msgstr "Fehlende Zusammenfassung."
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5812,7 +5812,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr ""
 
@@ -6166,7 +6166,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -6849,7 +6849,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -6859,7 +6859,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Herunterfahren des Containers erzwingen."
@@ -6903,7 +6903,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -7631,12 +7631,12 @@ msgid ""
 "container or virtual-machine)."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Profil %s erstellt\n"
@@ -7740,7 +7740,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -7949,7 +7949,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8371,9 +8371,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
 #: cmd/incus/info.go:742
@@ -8481,7 +8481,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8742,7 +8742,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -9866,7 +9866,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -9974,7 +9974,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -9983,7 +9983,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -9992,7 +9992,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -10018,7 +10018,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -10339,7 +10339,7 @@ msgstr ""
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, fuzzy, c-format
 msgid "error: %v"
 msgstr "Fehler: %v\n"
@@ -10939,7 +10939,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -657,11 +657,11 @@ msgstr "- Puerto %d (%s)"
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1123,13 +1123,13 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backing up storage bucket: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1171,7 +1171,7 @@ msgstr "Propiedad mala: %s"
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 #, fuzzy
 msgid "Both --all and instance name given"
 msgstr "Ambas: todas y el nombre del contenedor dado"
@@ -1506,9 +1506,9 @@ msgstr "Perfil %s eliminado de %s"
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1964,7 +1964,7 @@ msgstr "Auto actualización: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2227,9 +2227,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2457,7 +2457,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "FECHA DE EXPIRACIÓN"
@@ -2587,7 +2587,7 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2790,7 +2790,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2814,7 +2814,7 @@ msgstr "Aliases:"
 msgid "Export storage buckets as tarball."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2823,7 +2823,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3039,7 +3039,7 @@ msgstr "Acepta certificado"
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Acepta certificado"
@@ -3054,7 +3054,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Acepta certificado"
@@ -3692,11 +3692,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Perfil %s creado"
@@ -3722,15 +3722,15 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Import storage bucket"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3739,7 +3739,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3818,7 +3818,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Nombre del contenedor es: %s"
@@ -3839,7 +3839,7 @@ msgid "Invalid arguments"
 msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3943,7 +3943,7 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -5182,8 +5182,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5427,8 +5427,8 @@ msgstr "Nombre del contenedor es: %s"
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 msgid "Missing pool name"
 msgstr ""
 
@@ -5575,7 +5575,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr ""
 
@@ -5920,7 +5920,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -6585,7 +6585,7 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6595,7 +6595,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6639,7 +6639,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -7334,12 +7334,12 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Perfil %s creado"
@@ -7438,7 +7438,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
@@ -7640,7 +7640,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8055,9 +8055,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Contraseña admin para %s: "
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
 #: cmd/incus/info.go:742
@@ -8163,7 +8163,7 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8414,7 +8414,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -9204,7 +9204,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9272,17 +9272,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9297,7 +9297,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9505,7 +9505,7 @@ msgstr ""
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9985,7 +9985,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -668,11 +668,11 @@ msgstr ""
 "--console ne peut être pas utilisée pendant que l'arrêt de l'instance est "
 "forcé"
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid "--console can't be used with --all"
 msgstr "--console ne peut être utilisé avec --all"
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
@@ -1147,13 +1147,13 @@ msgstr "Sauvegarder l'instance : %s"
 msgid "Backing up storage bucket: %s"
 msgstr "Sauvegarder le bucket de stockage : %s"
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Sauvegarder le volume de stockage : %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
@@ -1197,7 +1197,7 @@ msgstr "Mauvaise propriété: %s"
 msgid "Bond:"
 msgstr "Liaison:"
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr "À la fois--all et le nom d'instance on été donné"
 
@@ -1540,9 +1540,9 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr "Nom du membre du cluster"
 
@@ -2051,7 +2051,7 @@ msgstr "État : %s"
 msgid "Default VLAN ID"
 msgstr "ID VLAN par défaut"
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -2324,9 +2324,9 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2561,7 +2561,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr "EXISTANT: %q (principal=%q, source=%q)"
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATE D'EXPIRATION"
@@ -2703,7 +2703,7 @@ msgstr "Clé de configuration invalide"
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2981,7 +2981,7 @@ msgstr ""
 "La cible de sortie est facultative et par défaut dans le répertoire de "
 "travail."
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -3006,7 +3006,7 @@ msgstr "Copie de l'image : %s"
 msgid "Export storage buckets as tarball."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
@@ -3016,7 +3016,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -3240,7 +3240,7 @@ msgstr "Échec de la création de la sauvegarde : %v"
 msgid "Failed to create certificate: %w"
 msgstr "Échec de la création du certificat : %w"
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Échec de la création de la sauvegarde du volume de stockage : %w"
@@ -3256,7 +3256,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Échec de la récupération de la sauvegarde de l'unité de stockage : %w"
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3952,12 +3952,12 @@ msgstr "Importer des sauvegardes d'instances, y compris leurs instantanés."
 msgid "Import backups of storage buckets."
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Copie de l'image : %s"
@@ -3988,16 +3988,16 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Import storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr "Le type d'importation doit être \"backup\" ou \"iso\""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 #, fuzzy
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr "Type d'importation : \"backup\" ou \"iso\" (par défaut \"backup\")"
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr "L'importation d'images ISO nécessite la définition d'un nom de volume"
 
@@ -4006,7 +4006,7 @@ msgstr "L'importation d'images ISO nécessite la définition d'un nom de volume"
 msgid "Importing bucket: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -4089,7 +4089,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Le nom du conteneur est : %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Cible invalide %s"
@@ -4110,7 +4110,7 @@ msgid "Invalid arguments"
 msgstr "Cible invalide %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, fuzzy, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "Segment de nom de sauvegarde non valide dans le chemin %q : %w"
@@ -4221,7 +4221,7 @@ msgstr "Cible invalide %s"
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -5544,8 +5544,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5792,8 +5792,8 @@ msgstr "Résumé manquant."
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5949,7 +5949,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr "NOM"
 
@@ -6305,7 +6305,7 @@ msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
@@ -7002,7 +7002,7 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -7012,7 +7012,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Forcer le conteneur à s'arrêter"
@@ -7072,7 +7072,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -7802,12 +7802,12 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Afficher la configuration étendue"
@@ -7911,7 +7911,7 @@ msgstr "Instantanés :"
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, c-format
 msgid "Some instances failed to %s"
 msgstr "Certaines instances n'ont pas réussi à %s"
@@ -8122,7 +8122,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8555,9 +8555,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, fuzzy, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
 #: cmd/incus/info.go:742
@@ -8666,7 +8666,7 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8929,7 +8929,7 @@ msgstr "Création du conteneur"
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -10082,7 +10082,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -10193,7 +10193,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -10205,7 +10205,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -10217,7 +10217,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -10249,7 +10249,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -10593,7 +10593,7 @@ msgstr "activé"
 msgid "ephemeral"
 msgstr "Type : éphémère"
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr "erreur : %v"
@@ -11095,7 +11095,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-05 23:30-0400\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -29,7 +29,8 @@ msgid "  Motherboard:"
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:273 cmd/incus/storage_bucket.go:1208
-msgid "### This is a YAML representation of a storage bucket.\n"
+msgid ""
+"### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A storage bucket consists of a set of configuration items.\n"
@@ -41,7 +42,8 @@ msgid "### This is a YAML representation of a storage bucket.\n"
 msgstr ""
 
 #: cmd/incus/storage.go:290
-msgid "### This is a YAML representation of a storage pool.\n"
+msgid ""
+"### This is a YAML representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
 "###\n"
 "### A storage pool consists of a set of configuration items.\n"
@@ -57,7 +59,8 @@ msgid "### This is a YAML representation of a storage pool.\n"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:985
-msgid "### This is a YAML representation of a storage volume.\n"
+msgid ""
+"### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A storage volume consists of a set of configuration items.\n"
@@ -70,19 +73,22 @@ msgid "### This is a YAML representation of a storage volume.\n"
 msgstr ""
 
 #: cmd/incus/config_trust.go:284
-msgid "### This is a YAML representation of the certificate.\n"
+msgid ""
+"### This is a YAML representation of the certificate.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
 #: cmd/incus/cluster_group.go:437
-msgid "### This is a YAML representation of the cluster group.\n"
+msgid ""
+"### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
 #: cmd/incus/config.go:117
-msgid "### This is a YAML representation of the configuration.\n"
+msgid ""
+"### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
@@ -102,7 +108,8 @@ msgid "### This is a YAML representation of the configuration.\n"
 msgstr ""
 
 #: cmd/incus/image.go:399
-msgid "### This is a YAML representation of the image properties.\n"
+msgid ""
+"### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### Each property is represented by a single line:\n"
@@ -111,7 +118,8 @@ msgid "### This is a YAML representation of the image properties.\n"
 msgstr ""
 
 #: cmd/incus/config_metadata.go:71
-msgid "### This is a YAML representation of the instance metadata.\n"
+msgid ""
+"### This is a YAML representation of the instance metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A sample configuration looks like:\n"
@@ -134,7 +142,8 @@ msgid "### This is a YAML representation of the instance metadata.\n"
 msgstr ""
 
 #: cmd/incus/network_acl.go:624
-msgid "### This is a YAML representation of the network ACL.\n"
+msgid ""
+"### This is a YAML representation of the network ACL.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A network ACL consists of a set of rules and configuration items.\n"
@@ -156,14 +165,17 @@ msgid "### This is a YAML representation of the network ACL.\n"
 "### config:\n"
 "###  user.foo: bah\n"
 "###\n"
-"### Note that only the ingress and egress rules, description and configuration keys can be changed."
+"### Note that only the ingress and egress rules, description and "
+"configuration keys can be changed."
 msgstr ""
 
 #: cmd/incus/network_forward.go:690
-msgid "### This is a YAML representation of the network forward.\n"
+msgid ""
+"### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
-"### A network forward consists of a default target address and optional set of port forwards for a listen address.\n"
+"### A network forward consists of a default target address and optional set "
+"of port forwards for a listen address.\n"
 "###\n"
 "### An example would look like:\n"
 "### listen_address: 192.0.2.1\n"
@@ -182,17 +194,20 @@ msgid "### This is a YAML representation of the network forward.\n"
 msgstr ""
 
 #: cmd/incus/network_integration.go:242
-msgid "### This is a YAML representation of the network integration.\n"
+msgid ""
+"### This is a YAML representation of the network integration.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:656
-msgid "### This is a YAML representation of the network load balancer.\n"
+msgid ""
+"### This is a YAML representation of the network load balancer.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
-"### A network load balancer consists of a set of target backends and port forwards for a listen address.\n"
+"### A network load balancer consists of a set of target backends and port "
+"forwards for a listen address.\n"
 "###\n"
 "### An example would look like:\n"
 "### listen_address: 192.0.2.1\n"
@@ -221,7 +236,8 @@ msgid "### This is a YAML representation of the network load balancer.\n"
 msgstr ""
 
 #: cmd/incus/network_peer.go:719
-msgid "### This is a YAML representation of the network peer.\n"
+msgid ""
+"### This is a YAML representation of the network peer.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### An example would look like:\n"
@@ -232,11 +248,13 @@ msgid "### This is a YAML representation of the network peer.\n"
 "### target_network: mynet\n"
 "### status: Pending\n"
 "###\n"
-"### Note that the name, target_project, target_network and status fields cannot be changed."
+"### Note that the name, target_project, target_network and status fields "
+"cannot be changed."
 msgstr ""
 
 #: cmd/incus/network_zone.go:1328
-msgid "### This is a YAML representation of the network zone record.\n"
+msgid ""
+"### This is a YAML representation of the network zone record.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A network zone consists of a set of rules and configuration items.\n"
@@ -249,7 +267,8 @@ msgid "### This is a YAML representation of the network zone record.\n"
 msgstr ""
 
 #: cmd/incus/network_zone.go:632
-msgid "### This is a YAML representation of the network zone.\n"
+msgid ""
+"### This is a YAML representation of the network zone.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A network zone consists of a set of rules and configuration items.\n"
@@ -262,7 +281,8 @@ msgid "### This is a YAML representation of the network zone.\n"
 msgstr ""
 
 #: cmd/incus/network.go:717
-msgid "### This is a YAML representation of the network.\n"
+msgid ""
+"### This is a YAML representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A network consists of a set of configuration items.\n"
@@ -281,7 +301,8 @@ msgid "### This is a YAML representation of the network.\n"
 msgstr ""
 
 #: cmd/incus/profile.go:518
-msgid "### This is a YAML representation of the profile.\n"
+msgid ""
+"### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A profile consists of a set of configuration items followed by a set of\n"
@@ -301,7 +322,8 @@ msgid "### This is a YAML representation of the profile.\n"
 msgstr ""
 
 #: cmd/incus/project.go:317
-msgid "### This is a YAML representation of the project.\n"
+msgid ""
+"### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
 "###\n"
 "### A project consists of a set of features and a description.\n"
@@ -321,7 +343,8 @@ msgid "### This is a YAML representation of the project.\n"
 msgstr ""
 
 #: cmd/incus/cluster.go:893
-msgid "### This is a yaml representation of the cluster member.\n"
+msgid ""
+"### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
@@ -393,11 +416,11 @@ msgstr ""
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -433,7 +456,8 @@ msgstr ""
 msgid "--target can only be used with clusters"
 msgstr ""
 
-#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615 cmd/incus/config.go:822 cmd/incus/info.go:624
+#: cmd/incus/config.go:165 cmd/incus/config.go:438 cmd/incus/config.go:615
+#: cmd/incus/config.go:822 cmd/incus/info.go:624
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -474,7 +498,8 @@ msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
 #: cmd/incus/image.go:677
-msgid "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
+msgid ""
+"<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
 
 #: cmd/incus/manpage.go:20
@@ -589,12 +614,15 @@ msgid "Add new remote servers"
 msgstr ""
 
 #: cmd/incus/remote.go:109
-msgid "Add new remote servers\n"
+msgid ""
+"Add new remote servers\n"
 "\n"
 "URL for remote resources must be HTTPS (https://).\n"
 "\n"
-"Basic authentication can be used when combined with the \"simplestreams\" protocol:\n"
-"  incus remote add some-name https://LOGIN:PASSWORD@example.com/some/path --protocol=simplestreams\n"
+"Basic authentication can be used when combined with the \"simplestreams\" "
+"protocol:\n"
+"  incus remote add some-name https://LOGIN:PASSWORD@example.com/some/path --"
+"protocol=simplestreams\n"
 msgstr ""
 
 #: cmd/incus/config_trust.go:90
@@ -606,7 +634,8 @@ msgid "Add new trusted client certificate"
 msgstr ""
 
 #: cmd/incus/config_trust.go:171
-msgid "Add new trusted client certificate\n"
+msgid ""
+"Add new trusted client certificate\n"
 "\n"
 "The following certificate types are supported:\n"
 "- client (default)\n"
@@ -614,16 +643,19 @@ msgid "Add new trusted client certificate\n"
 msgstr ""
 
 #: cmd/incus/config_trust.go:91
-msgid "Add new trusted client\n"
+msgid ""
+"Add new trusted client\n"
 "\n"
-"This will issue a trust token to be used by the client to add itself to the trust store.\n"
+"This will issue a trust token to be used by the client to add itself to the "
+"trust store.\n"
 msgstr ""
 
 #: cmd/incus/network_forward.go:911 cmd/incus/network_forward.go:912
 msgid "Add ports to a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1076 cmd/incus/network_load_balancer.go:1077
+#: cmd/incus/network_load_balancer.go:1076
+#: cmd/incus/network_load_balancer.go:1077
 msgid "Add ports to a load balancer"
 msgstr ""
 
@@ -640,7 +672,8 @@ msgid "Add rules to an ACL"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:128
-msgid "Additional storage pool configuration property (KEY=VALUE, empty when done):"
+msgid ""
+"Additional storage pool configuration property (KEY=VALUE, empty when done):"
 msgstr ""
 
 #: cmd/incus/admin_init.go:59
@@ -681,7 +714,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136 cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
+#: cmd/incus/image_alias.go:358
 msgid "Alias name missing"
 msgstr ""
 
@@ -715,7 +749,8 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: cmd/incus/image.go:993 cmd/incus/info.go:502 cmd/incus/info.go:506 cmd/incus/info.go:652
+#: cmd/incus/image.go:993 cmd/incus/info.go:502 cmd/incus/info.go:506
+#: cmd/incus/info.go:652
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -775,7 +810,8 @@ msgid "Attach to instance consoles"
 msgstr ""
 
 #: cmd/incus/console.go:37
-msgid "Attach to instance consoles\n"
+msgid ""
+"Attach to instance consoles\n"
 "\n"
 "This command allows you to interact with the boot console of an instance\n"
 "as well as retrieve past log entries from it."
@@ -827,12 +863,13 @@ msgstr ""
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2994
+#: cmd/incus/storage_volume.go:3033
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539 cmd/incus/storage_volume.go:3071
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -845,17 +882,22 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447 cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:382 cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455 cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
+#: cmd/incus/network.go:409 cmd/incus/network_acl.go:447
+#: cmd/incus/network_forward.go:382 cmd/incus/network_load_balancer.go:382
+#: cmd/incus/network_peer.go:409 cmd/incus/network_zone.go:455
+#: cmd/incus/network_zone.go:1142 cmd/incus/storage_bucket.go:154
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302 cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169 cmd/incus/storage_volume.go:651
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:169
+#: cmd/incus/storage_volume.go:651
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -869,7 +911,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -957,7 +999,8 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:144 cmd/incus/admin_init_interactive.go:828
+#: cmd/incus/admin_init_interactive.go:144
+#: cmd/incus/admin_init_interactive.go:828
 #, c-format
 msgid "Can't bind address %q: %w"
 msgstr ""
@@ -1000,7 +1043,8 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683 cmd/incus/warning.go:225
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,11 +1079,13 @@ msgstr ""
 
 #: cmd/incus/create.go:347
 #, c-format
-msgid "Cannot override config for device %q: Device not found in profile devices"
+msgid ""
+"Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:457
-msgid "Cannot set --destination-target when destination server is not clustered"
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:411
@@ -1072,12 +1118,14 @@ msgstr ""
 
 #: cmd/incus/remote.go:237
 #, c-format
-msgid "Certificate fingerprint mismatch between certificate token and server %q"
+msgid ""
+"Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
 #: cmd/incus/admin_init.go:185 cmd/incus/admin_init_interactive.go:207
 #, c-format
-msgid "Certificate fingerprint mismatch between join token and cluster member %q"
+msgid ""
+"Certificate fingerprint mismatch between join token and cluster member %q"
 msgstr ""
 
 #: cmd/incus/remote.go:466
@@ -1158,7 +1206,42 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64 cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1471 cmd/incus/network.go:1564 cmd/incus/network.go:1636 cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520 cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826 cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997 cmd/incus/network_load_balancer.go:251 cmd/incus/network_load_balancer.go:332 cmd/incus/network_load_balancer.go:503 cmd/incus/network_load_balancer.go:638 cmd/incus/network_load_balancer.go:803 cmd/incus/network_load_balancer.go:891 cmd/incus/network_load_balancer.go:967 cmd/incus/network_load_balancer.go:1080 cmd/incus/network_load_balancer.go:1154 cmd/incus/storage.go:108 cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832 cmd/incus/storage.go:934 cmd/incus/storage.go:1027 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738 cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903 cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337 cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560 cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966 cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325 cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126 cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2671 cmd/incus/storage_volume.go:2757 cmd/incus/storage_volume.go:2837 cmd/incus/storage_volume.go:2929 cmd/incus/storage_volume.go:3095
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
+#: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
+#: cmd/incus/network.go:1471 cmd/incus/network.go:1564
+#: cmd/incus/network.go:1636 cmd/incus/network_forward.go:251
+#: cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520
+#: cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826
+#: cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997
+#: cmd/incus/network_load_balancer.go:251
+#: cmd/incus/network_load_balancer.go:332
+#: cmd/incus/network_load_balancer.go:503
+#: cmd/incus/network_load_balancer.go:638
+#: cmd/incus/network_load_balancer.go:803
+#: cmd/incus/network_load_balancer.go:891
+#: cmd/incus/network_load_balancer.go:967
+#: cmd/incus/network_load_balancer.go:1080
+#: cmd/incus/network_load_balancer.go:1154 cmd/incus/storage.go:108
+#: cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832
+#: cmd/incus/storage.go:934 cmd/incus/storage.go:1027
+#: cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203
+#: cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397
+#: cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738
+#: cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903
+#: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
+#: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
+#: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
+#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
+#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
+#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
+#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr ""
 
@@ -1166,7 +1249,19 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092 cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421 cmd/incus/config_trust.go:610 cmd/incus/image.go:1093 cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072 cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:119 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:138 cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:687 cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904 cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548 cmd/incus/warning.go:93
+#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
+#: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
+#: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
+#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
+#: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
+#: cmd/incus/network_load_balancer.go:119 cmd/incus/network_peer.go:111
+#: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
+#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
+#: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
+#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
+#: cmd/incus/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1175,12 +1270,14 @@ msgid "Command line client for Incus"
 msgstr ""
 
 #: cmd/incus/main.go:85
-msgid "Command line client for Incus\n"
+msgid ""
+"Command line client for Incus\n"
 "\n"
 "All of Incus's features can be driven through the various commands below.\n"
 "For help with any of those, simply call them with --help.\n"
 "\n"
-"Custom commands can be defined through aliases, use \"incus alias\" to control those."
+"Custom commands can be defined through aliases, use \"incus alias\" to "
+"control those."
 msgstr ""
 
 #: cmd/incus/publish.go:39
@@ -1211,7 +1308,16 @@ msgstr ""
 msgid "Config option should be in the format KEY=VALUE"
 msgstr ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714 cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:767 cmd/incus/network_peer.go:804 cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405 cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300 cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413
+#: cmd/incus/config.go:276 cmd/incus/config.go:351
+#: cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353
+#: cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714
+#: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
+#: cmd/incus/network_load_balancer.go:767 cmd/incus/network_peer.go:804
+#: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
+#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
+#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1260,7 +1366,8 @@ msgid "Copy images between servers"
 msgstr ""
 
 #: cmd/incus/image.go:148
-msgid "Copy images between servers\n"
+msgid ""
+"Copy images between servers\n"
 "\n"
 "The auto-update flag instructs the server to keep this image up to date.\n"
 "It requires the source to be an alias and for it to be public."
@@ -1271,14 +1378,19 @@ msgid "Copy instances within or in between servers"
 msgstr ""
 
 #: cmd/incus/copy.go:40
-msgid "Copy instances within or in between servers\n"
+msgid ""
+"Copy instances within or in between servers\n"
 "\n"
 "Transfer modes (--mode):\n"
-" - pull: Target server pulls the data from the source server (source must listen on network)\n"
-" - push: Source server pushes the data to the target server (target must listen on network)\n"
-" - relay: The CLI connects to both source and server and proxies the data (both source and target must listen on network)\n"
+" - pull: Target server pulls the data from the source server (source must "
+"listen on network)\n"
+" - push: Source server pushes the data to the target server (target must "
+"listen on network)\n"
+" - relay: The CLI connects to both source and server and proxies the data "
+"(both source and target must listen on network)\n"
 "\n"
-"The pull transfer mode is the default as it is compatible with all server versions.\n"
+"The pull transfer mode is the default as it is compatible with all server "
+"versions.\n"
 msgstr ""
 
 #: cmd/incus/config_device.go:399 cmd/incus/config_device.go:400
@@ -1297,7 +1409,8 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65 cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1415,7 +1528,8 @@ msgid "Create instance snapshot"
 msgstr ""
 
 #: cmd/incus/snapshot.go:78
-msgid "Create instance snapshots\n"
+msgid ""
+"Create instance snapshots\n"
 "\n"
 "When --stateful is used, attempt to checkpoint the instance's\n"
 "running state, including process memory state, TCP connections, ..."
@@ -1453,7 +1567,8 @@ msgstr ""
 msgid "Create new network forwards"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:323 cmd/incus/network_load_balancer.go:324
+#: cmd/incus/network_load_balancer.go:323
+#: cmd/incus/network_load_balancer.go:324
 msgid "Create new network load balancers"
 msgstr ""
 
@@ -1489,7 +1604,8 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:663 cmd/incus/storage_volume.go:1443
+#: cmd/incus/image.go:999 cmd/incus/info.go:663
+#: cmd/incus/storage_volume.go:1443
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1517,7 +1633,16 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499 cmd/incus/config_trust.go:435 cmd/incus/image.go:1115 cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133 cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:137 cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134 cmd/incus/network_zone.go:917 cmd/incus/operation.go:151 cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916 cmd/incus/storage_volume.go:1672
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
+#: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
+#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
+#: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:137
+#: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
+#: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
+#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
+#: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1556,7 +1681,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2928
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1620,7 +1745,8 @@ msgstr ""
 msgid "Delete network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:799 cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:799
+#: cmd/incus/network_load_balancer.go:800
 msgid "Delete network load balancers"
 msgstr ""
 
@@ -1664,7 +1790,156 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:96 cmd/incus/network_load_balancer.go:248 cmd/incus/network_load_balancer.go:324 cmd/incus/network_load_balancer.go:427 cmd/incus/network_load_balancer.go:495 cmd/incus/network_load_balancer.go:605 cmd/incus/network_load_balancer.go:635 cmd/incus/network_load_balancer.go:800 cmd/incus/network_load_balancer.go:873 cmd/incus/network_load_balancer.go:888 cmd/incus/network_load_balancer.go:964 cmd/incus/network_load_balancer.go:1062 cmd/incus/network_load_balancer.go:1077 cmd/incus/network_load_balancer.go:1150 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2668 cmd/incus/storage_volume.go:2755 cmd/incus/storage_volume.go:2835 cmd/incus/storage_volume.go:2922 cmd/incus/storage_volume.go:3088 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83
+#: cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20
+#: cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45
+#: cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29
+#: cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29
+#: cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61
+#: cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223
+#: cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318
+#: cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507
+#: cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689
+#: cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994
+#: cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237
+#: cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449
+#: cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35
+#: cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186
+#: cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332
+#: cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609
+#: cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750
+#: cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888
+#: cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045
+#: cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51
+#: cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95
+#: cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751
+#: cmd/incus/config.go:883 cmd/incus/config_device.go:24
+#: cmd/incus/config_device.go:78 cmd/incus/config_device.go:220
+#: cmd/incus/config_device.go:317 cmd/incus/config_device.go:400
+#: cmd/incus/config_device.go:502 cmd/incus/config_device.go:618
+#: cmd/incus/config_device.go:625 cmd/incus/config_device.go:758
+#: cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26
+#: cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187
+#: cmd/incus/config_template.go:26 cmd/incus/config_template.go:66
+#: cmd/incus/config_template.go:134 cmd/incus/config_template.go:188
+#: cmd/incus/config_template.go:288 cmd/incus/config_template.go:356
+#: cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91
+#: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
+#: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
+#: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
+#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
+#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
+#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
+#: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
+#: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
+#: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
+#: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
+#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
+#: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
+#: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
+#: cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836
+#: cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251
+#: cmd/incus/network.go:1405 cmd/incus/network.go:1465
+#: cmd/incus/network.go:1561 cmd/incus/network.go:1633
+#: cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94
+#: cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251
+#: cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380
+#: cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565
+#: cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747
+#: cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861
+#: cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013
+#: cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28
+#: cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248
+#: cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427
+#: cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622
+#: cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823
+#: cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912
+#: cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28
+#: cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178
+#: cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352
+#: cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559
+#: cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694
+#: cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29
+#: cmd/incus/network_load_balancer.go:96 cmd/incus/network_load_balancer.go:248
+#: cmd/incus/network_load_balancer.go:324
+#: cmd/incus/network_load_balancer.go:427
+#: cmd/incus/network_load_balancer.go:495
+#: cmd/incus/network_load_balancer.go:605
+#: cmd/incus/network_load_balancer.go:635
+#: cmd/incus/network_load_balancer.go:800
+#: cmd/incus/network_load_balancer.go:873
+#: cmd/incus/network_load_balancer.go:888
+#: cmd/incus/network_load_balancer.go:964
+#: cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_load_balancer.go:1077
+#: cmd/incus/network_load_balancer.go:1150 cmd/incus/network_peer.go:28
+#: cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249
+#: cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466
+#: cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653
+#: cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837
+#: cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91
+#: cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317
+#: cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485
+#: cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616
+#: cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799
+#: cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934
+#: cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074
+#: cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261
+#: cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438
+#: cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514
+#: cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29
+#: cmd/incus/operation.go:62 cmd/incus/operation.go:113
+#: cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109
+#: cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357
+#: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
+#: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
+#: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
+#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
+#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
+#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
+#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
+#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
+#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
+#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
+#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
+#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
+#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
+#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
+#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
+#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
+#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
+#: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
+#: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
+#: cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733
+#: cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836
+#: cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027
+#: cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197
+#: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
+#: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
+#: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1723,16 +1998,22 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293 cmd/incus/config_device.go:557 cmd/incus/config_device.go:578 cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
+#: cmd/incus/config_device.go:279 cmd/incus/config_device.go:293
+#: cmd/incus/config_device.go:557 cmd/incus/config_device.go:578
+#: cmd/incus/config_device.go:692 cmd/incus/config_device.go:715
 msgid "Device doesn't exist"
 msgstr ""
 
 #: cmd/incus/config_device.go:718
-msgid "Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"
+msgid ""
+"Device from profile(s) cannot be modified for individual instance. Override "
+"device or modify profile instead"
 msgstr ""
 
 #: cmd/incus/config_device.go:581
-msgid "Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"
+msgid ""
+"Device from profile(s) cannot be removed from individual instance. Override "
+"device or modify profile instead"
 msgstr ""
 
 #: cmd/incus/config_device.go:296
@@ -1872,7 +2153,8 @@ msgstr ""
 msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623 cmd/incus/snapshot.go:337
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1881,7 +2163,9 @@ msgid "EXPIRY DATE"
 msgstr ""
 
 #: cmd/incus/file.go:76
-msgid "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
+msgid ""
+"Early server side processing of file transfer requests cannot be canceled "
+"(interrupt two more times to force)"
 msgstr ""
 
 #: cmd/incus/cluster_group.go:331 cmd/incus/cluster_group.go:332
@@ -1928,7 +2212,8 @@ msgstr ""
 msgid "Edit network integration configurations as YAML"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:634 cmd/incus/network_load_balancer.go:635
+#: cmd/incus/network_load_balancer.go:634
+#: cmd/incus/network_load_balancer.go:635
 msgid "Edit network load balancer configurations as YAML"
 msgstr ""
 
@@ -1969,17 +2254,31 @@ msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:954
-msgid "Edit storage volume configurations as YAML\n"
+msgid ""
+"Edit storage volume configurations as YAML\n"
 "\n"
 "If the type is not specified, incus assumes the type is \"custom\".\n"
-"Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/config_trust.go:274 cmd/incus/config_trust.go:275
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:631 cmd/incus/image.go:1133 cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113 cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:150 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:166 cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:722 cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925 cmd/incus/storage_volume.go:1700 cmd/incus/warning.go:236
+#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
+#: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
+#: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
+#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
+#: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
+#: cmd/incus/network_load_balancer.go:150 cmd/incus/network_peer.go:140
+#: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
+#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
+#: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
+#: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1989,18 +2288,23 @@ msgid "Enable clustering on a single non-clustered server"
 msgstr ""
 
 #: cmd/incus/cluster.go:780
-msgid "Enable clustering on a single non-clustered server\n"
+msgid ""
+"Enable clustering on a single non-clustered server\n"
 "\n"
 "  This command turns a non-clustered server into the first member of a new\n"
 "  cluster, which will have the given name.\n"
 "\n"
-"  It's required that the server is already available on the network. You can check\n"
-"  that by running 'incus config get core.https_address', and possibly set a value\n"
+"  It's required that the server is already available on the network. You can "
+"check\n"
+"  that by running 'incus config get core.https_address', and possibly set a "
+"value\n"
 "  for the address if not yet set."
 msgstr ""
 
 #: cmd/incus/top.go:184
-msgid "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' for disk):"
+msgid ""
+"Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
+"for disk):"
 msgstr ""
 
 #: cmd/incus/top.go:165
@@ -2039,7 +2343,15 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1539 cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595 cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:578 cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548 cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896 cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038 cmd/incus/storage_volume.go:2081
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019
+#: cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1539
+#: cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595
+#: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:578
+#: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
+#: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
+#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
+#: cmd/incus/storage_volume.go:2081
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2054,7 +2366,14 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013 cmd/incus/network.go:1533 cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662 cmd/incus/network_load_balancer.go:572 cmd/incus/network_peer.go:622 cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230 cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013
+#: cmd/incus/network.go:1533 cmd/incus/network_acl.go:534
+#: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
+#: cmd/incus/network_load_balancer.go:572 cmd/incus/network_peer.go:622
+#: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
+#: cmd/incus/storage_volume.go:2075
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2082,7 +2401,8 @@ msgid "Execute a SQL query against the local or global database"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:29
-msgid "Execute a SQL query against the local or global database\n"
+msgid ""
+"Execute a SQL query against the local or global database\n"
 "\n"
 "  The local database is specific to the cluster member you target the\n"
 "  command to, and contains member-specific data (such as the member network\n"
@@ -2104,7 +2424,8 @@ msgid "Execute a SQL query against the local or global database\n"
 "  text schema of the given database.\n"
 "\n"
 "  This internal command is mostly useful for debugging and disaster\n"
-"  recovery. The development team will occasionally provide hotfixes to users as a\n"
+"  recovery. The development team will occasionally provide hotfixes to users "
+"as a\n"
 "  set of database queries to fix some data inconsistency."
 msgstr ""
 
@@ -2113,7 +2434,8 @@ msgid "Execute commands in instances"
 msgstr ""
 
 #: cmd/incus/exec.go:41
-msgid "Execute commands in instances\n"
+msgid ""
+"Execute commands in instances\n"
 "\n"
 "The command is executed directly using exec, so there is no shell and\n"
 "shell patterns (variables, file redirects, ...) won't be understood.\n"
@@ -2122,7 +2444,8 @@ msgid "Execute commands in instances\n"
 "\n"
 "  incus exec <instance> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
-"Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
+"Mode defaults to non-interactive, interactive mode is selected if both stdin "
+"AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
 #: cmd/incus/utils_properties.go:95
@@ -2130,7 +2453,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526 cmd/incus/storage_volume.go:2648
+#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/storage_volume.go:1526
 msgid "Expires at"
 msgstr ""
 
@@ -2148,12 +2472,13 @@ msgid "Export and download images"
 msgstr ""
 
 #: cmd/incus/image.go:511
-msgid "Export and download images\n"
+msgid ""
+"Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2921 cmd/incus/storage_volume.go:2922
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2173,7 +2498,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2925
+#: cmd/incus/storage_volume.go:2964
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2182,7 +2507,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3054
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2200,7 +2525,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117 cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2397,7 +2723,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2989
+#: cmd/incus/storage_volume.go:3028
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2412,7 +2738,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3107
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -2492,14 +2818,17 @@ msgstr ""
 msgid "Failed to retrieve current server config: %w"
 msgstr ""
 
-#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49 cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79 cmd/incus/admin_init_dump.go:93
+#: cmd/incus/admin_init_dump.go:18 cmd/incus/admin_init_dump.go:49
+#: cmd/incus/admin_init_dump.go:64 cmd/incus/admin_init_dump.go:79
+#: cmd/incus/admin_init_dump.go:93
 #, c-format
 msgid "Failed to retrieve current server configuration: %w"
 msgstr ""
 
 #: cmd/incus/admin_init_dump.go:28
 #, c-format
-msgid "Failed to retrieve current server network configuration for project %q: %w"
+msgid ""
+"Failed to retrieve current server network configuration for project %q: %w"
 msgstr ""
 
 #: cmd/incus/admin_init_auto.go:129
@@ -2551,7 +2880,8 @@ msgstr ""
 msgid "Fetch instance backup file: %w"
 msgstr ""
 
-#: cmd/incus/network.go:1191 cmd/incus/network_acl.go:133 cmd/incus/network_zone.go:201 cmd/incus/operation.go:236
+#: cmd/incus/network.go:1191 cmd/incus/network_acl.go:133
+#: cmd/incus/network_zone.go:201 cmd/incus/operation.go:236
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2598,24 +2928,42 @@ msgstr ""
 
 #: cmd/incus/cluster.go:709
 #, c-format
-msgid "Forcefully removing a server from the cluster should only be done as a last\n"
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
 "resort.\n"
 "\n"
-"The removed server will not be functional after this action and will require a\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
 "full reset, losing any remaining instance, image or storage volume that\n"
 "the server may have held.\n"
 "\n"
-"When possible, a graceful removal should be preferred, this will require you to\n"
-"move any affected instance, image or storage volume to another server prior to\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected instance, image or storage volume to another server prior "
+"to\n"
 "the server being cleanly removed from the cluster.\n"
 "\n"
-"The --force flag should only be used if the server has died, been reinstalled\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:609 cmd/incus/image.go:1094 cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073 cmd/incus/network.go:1272 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:118 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:859 cmd/incus/operation.go:136 cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902 cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2565 cmd/incus/warning.go:94
+#: cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091
+#: cmd/incus/cluster_group.go:478 cmd/incus/config_template.go:290
+#: cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:609
+#: cmd/incus/image.go:1094 cmd/incus/image_alias.go:179 cmd/incus/list.go:135
+#: cmd/incus/network.go:1073 cmd/incus/network.go:1272
+#: cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:59
+#: cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437
+#: cmd/incus/network_load_balancer.go:118 cmd/incus/network_peer.go:110
+#: cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:859
+#: cmd/incus/operation.go:136 cmd/incus/profile.go:726 cmd/incus/project.go:529
+#: cmd/incus/project.go:1052 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315
+#: cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:500
+#: cmd/incus/storage_bucket.go:902 cmd/incus/storage_volume.go:1575
+#: cmd/incus/storage_volume.go:2561 cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2636,7 +2984,8 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: cmd/incus/info.go:517 cmd/incus/info.go:528 cmd/incus/info.go:533 cmd/incus/info.go:539
+#: cmd/incus/info.go:517 cmd/incus/info.go:528 cmd/incus/info.go:533
+#: cmd/incus/info.go:539
 #, c-format
 msgid "Free: %v"
 msgstr ""
@@ -2783,7 +3132,8 @@ msgstr ""
 msgid "Get values for network integration configuration keys"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:426 cmd/incus/network_load_balancer.go:427
+#: cmd/incus/network_load_balancer.go:426
+#: cmd/incus/network_load_balancer.go:427
 msgid "Get values for network load balancer configuration keys"
 msgstr ""
 
@@ -2820,12 +3170,15 @@ msgid "Get values for storage volume configuration keys"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:1178
-msgid "Get values for storage volume configuration keys\n"
+msgid ""
+"Get values for storage volume configuration keys\n"
 "\n"
 "If the type is not specified, incus assumes the type is \"custom\".\n"
-"Supported values for type are \"custom\", \"container\" and \"virtual-machine\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
 "\n"
-"For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine)."
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
 msgstr ""
 
 #: cmd/incus/storage_volume.go:440
@@ -2933,7 +3286,9 @@ msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
 #: cmd/incus/main.go:446
-msgid "If this is your first time running Incus on this machine, you should also run: incus admin init"
+msgid ""
+"If this is your first time running Incus on this machine, you should also "
+"run: incus admin init"
 msgstr ""
 
 #: cmd/incus/snapshot.go:90
@@ -2998,16 +3353,17 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3087
+#: cmd/incus/storage_volume.go:3126
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3088
+#: cmd/incus/storage_volume.go:3127
 msgid "Import custom storage volumes."
 msgstr ""
 
 #: cmd/incus/image.go:679
-msgid "Import image into the image store\n"
+msgid ""
+"Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
@@ -3024,15 +3380,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3162
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3097
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3167
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3041,7 +3397,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3171
+#: cmd/incus/storage_volume.go:3210
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3115,7 +3471,8 @@ msgstr ""
 msgid "Invalid IP address or DNS name"
 msgstr ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490 cmd/incus/storage_volume.go:3022
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
+#: cmd/incus/storage_volume.go:3061
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3134,7 +3491,8 @@ msgstr ""
 msgid "Invalid arguments"
 msgstr ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495 cmd/incus/storage_volume.go:3027
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3213,7 +3571,8 @@ msgstr ""
 
 #: cmd/incus/list.go:674
 #, c-format
-msgid "Invalid name in '%s', empty string is only allowed when defining maxWidth"
+msgid ""
+"Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
 #: cmd/incus/main.go:542 cmd/incus/storage.go:134
@@ -3234,7 +3593,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242 cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015 cmd/incus/storage_volume.go:2882
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
+#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
+#: cmd/incus/storage_volume.go:2921
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3290,7 +3651,10 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1296 cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:139 cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516 cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/list.go:617 cmd/incus/network.go:1296
+#: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:139
+#: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
+#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3332,7 +3696,8 @@ msgid "List DHCP leases"
 msgstr ""
 
 #: cmd/incus/network.go:1251
-msgid "List DHCP leases\n"
+msgid ""
+"List DHCP leases\n"
 "\n"
 "Default column layout: hmitL\n"
 "\n"
@@ -3363,7 +3728,8 @@ msgid "List all active certificate add tokens"
 msgstr ""
 
 #: cmd/incus/config_trust.go:590
-msgid "List all active certificate add tokens\n"
+msgid ""
+"List all active certificate add tokens\n"
 "\n"
 "Default column layout: ntE\n"
 "\n"
@@ -3388,7 +3754,8 @@ msgid "List all active cluster member join tokens"
 msgstr ""
 
 #: cmd/incus/cluster.go:1072
-msgid "List all active cluster member join tokens\n"
+msgid ""
+"List all active cluster member join tokens\n"
 "\n"
 "Default column layout: nte\n"
 "\n"
@@ -3413,7 +3780,8 @@ msgid "List all the cluster groups"
 msgstr ""
 
 #: cmd/incus/cluster_group.go:457
-msgid "List all the cluster groups\n"
+msgid ""
+"List all the cluster groups\n"
 "\n"
 "Default column layout: ndm\n"
 "\n"
@@ -3438,15 +3806,16 @@ msgid "List all the cluster members"
 msgstr ""
 
 #: cmd/incus/cluster.go:130
-msgid "List all the cluster members\n"
+msgid ""
+"List all the cluster members\n"
 "\n"
-"	The -c option takes a (optionally comma-separated) list of arguments\n"
-"	that control which image attributes to output when displaying in table\n"
-"	or csv format.\n"
+"\tThe -c option takes a (optionally comma-separated) list of arguments\n"
+"\tthat control which image attributes to output when displaying in table\n"
+"\tor csv format.\n"
 "\n"
-"	Default column layout is: nurafdsm\n"
+"\tDefault column layout is: nurafdsm\n"
 "\n"
-"	Column shorthand chars:\n"
+"\tColumn shorthand chars:\n"
 "\n"
 "    n - Server name\n"
 "    u - URL\n"
@@ -3475,7 +3844,8 @@ msgid "List available network forwards"
 msgstr ""
 
 #: cmd/incus/network_forward.go:91
-msgid "List available network forwards\n"
+msgid ""
+"List available network forwards\n"
 "\n"
 "Default column layout: ldDp\n"
 "\n"
@@ -3502,7 +3872,8 @@ msgid "List available network load balancers"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:96
-msgid "List available network load balancers\n"
+msgid ""
+"List available network load balancers\n"
 "\n"
 "Default column layout: ldp\n"
 "\n"
@@ -3528,7 +3899,8 @@ msgid "List available network peers"
 msgstr ""
 
 #: cmd/incus/network_peer.go:87
-msgid "List available network peers\n"
+msgid ""
+"List available network peers\n"
 "\n"
 "Default column layout: ndpts\n"
 "\n"
@@ -3559,7 +3931,8 @@ msgid "List available network zoneS"
 msgstr ""
 
 #: cmd/incus/network_zone.go:91
-msgid "List available network zone\n"
+msgid ""
+"List available network zone\n"
 "\n"
 "Default column layout: nDSdus\n"
 "\n"
@@ -3585,7 +3958,8 @@ msgid "List available networks"
 msgstr ""
 
 #: cmd/incus/network.go:1053
-msgid "List available networks\n"
+msgid ""
+"List available networks\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -3609,7 +3983,8 @@ msgid "List available storage pools"
 msgstr ""
 
 #: cmd/incus/storage.go:665
-msgid "List available storage pools\n"
+msgid ""
+"List available storage pools\n"
 "\n"
 "Default column layout: nDSdus\n"
 "\n"
@@ -3637,7 +4012,8 @@ msgid "List background operations"
 msgstr ""
 
 #: cmd/incus/operation.go:113
-msgid "List background operations\n"
+msgid ""
+"List background operations\n"
 "\n"
 "Default column layout: itdscCl\n"
 "\n"
@@ -3666,7 +4042,8 @@ msgid "List image aliases"
 msgstr ""
 
 #: cmd/incus/image_alias.go:158
-msgid "List image aliases\n"
+msgid ""
+"List image aliases\n"
 "\n"
 "Filters may be part of the image hash or part of the image alias name.\n"
 "Default column layout: aftd\n"
@@ -3693,7 +4070,8 @@ msgid "List images"
 msgstr ""
 
 #: cmd/incus/image.go:1067
-msgid "List images\n"
+msgid ""
+"List images\n"
 "\n"
 "Filters may be of the <key>=<value> form for property based filtering,\n"
 "or part of the image hash or part of the image alias name.\n"
@@ -3732,7 +4110,8 @@ msgid "List instance snapshots"
 msgstr ""
 
 #: cmd/incus/snapshot.go:294
-msgid "List instance snapshots\n"
+msgid ""
+"List instance snapshots\n"
 "\n"
 "Default column layout: nTEs\n"
 "\n"
@@ -3759,16 +4138,19 @@ msgstr ""
 
 #: cmd/incus/list.go:50
 #, c-format
-msgid "List instances\n"
+msgid ""
+"List instances\n"
 "\n"
 "Default column layout: ns46tS\n"
 "Fast column layout: nsacPt\n"
 "\n"
-"A single keyword like \"web\" which will list any instance with a name starting by \"web\".\n"
+"A single keyword like \"web\" which will list any instance with a name "
+"starting by \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
-"A key/value pair where the key is a shorthand. Multiple values must be delimited by ','. Available shorthands:\n"
+"A key/value pair where the key is a shorthand. Multiple values must be "
+"delimited by ','. Available shorthands:\n"
 "  - type={instance type}\n"
 "  - status={instance current lifecycle status}\n"
 "  - architecture={instance architecture}\n"
@@ -3777,14 +4159,17 @@ msgid "List instances\n"
 "  - ipv6={ip or CIDR}\n"
 "\n"
 "Examples:\n"
-"  - \"user.blah=abc\" will list all instances with the \"blah\" user property set to \"abc\".\n"
+"  - \"user.blah=abc\" will list all instances with the \"blah\" user "
+"property set to \"abc\".\n"
 "  - \"u.blah=abc\" will do the same\n"
 "  - \"security.privileged=true\" will list all privileged instances\n"
 "  - \"s.privileged=true\" will do the same\n"
 "  - \"type=container\" will list all container instances\n"
-"  - \"type=container status=running\" will list all running container instances\n"
+"  - \"type=container status=running\" will list all running container "
+"instances\n"
 "\n"
-"A regular expression matching a configuration item or its value. (e.g. volatile.eth0.hwaddr=00:16:3e:.*).\n"
+"A regular expression matching a configuration item or its value. (e.g. "
+"volatile.eth0.hwaddr=00:16:3e:.*).\n"
 "\n"
 "When multiple filters are passed, they are added one on top of the other,\n"
 "selecting instances which satisfy them all.\n"
@@ -3824,8 +4209,10 @@ msgid "List instances\n"
 "  f - Base Image Fingerprint (short)\n"
 "  F - Base Image Fingerprint (long)\n"
 "\n"
-"Custom columns are defined with \"[config:|devices:]key[:name][:maxWidth]\":\n"
-"  KEY: The (extended) config or devices key to display. If [config:|devices:] is omitted then it defaults to config key.\n"
+"Custom columns are defined with \"[config:|devices:]key[:name][:"
+"maxWidth]\":\n"
+"  KEY: The (extended) config or devices key to display. If [config:|"
+"devices:] is omitted then it defaults to config key.\n"
 "  NAME: Name to display in the column header.\n"
 "  Defaults to the key if not specified or empty.\n"
 "\n"
@@ -3842,7 +4229,8 @@ msgid "List network allocations in use"
 msgstr ""
 
 #: cmd/incus/network_allocations.go:34
-msgid "List network allocations in use\n"
+msgid ""
+"List network allocations in use\n"
 "Default column layout: uatnm\n"
 "\n"
 "== Columns ==\n"
@@ -3868,7 +4256,8 @@ msgid "List network integrations"
 msgstr ""
 
 #: cmd/incus/network_integration.go:416
-msgid "List network integrations\n"
+msgid ""
+"List network integrations\n"
 "\n"
 "Default column layout: ndtu\n"
 "\n"
@@ -3883,10 +4272,10 @@ msgid "List network integrations\n"
 "Commas between consecutive shorthand chars are optional.\n"
 "\n"
 "Pre-defined column shorthand chars:\n"
-"	n - Name\n"
-"	d - Description\n"
-"	t - Type\n"
-"	u - Used by"
+"\tn - Name\n"
+"\td - Description\n"
+"\tt - Type\n"
+"\tu - Used by"
 msgstr ""
 
 #: cmd/incus/network.go:1074
@@ -3906,7 +4295,8 @@ msgid "List profiles"
 msgstr ""
 
 #: cmd/incus/profile.go:710
-msgid "List profiles\n"
+msgid ""
+"List profiles\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -3925,7 +4315,8 @@ msgid "List projects"
 msgstr ""
 
 #: cmd/incus/project.go:508
-msgid "List projects\n"
+msgid ""
+"List projects\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -3949,7 +4340,8 @@ msgid "List storage bucket keys"
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:883
-msgid "List storage bucket keys\n"
+msgid ""
+"List storage bucket keys\n"
 "\n"
 "Default column layout: ndr\n"
 "\n"
@@ -3974,7 +4366,8 @@ msgid "List storage buckets"
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:479
-msgid "List storage buckets\n"
+msgid ""
+"List storage buckets\n"
 "\n"
 "Default column layout: ndL\n"
 "\n"
@@ -4000,20 +4393,17 @@ msgid "List storage volume snapshots"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:2550
-msgid "List storage volume snapshots\n"
+msgid ""
+"List storage volume snapshots\n"
 "\n"
-"	The -c option takes a (optionally comma-separated) list of arguments\n"
-"	that control which image attributes to output when displaying in table\n"
-"	or csv format.\n"
+"\tThe -c option takes a (optionally comma-separated) list of arguments\n"
+"\tthat control which image attributes to output when displaying in table\n"
+"\tor csv format.\n"
 "\n"
-"	Column shorthand chars:\n"
-"		c - Content type (filesystem or block)\n"
-"		d - Description\n"
-"		e - Project name\n"
-"		L - Location of the instance (e.g. its cluster member)\n"
-"		n - Name\n"
-"		t - Type of volume (custom, image, container or virtual-machine)\n"
-"		u - Number of references (used by)"
+"\tColumn shorthand chars:\n"
+"\t\tn - Name\n"
+"\t\tT - Taken at\n"
+"\t\tE - Expiry"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:1554
@@ -4021,7 +4411,8 @@ msgid "List storage volumes"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:1559
-msgid "List storage volumes\n"
+msgid ""
+"List storage volumes\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which image attributes to output when displaying in table\n"
@@ -4043,7 +4434,8 @@ msgid "List the available remotes"
 msgstr ""
 
 #: cmd/incus/remote.go:724
-msgid "List the available remotes\n"
+msgid ""
+"List the available remotes\n"
 "\n"
 "Default column layout: nupaPsg\n"
 "\n"
@@ -4072,25 +4464,27 @@ msgid "List trusted clients"
 msgstr ""
 
 #: cmd/incus/config_trust.go:400
-msgid "List trusted clients\n"
+msgid ""
+"List trusted clients\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
-"that control which certificate attributes to output when displaying in table\n"
+"that control which certificate attributes to output when displaying in "
+"table\n"
 "or csv format.\n"
 "\n"
 "Default column layout is: ntdfe\n"
 "\n"
 "Column shorthand chars:\n"
 "\n"
-"	n - Name\n"
-"	t - Type\n"
-"	c - Common Name\n"
-"	f - Fingerprint\n"
-"	d - Description\n"
-"	i - Issue date\n"
-"	e - Expiry date\n"
-"	r - Whether certificate is restricted\n"
-"	p - Newline-separated list of projects"
+"\tn - Name\n"
+"\tt - Type\n"
+"\tc - Common Name\n"
+"\tf - Fingerprint\n"
+"\td - Description\n"
+"\ti - Issue date\n"
+"\te - Expiry date\n"
+"\tr - Whether certificate is restricted\n"
+"\tp - Newline-separated list of projects"
 msgstr ""
 
 #: cmd/incus/warning.go:71
@@ -4098,7 +4492,8 @@ msgid "List warnings"
 msgstr ""
 
 #: cmd/incus/warning.go:72
-msgid "List warnings\n"
+msgid ""
+"List warnings\n"
 "\n"
 "The -c option takes a (optionally comma-separated) list of arguments\n"
 "that control which warning attributes to output when displaying in table\n"
@@ -4274,13 +4669,15 @@ msgid "Manage images"
 msgstr ""
 
 #: cmd/incus/image.go:40
-msgid "Manage images\n"
+msgid ""
+"Manage images\n"
 "\n"
 "Instances are created from images. Those images were themselves\n"
 "either generated from an existing instance or downloaded from an image\n"
 "server.\n"
 "\n"
-"When using remote images, the server will automatically cache images for you\n"
+"When using remote images, the server will automatically cache images for "
+"you\n"
 "and remove them upon expiration.\n"
 "\n"
 "The image unique identifier is the hash (sha-256) of its representation\n"
@@ -4291,7 +4688,8 @@ msgid "Manage images\n"
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19 cmd/incus/admin_other.go:20
+#: cmd/incus/admin.go:19 cmd/incus/admin.go:20 cmd/incus/admin_other.go:19
+#: cmd/incus/admin_other.go:20
 msgid "Manage incus daemon"
 msgstr ""
 
@@ -4331,11 +4729,13 @@ msgstr ""
 msgid "Manage network integrations"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:872 cmd/incus/network_load_balancer.go:873
+#: cmd/incus/network_load_balancer.go:872
+#: cmd/incus/network_load_balancer.go:873
 msgid "Manage network load balancer backends"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1061 cmd/incus/network_load_balancer.go:1062
+#: cmd/incus/network_load_balancer.go:1061
+#: cmd/incus/network_load_balancer.go:1062
 msgid "Manage network load balancer ports"
 msgstr ""
 
@@ -4396,9 +4796,11 @@ msgid "Manage storage volumes"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:56
-msgid "Manage storage volumes\n"
+msgid ""
+"Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -4482,14 +4884,20 @@ msgid "Minimal configuration (non-interactive)"
 msgstr ""
 
 #: cmd/incus/monitor.go:52
-msgid "Minimum level for log messages (only available when using pretty format)"
+msgid ""
+"Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:697
 msgid "Minimum size is 1GiB"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229 cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424 cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764 cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064 cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240 cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
+#: cmd/incus/storage_bucket.go:129 cmd/incus/storage_bucket.go:229
+#: cmd/incus/storage_bucket.go:305 cmd/incus/storage_bucket.go:424
+#: cmd/incus/storage_bucket.go:672 cmd/incus/storage_bucket.go:764
+#: cmd/incus/storage_bucket.go:973 cmd/incus/storage_bucket.go:1064
+#: cmd/incus/storage_bucket.go:1161 cmd/incus/storage_bucket.go:1240
+#: cmd/incus/storage_bucket.go:1363 cmd/incus/storage_bucket.go:1439
 msgid "Missing bucket name"
 msgstr ""
 
@@ -4497,43 +4905,103 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305 cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
+#: cmd/incus/cluster_group.go:239 cmd/incus/cluster_group.go:305
+#: cmd/incus/cluster_group.go:365 cmd/incus/cluster_group.go:783
 msgid "Missing cluster group name"
 msgstr ""
 
-#: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515 cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646 cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82 cmd/incus/cluster_role.go:150
+#: cmd/incus/cluster.go:914 cmd/incus/cluster.go:1515
+#: cmd/incus/cluster_group.go:145 cmd/incus/cluster_group.go:646
+#: cmd/incus/cluster_group.go:848 cmd/incus/cluster_role.go:82
+#: cmd/incus/cluster_role.go:150
 msgid "Missing cluster member name"
 msgstr ""
 
-#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219 cmd/incus/config_template.go:115 cmd/incus/config_template.go:170 cmd/incus/config_template.go:224 cmd/incus/config_template.go:321 cmd/incus/config_template.go:392 cmd/incus/profile.go:145 cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
+#: cmd/incus/config_metadata.go:110 cmd/incus/config_metadata.go:219
+#: cmd/incus/config_template.go:115 cmd/incus/config_template.go:170
+#: cmd/incus/config_template.go:224 cmd/incus/config_template.go:321
+#: cmd/incus/config_template.go:392 cmd/incus/profile.go:145
+#: cmd/incus/profile.go:226 cmd/incus/profile.go:904 cmd/incus/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165 cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
+#: cmd/incus/storage_bucket.go:1068 cmd/incus/storage_bucket.go:1165
+#: cmd/incus/storage_bucket.go:1244 cmd/incus/storage_bucket.go:1367
 msgid "Missing key name"
 msgstr ""
 
-#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357 cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557 cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863 cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038 cmd/incus/network_load_balancer.go:288 cmd/incus/network_load_balancer.go:357 cmd/incus/network_load_balancer.go:455 cmd/incus/network_load_balancer.go:540 cmd/incus/network_load_balancer.go:708 cmd/incus/network_load_balancer.go:840 cmd/incus/network_load_balancer.go:928 cmd/incus/network_load_balancer.go:1004 cmd/incus/network_load_balancer.go:1117 cmd/incus/network_load_balancer.go:1191
+#: cmd/incus/network_forward.go:288 cmd/incus/network_forward.go:357
+#: cmd/incus/network_forward.go:472 cmd/incus/network_forward.go:557
+#: cmd/incus/network_forward.go:732 cmd/incus/network_forward.go:863
+#: cmd/incus/network_forward.go:956 cmd/incus/network_forward.go:1038
+#: cmd/incus/network_load_balancer.go:288
+#: cmd/incus/network_load_balancer.go:357
+#: cmd/incus/network_load_balancer.go:455
+#: cmd/incus/network_load_balancer.go:540
+#: cmd/incus/network_load_balancer.go:708
+#: cmd/incus/network_load_balancer.go:840
+#: cmd/incus/network_load_balancer.go:928
+#: cmd/incus/network_load_balancer.go:1004
+#: cmd/incus/network_load_balancer.go:1117
+#: cmd/incus/network_load_balancer.go:1191
 msgid "Missing listen address"
 msgstr ""
 
-#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264 cmd/incus/config_device.go:358 cmd/incus/config_device.go:432 cmd/incus/config_device.go:544 cmd/incus/config_device.go:673 cmd/incus/config_device.go:794
+#: cmd/incus/config_device.go:131 cmd/incus/config_device.go:264
+#: cmd/incus/config_device.go:358 cmd/incus/config_device.go:432
+#: cmd/incus/config_device.go:544 cmd/incus/config_device.go:673
+#: cmd/incus/config_device.go:794
 msgid "Missing name"
 msgstr ""
 
-#: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280 cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415 cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666 cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834 cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
+#: cmd/incus/network_acl.go:220 cmd/incus/network_acl.go:280
+#: cmd/incus/network_acl.go:343 cmd/incus/network_acl.go:415
+#: cmd/incus/network_acl.go:513 cmd/incus/network_acl.go:666
+#: cmd/incus/network_acl.go:777 cmd/incus/network_acl.go:834
+#: cmd/incus/network_acl.go:970 cmd/incus/network_acl.go:1053
 msgid "Missing network ACL name"
 msgstr ""
 
-#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203 cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377 cmd/incus/network_integration.go:584 cmd/incus/network_integration.go:641 cmd/incus/network_integration.go:752
+#: cmd/incus/network_integration.go:131 cmd/incus/network_integration.go:203
+#: cmd/incus/network_integration.go:266 cmd/incus/network_integration.go:377
+#: cmd/incus/network_integration.go:584 cmd/incus/network_integration.go:641
+#: cmd/incus/network_integration.go:752
 msgid "Missing network integration name"
 msgstr ""
 
-#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480 cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752 cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1359 cmd/incus/network.go:1437 cmd/incus/network.go:1503 cmd/incus/network.go:1595 cmd/incus/network_forward.go:204 cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353 cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553 cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859 cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034 cmd/incus/network_load_balancer.go:203 cmd/incus/network_load_balancer.go:284 cmd/incus/network_load_balancer.go:353 cmd/incus/network_load_balancer.go:451 cmd/incus/network_load_balancer.go:536 cmd/incus/network_load_balancer.go:704 cmd/incus/network_load_balancer.go:836 cmd/incus/network_load_balancer.go:924 cmd/incus/network_load_balancer.go:1000 cmd/incus/network_load_balancer.go:1113 cmd/incus/network_load_balancer.go:1187 cmd/incus/network_peer.go:205 cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366 cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591 cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
+#: cmd/incus/network.go:179 cmd/incus/network.go:276 cmd/incus/network.go:480
+#: cmd/incus/network.go:542 cmd/incus/network.go:639 cmd/incus/network.go:752
+#: cmd/incus/network.go:875 cmd/incus/network.go:951 cmd/incus/network.go:1359
+#: cmd/incus/network.go:1437 cmd/incus/network.go:1503
+#: cmd/incus/network.go:1595 cmd/incus/network_forward.go:204
+#: cmd/incus/network_forward.go:284 cmd/incus/network_forward.go:353
+#: cmd/incus/network_forward.go:468 cmd/incus/network_forward.go:553
+#: cmd/incus/network_forward.go:728 cmd/incus/network_forward.go:859
+#: cmd/incus/network_forward.go:952 cmd/incus/network_forward.go:1034
+#: cmd/incus/network_load_balancer.go:203
+#: cmd/incus/network_load_balancer.go:284
+#: cmd/incus/network_load_balancer.go:353
+#: cmd/incus/network_load_balancer.go:451
+#: cmd/incus/network_load_balancer.go:536
+#: cmd/incus/network_load_balancer.go:704
+#: cmd/incus/network_load_balancer.go:836
+#: cmd/incus/network_load_balancer.go:924
+#: cmd/incus/network_load_balancer.go:1000
+#: cmd/incus/network_load_balancer.go:1113
+#: cmd/incus/network_load_balancer.go:1187 cmd/incus/network_peer.go:205
+#: cmd/incus/network_peer.go:283 cmd/incus/network_peer.go:366
+#: cmd/incus/network_peer.go:507 cmd/incus/network_peer.go:591
+#: cmd/incus/network_peer.go:750 cmd/incus/network_peer.go:871
 msgid "Missing network name"
 msgstr ""
 
-#: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353 cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521 cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773 cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967 cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209 cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548 cmd/incus/network_zone.go:1605
+#: cmd/incus/network_zone.go:284 cmd/incus/network_zone.go:353
+#: cmd/incus/network_zone.go:425 cmd/incus/network_zone.go:521
+#: cmd/incus/network_zone.go:662 cmd/incus/network_zone.go:773
+#: cmd/incus/network_zone.go:887 cmd/incus/network_zone.go:967
+#: cmd/incus/network_zone.go:1112 cmd/incus/network_zone.go:1209
+#: cmd/incus/network_zone.go:1471 cmd/incus/network_zone.go:1548
+#: cmd/incus/network_zone.go:1605
 msgid "Missing network zone name"
 msgstr ""
 
@@ -4541,19 +5009,42 @@ msgstr ""
 msgid "Missing network zone record name"
 msgstr ""
 
-#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370 cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595 cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
+#: cmd/incus/network_peer.go:287 cmd/incus/network_peer.go:370
+#: cmd/incus/network_peer.go:511 cmd/incus/network_peer.go:595
+#: cmd/incus/network_peer.go:754 cmd/incus/network_peer.go:875
 msgid "Missing peer name"
 msgstr ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970 cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668 cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969 cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157 cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2600 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440
+#: cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970
+#: cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225
+#: cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420
+#: cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668
+#: cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969
+#: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
+#: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
+#: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
+#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
+#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
+#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
+#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
+#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
+#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 msgid "Missing pool name"
 msgstr ""
 
-#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554 cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056 cmd/incus/profile.go:1137
+#: cmd/incus/profile.go:409 cmd/incus/profile.go:472 cmd/incus/profile.go:554
+#: cmd/incus/profile.go:672 cmd/incus/profile.go:988 cmd/incus/profile.go:1056
+#: cmd/incus/profile.go:1137
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353 cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824 cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
+#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
+#: cmd/incus/project.go:952 cmd/incus/project.go:1083
 msgid "Missing project name"
 msgstr ""
 
@@ -4600,12 +5091,14 @@ msgid "Monitor a local or remote server"
 msgstr ""
 
 #: cmd/incus/monitor.go:33
-msgid "Monitor a local or remote server\n"
+msgid ""
+"Monitor a local or remote server\n"
 "\n"
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659 cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/network.go:562 cmd/incus/network.go:659
+#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4626,14 +5119,19 @@ msgid "Move instances within or in between servers"
 msgstr ""
 
 #: cmd/incus/move.go:35
-msgid "Move instances within or in between servers\n"
+msgid ""
+"Move instances within or in between servers\n"
 "\n"
 "Transfer modes (--mode):\n"
-" - pull: Target server pulls the data from the source server (source must listen on network)\n"
-" - push: Source server pushes the data to the target server (target must listen on network)\n"
-" - relay: The CLI connects to both source and server and proxies the data (both source and target must listen on network)\n"
+" - pull: Target server pulls the data from the source server (source must "
+"listen on network)\n"
+" - push: Source server pushes the data to the target server (target must "
+"listen on network)\n"
+" - relay: The CLI connects to both source and server and proxies the data "
+"(both source and target must listen on network)\n"
 "\n"
-"The pull transfer mode is the default as it is compatible with all server versions.\n"
+"The pull transfer mode is the default as it is compatible with all server "
+"versions.\n"
 msgstr ""
 
 #: cmd/incus/move.go:60
@@ -4665,7 +5163,16 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:621 cmd/incus/list.go:583 cmd/incus/network.go:1093 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128 cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916 cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915 cmd/incus/storage_volume.go:1671
+#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111
+#: cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431
+#: cmd/incus/config_trust.go:621 cmd/incus/list.go:583
+#: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
+#: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
+#: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
+#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
+#: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
+#: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr ""
 
@@ -4694,11 +5201,15 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: cmd/incus/network.go:1142 cmd/incus/operation.go:199 cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604 cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631 cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
+#: cmd/incus/network.go:1142 cmd/incus/operation.go:199
+#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
+#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
 
-#: cmd/incus/info.go:117 cmd/incus/info.go:203 cmd/incus/info.go:290 cmd/incus/info.go:377
+#: cmd/incus/info.go:117 cmd/incus/info.go:203 cmd/incus/info.go:290
+#: cmd/incus/info.go:377
 #, c-format
 msgid "NUMA node: %v"
 msgstr ""
@@ -4716,7 +5227,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524 cmd/incus/storage_volume.go:2646
+#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
 
@@ -4733,7 +5245,8 @@ msgstr ""
 msgid "Name of the existing %s pool or dataset:"
 msgstr ""
 
-#: cmd/incus/admin_init_interactive.go:617 cmd/incus/admin_init_interactive.go:715
+#: cmd/incus/admin_init_interactive.go:617
+#: cmd/incus/admin_init_interactive.go:715
 msgid "Name of the existing CEPH cluster"
 msgstr ""
 
@@ -4775,7 +5288,8 @@ msgstr ""
 msgid "Name of the storage pool:"
 msgstr ""
 
-#: cmd/incus/info.go:633 cmd/incus/network.go:969 cmd/incus/storage_volume.go:1414
+#: cmd/incus/info.go:633 cmd/incus/network.go:969
+#: cmd/incus/storage_volume.go:1414
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4886,7 +5400,8 @@ msgstr ""
 
 #: cmd/incus/network_peer.go:445
 #, c-format
-msgid "Network peer %s pending (please complete mutual peering on peer network)"
+msgid ""
+"Network peer %s pending (please complete mutual peering on peer network)"
 msgstr ""
 
 #: cmd/incus/network.go:348
@@ -4985,7 +5500,9 @@ msgid "Node %d:\n"
 msgstr ""
 
 #: cmd/incus/admin_init_auto.go:32
-msgid "None of --storage-pool, --storage-create-device or --storage-create-loop may be used with the 'dir' backend"
+msgid ""
+"None of --storage-pool, --storage-create-device or --storage-create-loop may "
+"be used with the 'dir' backend"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:629
@@ -5000,7 +5517,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2976
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -5025,7 +5542,8 @@ msgid "Only managed networks can be modified"
 msgstr ""
 
 #: cmd/incus/admin_init_auto.go:36
-msgid "Only one of --storage-create-device or --storage-create-loop can be specified"
+msgid ""
+"Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
 #: cmd/incus/operation.go:92
@@ -5083,7 +5601,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092 cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132 cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513 cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352 cmd/incus/warning.go:213
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
+#: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
+#: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
+#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:352
+#: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5196,7 +5718,17 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:478 cmd/incus/network.go:803 cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:768 cmd/incus/network_peer.go:805 cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406 cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301 cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414
+#: cmd/incus/config.go:277 cmd/incus/config.go:352
+#: cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254
+#: cmd/incus/config_trust.go:354 cmd/incus/image.go:478
+#: cmd/incus/network.go:803 cmd/incus/network_acl.go:715
+#: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
+#: cmd/incus/network_load_balancer.go:768 cmd/incus/network_peer.go:805
+#: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
+#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
+#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5416,15 +5948,21 @@ msgid "Rebuild instances"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:28
-msgid "Recover missing instances and volumes from existing and unknown storage pools"
+msgid ""
+"Recover missing instances and volumes from existing and unknown storage pools"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:29
-msgid "Recover missing instances and volumes from existing and unknown storage pools\n"
+msgid ""
+"Recover missing instances and volumes from existing and unknown storage "
+"pools\n"
 "\n"
-"  This command is mostly used for disaster recovery. It will ask you about unknown storage pools and attempt to\n"
-"  access them, along with existing storage pools, and identify any missing instances and volumes that exist on the\n"
-"  pools but are not in the database. It will then offer to recreate these database records."
+"  This command is mostly used for disaster recovery. It will ask you about "
+"unknown storage pools and attempt to\n"
+"  access them, along with existing storage pools, and identify any missing "
+"instances and volumes that exist on the\n"
+"  pools but are not in the database. It will then offer to recreate these "
+"database records."
 msgstr ""
 
 #: cmd/incus/file.go:436 cmd/incus/file.go:654
@@ -5454,7 +5992,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
+#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -5494,7 +6033,9 @@ msgstr ""
 
 #: cmd/incus/project.go:219
 #, c-format
-msgid "Remove %s and everything it contains (instances, images, volumes, networks, ...) (yes/no): "
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: cmd/incus/cluster_group.go:609
@@ -5545,7 +6086,8 @@ msgstr ""
 msgid "Remove ports from a forward"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:1149 cmd/incus/network_load_balancer.go:1150
+#: cmd/incus/network_load_balancer.go:1149
+#: cmd/incus/network_load_balancer.go:1150
 msgid "Remove ports from a load balancer"
 msgstr ""
 
@@ -5582,7 +6124,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333 cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
+#: cmd/incus/image_alias.go:334
 msgid "Rename aliases"
 msgstr ""
 
@@ -5622,7 +6165,7 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2667 cmd/incus/storage_volume.go:2668
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 msgid "Rename storage volume snapshots"
 msgstr ""
 
@@ -5631,7 +6174,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2739
+#: cmd/incus/storage_volume.go:2778
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -5662,7 +6205,8 @@ msgid "Restore cluster member"
 msgstr ""
 
 #: cmd/incus/snapshot.go:510
-msgid "Restore instance from snapshots\n"
+msgid ""
+"Restore instance from snapshots\n"
 "\n"
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
@@ -5671,7 +6215,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2754 cmd/incus/storage_volume.go:2755
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5778,7 +6322,9 @@ msgstr ""
 msgid "STARTED AT"
 msgstr ""
 
-#: cmd/incus/list.go:588 cmd/incus/network.go:1100 cmd/incus/network_peer.go:132 cmd/incus/operation.go:152 cmd/incus/storage.go:713 cmd/incus/warning.go:215
+#: cmd/incus/list.go:588 cmd/incus/network.go:1100
+#: cmd/incus/network_peer.go:132 cmd/incus/operation.go:152
+#: cmd/incus/storage.go:713 cmd/incus/warning.go:215
 msgid "STATE"
 msgstr ""
 
@@ -5854,7 +6400,8 @@ msgstr ""
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273 cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
+#: cmd/incus/cluster.go:272 cmd/incus/cluster.go:1176 cmd/incus/cluster.go:1273
+#: cmd/incus/cluster.go:1381 cmd/incus/cluster_group.go:563
 msgid "Server isn't part of a cluster"
 msgstr ""
 
@@ -5889,16 +6436,20 @@ msgid "Set device configuration keys"
 msgstr ""
 
 #: cmd/incus/config_device.go:618
-msgid "Set device configuration keys\n"
+msgid ""
+"Set device configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
 #: cmd/incus/config_device.go:625
-msgid "Set device configuration keys\n"
+msgid ""
+"Set device configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
@@ -5911,9 +6462,11 @@ msgid "Set instance or server configuration keys"
 msgstr ""
 
 #: cmd/incus/config.go:525
-msgid "Set instance or server configuration keys\n"
+msgid ""
+"Set instance or server configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus config set [<remote>:][<instance>] <key> <value>"
 msgstr ""
 
@@ -5922,9 +6475,11 @@ msgid "Set network ACL configuration keys"
 msgstr ""
 
 #: cmd/incus/network_acl.go:477
-msgid "Set network ACL configuration keys\n"
+msgid ""
+"Set network ACL configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
@@ -5933,9 +6488,11 @@ msgid "Set network configuration keys"
 msgstr ""
 
 #: cmd/incus/network.go:1465
-msgid "Set network configuration keys\n"
+msgid ""
+"Set network configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
@@ -5944,9 +6501,11 @@ msgid "Set network forward keys"
 msgstr ""
 
 #: cmd/incus/network_forward.go:512
-msgid "Set network forward keys\n"
+msgid ""
+"Set network forward keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
@@ -5955,10 +6514,13 @@ msgid "Set network integration configuration keys"
 msgstr ""
 
 #: cmd/incus/network_integration.go:613
-msgid "Set network integration configuration keys\n"
+msgid ""
+"Set network integration configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
-"    incus network integration set [<remote>:]<network integration> <key> <value>"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
+"    incus network integration set [<remote>:]<network integration> <key> "
+"<value>"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:494
@@ -5966,9 +6528,11 @@ msgid "Set network load balancer keys"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:495
-msgid "Set network load balancer keys\n"
+msgid ""
+"Set network load balancer keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus network set [<remote>:]<network> <listen_address> <key> <value>"
 msgstr ""
 
@@ -5977,9 +6541,11 @@ msgid "Set network peer keys"
 msgstr ""
 
 #: cmd/incus/network_peer.go:551
-msgid "Set network peer keys\n"
+msgid ""
+"Set network peer keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus network set [<remote>:]<network> <peer_name> <key> <value>"
 msgstr ""
 
@@ -5988,9 +6554,11 @@ msgid "Set network zone configuration keys"
 msgstr ""
 
 #: cmd/incus/network_zone.go:485
-msgid "Set network zone configuration keys\n"
+msgid ""
+"Set network zone configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus network set [<remote>:]<Zone> <key> <value>"
 msgstr ""
 
@@ -6003,9 +6571,11 @@ msgid "Set profile configuration keys"
 msgstr ""
 
 #: cmd/incus/profile.go:1016
-msgid "Set profile configuration keys\n"
+msgid ""
+"Set profile configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
@@ -6014,9 +6584,11 @@ msgid "Set project configuration keys"
 msgstr ""
 
 #: cmd/incus/project.go:788
-msgid "Set project configuration keys\n"
+msgid ""
+"Set project configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
@@ -6025,9 +6597,11 @@ msgid "Set storage bucket configuration keys"
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:639
-msgid "Set storage bucket configuration keys\n"
+msgid ""
+"Set storage bucket configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus storage bucket set [<remote>:]<pool> <bucket> <key> <value>"
 msgstr ""
 
@@ -6036,9 +6610,11 @@ msgid "Set storage pool configuration keys"
 msgstr ""
 
 #: cmd/incus/storage.go:826
-msgid "Set storage pool configuration keys\n"
+msgid ""
+"Set storage pool configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -6047,13 +6623,17 @@ msgid "Set storage volume configuration keys"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:1947
-msgid "Set storage volume configuration keys\n"
+msgid ""
+"Set storage volume configuration keys\n"
 "\n"
-"For backward compatibility, a single configuration key may still be set with:\n"
-"    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>\n"
+"For backward compatibility, a single configuration key may still be set "
+"with:\n"
+"    incus storage volume set [<remote>:]<pool> [<type>/]<volume> <key> "
+"<value>\n"
 "\n"
 "If the type is not specified, Incus assumes the type is \"custom\".\n"
-"Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:1091 cmd/incus/remote.go:1092
@@ -6240,7 +6820,8 @@ msgstr ""
 msgid "Show network integration options"
 msgstr ""
 
-#: cmd/incus/network_load_balancer.go:247 cmd/incus/network_load_balancer.go:248
+#: cmd/incus/network_load_balancer.go:247
+#: cmd/incus/network_load_balancer.go:248
 msgid "Show network load balancer configurations"
 msgstr ""
 
@@ -6285,19 +6866,22 @@ msgid "Show storage volume configurations"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:2110
-msgid "Show storage volume configurations\n"
+msgid ""
+"Show storage volume configurations\n"
 "\n"
 "If the type is not specified, Incus assumes the type is \"custom\".\n"
-"Supported values for type are \"custom\", \"container\" and \"virtual-machine\".\n"
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\".\n"
 "\n"
-"For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine)."
+"For snapshots, add the snapshot name (only if type is one of custom, "
+"container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2835
+#: cmd/incus/storage_volume.go:2874
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2873
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
@@ -6306,10 +6890,12 @@ msgid "Show storage volume state information"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:1314
-msgid "Show storage volume state information\n"
+msgid ""
+"Show storage volume state information\n"
 "\n"
 "If the type is not specified, Incus assumes the type is \"custom\".\n"
-"Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
@@ -6391,7 +6977,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -6401,7 +6987,9 @@ msgid "Sorting Method:"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:121
-msgid "Source of the storage pool (block device, volume group, dataset, path, ... as applicable):"
+msgid ""
+"Source of the storage pool (block device, volume group, dataset, path, ... "
+"as applicable):"
 msgstr ""
 
 #: cmd/incus/image.go:1034
@@ -6514,7 +7102,8 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34 cmd/incus/move.go:63
+#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
 
@@ -6587,7 +7176,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -6599,11 +7188,16 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123 cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094 cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73 cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131 cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
+#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
+#: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525 cmd/incus/storage_volume.go:2647
+#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr ""
 
@@ -6620,7 +7214,8 @@ msgid "Tell the daemon to shutdown all instances and exit"
 msgstr ""
 
 #: cmd/incus/admin_shutdown.go:30
-msgid "Tell the daemon to shutdown all instances and exit\n"
+msgid ""
+"Tell the daemon to shutdown all instances and exit\n"
 "\n"
 "  This will tell the daemon to start a clean shutdown of all instances,\n"
 "  followed by having itself shutdown and exit.\n"
@@ -6643,26 +7238,35 @@ msgid "The LVM thin provisioning tools couldn't be found on the system"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:739
-msgid "The LVM thin provisioning tools couldn't be found.\n"
-"LVM can still be used without thin provisioning but this will disable over-provisioning,\n"
-"increase the space requirements and creation time of images, instances and snapshots.\n"
+msgid ""
+"The LVM thin provisioning tools couldn't be found.\n"
+"LVM can still be used without thin provisioning but this will disable over-"
+"provisioning,\n"
+"increase the space requirements and creation time of images, instances and "
+"snapshots.\n"
 "\n"
-"If you wish to use thin provisioning, abort now, install the tools from your Linux distribution\n"
-"and make sure that your user can see and run the \"thin_check\" command before running \"init\" again."
+"If you wish to use thin provisioning, abort now, install the tools from your "
+"Linux distribution\n"
+"and make sure that your user can see and run the \"thin_check\" command "
+"before running \"init\" again."
 msgstr ""
 
 #: cmd/incus/admin_cluster.go:47
-msgid "The \"cluster\" subcommand requires access to internal server data.\n"
-"To do so, it's actually part of the \"incusd\" binary rather than \"incus\".\n"
+msgid ""
+"The \"cluster\" subcommand requires access to internal server data.\n"
+"To do so, it's actually part of the \"incusd\" binary rather than "
+"\"incus\".\n"
 "\n"
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
 #: cmd/incus/console.go:379
-msgid "The client automatically uses either spicy or remote-viewer when present."
+msgid ""
+"The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180 cmd/incus/config_device.go:444
+#: cmd/incus/config_device.go:163 cmd/incus/config_device.go:180
+#: cmd/incus/config_device.go:444
 msgid "The device already exists"
 msgstr ""
 
@@ -6683,7 +7287,9 @@ msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
 #: cmd/incus/publish.go:122
-msgid "The instance is currently running. Use --force to have it stopped and restarted"
+msgid ""
+"The instance is currently running. Use --force to have it stopped and "
+"restarted"
 msgstr ""
 
 #: cmd/incus/create.go:466
@@ -6805,7 +7411,8 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:1261
 #, c-format
-msgid "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgid ""
+"The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
 #: cmd/incus/utils_properties.go:100
@@ -6819,7 +7426,8 @@ msgstr ""
 
 #: cmd/incus/admin_init_auto.go:27
 #, c-format
-msgid "The requested backend '%s' isn't available on your system (missing tools)"
+msgid ""
+"The requested backend '%s' isn't available on your system (missing tools)"
 msgstr ""
 
 #: cmd/incus/admin_init_auto.go:23
@@ -6833,19 +7441,23 @@ msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:353
 #, c-format
-msgid "The requested network bridge \"%s\" already exists. Please choose another name."
+msgid ""
+"The requested network bridge \"%s\" already exists. Please choose another "
+"name."
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:528
 #, c-format
-msgid "The requested storage pool \"%s\" already exists. Please choose another name."
+msgid ""
+"The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/network.go:576 cmd/incus/network.go:673
+#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6862,10 +7474,13 @@ msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
 #: cmd/incus/main.go:306
-msgid "This client hasn't been configured to use a remote server yet.\n"
-"As your platform can't run native Linux instances, you must connect to a remote server.\n"
+msgid ""
+"This client hasn't been configured to use a remote server yet.\n"
+"As your platform can't run native Linux instances, you must connect to a "
+"remote server.\n"
 "\n"
-"If you already added a remote server, make it the default with \"incus remote switch NAME\"."
+"If you already added a remote server, make it the default with \"incus "
+"remote switch NAME\"."
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -6905,11 +7520,14 @@ msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
 #: cmd/incus/main.go:451
-msgid "To start your first container, try: incus launch images:ubuntu/22.04\n"
+msgid ""
+"To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386 cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
+#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6922,7 +7540,8 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535 cmd/incus/info.go:541
+#: cmd/incus/info.go:519 cmd/incus/info.go:530 cmd/incus/info.go:535
+#: cmd/incus/info.go:541
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -6971,9 +7590,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
 #: cmd/incus/info.go:742
@@ -6985,14 +7604,18 @@ msgid "Type of certificate"
 msgstr ""
 
 #: cmd/incus/console.go:45
-msgid "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
+msgid ""
+"Type of connection to establish: 'console' for serial console, 'vga' for "
+"SPICE graphical output"
 msgstr ""
 
 #: cmd/incus/network_peer.go:333
 msgid "Type of peer (local or remote)"
 msgstr ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433 cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973 cmd/incus/storage_volume.go:1423
+#: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
+#: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
+#: cmd/incus/storage_volume.go:1423
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7021,7 +7644,11 @@ msgstr ""
 msgid "USB devices:"
 msgstr ""
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452 cmd/incus/network_zone.go:135 cmd/incus/profile.go:748 cmd/incus/project.go:556 cmd/incus/storage.go:712 cmd/incus/storage_volume.go:1674
+#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
+#: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
+#: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
+#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
 
@@ -7057,7 +7684,19 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455 cmd/incus/config_trust.go:637 cmd/incus/image.go:1141 cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119 cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:172 cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:728 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1708 cmd/incus/warning.go:244
+#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
+#: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
+#: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
+#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
+#: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
+#: cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:146
+#: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
+#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
+#: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
+#: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7171,10 +7810,12 @@ msgid "Unset storage volume configuration keys"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:2215
-msgid "Unset storage volume configuration keys\n"
+msgid ""
+"Unset storage volume configuration keys\n"
 "\n"
 "If the type is not specified, Incus assumes the type is \"custom\".\n"
-"Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
+"Supported values for type are \"custom\", \"container\" and \"virtual-"
+"machine\"."
 msgstr ""
 
 #: cmd/incus/cluster_group.go:1047
@@ -7255,7 +7896,9 @@ msgid "Update cluster certificate"
 msgstr ""
 
 #: cmd/incus/cluster.go:1326
-msgid "Update cluster certificate with PEM certificate and key read from input files."
+msgid ""
+"Update cluster certificate with PEM certificate and key read from input "
+"files."
 msgstr ""
 
 #: cmd/incus/profile.go:278
@@ -7281,15 +7924,17 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2927
-msgid "Use storage driver optimized format (can only be restored on a similar pool)"
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+msgid ""
+"Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
 #: cmd/incus/main.go:106
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534 cmd/incus/info.go:540
+#: cmd/incus/info.go:518 cmd/incus/info.go:529 cmd/incus/info.go:534
+#: cmd/incus/info.go:540
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -7302,12 +7947,14 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224 cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
 
 #: cmd/incus/file.go:73
-msgid "User signaled us three times, exiting. The remote operation will keep running"
+msgid ""
+"User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
 
 #: cmd/incus/info.go:167 cmd/incus/info.go:276
@@ -7337,7 +7984,8 @@ msgstr ""
 msgid "Vendor: %s"
 msgstr ""
 
-#: cmd/incus/info.go:326 cmd/incus/info.go:360 cmd/incus/info.go:373 cmd/incus/info.go:409
+#: cmd/incus/info.go:326 cmd/incus/info.go:360 cmd/incus/info.go:373
+#: cmd/incus/info.go:409
 #, c-format
 msgid "Vendor: %v"
 msgstr ""
@@ -7376,9 +8024,11 @@ msgid "Wait for the daemon to be ready to process requests"
 msgstr ""
 
 #: cmd/incus/admin_waitready.go:27
-msgid "Wait for the daemon to be ready to process requests\n"
+msgid ""
+"Wait for the daemon to be ready to process requests\n"
 "\n"
-"  This command will block until the daemon is reachable over its REST API and\n"
+"  This command will block until the daemon is reachable over its REST API "
+"and\n"
 "  is done with early start tasks like re-starting previously started\n"
 "  containers."
 msgstr ""
@@ -7388,7 +8038,8 @@ msgid "Wait for the operation to complete"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:768
-msgid "We detected that you are running inside an unprivileged container.\n"
+msgid ""
+"We detected that you are running inside an unprivileged container.\n"
 "This means that unless you manually configured your host otherwise,\n"
 "you will not have enough uids and gids to allocate to your containers.\n"
 "\n"
@@ -7427,7 +8078,9 @@ msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: cmd/incus/snapshot.go:518
-msgid "Whether or not to restore the instance's running state from snapshot (if available)"
+msgid ""
+"Whether or not to restore the instance's running state from snapshot (if "
+"available)"
 msgstr ""
 
 #: cmd/incus/snapshot.go:89
@@ -7435,7 +8088,9 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: cmd/incus/rebuild.go:27
-msgid "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
+msgid ""
+"Wipe the instance root disk and re-initialize. The original image is used to "
+"re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:77
@@ -7492,14 +8147,19 @@ msgid "Would you like to use an existing bridge or host interface?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:652
-msgid "Would you like to use an existing empty block device (e.g. a disk or partition)?"
+msgid ""
+"Would you like to use an existing empty block device (e.g. a disk or "
+"partition)?"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:107
 msgid "Would you like to use clustering?"
 msgstr ""
 
-#: cmd/incus/network.go:1139 cmd/incus/operation.go:202 cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606 cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633 cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
+#: cmd/incus/network.go:1139 cmd/incus/operation.go:202
+#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
+#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
 
@@ -7535,7 +8195,13 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070 cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31 cmd/incus/network.go:1050 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505 cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070
+#: cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397
+#: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
+#: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
+#: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -7563,7 +8229,8 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249 cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
+#: cmd/incus/network_acl.go:188 cmd/incus/network_acl.go:249
+#: cmd/incus/network_acl.go:606 cmd/incus/network_acl.go:801
 msgid "[<remote>:]<ACL>"
 msgstr ""
 
@@ -7591,7 +8258,8 @@ msgstr ""
 msgid "[<remote>:]<API path>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614 cmd/incus/network_zone.go:740
+#: cmd/incus/network_zone.go:252 cmd/incus/network_zone.go:614
+#: cmd/incus/network_zone.go:740
 msgid "[<remote>:]<Zone>"
 msgstr ""
 
@@ -7619,11 +8287,13 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740 cmd/incus/config_trust.go:858
+#: cmd/incus/config_trust.go:273 cmd/incus/config_trust.go:740
+#: cmd/incus/config_trust.go:858
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269 cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
+#: cmd/incus/cluster_group.go:184 cmd/incus/cluster_group.go:269
+#: cmd/incus/cluster_group.go:330 cmd/incus/cluster_group.go:748
 msgid "[<remote>:]<group>"
 msgstr ""
 
@@ -7671,7 +8341,10 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752 cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185 cmd/incus/config_template.go:286 cmd/incus/console.go:35 cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
+#: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/snapshot.go:292
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7719,7 +8392,8 @@ msgstr ""
 msgid "[<remote>:]<instance> <snapshot>"
 msgstr ""
 
-#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131 cmd/incus/config_template.go:186 cmd/incus/config_template.go:354
+#: cmd/incus/config_template.go:64 cmd/incus/config_template.go:131
+#: cmd/incus/config_template.go:186 cmd/incus/config_template.go:354
 msgid "[<remote>:]<instance> <template>"
 msgstr ""
 
@@ -7731,7 +8405,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81 cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
+#: cmd/incus/action.go:30 cmd/incus/action.go:55 cmd/incus/action.go:81
+#: cmd/incus/action.go:107 cmd/incus/action.go:132 cmd/incus/delete.go:29
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -7756,7 +8431,8 @@ msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
 #: cmd/incus/file.go:427
-msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
+msgid ""
+"[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
 #: cmd/incus/file.go:1151
@@ -7767,11 +8443,14 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: cmd/incus/cluster.go:316 cmd/incus/cluster.go:373 cmd/incus/cluster.go:686 cmd/incus/cluster.go:871 cmd/incus/cluster.go:1235 cmd/incus/cluster.go:1447 cmd/incus/cluster.go:1476
+#: cmd/incus/cluster.go:316 cmd/incus/cluster.go:373 cmd/incus/cluster.go:686
+#: cmd/incus/cluster.go:871 cmd/incus/cluster.go:1235 cmd/incus/cluster.go:1447
+#: cmd/incus/cluster.go:1476
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607 cmd/incus/cluster_group.go:810
+#: cmd/incus/cluster_group.go:98 cmd/incus/cluster_group.go:607
+#: cmd/incus/cluster_group.go:810
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -7795,7 +8474,8 @@ msgstr ""
 msgid "[<remote>:]<name>"
 msgstr ""
 
-#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228 cmd/incus/network_integration.go:725
+#: cmd/incus/network_integration.go:175 cmd/incus/network_integration.go:228
+#: cmd/incus/network_integration.go:725
 msgid "[<remote>:]<network integration>"
 msgstr ""
 
@@ -7815,7 +8495,10 @@ msgstr ""
 msgid "[<remote>:]<network integration> <type>"
 msgstr ""
 
-#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915 cmd/incus/network.go:1249 cmd/incus/network.go:1559 cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93 cmd/incus/network_peer.go:84
+#: cmd/incus/network.go:445 cmd/incus/network.go:698 cmd/incus/network.go:915
+#: cmd/incus/network.go:1249 cmd/incus/network.go:1559
+#: cmd/incus/network_forward.go:88 cmd/incus/network_load_balancer.go:93
+#: cmd/incus/network_peer.go:84
 msgid "[<remote>:]<network>"
 msgstr ""
 
@@ -7835,7 +8518,10 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667 cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:246 cmd/incus/network_load_balancer.go:633 cmd/incus/network_load_balancer.go:797
+#: cmd/incus/network_forward.go:246 cmd/incus/network_forward.go:667
+#: cmd/incus/network_forward.go:820 cmd/incus/network_load_balancer.go:246
+#: cmd/incus/network_load_balancer.go:633
+#: cmd/incus/network_load_balancer.go:797
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
 
@@ -7844,10 +8530,14 @@ msgid "[<remote>:]<network> <listen_address> <backend_name>"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:886
-msgid "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
+msgid ""
+"[<remote>:]<network> <listen_address> <backend_name> <target_address> "
+"[<target_port(s)>]"
 msgstr ""
 
-#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620 cmd/incus/network_load_balancer.go:425 cmd/incus/network_load_balancer.go:603
+#: cmd/incus/network_forward.go:425 cmd/incus/network_forward.go:620
+#: cmd/incus/network_load_balancer.go:425
+#: cmd/incus/network_load_balancer.go:603
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
@@ -7856,11 +8546,15 @@ msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:1075
-msgid "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
+msgid ""
+"[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
+"<backend_name>[,<backend_name>...]"
 msgstr ""
 
 #: cmd/incus/network_forward.go:910
-msgid "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
+msgid ""
+"[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
+"<target_address> [<target_port(s)>]"
 msgstr ""
 
 #: cmd/incus/network_forward.go:991 cmd/incus/network_load_balancer.go:1148
@@ -7884,7 +8578,9 @@ msgid "[<remote>:]<network> <peer_name>"
 msgstr ""
 
 #: cmd/incus/network_peer.go:318
-msgid "[<remote>:]<network> <peer_name> <[target project/]<target network or integration> [key=value...]"
+msgid ""
+"[<remote>:]<network> <peer_name> <[target project/]<target network or "
+"integration> [key=value...]"
 msgstr ""
 
 #: cmd/incus/network_peer.go:464 cmd/incus/network_peer.go:651
@@ -7911,7 +8607,8 @@ msgstr ""
 msgid "[<remote>:]<operation>"
 msgstr ""
 
-#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482 cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
+#: cmd/incus/storage.go:209 cmd/incus/storage.go:268 cmd/incus/storage.go:482
+#: cmd/incus/storage.go:928 cmd/incus/storage_bucket.go:475
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7919,15 +8616,18 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3086
+#: cmd/incus/storage_volume.go:3125
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260 cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
+#: cmd/incus/storage_bucket.go:198 cmd/incus/storage_bucket.go:260
+#: cmd/incus/storage_bucket.go:731 cmd/incus/storage_bucket.go:879
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800 cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131 cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
+#: cmd/incus/storage_bucket.go:393 cmd/incus/storage_bucket.go:800
+#: cmd/incus/storage_bucket.go:1025 cmd/incus/storage_bucket.go:1131
+#: cmd/incus/storage_bucket.go:1195 cmd/incus/storage_bucket.go:1330
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
@@ -7971,15 +8671,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:2705
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2753
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2920
+#: cmd/incus/storage_volume.go:2959
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7991,7 +8691,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2833
+#: cmd/incus/storage_volume.go:2872
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
@@ -7999,7 +8699,8 @@ msgstr ""
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312 cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
+#: cmd/incus/storage_volume.go:2108
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
@@ -8023,7 +8724,9 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754 cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496 cmd/incus/profile.go:1103
+#: cmd/incus/config_device.go:322 cmd/incus/config_device.go:754
+#: cmd/incus/profile.go:355 cmd/incus/profile.go:437 cmd/incus/profile.go:496
+#: cmd/incus/profile.go:1103
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -8059,7 +8762,8 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295 cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
+#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
 msgid "[<remote>:]<project>"
 msgstr ""
 
@@ -8087,7 +8791,8 @@ msgstr ""
 msgid "[<remote>:]<zone>"
 msgstr ""
 
-#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306 cmd/incus/network_zone.go:1435
+#: cmd/incus/network_zone.go:932 cmd/incus/network_zone.go:1306
+#: cmd/incus/network_zone.go:1435
 msgid "[<remote>:]<zone> <record>"
 msgstr ""
 
@@ -8159,33 +8864,38 @@ msgstr ""
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr ""
 
 #: cmd/incus/alias.go:63
-msgid "incus alias add list \"list -c ns46S\"\n"
+msgid ""
+"incus alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
 #: cmd/incus/alias.go:225
-msgid "incus alias remove my-list\n"
+msgid ""
+"incus alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
 #: cmd/incus/alias.go:170
-msgid "incus alias rename list my-list\n"
+msgid ""
+"incus alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
 #: cmd/incus/cluster.go:875
-msgid "incus cluster edit <cluster member> < member.yaml\n"
+msgid ""
+"incus cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
 #: cmd/incus/cluster_group.go:103
-msgid "incus cluster group assign foo default,bar\n"
+msgid ""
+"incus cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
 "\n"
 "incus cluster group assign foo default\n"
@@ -8193,27 +8903,33 @@ msgid "incus cluster group assign foo default,bar\n"
 msgstr ""
 
 #: cmd/incus/cluster_group.go:189
-msgid "incus cluster group create g1\n"
+msgid ""
+"incus cluster group create g1\n"
 "\n"
 "incus cluster group create g1 < config.yaml\n"
-"	Create a cluster group with configuration from config.yaml"
+"\tCreate a cluster group with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/config_device.go:82
-msgid "incus config device add [<remote>:]instance1 <device-name> disk source=/share/c1 path=/opt\n"
+msgid ""
+"incus config device add [<remote>:]instance1 <device-name> disk source=/"
+"share/c1 path=/opt\n"
 "    Will mount the host's /share/c1 onto /opt in the instance.\n"
 "\n"
-"incus config device add [<remote>:]instance1 <device-name> disk pool=some-pool source=some-volume path=/opt\n"
+"incus config device add [<remote>:]instance1 <device-name> disk pool=some-"
+"pool source=some-volume path=/opt\n"
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
 #: cmd/incus/config.go:97
-msgid "incus config edit <instance> < instance.yaml\n"
+msgid ""
+"incus config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
 #: cmd/incus/config.go:530
-msgid "incus config set [<remote>:]<instance> limits.cpu=2\n"
+msgid ""
+"incus config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
 "\n"
 "incus config set core.https_address=[::]:8443\n"
@@ -8221,64 +8937,75 @@ msgid "incus config set [<remote>:]<instance> limits.cpu=2\n"
 msgstr ""
 
 #: cmd/incus/config_template.go:68
-msgid "incus config template create u1 t1\n"
+msgid ""
+"incus config template create u1 t1\n"
 "\n"
 "incus config template create u1 t1 < config.tpl\n"
 "    Create template t1 for instance u1 from config.tpl"
 msgstr ""
 
 #: cmd/incus/create.go:44
-msgid "incus create images:ubuntu/22.04 u1\n"
+msgid ""
+"incus create images:ubuntu/22.04 u1\n"
 "\n"
 "incus create images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create the instance with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/storage.go:102
-msgid "incus create storage s1 dir\n"
+msgid ""
+"incus create storage s1 dir\n"
 "\n"
 "incus create storage s1 dir < config.yaml\n"
 "    Create a storage pool using the content of config.yaml.\n"
-"	"
+"\t"
 msgstr ""
 
 #: cmd/incus/exec.go:52
-msgid "incus exec c1 bash\n"
-"	Run the \"bash\" command in instance \"c1\"\n"
+msgid ""
+"incus exec c1 bash\n"
+"\tRun the \"bash\" command in instance \"c1\"\n"
 "\n"
 "incus exec c1 -- ls -lh /\n"
-"	Run the \"ls -lh /\" command in instance \"c1\""
+"\tRun the \"ls -lh /\" command in instance \"c1\""
 msgstr ""
 
 #: cmd/incus/export.go:34
-msgid "incus export u1 backup0.tar.gz\n"
+msgid ""
+"incus export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
 #: cmd/incus/file.go:134
-msgid "incus file create foo/bar\n"
-"	   To create a file /bar in the foo instance.\n"
+msgid ""
+"incus file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
 "incus file create --type=symlink foo/bar baz\n"
-"	   To create a symlink /bar in instance foo whose target is baz."
+"\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
 #: cmd/incus/file.go:1155
-msgid "incus file mount foo/root fooroot\n"
+msgid ""
+"incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
 #: cmd/incus/file.go:431
-msgid "incus file pull foo/etc/hosts .\n"
-"   To pull /etc/hosts from the instance and write it to the current directory."
+msgid ""
+"incus file pull foo/etc/hosts .\n"
+"   To pull /etc/hosts from the instance and write it to the current "
+"directory."
 msgstr ""
 
 #: cmd/incus/file.go:650
-msgid "incus file push /etc/hosts foo/etc/hosts\n"
+msgid ""
+"incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
 #: cmd/incus/image.go:378
-msgid "incus image edit <image>\n"
+msgid ""
+"incus image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
 "\n"
 "incus image edit <image> < image.yaml\n"
@@ -8286,12 +9013,14 @@ msgid "incus image edit <image>\n"
 msgstr ""
 
 #: cmd/incus/import.go:29
-msgid "incus import backup0.tar.gz\n"
+msgid ""
+"incus import backup0.tar.gz\n"
 "    Create a new instance using backup0.tar.gz as the source."
 msgstr ""
 
 #: cmd/incus/info.go:37
-msgid "incus info [<remote>:]<instance> [--show-log]\n"
+msgid ""
+"incus info [<remote>:]<instance> [--show-log]\n"
 "    For instance information.\n"
 "\n"
 "incus info [<remote>:] [--resources]\n"
@@ -8299,22 +9028,29 @@ msgid "incus info [<remote>:]<instance> [--show-log]\n"
 msgstr ""
 
 #: cmd/incus/launch.go:26
-msgid "incus launch images:ubuntu/22.04 u1\n"
+msgid ""
+"incus launch images:ubuntu/22.04 u1\n"
 "\n"
 "incus launch images:ubuntu/22.04 u1 < config.yaml\n"
 "    Create and start a container with configuration from config.yaml\n"
 "\n"
 "incus launch images:ubuntu/22.04 u2 -t aws:t2.micro\n"
-"    Create and start a container using the same size as an AWS t2.micro (1 vCPU, 1GiB of RAM)\n"
+"    Create and start a container using the same size as an AWS t2.micro (1 "
+"vCPU, 1GiB of RAM)\n"
 "\n"
-"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits.memory=4GiB\n"
+"incus launch images:ubuntu/22.04 v1 --vm -c limits.cpu=4 -c limits."
+"memory=4GiB\n"
 "    Create and start a virtual machine with 4 vCPUs and 4GiB of RAM"
 msgstr ""
 
 #: cmd/incus/list.go:124
-msgid "incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
-"  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", \"IPV6\" and \"MAC\" columns.\n"
-"  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from instance configuration keys.\n"
+msgid ""
+"incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
+"parent:ETHP\n"
+"  Show instances using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
+"\"IPV6\" and \"MAC\" columns.\n"
+"  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from "
+"instance configuration keys.\n"
 "  \"ETHP\" is a custom column generated from a device key.\n"
 "\n"
 "incus list -c ns,user.comment:comment\n"
@@ -8322,7 +9058,8 @@ msgid "incus list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0
 msgstr ""
 
 #: cmd/incus/monitor.go:37
-msgid "incus monitor --type=logging\n"
+msgid ""
+"incus monitor --type=logging\n"
 "    Only show log messages.\n"
 "\n"
 "incus monitor --pretty --type=logging --loglevel=info\n"
@@ -8333,8 +9070,11 @@ msgid "incus monitor --type=logging\n"
 msgstr ""
 
 #: cmd/incus/move.go:45
-msgid "incus move [<remote>:]<source instance> [<remote>:][<destination instance>] [--instance-only]\n"
-"    Move an instance between two hosts, renaming it if destination name differs.\n"
+msgid ""
+"incus move [<remote>:]<source instance> [<remote>:][<destination instance>] "
+"[--instance-only]\n"
+"    Move an instance between two hosts, renaming it if destination name "
+"differs.\n"
 "\n"
 "incus move <old name> <new name> [--instance-only]\n"
 "    Rename a local instance.\n"
@@ -8344,14 +9084,16 @@ msgid "incus move [<remote>:]<source instance> [<remote>:][<destination instance
 msgstr ""
 
 #: cmd/incus/network_acl.go:381
-msgid "incus network acl create a1\n"
+msgid ""
+"incus network acl create a1\n"
 "\n"
 "incus network acl create a1 < config.yaml\n"
 "    Create network acl with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/network.go:338
-msgid "incus network create foo\n"
+msgid ""
+"incus network create foo\n"
 "    Create a new network called foo\n"
 "\n"
 "incus network create foo < config.yaml\n"
@@ -8362,64 +9104,80 @@ msgid "incus network create foo\n"
 msgstr ""
 
 #: cmd/incus/network_forward.go:325
-msgid "incus network forward create n1 127.0.0.1\n"
+msgid ""
+"incus network forward create n1 127.0.0.1\n"
 "\n"
 "incus network forward create n1 127.0.0.1 < config.yaml\n"
 "    Create a new network forward for network n1 from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:87
-msgid "incus network integration create o1 ovn\n"
+msgid ""
+"incus network integration create o1 ovn\n"
 "\n"
 "incus network integration create o1 ovn < config.yaml\n"
-"    Create network integration o1 of type ovn with configuration from config.yaml"
+"    Create network integration o1 of type ovn with configuration from config."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_integration.go:232
-msgid "incus network integration edit <network integration> < network-integration.yaml\n"
-"    Update a network integration using the content of network-integration.yaml"
+msgid ""
+"incus network integration edit <network integration> < network-integration."
+"yaml\n"
+"    Update a network integration using the content of network-integration."
+"yaml"
 msgstr ""
 
 #: cmd/incus/network_load_balancer.go:325
-msgid "incus network load-balancer create n1 127.0.0.1\n"
+msgid ""
+"incus network load-balancer create n1 127.0.0.1\n"
 "\n"
 "incus network load-balancer create n1 127.0.0.1 < config.yaml\n"
-"    Create network load-balancer for network n1 with configuration from config.yaml"
+"    Create network load-balancer for network n1 with configuration from "
+"config.yaml"
 msgstr ""
 
 #: cmd/incus/network_peer.go:321
-msgid "incus network peer create default peer1 web/default\n"
-"    Create a new peering between network \"default\" in the current project and network \"default\" in the \"web\" project\n"
+msgid ""
+"incus network peer create default peer1 web/default\n"
+"    Create a new peering between network \"default\" in the current project "
+"and network \"default\" in the \"web\" project\n"
 "\n"
 "incus network peer create default peer2 ovn-ic --type=remote\n"
-"    Create a new peering between network \"default\" in the current project and other remote networks through the \"ovn-ic\" integration\n"
+"    Create a new peering between network \"default\" in the current project "
+"and other remote networks through the \"ovn-ic\" integration\n"
 "\n"
 "incus network peer create default peer3 web/default < config.yaml\n"
-"	Create a new peering between network default in the current project and network default in the web project using the configuration\n"
-"	in the file config.yaml"
+"\tCreate a new peering between network default in the current project and "
+"network default in the web project using the configuration\n"
+"\tin the file config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:391
-msgid "incus network zone create z1\n"
+msgid ""
+"incus network zone create z1\n"
 "\n"
 "incus network zone create z1 < config.yaml\n"
 "    Create network zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/network_zone.go:1075
-msgid "incus network zone record create z1 r1\n"
+msgid ""
+"incus network zone record create z1 r1\n"
 "\n"
 "incus network zone record create z1 r1 < config.yaml\n"
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/operation.go:290
-msgid "incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
+msgid ""
+"incus operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
 #: cmd/incus/profile.go:186
-msgid "incus profile assign foo default,bar\n"
+msgid ""
+"incus profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
 "\n"
 "incus profile assign foo default\n"
@@ -8430,7 +9188,8 @@ msgid "incus profile assign foo default,bar\n"
 msgstr ""
 
 #: cmd/incus/profile.go:359
-msgid "incus profile create p1\n"
+msgid ""
+"incus profile create p1\n"
 "    Create a profile named p1\n"
 "\n"
 "incus profile create p1 < config.yaml\n"
@@ -8438,20 +9197,25 @@ msgid "incus profile create p1\n"
 msgstr ""
 
 #: cmd/incus/config_device.go:90
-msgid "incus profile device add [<remote>:]profile1 <device-name> disk source=/share/c1 path=/opt\n"
+msgid ""
+"incus profile device add [<remote>:]profile1 <device-name> disk source=/"
+"share/c1 path=/opt\n"
 "    Will mount the host's /share/c1 onto /opt in the instance.\n"
 "\n"
-"incus profile device add [<remote>:]profile1 <device-name> disk pool=some-pool source=some-volume path=/opt\n"
+"incus profile device add [<remote>:]profile1 <device-name> disk pool=some-"
+"pool source=some-volume path=/opt\n"
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
 #: cmd/incus/profile.go:500
-msgid "incus profile edit <profile> < profile.yaml\n"
+msgid ""
+"incus profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
 #: cmd/incus/project.go:102
-msgid "incus project create p1\n"
+msgid ""
+"incus project create p1\n"
 "    Create a project named p1\n"
 "\n"
 "incus project create p1 < config.yaml\n"
@@ -8459,152 +9223,189 @@ msgid "incus project create p1\n"
 msgstr ""
 
 #: cmd/incus/project.go:299
-msgid "incus project edit <project> < project.yaml\n"
+msgid ""
+"incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
 #: cmd/incus/query.go:36
-msgid "incus query -X DELETE --wait /1.0/instances/c1\n"
+msgid ""
+"incus query -X DELETE --wait /1.0/instances/c1\n"
 "    Delete local instance \"c1\"."
 msgstr ""
 
 #: cmd/incus/snapshot.go:83
-msgid "incus snapshot create u1 snap0\n"
-"	Create a snapshot of \"u1\" called \"snap0\".\n"
+msgid ""
+"incus snapshot create u1 snap0\n"
+"\tCreate a snapshot of \"u1\" called \"snap0\".\n"
 "\n"
 "incus snapshot create u1 snap0 < config.yaml\n"
-"	Create a snapshot of \"u1\" called \"snap0\" with the configuration from \"config.yaml\"."
+"\tCreate a snapshot of \"u1\" called \"snap0\" with the configuration from "
+"\"config.yaml\"."
 msgstr ""
 
 #: cmd/incus/snapshot.go:514
-msgid "incus snapshot restore u1 snap0\n"
+msgid ""
+"incus snapshot restore u1 snap0\n"
 "    Restore instance u1 to snapshot snap0"
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:97
-msgid "incus storage bucket create p1 b01\n"
-"	Create a new storage bucket named b01 in storage pool p1\n"
+msgid ""
+"incus storage bucket create p1 b01\n"
+"\tCreate a new storage bucket named b01 in storage pool p1\n"
 "\n"
 "incus storage bucket create p1 b01 < config.yaml\n"
-"	Create a new storage bucket named b01 in storage pool p1 using the content of config.yaml"
+"\tCreate a new storage bucket named b01 in storage pool p1 using the content "
+"of config.yaml"
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:263
-msgid "incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
+msgid ""
+"incus storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:1198
-msgid "incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
+msgid ""
+"incus storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:1406
-msgid "incus storage bucket export default b1\n"
+msgid ""
+"incus storage bucket export default b1\n"
 "    Download a backup tarball of the b1 storage bucket from the default pool."
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:1557
-msgid "incus storage bucket import default backup0.tar.gz\n"
-"		Create a new storage bucket using backup0.tar.gz as the source."
+msgid ""
+"incus storage bucket import default backup0.tar.gz\n"
+"\t\tCreate a new storage bucket using backup0.tar.gz as the source."
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:1028
-msgid "incus storage bucket key create p1 b01 k1\n"
-"	Create a key called k1 for the bucket b01 in the pool p1.\n"
+msgid ""
+"incus storage bucket key create p1 b01 k1\n"
+"\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
 "\n"
 "incus storage bucket key create p1 b01 k1 < config.yaml\n"
-"	Create a key called k1 for the bucket b01 in the pool p1 using the content of config.yaml."
+"\tCreate a key called k1 for the bucket b01 in the pool p1 using the content "
+"of config.yaml."
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:1333
-msgid "incus storage bucket key show default data foo\n"
-"    Will show the properties of a bucket key called \"foo\" for a bucket called \"data\" in the \"default\" pool."
+msgid ""
+"incus storage bucket key show default data foo\n"
+"    Will show the properties of a bucket key called \"foo\" for a bucket "
+"called \"data\" in the \"default\" pool."
 msgstr ""
 
 #: cmd/incus/storage_bucket.go:734
-msgid "incus storage bucket show default data\n"
-"    Will show the properties of a bucket called \"data\" in the \"default\" pool."
+msgid ""
+"incus storage bucket show default data\n"
+"    Will show the properties of a bucket called \"data\" in the \"default\" "
+"pool."
 msgstr ""
 
 #: cmd/incus/storage.go:272
-msgid "incus storage edit [<remote>:]<pool> < pool.yaml\n"
+msgid ""
+"incus storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
 #: cmd/incus/storage_volume.go:578
-msgid "incus storage volume create default foo\n"
+msgid ""
+"incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
 "\n"
 "incus storage volume create default foo < config.yaml\n"
-"    Create custom storage volume \"foo\" in pool \"default\" with configuration from config.yaml"
+"    Create custom storage volume \"foo\" in pool \"default\" with "
+"configuration from config.yaml"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:959
-msgid "incus storage volume edit default container/c1\n"
+msgid ""
+"incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
 "\n"
 "incus storage volume edit default foo < volume.yaml\n"
-"    Edit custom storage volume \"foo\" in pool \"default\" using the content of volume.yaml"
+"    Edit custom storage volume \"foo\" in pool \"default\" using the content "
+"of volume.yaml"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:1185
-msgid "incus storage volume get default data size\n"
+msgid ""
+"incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
 "\n"
 "incus storage volume get default virtual-machine/data snapshots.expiry\n"
-"    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\""
+"    Returns the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3090
-msgid "incus storage volume import default backup0.tar.gz\n"
+#: cmd/incus/storage_volume.go:3129
+msgid ""
+"incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
 "\n"
 "incus storage volume import default some-installer.iso installer --type=iso\n"
-"    Create a new custom volume storing some-installer.iso for use as a CD-ROM image"
+"    Create a new custom volume storing some-installer.iso for use as a CD-"
+"ROM image"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:1319
-msgid "incus storage volume info default foo\n"
-"    Returns state information for a custom volume \"foo\" in pool \"default\"\n"
+msgid ""
+"incus storage volume info default foo\n"
+"    Returns state information for a custom volume \"foo\" in pool "
+"\"default\"\n"
 "\n"
 "incus storage volume info default virtual-machine/v1\n"
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
 #: cmd/incus/storage_volume.go:1955
-msgid "incus storage volume set default data size=1GiB\n"
+msgid ""
+"incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
 "\n"
 "incus storage volume set default virtual-machine/data snapshots.expiry=7d\n"
-"    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days"
+"    Sets the snapshot expiration period for a virtual machine \"data\" in "
+"pool \"default\" to seven days"
 msgstr ""
 
 #: cmd/incus/storage_volume.go:2117
-msgid "incus storage volume show default foo\n"
+msgid ""
+"incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
 "\n"
 "incus storage volume show default virtual-machine/v1\n"
-"    Will show the properties of the virtual-machine volume \"v1\" in pool \"default\"\n"
+"    Will show the properties of the virtual-machine volume \"v1\" in pool "
+"\"default\"\n"
 "\n"
 "incus storage volume show default container/c1\n"
-"    Will show the properties of the container volume \"c1\" in pool \"default\""
+"    Will show the properties of the container volume \"c1\" in pool "
+"\"default\""
 msgstr ""
 
 #: cmd/incus/storage_volume.go:2324
-msgid "incus storage volume snapshot create default foo snap0\n"
+msgid ""
+"incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
 "\n"
 "incus storage volume snapshot create default vol1 snap0 < config.yaml\n"
-"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with the configuration from \"config.yaml\""
+"    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with "
+"the configuration from \"config.yaml\""
 msgstr ""
 
 #: cmd/incus/storage_volume.go:2220
-msgid "incus storage volume unset default foo size\n"
+msgid ""
+"incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
 "\n"
 "incus storage volume unset default virtual-machine/v1 snapshots.expiry\n"
-"    Removes the snapshot expiration period of virtual machine volume \"v1\" in pool \"default\""
+"    Removes the snapshot expiration period of virtual machine volume \"v1\" "
+"in pool \"default\""
 msgstr ""
 
 #: cmd/incus/storage.go:547
@@ -8619,7 +9420,8 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976 cmd/incus/image.go:1181
+#: cmd/incus/config_trust.go:496 cmd/incus/image.go:971 cmd/incus/image.go:976
+#: cmd/incus/image.go:1181
 msgid "no"
 msgstr ""
 
@@ -8664,6 +9466,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493 cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978 cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
+#: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
+#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-09-13 01:28+0200\n"
+        "POT-Creation-Date: 2024-09-18 23:59+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -393,11 +393,11 @@ msgstr  ""
 msgid   "--console can't be used while forcing instance shutdown"
 msgstr  ""
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid   "--console can't be used with --all"
 msgstr  ""
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 msgid   "--console only works with a single instance"
 msgstr  ""
 
@@ -827,12 +827,12 @@ msgstr  ""
 msgid   "Backing up storage bucket: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539 cmd/incus/storage_volume.go:3112
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539 cmd/incus/storage_volume.go:3110
 msgid   "Backup exported successfully!"
 msgstr  ""
 
@@ -869,7 +869,7 @@ msgstr  ""
 msgid   "Bond:"
 msgstr  ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid   "Both --all and instance name given"
 msgstr  ""
 
@@ -1158,7 +1158,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64 cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1471 cmd/incus/network.go:1564 cmd/incus/network.go:1636 cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520 cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826 cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997 cmd/incus/network_load_balancer.go:251 cmd/incus/network_load_balancer.go:332 cmd/incus/network_load_balancer.go:503 cmd/incus/network_load_balancer.go:638 cmd/incus/network_load_balancer.go:803 cmd/incus/network_load_balancer.go:891 cmd/incus/network_load_balancer.go:967 cmd/incus/network_load_balancer.go:1080 cmd/incus/network_load_balancer.go:1154 cmd/incus/storage.go:108 cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832 cmd/incus/storage.go:934 cmd/incus/storage.go:1027 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738 cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903 cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337 cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560 cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966 cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325 cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126 cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712 cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878 cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64 cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1471 cmd/incus/network.go:1564 cmd/incus/network.go:1636 cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520 cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826 cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997 cmd/incus/network_load_balancer.go:251 cmd/incus/network_load_balancer.go:332 cmd/incus/network_load_balancer.go:503 cmd/incus/network_load_balancer.go:638 cmd/incus/network_load_balancer.go:803 cmd/incus/network_load_balancer.go:891 cmd/incus/network_load_balancer.go:967 cmd/incus/network_load_balancer.go:1080 cmd/incus/network_load_balancer.go:1154 cmd/incus/storage.go:108 cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832 cmd/incus/storage.go:934 cmd/incus/storage.go:1027 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738 cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903 cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337 cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560 cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966 cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325 cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126 cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1556,7 +1556,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1664,7 +1664,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:96 cmd/incus/network_load_balancer.go:248 cmd/incus/network_load_balancer.go:324 cmd/incus/network_load_balancer.go:427 cmd/incus/network_load_balancer.go:495 cmd/incus/network_load_balancer.go:605 cmd/incus/network_load_balancer.go:635 cmd/incus/network_load_balancer.go:800 cmd/incus/network_load_balancer.go:873 cmd/incus/network_load_balancer.go:888 cmd/incus/network_load_balancer.go:964 cmd/incus/network_load_balancer.go:1062 cmd/incus/network_load_balancer.go:1077 cmd/incus/network_load_balancer.go:1150 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:96 cmd/incus/network_load_balancer.go:248 cmd/incus/network_load_balancer.go:324 cmd/incus/network_load_balancer.go:427 cmd/incus/network_load_balancer.go:495 cmd/incus/network_load_balancer.go:605 cmd/incus/network_load_balancer.go:635 cmd/incus/network_load_balancer.go:800 cmd/incus/network_load_balancer.go:873 cmd/incus/network_load_balancer.go:888 cmd/incus/network_load_balancer.go:964 cmd/incus/network_load_balancer.go:1062 cmd/incus/network_load_balancer.go:1077 cmd/incus/network_load_balancer.go:1150 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794 cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961 cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1872,7 +1872,7 @@ msgstr  ""
 msgid   "EXISTING: %q (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623 cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623 cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 msgid   "EXPIRES AT"
 msgstr  ""
 
@@ -1979,7 +1979,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:631 cmd/incus/image.go:1133 cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113 cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:150 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:166 cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:722 cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925 cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660 cmd/incus/warning.go:236
+#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:631 cmd/incus/image.go:1133 cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113 cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:150 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:166 cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:722 cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925 cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658 cmd/incus/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -2153,7 +2153,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -2173,7 +2173,7 @@ msgstr  ""
 msgid   "Export storage buckets as tarball."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
@@ -2182,7 +2182,7 @@ msgstr  ""
 msgid   "Exporting backup of storage bucket: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2397,7 +2397,7 @@ msgstr  ""
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, c-format
 msgid   "Failed to create storage volume backup: %w"
 msgstr  ""
@@ -2412,7 +2412,7 @@ msgstr  ""
 msgid   "Failed to fetch storage bucket backup: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, c-format
 msgid   "Failed to fetch storage volume backup file: %w"
 msgstr  ""
@@ -2998,11 +2998,11 @@ msgstr  ""
 msgid   "Import backups of storage buckets."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 msgid   "Import custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 msgid   "Import custom storage volumes."
 msgstr  ""
 
@@ -3024,15 +3024,15 @@ msgstr  ""
 msgid   "Import storage bucket"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid   "Import type needs to be \"backup\" or \"iso\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid   "Importing ISO images requires a volume name to be set"
 msgstr  ""
 
@@ -3041,7 +3041,7 @@ msgstr  ""
 msgid   "Importing bucket: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -3115,7 +3115,7 @@ msgstr  ""
 msgid   "Invalid IP address or DNS name"
 msgstr  ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490 cmd/incus/storage_volume.go:3063
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490 cmd/incus/storage_volume.go:3061
 #, c-format
 msgid   "Invalid URL %q: %w"
 msgstr  ""
@@ -3134,7 +3134,7 @@ msgstr  ""
 msgid   "Invalid arguments"
 msgstr  ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495 cmd/incus/storage_volume.go:3068
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495 cmd/incus/storage_volume.go:3066
 #, c-format
 msgid   "Invalid backup name segment in path %q: %w"
 msgstr  ""
@@ -3234,7 +3234,7 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242 cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015 cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242 cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015 cmd/incus/storage_volume.go:2921
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -4541,7 +4541,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970 cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668 cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969 cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157 cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596 cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836 cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970 cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668 cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969 cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157 cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596 cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2911
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -4661,7 +4661,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:621 cmd/incus/list.go:583 cmd/incus/network.go:1093 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128 cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916 cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915 cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:621 cmd/incus/list.go:583 cmd/incus/network.go:1093 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128 cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916 cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915 cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid   "NAME"
 msgstr  ""
 
@@ -4996,7 +4996,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
@@ -5618,7 +5618,7 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 msgid   "Rename storage volume snapshots"
 msgstr  ""
 
@@ -5627,7 +5627,7 @@ msgstr  ""
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, c-format
 msgid   "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr  ""
@@ -5667,7 +5667,7 @@ msgstr  ""
 msgid   "Restore instance snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -6289,11 +6289,11 @@ msgid   "Show storage volume configurations\n"
         "For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine)."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 msgid   "Show storage volume snapshhot configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 msgid   "Show storage volume snapshot configurations"
 msgstr  ""
 
@@ -6387,7 +6387,7 @@ msgstr  ""
 msgid   "Socket %d:"
 msgstr  ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, c-format
 msgid   "Some instances failed to %s"
 msgstr  ""
@@ -6583,7 +6583,7 @@ msgstr  ""
 msgid   "System:"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid   "TAKEN AT"
 msgstr  ""
 
@@ -6967,9 +6967,9 @@ msgstr  ""
 msgid   "Trust token for %s: "
 msgstr  ""
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid   "Try `incus info --show-log %s` for more info"
+msgid   "Try `incus info --show-log %s%s` for more info"
 msgstr  ""
 
 #: cmd/incus/info.go:742
@@ -7053,7 +7053,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455 cmd/incus/config_trust.go:637 cmd/incus/image.go:1141 cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119 cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:172 cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:728 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666 cmd/incus/warning.go:244
+#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455 cmd/incus/config_trust.go:637 cmd/incus/image.go:1141 cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119 cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:156 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:172 cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:728 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664 cmd/incus/warning.go:244
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -7277,7 +7277,7 @@ msgstr  ""
 msgid   "Usage: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -7915,7 +7915,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -7967,15 +7967,15 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 msgid   "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
@@ -7987,7 +7987,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 msgid   "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr  ""
 
@@ -8155,7 +8155,7 @@ msgstr  ""
 msgid   "ephemeral"
 msgstr  ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid   "error: %v"
 msgstr  ""
@@ -8552,7 +8552,7 @@ msgid   "incus storage volume get default data size\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid   "incus storage volume import default backup0.tar.gz\n"
         "    Create a new custom volume using backup0.tar.gz as the source\n"
         "\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -660,11 +660,11 @@ msgstr "- Porta %d (%s)"
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -1122,13 +1122,13 @@ msgstr "Creazione del container in corso"
 msgid "Backing up storage bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1170,7 +1170,7 @@ msgstr "Proprietà errata: %s"
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1501,9 +1501,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr ""
 
@@ -1957,7 +1957,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2220,9 +2220,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2451,7 +2451,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DI SCADENZA"
@@ -2581,7 +2581,7 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2783,7 +2783,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2807,7 +2807,7 @@ msgstr "Creazione del container in corso"
 msgid "Export storage buckets as tarball."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2816,7 +2816,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -3032,7 +3032,7 @@ msgstr "Accetta certificato"
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Accetta certificato"
@@ -3047,7 +3047,7 @@ msgstr "Accetta certificato"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Accetta certificato"
@@ -3682,11 +3682,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Creazione del container in corso"
@@ -3712,15 +3712,15 @@ msgstr "Creazione del container in corso"
 msgid "Import storage bucket"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3729,7 +3729,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3806,7 +3806,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Il nome del container è: %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Proprietà errata: %s"
@@ -3827,7 +3827,7 @@ msgid "Invalid arguments"
 msgstr "Proprietà errata: %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3932,7 +3932,7 @@ msgstr "Proprietà errata: %s"
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -5177,8 +5177,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5421,8 +5421,8 @@ msgstr "Il nome del container è: %s"
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 msgid "Missing pool name"
 msgstr ""
 
@@ -5569,7 +5569,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr ""
 
@@ -5914,7 +5914,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -6582,7 +6582,7 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Creazione del container in corso"
@@ -6592,7 +6592,7 @@ msgstr "Creazione del container in corso"
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6636,7 +6636,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -7327,12 +7327,12 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Il nome del container è: %s"
@@ -7432,7 +7432,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
@@ -7635,7 +7635,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8052,9 +8052,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
 #: cmd/incus/info.go:742
@@ -8162,7 +8162,7 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8409,7 +8409,7 @@ msgstr "Creazione del container in corso"
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -9203,7 +9203,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -9271,17 +9271,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
@@ -9296,7 +9296,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Creazione del container in corso"
@@ -9504,7 +9504,7 @@ msgstr ""
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9984,7 +9984,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -653,11 +653,11 @@ msgstr "- ポート %d（%s）"
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "インスタンスの強制シャットダウンの際は --console は使えません"
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid "--console can't be used with --all"
 msgstr "--console と --all は同時に指定できません"
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
@@ -1126,13 +1126,13 @@ msgstr "インスタンスのバックアップ中: %s"
 msgid "Backing up storage bucket: %s"
 msgstr "ストレージバケット %s のバックアップを行います"
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
@@ -1176,7 +1176,7 @@ msgstr "不正なイメージプロパティ形式: %s"
 msgid "Bond:"
 msgstr "ボンディング:"
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr "--all とインスタンス名を両方同時に指定することはできません"
 
@@ -1515,9 +1515,9 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr "クラスターメンバ名"
 
@@ -1988,7 +1988,7 @@ msgstr "状態: %s"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -2245,9 +2245,9 @@ msgstr "警告を削除します"
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2477,7 +2477,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr "既存: %q (バックエンド=%q, ソース=%q)"
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 msgid "EXPIRES AT"
 msgstr "EXPIRES AT"
 
@@ -2603,7 +2603,7 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2857,7 +2857,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2877,7 +2877,7 @@ msgstr "ストレージバケットをエクスポートします"
 msgid "Export storage buckets as tarball."
 msgstr "ストレージバケットを tarball 形式でエクスポートします。"
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
@@ -2887,7 +2887,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "ストレージバケット %s のバックアップをエクスポートします"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -3103,7 +3103,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "ストレージボリュームのバックアップ作成に失敗しました: %w"
@@ -3118,7 +3118,7 @@ msgstr "移動元のインスタンスをコピーしたあとの削除に失敗
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "ストレージボリュームのバックアップファイルの取得に失敗しました: %w"
@@ -3773,11 +3773,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "新たにカスタムストレージボリュームをインポートします"
@@ -3806,16 +3806,16 @@ msgstr "インスタンスのバックアップをインポートします"
 msgid "Import storage bucket"
 msgstr "ストレージバケットを一覧表示します"
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 "インポートするタイプは \"backup\" もしくは \"iso\" である必要があります"
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr "インポートするタイプ。backup もしくは iso (デフォルト \\\"backup\\\")"
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr "ISO イメージをインポートするには、ボリューム名を設定する必要があります"
 
@@ -3824,7 +3824,7 @@ msgstr "ISO イメージをインポートするには、ボリューム名を�
 msgid "Importing bucket: %s"
 msgstr "インスタンスのインポート中: %s"
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3902,7 +3902,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "不正なスナップショット名"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "不正なフォーマット %q"
@@ -3923,7 +3923,7 @@ msgid "Invalid arguments"
 msgstr "不正な引数 %q"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "パス %q に不正なバックアップ名のセグメントがあります: %w"
@@ -4032,7 +4032,7 @@ msgstr "不正なプロトコル: %s"
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -5893,8 +5893,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -6130,8 +6130,8 @@ msgstr "ピア名を指定する必要があります"
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -6296,7 +6296,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr "NAME"
 
@@ -6652,7 +6652,7 @@ msgstr "OVN:"
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
@@ -7324,7 +7324,7 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
@@ -7334,7 +7334,7 @@ msgstr "スナップショットからストレージボリュームをリスト
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -7380,7 +7380,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "スナップショットからインスタンスをリストアします"
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -8147,12 +8147,12 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "ストレージボリュームの設定を表示する"
@@ -8251,7 +8251,7 @@ msgstr "スナップショット:"
 msgid "Socket %d:"
 msgstr "ソケット %d:"
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, c-format
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
@@ -8454,7 +8454,7 @@ msgstr "シンボリックリンクのターゲットパスは \"symlink\" タ�
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8936,9 +8936,9 @@ msgstr "通信ポリシー"
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, fuzzy, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
 #: cmd/incus/info.go:742
@@ -9046,7 +9046,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -9290,7 +9290,7 @@ msgstr "上位デバイス"
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -10040,7 +10040,7 @@ msgstr "[<remote>:]<pool>"
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -10098,16 +10098,16 @@ msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
@@ -10119,7 +10119,7 @@ msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
@@ -10299,7 +10299,7 @@ msgstr "有効"
 msgid "ephemeral"
 msgstr "タイプ: %s (ephemeral)"
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr "エラー: %v"
@@ -11039,7 +11039,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -423,11 +423,11 @@ msgstr ""
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1246,9 +1246,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr ""
 
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1942,9 +1942,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2161,7 +2161,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2284,7 +2284,7 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2485,7 +2485,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2505,7 +2505,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2730,7 +2730,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2745,7 +2745,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3360,11 +3360,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3387,15 +3387,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3404,7 +3404,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3479,7 +3479,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3499,7 +3499,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3602,7 +3602,7 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -4806,8 +4806,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5038,8 +5038,8 @@ msgstr ""
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 msgid "Missing pool name"
 msgstr ""
 
@@ -5179,7 +5179,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr ""
 
@@ -5524,7 +5524,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -6172,7 +6172,7 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 msgid "Rename storage volume snapshots"
 msgstr ""
 
@@ -6181,7 +6181,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6222,7 +6222,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6884,11 +6884,11 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
@@ -6984,7 +6984,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -7183,7 +7183,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7597,9 +7597,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
 #: cmd/incus/info.go:742
@@ -7702,7 +7702,7 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7931,7 +7931,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8623,7 +8623,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -8678,15 +8678,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -8698,7 +8698,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
@@ -8871,7 +8871,7 @@ msgstr ""
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9351,7 +9351,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -671,11 +671,11 @@ msgstr ""
 "--console kan niet gebruikt worden tijden een geforceerde instantie "
 "(instance) shutdown"
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid "--console can't be used with --all"
 msgstr "--console kan niet gebruikt worden samen met --all"
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 msgid "--console only works with a single instance"
 msgstr "--console werkt alleen als het een enkele instantie (instance) betreft"
 
@@ -1145,13 +1145,13 @@ msgstr "Backup aan het maken van instantie (instance): %s"
 msgid "Backing up storage bucket: %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
@@ -1193,7 +1193,7 @@ msgstr "Ongeldig eigenschap: %s"
 msgid "Bond:"
 msgstr "Samenvoeging (Bond):"
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr "Beide --all en instantie naam (instance name) zijn gegeven"
 
@@ -1525,9 +1525,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr ""
 
@@ -1969,7 +1969,7 @@ msgstr "Cached: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2225,9 +2225,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2446,7 +2446,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2569,7 +2569,7 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2770,7 +2770,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2790,7 +2790,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2799,7 +2799,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -3015,7 +3015,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -3030,7 +3030,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3649,11 +3649,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
@@ -3677,15 +3677,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3694,7 +3694,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3769,7 +3769,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3789,7 +3789,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3892,7 +3892,7 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -5099,8 +5099,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5332,8 +5332,8 @@ msgstr ""
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 msgid "Missing pool name"
 msgstr ""
 
@@ -5473,7 +5473,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr ""
 
@@ -5818,7 +5818,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -6468,7 +6468,7 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 msgid "Rename storage volume snapshots"
 msgstr ""
 
@@ -6477,7 +6477,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6518,7 +6518,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -7186,11 +7186,11 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
@@ -7286,7 +7286,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -7485,7 +7485,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7899,9 +7899,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
 #: cmd/incus/info.go:742
@@ -8004,7 +8004,7 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8235,7 +8235,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8927,7 +8927,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -8982,15 +8982,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -9002,7 +9002,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
@@ -9175,7 +9175,7 @@ msgstr ""
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9655,7 +9655,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -416,11 +416,11 @@ msgstr ""
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -863,13 +863,13 @@ msgstr ""
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1239,9 +1239,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr ""
 
@@ -1681,7 +1681,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1935,9 +1935,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2154,7 +2154,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2277,7 +2277,7 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2478,7 +2478,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2498,7 +2498,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2723,7 +2723,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2738,7 +2738,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3380,15 +3380,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3397,7 +3397,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3472,7 +3472,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3492,7 +3492,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3595,7 +3595,7 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -4799,8 +4799,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5031,8 +5031,8 @@ msgstr ""
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 msgid "Missing pool name"
 msgstr ""
 
@@ -5172,7 +5172,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr ""
 
@@ -5517,7 +5517,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -6165,7 +6165,7 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 msgid "Rename storage volume snapshots"
 msgstr ""
 
@@ -6174,7 +6174,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6215,7 +6215,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6877,11 +6877,11 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
@@ -6977,7 +6977,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -7176,7 +7176,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7590,9 +7590,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
 #: cmd/incus/info.go:742
@@ -7695,7 +7695,7 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7924,7 +7924,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8616,7 +8616,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -8671,15 +8671,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -8691,7 +8691,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
@@ -8864,7 +8864,7 @@ msgstr ""
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9344,7 +9344,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -652,12 +652,12 @@ msgstr ""
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1133,13 +1133,13 @@ msgstr "Editar arquivos no container"
 msgid "Backing up storage bucket: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
@@ -1181,7 +1181,7 @@ msgstr "Propriedade ruim: %s"
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1514,9 +1514,9 @@ msgstr "Dispositivo %s removido de %s"
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1989,7 +1989,7 @@ msgstr "Criado: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -2259,9 +2259,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2490,7 +2490,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DE VALIDADE"
@@ -2629,7 +2629,7 @@ msgstr "Editar configurações de perfil como YAML"
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2831,7 +2831,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2853,7 +2853,7 @@ msgstr "Apagar projetos"
 msgid "Export storage buckets as tarball."
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2862,7 +2862,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Criar novas redes"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -3078,7 +3078,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Aceitar certificado"
@@ -3093,7 +3093,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Aceitar certificado"
@@ -3736,11 +3736,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Criar novas redes"
@@ -3765,15 +3765,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3782,7 +3782,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3859,7 +3859,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Editar arquivos no container"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Editar arquivos no container"
@@ -3880,7 +3880,7 @@ msgid "Invalid arguments"
 msgstr "Editar arquivos no container"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3984,7 +3984,7 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -5230,8 +5230,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5475,8 +5475,8 @@ msgstr "Nome de membro do cluster"
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 msgid "Missing pool name"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr ""
 
@@ -5968,7 +5968,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -6644,7 +6644,7 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -6654,7 +6654,7 @@ msgstr "Desconectar volumes de armazenamento dos containers"
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -6703,7 +6703,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -7411,12 +7411,12 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -7518,7 +7518,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -7720,7 +7720,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8136,9 +8136,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Senha de administrador para %s: "
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
 #: cmd/incus/info.go:742
@@ -8246,7 +8246,7 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8504,7 +8504,7 @@ msgstr "Editar arquivos no container"
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -9252,7 +9252,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -9316,16 +9316,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
@@ -9338,7 +9338,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Criar perfis"
@@ -9530,7 +9530,7 @@ msgstr ""
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -10010,7 +10010,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -676,11 +676,11 @@ msgstr "- Порт %d (%s)"
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -1147,13 +1147,13 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Backing up storage bucket: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1195,7 +1195,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1527,9 +1527,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr ""
 
@@ -1989,7 +1989,7 @@ msgstr "Авто-обновление: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2255,9 +2255,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2486,7 +2486,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2617,7 +2617,7 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2823,7 +2823,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2848,7 +2848,7 @@ msgstr "Копирование образа: %s"
 msgid "Export storage buckets as tarball."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
@@ -2858,7 +2858,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -3074,7 +3074,7 @@ msgstr "Принять сертификат"
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Принять сертификат"
@@ -3089,7 +3089,7 @@ msgstr "Принять сертификат"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Принять сертификат"
@@ -3728,12 +3728,12 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Копирование образа: %s"
@@ -3760,15 +3760,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Import storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3777,7 +3777,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3855,7 +3855,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Имя контейнера: %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Имя контейнера: %s"
@@ -3876,7 +3876,7 @@ msgid "Invalid arguments"
 msgstr "Имя контейнера: %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3980,7 +3980,7 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -5235,8 +5235,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5481,8 +5481,8 @@ msgstr "Имя контейнера: %s"
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 msgid "Missing pool name"
 msgstr ""
 
@@ -5629,7 +5629,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr ""
 
@@ -5981,7 +5981,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -6647,7 +6647,7 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -6657,7 +6657,7 @@ msgstr "Копирование образа: %s"
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Копирование образа: %s"
@@ -6701,7 +6701,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -7402,12 +7402,12 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Копирование образа: %s"
@@ -7510,7 +7510,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -7715,7 +7715,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8130,9 +8130,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
 #: cmd/incus/info.go:742
@@ -8239,7 +8239,7 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8493,7 +8493,7 @@ msgstr "Копирование образа: %s"
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -9576,7 +9576,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -9683,7 +9683,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -9691,7 +9691,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -9699,7 +9699,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -9723,7 +9723,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -10036,7 +10036,7 @@ msgstr ""
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -10516,7 +10516,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-13 01:28+0200\n"
+"POT-Creation-Date: 2024-09-18 23:59+0000\n"
 "PO-Revision-Date: 2024-08-14 07:23+0000\n"
 "Last-Translator: Kwok Guy <kwokjuy@163.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -577,11 +577,11 @@ msgstr ""
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: cmd/incus/action.go:430
+#: cmd/incus/action.go:435
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: cmd/incus/action.go:434
+#: cmd/incus/action.go:439
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -1024,13 +1024,13 @@ msgstr ""
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3035
+#: cmd/incus/storage_volume.go:3033
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3112
+#: cmd/incus/storage_volume.go:3110
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: cmd/incus/action.go:187 cmd/incus/action.go:386
+#: cmd/incus/action.go:187 cmd/incus/action.go:391
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1400,9 +1400,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
 #: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
 #: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2712
-#: cmd/incus/storage_volume.go:2798 cmd/incus/storage_volume.go:2878
-#: cmd/incus/storage_volume.go:2970 cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
 msgid "Cluster member name"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2969
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2096,9 +2096,9 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
 #: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
 #: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2796
-#: cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2963
-#: cmd/incus/storage_volume.go:3129 cmd/incus/top.go:33 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid "Description"
@@ -2315,7 +2315,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2652
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2438,7 +2438,7 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2660
+#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
 #: cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2639,7 +2639,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2962 cmd/incus/storage_volume.go:2963
+#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2659,7 +2659,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2966
+#: cmd/incus/storage_volume.go:2964
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2668,7 +2668,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3095
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2884,7 +2884,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3030
+#: cmd/incus/storage_volume.go:3028
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2899,7 +2899,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3109
+#: cmd/incus/storage_volume.go:3107
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3514,11 +3514,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3128
+#: cmd/incus/storage_volume.go:3126
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3127
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3541,15 +3541,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3203
+#: cmd/incus/storage_volume.go:3201
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3138
+#: cmd/incus/storage_volume.go:3136
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3208
+#: cmd/incus/storage_volume.go:3206
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3558,7 +3558,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3212
+#: cmd/incus/storage_volume.go:3210
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3633,7 +3633,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3063
+#: cmd/incus/storage_volume.go:3061
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3653,7 +3653,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3068
+#: cmd/incus/storage_volume.go:3066
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3756,7 +3756,7 @@ msgstr ""
 
 #: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
 #: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2923
+#: cmd/incus/storage_volume.go:2921
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -4960,8 +4960,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5192,8 +5192,8 @@ msgstr ""
 #: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
 #: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
 #: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2751 cmd/incus/storage_volume.go:2836
-#: cmd/incus/storage_volume.go:2913
+#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
+#: cmd/incus/storage_volume.go:2911
 msgid "Missing pool name"
 msgstr ""
 
@@ -5334,7 +5334,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/remote.go:759
 #: cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2650
+#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid "NAME"
 msgstr ""
 
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3017
+#: cmd/incus/storage_volume.go:3015
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -6336,7 +6336,7 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2708 cmd/incus/storage_volume.go:2709
+#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
 msgid "Rename storage volume snapshots"
 msgstr ""
 
@@ -6345,7 +6345,7 @@ msgstr ""
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2780
+#: cmd/incus/storage_volume.go:2778
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6386,7 +6386,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2795 cmd/incus/storage_volume.go:2796
+#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -7048,11 +7048,11 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2876
+#: cmd/incus/storage_volume.go:2874
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2875
+#: cmd/incus/storage_volume.go:2873
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
@@ -7148,7 +7148,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: cmd/incus/action.go:463
+#: cmd/incus/action.go:468
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -7347,7 +7347,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2651
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7762,9 +7762,9 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: cmd/incus/action.go:334 cmd/incus/launch.go:146
+#: cmd/incus/action.go:339 cmd/incus/launch.go:151
 #, c-format
-msgid "Try `incus info --show-log %s` for more info"
+msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
 #: cmd/incus/info.go:742
@@ -7867,7 +7867,7 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2666
+#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
 #: cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -8096,7 +8096,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2968
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8788,7 +8788,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3125
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -8843,15 +8843,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2705
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2959
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -8863,7 +8863,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2872
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
@@ -9036,7 +9036,7 @@ msgstr ""
 msgid "ephemeral"
 msgstr ""
 
-#: cmd/incus/action.go:455
+#: cmd/incus/action.go:460
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -9516,7 +9516,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3131
+#: cmd/incus/storage_volume.go:3129
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"


### PR DESCRIPTION
This PR fixes a problem where, in case of an error, the CLI would prompt the user to run an invalid command if they had specified a project other than the default one.

Before:
```
#> incus start debian --project test
Error: Failed to run: <...>
Try `incus info --show-log debian` for more info
```

After:
```
#> incus start debian --project test
Error: Failed to run: <...>
Try `incus info --show-log debian --project test` for more info
```