### PR TITLE
doc: add prerequisites section for building documentation

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -86,6 +86,13 @@ You can (and should!) run these tests locally as well with the following command
 - Check the Markdown formatting: `make doc-lint`
 - Check for inclusive language: `make doc-woke`
 
+To run the above, you will need the following:
+
+- Python 3.8 or higher
+- The `venv` python package
+- The `aspell` tool for spellchecking
+- The `mdl` markdown lint tool
+
 ### Document configuration options
 
 ```{note}


### PR DESCRIPTION
Missing prerequisites may hinder documentation contributions as it may throw errors when running `make doc` (specially the Python version) or when trying to validate spellcheck or linting.

Personally I found I had those tools missing when trying to compile the doc first time and Sphinx uses a python notation that is available since 3.8 but the error thrown is cryptic if python version is older.