### PR TITLE
Add operating system details to instance state

### DIFF
--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -672,6 +672,17 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 			fmt.Printf(i18n.G("Started: %s")+"\n", inst.State.StartedAt.Local().Format(dateLayout))
 		}
 
+		// Operating System info
+		if inst.State.OSInfo != nil {
+			fmt.Println("\n" + i18n.G("Operating System:"))
+			osInfo := fmt.Sprintf("  %s: %s\n", i18n.G("OS"), inst.State.OSInfo.OS)
+			osInfo += fmt.Sprintf("  %s: %s\n", i18n.G("OS Version"), inst.State.OSInfo.OSVersion)
+			osInfo += fmt.Sprintf("  %s: %s\n", i18n.G("Kernel Version"), inst.State.OSInfo.KernelVersion)
+			osInfo += fmt.Sprintf("  %s: %s\n", i18n.G("Hostname"), inst.State.OSInfo.Hostname)
+			osInfo += fmt.Sprintf("  %s: %s\n", i18n.G("FQDN"), inst.State.OSInfo.FQDN)
+			fmt.Print(osInfo)
+		}
+
 		fmt.Println("\n" + i18n.G("Resources:"))
 		// Processes
 		fmt.Printf("  "+i18n.G("Processes: %d")+"\n", inst.State.Processes)

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2606,3 +2606,7 @@ This implements a new `security.promiscuous` configuration option on OVN NICs.
 ## `ovn_nic_ip_address_none`
 
 This adds `none` as a value for `ipv4.address` and `ipv6.address` for OVN NICs.
+
+## `instances_state_os_info`
+
+This extension adds a pointer to an `InstanceStateOSInfo` struct to the instance's state API.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2161,6 +2161,8 @@ definitions:
                 description: Network usage key/value pairs
                 type: object
                 x-go-name: Network
+            os_info:
+                $ref: '#/definitions/InstanceStateOSInfo'
             pid:
                 description: PID of the runtime
                 example: 7281
@@ -2373,6 +2375,36 @@ definitions:
                 format: int64
                 type: integer
                 x-go-name: PacketsSent
+        type: object
+        x-go-package: github.com/lxc/incus/v6/shared/api
+    InstanceStateOSInfo:
+        properties:
+            fqdn:
+                description: FQDN of the instance.
+                example: myhost.mydomain.local
+                type: string
+                x-go-name: FQDN
+            hostname:
+                description: Hostname of the instance.
+                example: myhost
+                type: string
+                x-go-name: Hostname
+            kernel_version:
+                description: Version of the kernel running in the instance.
+                example: 6.1.0-25-amd64
+                type: string
+                x-go-name: KernelVersion
+            os:
+                description: Operating system running in the instance.
+                example: Debian GNU/Linux
+                type: string
+                x-go-name: OS
+            os_version:
+                description: Version of the operating system.
+                example: 12 (bookworm)
+                type: string
+                x-go-name: OSVersion
+        title: InstanceStateOSInfo represents the operating system information section of an instance's state.
         type: object
         x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceStatePut:

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -442,6 +442,7 @@ var APIExtensions = []string{
 	"storage_lvm_metadatasize",
 	"ovn_nic_promiscuous",
 	"ovn_nic_ip_address_none",
+	"instances_state_os_info",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: Tobias Gerold <tobias@g3ro.eu>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -636,12 +636,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -758,7 +758,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 "Sind Sie sicher, dass sie das Cluster Mitglied %q %s? (ja/nein) "
 "[default=nein]: "
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 "Da keines der genannten Programme gefunden werden konnte, finden Sie hier "
@@ -1186,7 +1186,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1242,11 +1242,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1275,11 +1275,11 @@ msgstr "Prozessorauslastung (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr "Prozessorauslastung:"
 
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1372,7 +1372,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1851,11 +1851,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1973,7 +1973,7 @@ msgstr "Erstellt: %s"
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Erstelle %s"
@@ -2065,7 +2065,7 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2201,9 +2201,9 @@ msgstr ""
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2424,7 +2424,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2441,7 +2441,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr " Prozessorauslastung:"
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
@@ -2563,7 +2563,7 @@ msgstr "ABLAUFDATUM"
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2578,7 +2578,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 #, fuzzy
 msgid "Expires at"
@@ -3017,12 +3017,16 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr "ZUERST BEOBACHTET"
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, fuzzy, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "SSH handshake mit Client %q gescheitert: %v"
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -3037,12 +3041,12 @@ msgstr "Check ob Instanz existiert fehlgeschlagen \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3072,7 +3076,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3112,7 +3116,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3122,17 +3126,17 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed parsing validation response: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3236,7 +3240,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3334,7 +3338,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to update cluster member state: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3380,7 +3384,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -3707,31 +3711,36 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
+
+#: cmd/incus/info.go:681
+#, fuzzy
+msgid "Hostname"
+msgstr "Name"
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3767,7 +3776,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
@@ -3950,16 +3959,16 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3973,7 +3982,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -4072,7 +4081,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -4108,7 +4117,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -4140,17 +4149,17 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid sorting type provided"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Ungültiges Ziel %s"
@@ -4170,6 +4179,10 @@ msgstr ""
 
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
+msgstr ""
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
 msgstr ""
 
 #: cmd/incus/warning.go:212
@@ -5103,7 +5116,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr ""
 
@@ -5111,12 +5124,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -5142,7 +5155,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
@@ -5194,7 +5207,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -5240,7 +5253,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5411,8 +5424,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5467,15 +5480,15 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr ""
 
@@ -5696,7 +5709,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid "Missing target directory"
 msgstr ""
 
@@ -5736,12 +5749,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5867,7 +5880,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
@@ -6053,7 +6066,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -6158,6 +6171,15 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+#, fuzzy
+msgid "OS Version"
+msgstr "Fingerabdruck: %s\n"
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -6195,12 +6217,17 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+#, fuzzy
+msgid "Operating System:"
+msgstr "Profil %s gelöscht\n"
+
 #: cmd/incus/operation.go:92
 #, fuzzy, c-format
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6272,11 +6299,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr ""
 
@@ -6289,7 +6316,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Administrator Passwort für %s: "
@@ -6368,7 +6395,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6402,7 +6429,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -6553,22 +6580,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6630,7 +6657,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6877,7 +6904,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr ""
 
@@ -6997,17 +7024,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -7134,7 +7161,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7361,30 +7388,30 @@ msgstr "Profil %s erstellt\n"
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 #, fuzzy
 msgid "Set the file's gid on create"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 #, fuzzy
 msgid "Set the file's perms on create"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 #, fuzzy
 msgid "Set the file's uid on create"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -7462,7 +7489,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7731,7 +7758,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7778,7 +7805,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
@@ -7788,7 +7815,7 @@ msgstr "Erstellt: %s"
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr ""
 
@@ -7925,11 +7952,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7941,7 +7968,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7970,16 +7997,16 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8003,7 +8030,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -8034,7 +8061,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -8243,7 +8270,7 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -8296,7 +8323,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8312,7 +8339,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -8376,7 +8403,7 @@ msgstr "Administrator Passwort für %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid "Type"
 msgstr ""
 
@@ -8450,7 +8477,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8465,7 +8492,7 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -8487,12 +8514,12 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, fuzzy, c-format
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -8502,7 +8529,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, fuzzy, c-format
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -8698,7 +8725,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8771,7 +8798,7 @@ msgstr "Profil %s erstellt\n"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -9486,7 +9513,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -9495,7 +9522,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
@@ -9504,7 +9531,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -9512,7 +9539,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -9522,7 +9549,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -10458,7 +10485,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -10466,20 +10493,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -11042,16 +11069,16 @@ msgstr "bitte nutzen Sie ìncus profile`"
 msgid "space used"
 msgstr "Speicherplatz in Benutzung"
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr "sshfs wurde gestoppt"
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs mounted %q auf %q"
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs wurde nicht gefunden. Versuchen Sie stattdessen SSH SFTP mode mit dem "

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -623,12 +623,12 @@ msgstr "%s (%d más)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -741,7 +741,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1190,11 +1190,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr "Expira: %s"
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1223,11 +1223,11 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1314,7 +1314,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1786,11 +1786,11 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Creando el contenedor"
@@ -1897,7 +1897,7 @@ msgstr "Creado: %s"
 msgid "Creating %s"
 msgstr "Creando %s"
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Creando %s"
@@ -1989,7 +1989,7 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 msgid "Delete files in instances"
 msgstr ""
 
@@ -2121,9 +2121,9 @@ msgstr ""
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2334,7 +2334,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2351,7 +2351,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
@@ -2466,7 +2466,7 @@ msgstr "FECHA DE EXPIRACIÓN"
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2480,7 +2480,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2764,7 +2764,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 #, fuzzy
 msgid "Expires at"
@@ -2850,12 +2850,16 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2870,12 +2874,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2905,7 +2909,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2945,7 +2949,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2955,17 +2959,17 @@ msgstr "Acepta certificado"
 msgid "Failed parsing validation response: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -3069,7 +3073,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -3167,7 +3171,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to update cluster member state: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3210,7 +3214,7 @@ msgstr "Huella dactilar: %s"
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -3529,31 +3533,36 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 #, fuzzy
 msgid "Host interface"
+msgstr "Aliases:"
+
+#: cmd/incus/info.go:681
+#, fuzzy
+msgid "Hostname"
 msgstr "Aliases:"
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -3589,7 +3598,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
@@ -3770,16 +3779,16 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3794,7 +3803,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3891,7 +3900,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3926,7 +3935,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3958,17 +3967,17 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid sorting type provided"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3984,6 +3993,10 @@ msgstr ""
 
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
+msgstr ""
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
 msgstr ""
 
 #: cmd/incus/warning.go:212
@@ -4899,7 +4912,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr "Registro:"
 
@@ -4907,12 +4920,12 @@ msgstr "Registro:"
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -4936,7 +4949,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
@@ -4984,7 +4997,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -5026,7 +5039,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 msgid "Manage files in instances"
 msgstr ""
 
@@ -5182,8 +5195,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5237,15 +5250,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr ""
 
@@ -5463,7 +5476,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -5503,11 +5516,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -5630,7 +5643,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
@@ -5811,7 +5824,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid "Network usage:"
 msgstr ""
 
@@ -5912,6 +5925,15 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+#, fuzzy
+msgid "OS Version"
+msgstr "Versión de CUDA: %v"
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -5949,12 +5971,16 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+msgid "Operating System:"
+msgstr ""
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6024,11 +6050,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr ""
 
@@ -6041,7 +6067,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Contraseña admin para %s:"
@@ -6118,7 +6144,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6152,7 +6178,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -6300,20 +6326,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6375,7 +6401,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6613,7 +6639,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr ""
 
@@ -6731,17 +6757,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6858,7 +6884,7 @@ msgstr "Perfil %s creado"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7078,27 +7104,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7174,7 +7200,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7429,7 +7455,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7475,7 +7501,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
@@ -7485,7 +7511,7 @@ msgstr "Auto actualización: %s"
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr ""
 
@@ -7616,11 +7642,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7632,7 +7658,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7661,15 +7687,15 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7693,7 +7719,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7724,7 +7750,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7929,7 +7955,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -7980,7 +8006,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7996,7 +8022,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -8060,7 +8086,7 @@ msgstr "Contraseña admin para %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
@@ -8133,7 +8159,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8147,7 +8173,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8169,12 +8195,12 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8184,7 +8210,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8371,7 +8397,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8443,7 +8469,7 @@ msgstr "Perfil %s creado"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8963,28 +8989,28 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9617,7 +9643,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9625,20 +9651,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -10078,16 +10104,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -633,12 +633,12 @@ msgstr "%s (%s) (%d disponible)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (principal=%q, source=%q)"
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge"
@@ -746,7 +746,7 @@ msgstr "<serveur distant> <nouveau nom>"
 msgid "<remote>: <path>"
 msgstr "<serveur_distant>: <chemin>"
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<chemin_source>... [<serveur_distant>:]<instance>/<chemin>"
 
@@ -1047,7 +1047,7 @@ msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "Êtes-vous sûr de %s le membre du cluster %q ? (oui/non) [défaut=non] : "
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "Aucun n'a pu être trouvé, la socket SPICE peut être trouvé à:"
 
@@ -1157,7 +1157,7 @@ msgstr "Sauvegarder le volume de stockage : %s"
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1215,11 +1215,11 @@ msgstr "Pont:"
 msgid "Bus Address: %v"
 msgstr "Adresse du bus : %v"
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1248,11 +1248,11 @@ msgstr "TEMPS CPU(s)"
 msgid "CPU USAGE"
 msgstr "UTILISATION CPU"
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
@@ -1302,7 +1302,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Impossible de fournir un nom à l'image cible"
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossible de récupérer un répertoire sans --recursive"
 
@@ -1339,7 +1339,7 @@ msgstr ""
 "Impossible de spécifier la colonne L lorsque le serveur ne fait pas partie "
 "d'un cluster"
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Impossible de spécifier uid/gid/mode dans le mode récursif"
 
@@ -1842,11 +1842,11 @@ msgstr "Créer une instance vide"
 msgid "Create and start instances from images"
 msgstr "Créer et démarrer des instances à partir d'images"
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr "Créer tous les répertoires nécessaires"
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Créer des fichiers et répertoires dans les instances"
@@ -1984,7 +1984,7 @@ msgstr "Créé : %s"
 msgid "Creating %s"
 msgstr "Création de %s"
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Création de %s"
@@ -2078,7 +2078,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
@@ -2218,9 +2218,9 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2436,7 +2436,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr "Dossier dans lequel exécuter la commande (/root par défaut)"
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 "Désactivez l'authentification lorsque vous utilisez SSH SFTP en mode écoute"
@@ -2454,7 +2454,7 @@ msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 msgid "Disk %d:"
 msgstr "Disque %d:"
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid "Disk usage:"
 msgstr "Disque utilisé :"
 
@@ -2570,7 +2570,7 @@ msgstr "DATE D'EXPIRATION"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2588,7 +2588,7 @@ msgstr "Modifier un groupe de serveurs"
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2949,7 +2949,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 #, fuzzy
 msgid "Expires at"
@@ -3044,12 +3044,16 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr "PREMIÈRE VUE"
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "Échec de l'authentification SSH avec le client %q : %v"
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "Échec de l'acceptation du canal client %q : %v"
@@ -3066,12 +3070,12 @@ msgstr ""
 "Échec de la vérification de l'existence de l'instantané d'instance \"%s:"
 "%s\" : %w"
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "Échec de la connexion au SFTP de l'instance pour le client %q : %v"
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Échec de la connexion au SFTP de l'instance : %w"
@@ -3104,7 +3108,7 @@ msgstr "Échec de la suppression de l'instance %q dans le projet %q : %w"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Échec de la suppression du volume source après la copie : %w"
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec de la génération de la clé hôte SSH : %w"
@@ -3145,7 +3149,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Échec du chargement du pool de stockage %q : %w"
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec de l'analyse de la clé d'hôte SSH : %w"
@@ -3155,17 +3159,17 @@ msgstr "Échec de l'analyse de la clé d'hôte SSH : %w"
 msgid "Failed parsing validation response: %w"
 msgstr "Échec de l'analyse de la réponse de validation : %w"
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "Échec de l'exécution de la commande : %w"
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec du démarrage de sshfs : %w"
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec de l'acceptation de la connexion entrante : %w"
@@ -3272,7 +3276,7 @@ msgstr "Échec de la recherche du projet : %w"
 msgid "Failed to join cluster: %w"
 msgstr "Échec de l'adhésion au cluster : %w"
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec de la mise en écoute des demandes de connexion : %w"
@@ -3373,7 +3377,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr "Échec de la mise à jour de l'état du membre du cluster : %w"
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "Échec du parcours des fichiers du répertoire %s : %s"
@@ -3418,7 +3422,7 @@ msgstr "Empreinte : %s"
 msgid "Force a particular evacuation action"
 msgstr "Forcer une action d'évacuation particulière"
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr "Forcer la création de fichiers ou de répertoires"
 
@@ -3776,31 +3780,36 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 #, fuzzy
 msgid "Host interface"
+msgstr "L'arrêt du conteneur a échoué !"
+
+#: cmd/incus/info.go:681
+#, fuzzy
+msgid "Hostname"
 msgstr "L'arrêt du conteneur a échoué !"
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "La copie d'E/S de SSH vers l'instance a échoué : %v"
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "La copie d'E/S de l'instance vers SSH a échoué : %v"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "La copie d'E/S de l'instance vers sshfs a échoué : %v"
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "La copie d'E/S de sshfs vers l'instance a échoué : %v"
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr "ADRESSE IP"
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
@@ -4037,17 +4046,17 @@ msgstr "Infiniband :"
 msgid "Input data"
 msgstr "Données d'entrée"
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "Instance déconnectée pour le client %q"
@@ -4062,7 +4071,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 #, fuzzy
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -4164,7 +4173,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -4204,7 +4213,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -4236,17 +4245,17 @@ msgstr "Cible invalide %s"
 msgid "Invalid sorting type provided"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Cible invalide %s"
@@ -4263,6 +4272,10 @@ msgstr "Rejoindre un cluster existant nécessite d'être root"
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
+msgstr ""
 
 #: cmd/incus/warning.go:212
 #, fuzzy
@@ -5242,7 +5255,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr "Journal :"
 
@@ -5250,12 +5263,12 @@ msgstr "Journal :"
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -5281,7 +5294,7 @@ msgstr "Création du conteneur"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
@@ -5329,7 +5342,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -5373,7 +5386,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
@@ -5544,8 +5557,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5600,15 +5613,15 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr "Mémoire utilisée :"
 
@@ -5830,7 +5843,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -5873,12 +5886,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -6004,7 +6017,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 #, fuzzy
 msgid "Name"
@@ -6191,7 +6204,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid "Network usage:"
 msgstr "Réseau utilisé :"
 
@@ -6295,6 +6308,15 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+#, fuzzy
+msgid "OS Version"
+msgstr "Version CUDA : %v"
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -6343,12 +6365,17 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+#, fuzzy
+msgid "Operating System:"
+msgstr "Le réseau %s a été supprimé"
+
 #: cmd/incus/operation.go:92
 #, fuzzy, c-format
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6421,11 +6448,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -6439,7 +6466,7 @@ msgstr "Options :"
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Mot de passe administrateur pour %s : "
@@ -6517,7 +6544,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6552,7 +6579,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -6702,22 +6729,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6780,7 +6807,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -7030,7 +7057,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -7166,17 +7193,17 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -7300,7 +7327,7 @@ msgstr "Clé de configuration invalide"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7528,30 +7555,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 #, fuzzy
 msgid "Set the file's gid on create"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 #, fuzzy
 msgid "Set the file's perms on create"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 #, fuzzy
 msgid "Set the file's uid on create"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -7629,7 +7656,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7902,7 +7929,7 @@ msgstr "Copie de l'image : %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -7949,7 +7976,7 @@ msgstr "Démarrage de %s"
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
@@ -7959,7 +7986,7 @@ msgstr "État : %s"
 msgid "State: %s"
 msgstr "État : %s"
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
@@ -8096,11 +8123,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -8114,7 +8141,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -8143,16 +8170,16 @@ msgstr ""
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8176,7 +8203,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -8207,7 +8234,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -8424,7 +8451,7 @@ msgstr "Le périphérique indiqué n'existe pas"
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -8478,7 +8505,7 @@ msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 msgid "To create a new network, use: incus network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8496,7 +8523,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -8560,7 +8587,7 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
@@ -8635,7 +8662,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8650,7 +8677,7 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8672,12 +8699,12 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8687,7 +8714,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8885,7 +8912,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8959,7 +8986,7 @@ msgstr "L'utilisateur a annulé l'opération de suppression."
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -9675,7 +9702,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -9687,7 +9714,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
@@ -9699,7 +9726,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -9707,7 +9734,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -9720,7 +9747,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -10705,7 +10732,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -10713,20 +10740,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -11189,16 +11216,16 @@ msgstr "veuillez utiliser `incus profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr "sshfs s'est arrêté"
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs monté %q sur %q"
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs non trouvé. Essayez le mode SSH SFTP en utilisant l'option --listen"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -383,12 +383,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -493,7 +493,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -873,7 +873,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -929,11 +929,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr ""
 
@@ -961,11 +961,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr ""
 
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1048,7 +1048,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1510,11 +1510,11 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 msgid "Create files and directories in instances"
 msgstr ""
 
@@ -1615,7 +1615,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1705,7 +1705,7 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1829,9 +1829,9 @@ msgstr ""
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2037,7 +2037,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid "Disk usage:"
 msgstr ""
 
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2176,7 +2176,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 msgid "Expires at"
 msgstr ""
@@ -2534,12 +2534,16 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2554,12 +2558,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2589,7 +2593,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2629,7 +2633,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2639,17 +2643,17 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2753,7 +2757,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2851,7 +2855,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2894,7 +2898,7 @@ msgstr ""
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -3194,30 +3198,34 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 msgid "Host interface"
+msgstr ""
+
+#: cmd/incus/info.go:681
+msgid "Hostname"
 msgstr ""
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3253,7 +3261,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 msgid "IP addresses"
 msgstr ""
 
@@ -3427,15 +3435,15 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3449,7 +3457,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3544,7 +3552,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3579,7 +3587,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3607,17 +3615,17 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3633,6 +3641,10 @@ msgstr ""
 
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
+msgstr ""
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
 msgstr ""
 
 #: cmd/incus/warning.go:212
@@ -4531,7 +4543,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr ""
 
@@ -4539,12 +4551,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -4568,7 +4580,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 msgid "MAC address"
 msgstr ""
 
@@ -4615,7 +4627,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -4656,7 +4668,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4799,8 +4811,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -4853,15 +4865,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr ""
 
@@ -5064,7 +5076,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid "Missing target directory"
 msgstr ""
 
@@ -5102,11 +5114,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5227,7 +5239,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
@@ -5408,7 +5420,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid "Network usage:"
 msgstr ""
 
@@ -5509,6 +5521,14 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+msgid "OS Version"
+msgstr ""
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -5546,12 +5566,16 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+msgid "Operating System:"
+msgstr ""
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5621,11 +5645,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr ""
 
@@ -5638,7 +5662,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5714,7 +5738,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5748,7 +5772,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5892,20 +5916,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5965,7 +5989,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6192,7 +6216,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr ""
 
@@ -6303,17 +6327,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6427,7 +6451,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6640,27 +6664,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6728,7 +6752,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6968,7 +6992,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7014,7 +7038,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 msgid "State"
 msgstr ""
 
@@ -7023,7 +7047,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr ""
 
@@ -7152,11 +7176,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7168,7 +7192,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7197,15 +7221,15 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7229,7 +7253,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7260,7 +7284,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7465,7 +7489,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -7515,7 +7539,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7531,7 +7555,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -7595,7 +7619,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid "Type"
 msgstr ""
 
@@ -7665,7 +7689,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7679,7 +7703,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7701,12 +7725,12 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7716,7 +7740,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -7882,7 +7906,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7952,7 +7976,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8418,24 +8442,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -8976,7 +9000,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -8984,20 +9008,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9437,16 +9461,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-09-18 23:59+0000\n"
+        "POT-Creation-Date: 2024-09-24 08:09-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -360,12 +360,12 @@ msgstr  ""
 msgid   "%s (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -469,7 +469,7 @@ msgstr  ""
 msgid   "<remote>: <path>"
 msgstr  ""
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -734,7 +734,7 @@ msgstr  ""
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
@@ -836,7 +836,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid   "Backups:"
 msgstr  ""
 
@@ -887,11 +887,11 @@ msgstr  ""
 msgid   "Bus Address: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid   "Bytes received"
 msgstr  ""
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -919,11 +919,11 @@ msgstr  ""
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid   "CPU usage:"
 msgstr  ""
 
@@ -970,7 +970,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -1004,7 +1004,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -1397,11 +1397,11 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid   "Create any directories necessary"
 msgstr  ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 msgid   "Create files and directories in instances"
 msgstr  ""
 
@@ -1499,7 +1499,7 @@ msgstr  ""
 msgid   "Creating %s"
 msgstr  ""
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, c-format
 msgid   "Creating %s: %%s"
 msgstr  ""
@@ -1580,7 +1580,7 @@ msgstr  ""
 msgid   "Delete custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 msgid   "Delete files in instances"
 msgstr  ""
 
@@ -1664,7 +1664,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132 cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429 cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:96 cmd/incus/network_load_balancer.go:248 cmd/incus/network_load_balancer.go:324 cmd/incus/network_load_balancer.go:427 cmd/incus/network_load_balancer.go:495 cmd/incus/network_load_balancer.go:605 cmd/incus/network_load_balancer.go:635 cmd/incus/network_load_balancer.go:800 cmd/incus/network_load_balancer.go:873 cmd/incus/network_load_balancer.go:888 cmd/incus/network_load_balancer.go:964 cmd/incus/network_load_balancer.go:1062 cmd/incus/network_load_balancer.go:1077 cmd/incus/network_load_balancer.go:1150 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794 cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961 cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:29 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134 cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431 cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:96 cmd/incus/network_load_balancer.go:248 cmd/incus/network_load_balancer.go:324 cmd/incus/network_load_balancer.go:427 cmd/incus/network_load_balancer.go:495 cmd/incus/network_load_balancer.go:605 cmd/incus/network_load_balancer.go:635 cmd/incus/network_load_balancer.go:800 cmd/incus/network_load_balancer.go:873 cmd/incus/network_load_balancer.go:888 cmd/incus/network_load_balancer.go:964 cmd/incus/network_load_balancer.go:1062 cmd/incus/network_load_balancer.go:1077 cmd/incus/network_load_balancer.go:1150 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794 cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961 cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1756,7 +1756,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1773,7 +1773,7 @@ msgstr  ""
 msgid   "Disk %d:"
 msgstr  ""
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid   "Disk usage:"
 msgstr  ""
 
@@ -1880,7 +1880,7 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
@@ -1892,7 +1892,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -2130,7 +2130,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
 msgid   "Expires at"
 msgstr  ""
 
@@ -2208,12 +2208,16 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid   "FQDN"
+msgstr  ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -2228,12 +2232,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2263,7 +2267,7 @@ msgstr  ""
 msgid   "Failed deleting source volume after copy: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2303,7 +2307,7 @@ msgstr  ""
 msgid   "Failed loading storage pool %q: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2313,17 +2317,17 @@ msgstr  ""
 msgid   "Failed parsing validation response: %w"
 msgstr  ""
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, c-format
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2427,7 +2431,7 @@ msgstr  ""
 msgid   "Failed to join cluster: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -2522,7 +2526,7 @@ msgstr  ""
 msgid   "Failed to update cluster member state: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2564,7 +2568,7 @@ msgstr  ""
 msgid   "Force a particular evacuation action"
 msgstr  ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid   "Force creating files or directories"
 msgstr  ""
 
@@ -2841,30 +2845,34 @@ msgstr  ""
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 msgid   "Host interface"
+msgstr  ""
+
+#: cmd/incus/info.go:681
+msgid   "Hostname"
 msgstr  ""
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2900,7 +2908,7 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 msgid   "IP addresses"
 msgstr  ""
 
@@ -3071,15 +3079,15 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 msgid   "Instance Only"
 msgstr  ""
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -3093,7 +3101,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -3186,7 +3194,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -3220,7 +3228,7 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -3246,17 +3254,17 @@ msgstr  ""
 msgid   "Invalid sorting type provided"
 msgstr  ""
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, c-format
 msgid   "Invalid type %q"
 msgstr  ""
@@ -3272,6 +3280,10 @@ msgstr  ""
 
 #: cmd/incus/image.go:156
 msgid   "Keep the image up to date after initial copy"
+msgstr  ""
+
+#: cmd/incus/info.go:680
+msgid   "Kernel Version"
 msgstr  ""
 
 #: cmd/incus/warning.go:212
@@ -4132,7 +4144,7 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid   "Log:"
 msgstr  ""
 
@@ -4140,12 +4152,12 @@ msgstr  ""
 msgid   "Logical router"
 msgstr  ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid   "Login with username %q and password %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid   "Login without username and password"
 msgstr  ""
 
@@ -4169,7 +4181,7 @@ msgstr  ""
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 msgid   "MAC address"
 msgstr  ""
 
@@ -4216,7 +4228,7 @@ msgstr  ""
 msgid   "MII state"
 msgstr  ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid   "MTU"
 msgstr  ""
 
@@ -4257,7 +4269,7 @@ msgstr  ""
 msgid   "Manage devices"
 msgstr  ""
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 msgid   "Manage files in instances"
 msgstr  ""
 
@@ -4447,15 +4459,15 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid   "Memory (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid   "Memory usage:"
 msgstr  ""
 
@@ -4569,7 +4581,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -4605,11 +4617,11 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -4712,7 +4724,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
 msgid   "Name"
 msgstr  ""
 
@@ -4889,7 +4901,7 @@ msgstr  ""
 msgid   "Network type"
 msgstr  ""
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid   "Network usage:"
 msgstr  ""
 
@@ -4988,6 +5000,14 @@ msgstr  ""
 msgid   "Number of placement groups"
 msgstr  ""
 
+#: cmd/incus/info.go:678
+msgid   "OS"
+msgstr  ""
+
+#: cmd/incus/info.go:679
+msgid   "OS Version"
+msgstr  ""
+
 #: cmd/incus/network.go:1028
 msgid   "OVN:"
 msgstr  ""
@@ -5024,12 +5044,16 @@ msgstr  ""
 msgid   "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr  ""
 
+#: cmd/incus/info.go:677
+msgid   "Operating System:"
+msgstr  ""
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -5095,11 +5119,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid   "Packets received"
 msgstr  ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid   "Packets sent"
 msgstr  ""
 
@@ -5112,7 +5136,7 @@ msgstr  ""
 msgid   "Password for %s: "
 msgstr  ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, c-format
 msgid   "Password rejected for %q"
 msgstr  ""
@@ -5188,7 +5212,7 @@ msgstr  ""
 msgid   "Press CTRL-C to exit"
 msgstr  ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
@@ -5212,7 +5236,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -5356,20 +5380,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 msgid   "Push files into instances"
 msgstr  ""
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -5423,7 +5447,7 @@ msgid   "Recover missing instances and volumes from existing and unknown storage
         "  pools but are not in the database. It will then offer to recreate these database records."
 msgstr  ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -5645,7 +5669,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid   "Resources:"
 msgstr  ""
 
@@ -5755,17 +5779,17 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid   "SSH SFTP listening on %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -5876,7 +5900,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -6056,27 +6080,27 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 msgid   "Set the file's gid on create"
 msgstr  ""
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 msgid   "Set the file's perms on create"
 msgstr  ""
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 msgid   "Set the file's uid on create"
 msgstr  ""
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -6144,7 +6168,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -6378,7 +6402,7 @@ msgstr  ""
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -6422,7 +6446,7 @@ msgstr  ""
 msgid   "Starting recovery..."
 msgstr  ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 msgid   "State"
 msgstr  ""
 
@@ -6431,7 +6455,7 @@ msgstr  ""
 msgid   "State: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid   "Stateful"
 msgstr  ""
 
@@ -6559,11 +6583,11 @@ msgstr  ""
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid   "Swap (current)"
 msgstr  ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -6575,7 +6599,7 @@ msgstr  ""
 msgid   "Switch the default remote"
 msgstr  ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid   "Symlink target path can only be used for type \"symlink\""
 msgstr  ""
 
@@ -6599,15 +6623,15 @@ msgstr  ""
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid   "Taken at"
 msgstr  ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -6630,7 +6654,7 @@ msgstr  ""
 msgid   "The %s storage pool already exists"
 msgstr  ""
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid   "The --show-log flag is only supported for by 'console' output type"
 msgstr  ""
 
@@ -6654,7 +6678,7 @@ msgid   "The \"cluster\" subcommand requires access to internal server data.\n"
         "You can invoke it through \"incusd cluster\"."
 msgstr  ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid   "The client automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
@@ -6849,7 +6873,7 @@ msgstr  ""
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid   "The type to create (file, symlink, or directory)"
 msgstr  ""
 
@@ -6896,7 +6920,7 @@ msgstr  ""
 msgid   "To create a new network, use: incus network create"
 msgstr  ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
@@ -6909,7 +6933,7 @@ msgstr  ""
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid   "Too many links"
 msgstr  ""
 
@@ -6972,7 +6996,7 @@ msgstr  ""
 msgid   "Try `incus info --show-log %s%s` for more info"
 msgstr  ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid   "Type"
 msgstr  ""
 
@@ -7034,7 +7058,7 @@ msgstr  ""
 msgid   "Unable to connect to any of the cluster members specified in join token"
 msgstr  ""
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -7048,7 +7072,7 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
@@ -7058,12 +7082,12 @@ msgstr  ""
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -7073,7 +7097,7 @@ msgstr  ""
 msgid   "Unknown key: %s"
 msgstr  ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid   "Unknown output type %q"
 msgstr  ""
@@ -7237,7 +7261,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
@@ -7302,7 +7326,7 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
@@ -7739,23 +7763,23 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 msgid   "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr  ""
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -8251,24 +8275,24 @@ msgid   "incus export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid   "incus file create foo/bar\n"
         "	   To create a file /bar in the foo instance.\n"
         "incus file create --type=symlink foo/bar baz\n"
         "	   To create a symlink /bar in instance foo whose target is baz."
 msgstr  ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid   "incus file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid   "incus file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid   "incus file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -8631,16 +8655,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -627,12 +627,12 @@ msgstr "%s (altri %d)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -740,7 +740,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1132,7 +1132,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1188,11 +1188,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1221,11 +1221,11 @@ msgstr "Utilizzo CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Creazione del container in corso"
@@ -1890,7 +1890,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Creazione di %s in corso"
@@ -1982,7 +1982,7 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
@@ -2114,9 +2114,9 @@ msgstr ""
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2326,7 +2326,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2343,7 +2343,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
@@ -2460,7 +2460,7 @@ msgstr "DATA DI SCADENZA"
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2474,7 +2474,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -2758,7 +2758,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 msgid "Expires at"
 msgstr ""
@@ -2843,12 +2843,16 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2863,12 +2867,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2898,7 +2902,7 @@ msgstr "Accetta certificato"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2938,7 +2942,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2948,17 +2952,17 @@ msgstr "Accetta certificato"
 msgid "Failed parsing validation response: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -3062,7 +3066,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -3160,7 +3164,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to update cluster member state: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3204,7 +3208,7 @@ msgstr ""
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -3520,31 +3524,36 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 #, fuzzy
 msgid "Host interface"
+msgstr "Creazione del container in corso"
+
+#: cmd/incus/info.go:681
+#, fuzzy
+msgid "Hostname"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -3580,7 +3589,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 msgid "IP addresses"
 msgstr ""
 
@@ -3759,16 +3768,16 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3782,7 +3791,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3879,7 +3888,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3915,7 +3924,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3947,17 +3956,17 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid sorting type provided"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Proprietà errata: %s"
@@ -3973,6 +3982,10 @@ msgstr ""
 
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
+msgstr ""
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
 msgstr ""
 
 #: cmd/incus/warning.go:212
@@ -4889,7 +4902,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr ""
 
@@ -4897,12 +4910,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -4928,7 +4941,7 @@ msgstr "Creazione del container in corso"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 msgid "MAC address"
 msgstr ""
 
@@ -4975,7 +4988,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -5018,7 +5031,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
@@ -5177,8 +5190,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5232,15 +5245,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr ""
 
@@ -5457,7 +5470,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid "Missing target directory"
 msgstr ""
 
@@ -5497,11 +5510,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -5624,7 +5637,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
@@ -5805,7 +5818,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid "Network usage:"
 msgstr ""
 
@@ -5906,6 +5919,14 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+msgid "OS Version"
+msgstr ""
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -5943,12 +5964,16 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+msgid "Operating System:"
+msgstr ""
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6020,11 +6045,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr ""
 
@@ -6037,7 +6062,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Password amministratore per %s: "
@@ -6115,7 +6140,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6149,7 +6174,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6295,21 +6320,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6371,7 +6396,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6610,7 +6635,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr ""
 
@@ -6728,17 +6753,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6855,7 +6880,7 @@ msgstr "Il nome del container è: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7073,27 +7098,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7167,7 +7192,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7423,7 +7448,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7470,7 +7495,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
@@ -7480,7 +7505,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr ""
 
@@ -7611,11 +7636,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7627,7 +7652,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7656,16 +7681,16 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7689,7 +7714,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "La periferica esiste già"
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7720,7 +7745,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7926,7 +7951,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -7977,7 +8002,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7993,7 +8018,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -8057,7 +8082,7 @@ msgstr "Password amministratore per %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid "Type"
 msgstr ""
 
@@ -8131,7 +8156,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8146,7 +8171,7 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8168,12 +8193,12 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8183,7 +8208,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8365,7 +8390,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8438,7 +8463,7 @@ msgstr "Il nome del container è: %s"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8962,28 +8987,28 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -9616,7 +9641,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9624,20 +9649,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -10078,16 +10103,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -620,12 +620,12 @@ msgstr "%s (%s) (%d個使用可能)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s（バックエンド=%q, ソース=%q）"
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -731,7 +731,7 @@ msgstr "<remote> <new-name>"
 msgid "<remote>: <path>"
 msgstr "<remote>: <path>"
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -1026,7 +1026,7 @@ msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "本当に %s しますか? （対象: クラスターメンバー %q） (yes/no) [default=no]: "
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
@@ -1136,7 +1136,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1194,11 +1194,11 @@ msgstr "ブリッジ:"
 msgid "Bus Address: %v"
 msgstr "アドレス: %s"
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1227,11 +1227,11 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
@@ -1280,7 +1280,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1316,7 +1316,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスターでない場合はカラムとして L は指定できません"
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1811,11 +1811,11 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 msgid "Create files and directories in instances"
 msgstr "インスタンス内にファイル、もしくはディレクトリーを作成します"
 
@@ -1921,7 +1921,7 @@ msgstr "作成日時: %s"
 msgid "Creating %s"
 msgstr "%s を作成中"
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, c-format
 msgid "Creating %s: %%s"
 msgstr "%s: %%s を作成中"
@@ -2014,7 +2014,7 @@ msgstr "警告をすべて削除します"
 msgid "Delete custom storage volumes"
 msgstr "ストレージボリュームを削除します"
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
@@ -2139,9 +2139,9 @@ msgstr "警告を削除します"
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2356,7 +2356,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2373,7 +2373,7 @@ msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
@@ -2485,7 +2485,7 @@ msgstr "EXPIRES AT"
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2501,7 +2501,7 @@ msgstr "クラスターグループを編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 msgid "Expires at"
 msgstr "失効日時"
@@ -2914,12 +2914,16 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2934,12 +2938,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2969,7 +2973,7 @@ msgstr "インスタンス %q （プロジェクト %q 内）の削除に失敗�
 msgid "Failed deleting source volume after copy: %w"
 msgstr "コピー後のソースボリュームの削除に失敗しました: %w"
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -3009,7 +3013,7 @@ msgstr "デバイス上書きのためのプロファイル %q のロードに�
 msgid "Failed loading storage pool %q: %w"
 msgstr "ストレージプール %q の取得に失敗しました: %w"
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -3019,17 +3023,17 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed parsing validation response: %w"
 msgstr "バリデーションレスポンスの読み取りに失敗しました: %w"
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -3133,7 +3137,7 @@ msgstr "プロジェクトが見つけられませんでした: %w"
 msgid "Failed to join cluster: %w"
 msgstr "クラスターへの join に失敗しました: %w"
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -3231,7 +3235,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to update cluster member state: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -3274,7 +3278,7 @@ msgstr "証明書のフィンガープリント: %s"
 msgid "Force a particular evacuation action"
 msgstr "特定の待避アクションを強制します"
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr "強制的にファイルまたはディレクトリーを作成します"
 
@@ -3606,30 +3610,35 @@ msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 msgid "Host interface"
 msgstr "ホストインターフェース"
+
+#: cmd/incus/info.go:681
+#, fuzzy
+msgid "Hostname"
+msgstr "名前"
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -3665,7 +3674,7 @@ msgstr "IOMMU グループ: %v"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 msgid "IP addresses"
 msgstr "IP アドレス"
 
@@ -3856,15 +3865,15 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3878,7 +3887,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3977,7 +3986,7 @@ msgstr "入力が無効です。正の値を入力してください"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -4015,7 +4024,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -4046,17 +4055,17 @@ msgstr "不正な送り先 %s"
 msgid "Invalid sorting type provided"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "不正な送り先 %s"
@@ -4073,6 +4082,11 @@ msgstr "既存のクラスターに加わるには root 権限が必要です"
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
+
+#: cmd/incus/info.go:680
+#, fuzzy
+msgid "Kernel Version"
+msgstr "サーバのバージョン: %s\n"
 
 #: cmd/incus/warning.go:212
 msgid "LAST SEEN"
@@ -5606,7 +5620,7 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr "ログ:"
 
@@ -5614,12 +5628,12 @@ msgstr "ログ:"
 msgid "Logical router"
 msgstr "論理ルーター"
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr "ユーザー名 %q とパスワード %q でログイン"
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr "ユーザー名、パスワードを使用せずにログイン"
 
@@ -5643,7 +5657,7 @@ msgstr "Lower devices"
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 msgid "MAC address"
 msgstr "MAC アドレス"
 
@@ -5691,7 +5705,7 @@ msgstr "MII 監視頻度"
 msgid "MII state"
 msgstr "MII 状態"
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr "MTU"
 
@@ -5732,7 +5746,7 @@ msgstr "コマンドのエイリアスを管理します"
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
@@ -5893,8 +5907,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -5951,15 +5965,15 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
@@ -6164,7 +6178,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -6208,13 +6222,13 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -6351,7 +6365,7 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr "名前"
@@ -6538,7 +6552,7 @@ msgstr ""
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -6644,6 +6658,15 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr "配置するグループの数"
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+#, fuzzy
+msgid "OS Version"
+msgstr "CUDA バージョン: %v"
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr "OVN:"
@@ -6684,12 +6707,17 @@ msgstr ""
 "指定できるのは、--storage-create-device もしくは --storage-create-loop のいず"
 "れか一方のみです"
 
+#: cmd/incus/info.go:677
+#, fuzzy
+msgid "Operating System:"
+msgstr "バックグラウンド操作 %s を削除しました"
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -6762,11 +6790,11 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -6779,7 +6807,7 @@ msgstr "パーティション:"
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "%s のパスワード: "
@@ -6856,7 +6884,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
@@ -6892,7 +6920,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -7036,20 +7064,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -7119,7 +7147,7 @@ msgstr ""
 "リュームを特定します。\n"
 "  そして、データベースレコードの再作成を提案します。"
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -7352,7 +7380,7 @@ msgstr "クラスターメンバーに join するためのトークンを要求
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -7470,17 +7498,17 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr "SSH SFTP は %v でリッスンしています"
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -7601,7 +7629,7 @@ msgstr "クラスターメンバーの設定を行います"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -7890,30 +7918,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 #, fuzzy
 msgid "Set the file's gid on create"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 #, fuzzy
 msgid "Set the file's perms on create"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 #, fuzzy
 msgid "Set the file's uid on create"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -7992,7 +8020,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr "インスタンスプロパティとして設定します"
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -8242,7 +8270,7 @@ msgstr "ストレージボリュームのスナップショットを取得しま
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -8290,7 +8318,7 @@ msgstr "%s を起動中"
 msgid "Starting recovery..."
 msgstr "リカバリーを開始します..."
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 msgid "State"
 msgstr "状態"
 
@@ -8299,7 +8327,7 @@ msgstr "状態"
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr "ステートフル"
 
@@ -8430,11 +8458,11 @@ msgstr "サポートするモード: %s"
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -8446,7 +8474,7 @@ msgstr "現在のプロジェクトを切り替えます"
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr "シンボリックリンクのターゲットパスは \"symlink\" タイプにのみ使えます"
 
@@ -8475,15 +8503,15 @@ msgstr "TOKEN"
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr "取得日時"
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -8516,7 +8544,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "デバイスはすでに存在します"
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
 
@@ -8563,7 +8591,7 @@ msgstr ""
 "\n"
 "\"incusd cluster\" から呼び出すことができます。"
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 #, fuzzy
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
@@ -8786,7 +8814,7 @@ msgstr "指定したデバイスが存在しません"
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr "作成するタイプ（file, symlink, directory）"
 
@@ -8855,7 +8883,7 @@ msgid "To create a new network, use: incus network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
@@ -8877,7 +8905,7 @@ msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスターに属していなければ"
 "なりません"
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr "リンクが多すぎます"
 
@@ -8941,7 +8969,7 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid "Type"
 msgstr "タイプ"
 
@@ -9016,7 +9044,7 @@ msgstr "UUID: %v"
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "クラスタメンバへの接続に失敗しました"
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -9030,7 +9058,7 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
@@ -9052,12 +9080,12 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -9067,7 +9095,7 @@ msgstr "未知のファイルタイプ '%s'"
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
@@ -9246,7 +9274,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr "インスタンスプロパティの設定を削除します"
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
@@ -9321,7 +9349,7 @@ msgstr "ユーザが削除操作を中断しました"
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -9824,26 +9852,26 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -10471,7 +10499,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -10484,7 +10512,7 @@ msgstr ""
 "\t   インスタンス foo 内に、ターゲットが baz であるシンボリックリンク /bar を"
 "作成します。"
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 #, fuzzy
 msgid ""
 "incus file mount foo/root fooroot\n"
@@ -10494,7 +10522,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 #, fuzzy
 msgid ""
 "incus file pull foo/etc/hosts .\n"
@@ -10505,7 +10533,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 #, fuzzy
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
@@ -11155,16 +11183,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -390,12 +390,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -500,7 +500,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -936,11 +936,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr ""
 
@@ -968,11 +968,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1055,7 +1055,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1517,11 +1517,11 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 msgid "Create files and directories in instances"
 msgstr ""
 
@@ -1622,7 +1622,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1712,7 +1712,7 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1836,9 +1836,9 @@ msgstr ""
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2044,7 +2044,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2061,7 +2061,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid "Disk usage:"
 msgstr ""
 
@@ -2169,7 +2169,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2183,7 +2183,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 msgid "Expires at"
 msgstr ""
@@ -2541,12 +2541,16 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2561,12 +2565,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2596,7 +2600,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2636,7 +2640,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2646,17 +2650,17 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2760,7 +2764,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2858,7 +2862,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2901,7 +2905,7 @@ msgstr ""
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -3201,30 +3205,35 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 msgid "Host interface"
 msgstr ""
+
+#: cmd/incus/info.go:681
+#, fuzzy
+msgid "Hostname"
+msgstr "navn"
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3260,7 +3269,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 msgid "IP addresses"
 msgstr ""
 
@@ -3434,15 +3443,15 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3456,7 +3465,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3551,7 +3560,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3586,7 +3595,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3614,17 +3623,17 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3640,6 +3649,10 @@ msgstr ""
 
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
+msgstr ""
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
 msgstr ""
 
 #: cmd/incus/warning.go:212
@@ -4538,7 +4551,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr ""
 
@@ -4546,12 +4559,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -4575,7 +4588,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 msgid "MAC address"
 msgstr ""
 
@@ -4622,7 +4635,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -4663,7 +4676,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4806,8 +4819,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -4860,15 +4873,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr ""
 
@@ -5071,7 +5084,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid "Missing target directory"
 msgstr ""
 
@@ -5109,11 +5122,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5234,7 +5247,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
@@ -5415,7 +5428,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid "Network usage:"
 msgstr ""
 
@@ -5516,6 +5529,14 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+msgid "OS Version"
+msgstr ""
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -5553,12 +5574,16 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+msgid "Operating System:"
+msgstr ""
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5628,11 +5653,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr ""
 
@@ -5645,7 +5670,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5721,7 +5746,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5755,7 +5780,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5899,20 +5924,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5972,7 +5997,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6199,7 +6224,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr ""
 
@@ -6310,17 +6335,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6434,7 +6459,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6647,27 +6672,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6735,7 +6760,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6975,7 +7000,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7021,7 +7046,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 msgid "State"
 msgstr ""
 
@@ -7030,7 +7055,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr ""
 
@@ -7159,11 +7184,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7175,7 +7200,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7204,15 +7229,15 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7236,7 +7261,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7267,7 +7292,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7472,7 +7497,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -7522,7 +7547,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7538,7 +7563,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -7602,7 +7627,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid "Type"
 msgstr ""
 
@@ -7672,7 +7697,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7686,7 +7711,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7708,12 +7733,12 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7723,7 +7748,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -7889,7 +7914,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7959,7 +7984,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8425,24 +8450,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -8983,7 +9008,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -8991,20 +9016,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9444,16 +9469,16 @@ msgstr "vennligst bruk `incus profile`"
 msgid "space used"
 msgstr "brukt plass"
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr "sshfs har stoppet"
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: 2024-01-27 21:01+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -636,12 +636,12 @@ msgstr "%s (%s) (%d beschikbaar)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (backend=%q, source=%q)"
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s is geen directory"
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' is geen ondersteund bestandstype"
@@ -752,7 +752,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr "Wilt u lid worden (joining) van een bestaand cluster?"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr "Weet je zeker dat je %s wilt clusteren met %q ? (yes/no) "
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 "Beide konden niet worden gevonden, de directe SPICE plug (raw SPICE socket) "
@@ -1155,7 +1155,7 @@ msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1211,11 +1211,11 @@ msgstr "Brug (Bridge):"
 msgid "Bus Address: %v"
 msgstr "Adres: %s"
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr "Bytes ontvangen (received)"
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr "Bytes verzonden"
 
@@ -1244,11 +1244,11 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU GEBRUIK"
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr "CPU gebruik (in seconde)"
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr "CPU gebruik:"
 
@@ -1299,7 +1299,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1797,11 +1797,11 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 msgid "Create files and directories in instances"
 msgstr ""
 
@@ -1903,7 +1903,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1994,7 +1994,7 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 msgid "Delete files in instances"
 msgstr ""
 
@@ -2119,9 +2119,9 @@ msgstr ""
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid "Disk usage:"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2468,7 +2468,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2745,7 +2745,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 msgid "Expires at"
 msgstr ""
@@ -2826,12 +2826,16 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2846,12 +2850,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2881,7 +2885,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2921,7 +2925,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2931,17 +2935,17 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -3045,7 +3049,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -3143,7 +3147,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3186,7 +3190,7 @@ msgstr ""
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -3490,30 +3494,34 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 msgid "Host interface"
+msgstr ""
+
+#: cmd/incus/info.go:681
+msgid "Hostname"
 msgstr ""
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3549,7 +3557,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 msgid "IP addresses"
 msgstr ""
 
@@ -3724,15 +3732,15 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3746,7 +3754,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3841,7 +3849,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3876,7 +3884,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3904,17 +3912,17 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3930,6 +3938,10 @@ msgstr ""
 
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
+msgstr ""
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
 msgstr ""
 
 #: cmd/incus/warning.go:212
@@ -4830,7 +4842,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr ""
 
@@ -4838,12 +4850,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -4867,7 +4879,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 msgid "MAC address"
 msgstr ""
 
@@ -4914,7 +4926,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -4955,7 +4967,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 msgid "Manage files in instances"
 msgstr ""
 
@@ -5099,8 +5111,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5153,15 +5165,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr ""
 
@@ -5365,7 +5377,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid "Missing target directory"
 msgstr ""
 
@@ -5403,11 +5415,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5528,7 +5540,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
@@ -5709,7 +5721,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid "Network usage:"
 msgstr ""
 
@@ -5810,6 +5822,15 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+#, fuzzy
+msgid "OS Version"
+msgstr "CUDA Versie: %v"
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -5847,12 +5868,16 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+msgid "Operating System:"
+msgstr ""
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5922,11 +5947,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr ""
 
@@ -5939,7 +5964,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -6015,7 +6040,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6049,7 +6074,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6193,20 +6218,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6266,7 +6291,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6495,7 +6520,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr ""
 
@@ -6606,17 +6631,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6732,7 +6757,7 @@ msgstr "Toekennen van netwerk (network) interfaces aan profielen (profiles)"
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6946,27 +6971,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7036,7 +7061,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7277,7 +7302,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7323,7 +7348,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 msgid "State"
 msgstr ""
 
@@ -7332,7 +7357,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr ""
 
@@ -7461,11 +7486,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7477,7 +7502,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7506,15 +7531,15 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7538,7 +7563,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7569,7 +7594,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7774,7 +7799,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -7824,7 +7849,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7840,7 +7865,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -7904,7 +7929,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid "Type"
 msgstr ""
 
@@ -7974,7 +7999,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7988,7 +8013,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8010,12 +8035,12 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8025,7 +8050,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8193,7 +8218,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8263,7 +8288,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8729,24 +8754,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -9287,7 +9312,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9295,20 +9320,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9748,16 +9773,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -383,12 +383,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -493,7 +493,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -873,7 +873,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -929,11 +929,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr ""
 
@@ -961,11 +961,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr ""
 
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1048,7 +1048,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1510,11 +1510,11 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 msgid "Create files and directories in instances"
 msgstr ""
 
@@ -1615,7 +1615,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1705,7 +1705,7 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1829,9 +1829,9 @@ msgstr ""
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2037,7 +2037,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid "Disk usage:"
 msgstr ""
 
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2176,7 +2176,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 msgid "Expires at"
 msgstr ""
@@ -2534,12 +2534,16 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2554,12 +2558,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2589,7 +2593,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2629,7 +2633,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2639,17 +2643,17 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2753,7 +2757,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2851,7 +2855,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2894,7 +2898,7 @@ msgstr ""
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -3194,30 +3198,34 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 msgid "Host interface"
+msgstr ""
+
+#: cmd/incus/info.go:681
+msgid "Hostname"
 msgstr ""
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3253,7 +3261,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 msgid "IP addresses"
 msgstr ""
 
@@ -3427,15 +3435,15 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3449,7 +3457,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3544,7 +3552,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3579,7 +3587,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3607,17 +3615,17 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3633,6 +3641,10 @@ msgstr ""
 
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
+msgstr ""
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
 msgstr ""
 
 #: cmd/incus/warning.go:212
@@ -4531,7 +4543,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr ""
 
@@ -4539,12 +4551,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -4568,7 +4580,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 msgid "MAC address"
 msgstr ""
 
@@ -4615,7 +4627,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -4656,7 +4668,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4799,8 +4811,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -4853,15 +4865,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr ""
 
@@ -5064,7 +5076,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid "Missing target directory"
 msgstr ""
 
@@ -5102,11 +5114,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5227,7 +5239,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
@@ -5408,7 +5420,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid "Network usage:"
 msgstr ""
 
@@ -5509,6 +5521,14 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+msgid "OS Version"
+msgstr ""
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -5546,12 +5566,16 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+msgid "Operating System:"
+msgstr ""
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5621,11 +5645,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr ""
 
@@ -5638,7 +5662,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5714,7 +5738,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5748,7 +5772,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -5892,20 +5916,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5965,7 +5989,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6192,7 +6216,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr ""
 
@@ -6303,17 +6327,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6427,7 +6451,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6640,27 +6664,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6728,7 +6752,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6968,7 +6992,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7014,7 +7038,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 msgid "State"
 msgstr ""
 
@@ -7023,7 +7047,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr ""
 
@@ -7152,11 +7176,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7168,7 +7192,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7197,15 +7221,15 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7229,7 +7253,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7260,7 +7284,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7465,7 +7489,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -7515,7 +7539,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7531,7 +7555,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -7595,7 +7619,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid "Type"
 msgstr ""
 
@@ -7665,7 +7689,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7679,7 +7703,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7701,12 +7725,12 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7716,7 +7740,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -7882,7 +7906,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -7952,7 +7976,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8418,24 +8442,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -8976,7 +9000,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -8984,20 +9008,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9437,16 +9461,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -618,12 +618,12 @@ msgstr "%s (%d mais)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -741,7 +741,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr "Criar perfis"
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1199,11 +1199,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1232,11 +1232,11 @@ msgstr "Utilização do CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1801,11 +1801,11 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Editar arquivos no container"
@@ -1922,7 +1922,7 @@ msgstr "Criado: %s"
 msgid "Creating %s"
 msgstr "Criando %s"
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Criando %s"
@@ -2016,7 +2016,7 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "Delete custom storage volumes"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
@@ -2153,9 +2153,9 @@ msgstr ""
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2366,7 +2366,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2383,7 +2383,7 @@ msgstr "Desabilitar stdin (ler de /dev/null)"
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
@@ -2499,7 +2499,7 @@ msgstr "DATA DE VALIDADE"
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -2806,7 +2806,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 msgid "Expires at"
 msgstr ""
@@ -2889,12 +2889,16 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2909,12 +2913,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2944,7 +2948,7 @@ msgstr "Aceitar certificado"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2984,7 +2988,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2994,17 +2998,17 @@ msgstr "Aceitar certificado"
 msgid "Failed parsing validation response: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -3108,7 +3112,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -3206,7 +3210,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to update cluster member state: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3249,7 +3253,7 @@ msgstr ""
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -3574,30 +3578,34 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 msgid "Host interface"
+msgstr ""
+
+#: cmd/incus/info.go:681
+msgid "Hostname"
 msgstr ""
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -3633,7 +3641,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 msgid "IP addresses"
 msgstr ""
 
@@ -3813,15 +3821,15 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3835,7 +3843,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3932,7 +3940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -3967,7 +3975,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3999,17 +4007,17 @@ msgstr "Editar arquivos no container"
 msgid "Invalid sorting type provided"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Editar arquivos no container"
@@ -4025,6 +4033,10 @@ msgstr ""
 
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
+msgstr ""
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
 msgstr ""
 
 #: cmd/incus/warning.go:212
@@ -4937,7 +4949,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr ""
 
@@ -4945,12 +4957,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -4976,7 +4988,7 @@ msgstr "Editar arquivos no container"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 msgid "MAC address"
 msgstr ""
 
@@ -5023,7 +5035,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -5066,7 +5078,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
@@ -5230,8 +5242,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5286,15 +5298,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr ""
 
@@ -5510,7 +5522,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid "Missing target directory"
 msgstr ""
 
@@ -5550,11 +5562,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -5678,7 +5690,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
@@ -5859,7 +5871,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid "Network usage:"
 msgstr ""
 
@@ -5960,6 +5972,15 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+#, fuzzy
+msgid "OS Version"
+msgstr "Versão CUDA: %v"
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -5997,12 +6018,16 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+msgid "Operating System:"
+msgstr ""
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6074,11 +6099,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr ""
 
@@ -6091,7 +6116,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -6168,7 +6193,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6202,7 +6227,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6351,21 +6376,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6427,7 +6452,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6672,7 +6697,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr ""
 
@@ -6795,17 +6820,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6922,7 +6947,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7147,27 +7172,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7244,7 +7269,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7509,7 +7534,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7555,7 +7580,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 msgid "State"
 msgstr ""
 
@@ -7564,7 +7589,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr ""
 
@@ -7696,11 +7721,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7712,7 +7737,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7741,16 +7766,16 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7774,7 +7799,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "Alias %s já existe"
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7805,7 +7830,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -8010,7 +8035,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -8061,7 +8086,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8077,7 +8102,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -8141,7 +8166,7 @@ msgstr "Senha de administrador para %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid "Type"
 msgstr ""
 
@@ -8215,7 +8240,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8230,7 +8255,7 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8252,12 +8277,12 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8267,7 +8292,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8460,7 +8485,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8533,7 +8558,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -9029,25 +9054,25 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -9642,7 +9667,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9650,20 +9675,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -10103,16 +10128,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -643,12 +643,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -758,7 +758,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1049,7 +1049,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1213,11 +1213,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1246,11 +1246,11 @@ msgstr " Использование ЦП:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1802,11 +1802,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 #, fuzzy
 msgid "Create files and directories in instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1922,7 +1922,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -2014,7 +2014,7 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2149,9 +2149,9 @@ msgstr ""
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2360,7 +2360,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2377,7 +2377,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2508,7 +2508,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2797,7 +2797,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 msgid "Expires at"
 msgstr ""
@@ -2885,12 +2885,16 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2905,12 +2909,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2940,7 +2944,7 @@ msgstr "Принять сертификат"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2980,7 +2984,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2990,17 +2994,17 @@ msgstr "Принять сертификат"
 msgid "Failed parsing validation response: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -3104,7 +3108,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -3202,7 +3206,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to update cluster member state: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3245,7 +3249,7 @@ msgstr ""
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -3566,31 +3570,36 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 #, fuzzy
 msgid "Host interface"
+msgstr "Псевдонимы:"
+
+#: cmd/incus/info.go:681
+#, fuzzy
+msgid "Hostname"
 msgstr "Псевдонимы:"
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3626,7 +3635,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 msgid "IP addresses"
 msgstr ""
 
@@ -3807,16 +3816,16 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3831,7 +3840,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3928,7 +3937,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -3963,7 +3972,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3995,17 +4004,17 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid sorting type provided"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Имя контейнера: %s"
@@ -4021,6 +4030,10 @@ msgstr ""
 
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
+msgstr ""
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
 msgstr ""
 
 #: cmd/incus/warning.go:212
@@ -4940,7 +4953,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr ""
 
@@ -4948,12 +4961,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -4979,7 +4992,7 @@ msgstr "Копирование образа: %s"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 msgid "MAC address"
 msgstr ""
 
@@ -5026,7 +5039,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -5070,7 +5083,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 msgid "Manage files in instances"
 msgstr ""
 
@@ -5235,8 +5248,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5290,15 +5303,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
@@ -5518,7 +5531,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid "Missing target directory"
 msgstr ""
 
@@ -5557,11 +5570,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5684,7 +5697,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
@@ -5870,7 +5883,7 @@ msgstr ""
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -5973,6 +5986,14 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+msgid "OS Version"
+msgstr ""
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -6010,12 +6031,16 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+msgid "Operating System:"
+msgstr ""
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6087,11 +6112,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr ""
 
@@ -6104,7 +6129,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Пароль администратора для %s: "
@@ -6181,7 +6206,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6215,7 +6240,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6359,20 +6384,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6434,7 +6459,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6675,7 +6700,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr ""
 
@@ -6794,17 +6819,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6921,7 +6946,7 @@ msgstr "Копирование образа: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7141,27 +7166,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7239,7 +7264,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7501,7 +7526,7 @@ msgstr "Копирование образа: %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7547,7 +7572,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
@@ -7557,7 +7582,7 @@ msgstr "Авто-обновление: %s"
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr ""
 
@@ -7691,11 +7716,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7707,7 +7732,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7736,15 +7761,15 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7768,7 +7793,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7799,7 +7824,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -8004,7 +8029,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -8055,7 +8080,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8071,7 +8096,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -8135,7 +8160,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid "Type"
 msgstr ""
 
@@ -8209,7 +8234,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8223,7 +8248,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8245,12 +8270,12 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8260,7 +8285,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8449,7 +8474,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8522,7 +8547,7 @@ msgstr "Копирование образа: %s"
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -9206,7 +9231,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -9214,7 +9239,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
@@ -9222,7 +9247,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -9230,7 +9255,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -9239,7 +9264,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -10148,7 +10173,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -10156,20 +10181,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -10609,16 +10634,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-09-18 23:59+0000\n"
+"POT-Creation-Date: 2024-09-24 08:09-0600\n"
 "PO-Revision-Date: 2024-08-14 07:23+0000\n"
 "Last-Translator: Kwok Guy <kwokjuy@163.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -544,12 +544,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1102
+#: cmd/incus/file.go:1104
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是目录"
 
-#: cmd/incus/file.go:992
+#: cmd/incus/file.go:994
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -654,7 +654,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:646
+#: cmd/incus/file.go:648
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:380
+#: cmd/incus/console.go:384
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1034,7 +1034,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:833 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
 msgid "Backups:"
 msgstr ""
 
@@ -1090,11 +1090,11 @@ msgstr ""
 msgid "Bus Address: %v"
 msgstr ""
 
-#: cmd/incus/info.go:756 cmd/incus/network.go:987
+#: cmd/incus/info.go:767 cmd/incus/network.go:987
 msgid "Bytes received"
 msgstr ""
 
-#: cmd/incus/info.go:757 cmd/incus/network.go:988
+#: cmd/incus/info.go:768 cmd/incus/network.go:988
 msgid "Bytes sent"
 msgstr ""
 
@@ -1122,11 +1122,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: cmd/incus/info.go:697
+#: cmd/incus/info.go:708
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: cmd/incus/info.go:701
+#: cmd/incus/info.go:712
 msgid "CPU usage:"
 msgstr ""
 
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:521
+#: cmd/incus/file.go:523
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1209,7 +1209,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:723
+#: cmd/incus/file.go:725
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1671,11 +1671,11 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:140 cmd/incus/file.go:435 cmd/incus/file.go:655
+#: cmd/incus/file.go:142 cmd/incus/file.go:437 cmd/incus/file.go:657
 msgid "Create any directories necessary"
 msgstr ""
 
-#: cmd/incus/file.go:131 cmd/incus/file.go:132
+#: cmd/incus/file.go:133 cmd/incus/file.go:134
 msgid "Create files and directories in instances"
 msgstr ""
 
@@ -1776,7 +1776,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:270
+#: cmd/incus/file.go:272
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:309 cmd/incus/file.go:310
+#: cmd/incus/file.go:311 cmd/incus/file.go:312
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1990,9 +1990,9 @@ msgstr ""
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
-#: cmd/incus/export.go:32 cmd/incus/file.go:85 cmd/incus/file.go:132
-#: cmd/incus/file.go:310 cmd/incus/file.go:359 cmd/incus/file.go:429
-#: cmd/incus/file.go:648 cmd/incus/file.go:1153 cmd/incus/image.go:40
+#: cmd/incus/export.go:32 cmd/incus/file.go:87 cmd/incus/file.go:134
+#: cmd/incus/file.go:312 cmd/incus/file.go:361 cmd/incus/file.go:431
+#: cmd/incus/file.go:650 cmd/incus/file.go:1155 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376
 #: cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1161
+#: cmd/incus/file.go:1163
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2215,7 +2215,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: cmd/incus/info.go:690
+#: cmd/incus/info.go:701
 msgid "Disk usage:"
 msgstr ""
 
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: cmd/incus/file.go:76
+#: cmd/incus/file.go:78
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2337,7 +2337,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:358 cmd/incus/file.go:359
+#: cmd/incus/file.go:360 cmd/incus/file.go:361
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:819 cmd/incus/info.go:870 cmd/incus/storage_volume.go:1476
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
 #: cmd/incus/storage_volume.go:1526
 msgid "Expires at"
 msgstr ""
@@ -2695,12 +2695,16 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: cmd/incus/file.go:1404
+#: cmd/incus/info.go:682
+msgid "FQDN"
+msgstr ""
+
+#: cmd/incus/file.go:1406
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1427
+#: cmd/incus/file.go:1429
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2715,12 +2719,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1454
+#: cmd/incus/file.go:1456
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1239
+#: cmd/incus/file.go:1241
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2750,7 +2754,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1360
+#: cmd/incus/file.go:1362
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2790,7 +2794,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1367
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2800,17 +2804,17 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:358
+#: cmd/incus/console.go:362
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1265
+#: cmd/incus/file.go:1267
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1392
+#: cmd/incus/file.go:1394
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2914,7 +2918,7 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1377
+#: cmd/incus/file.go:1379
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -3012,7 +3016,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:987
+#: cmd/incus/file.go:989
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3055,7 +3059,7 @@ msgstr ""
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: cmd/incus/file.go:141
+#: cmd/incus/file.go:143
 msgid "Force creating files or directories"
 msgstr ""
 
@@ -3355,30 +3359,34 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: cmd/incus/info.go:745
+#: cmd/incus/info.go:756
 msgid "Host interface"
+msgstr ""
+
+#: cmd/incus/info.go:681
+msgid "Hostname"
 msgstr ""
 
 #: cmd/incus/info.go:516 cmd/incus/info.go:527
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1477
+#: cmd/incus/file.go:1479
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1466
+#: cmd/incus/file.go:1468
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1291
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1299
+#: cmd/incus/file.go:1301
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3414,7 +3422,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:761
+#: cmd/incus/info.go:772
 msgid "IP addresses"
 msgstr ""
 
@@ -3588,15 +3596,15 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: cmd/incus/info.go:871
+#: cmd/incus/info.go:882
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1291
+#: cmd/incus/file.go:1293
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1468
+#: cmd/incus/file.go:1470
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3610,7 +3618,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1211
+#: cmd/incus/file.go:1213
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3705,7 +3713,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1206
+#: cmd/incus/file.go:1208
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3740,7 +3748,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:334
+#: cmd/incus/file.go:336
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3768,17 +3776,17 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:494
+#: cmd/incus/file.go:496
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:174 cmd/incus/file.go:676
+#: cmd/incus/file.go:176 cmd/incus/file.go:678
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:160
+#: cmd/incus/file.go:162
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -3794,6 +3802,10 @@ msgstr ""
 
 #: cmd/incus/image.go:156
 msgid "Keep the image up to date after initial copy"
+msgstr ""
+
+#: cmd/incus/info.go:680
+msgid "Kernel Version"
 msgstr ""
 
 #: cmd/incus/warning.go:212
@@ -4692,7 +4704,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: cmd/incus/info.go:899
+#: cmd/incus/info.go:910
 msgid "Log:"
 msgstr ""
 
@@ -4700,12 +4712,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1383
+#: cmd/incus/file.go:1385
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1387
 msgid "Login without username and password"
 msgstr ""
 
@@ -4729,7 +4741,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: cmd/incus/info.go:749
+#: cmd/incus/info.go:760
 msgid "MAC address"
 msgstr ""
 
@@ -4776,7 +4788,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: cmd/incus/info.go:753
+#: cmd/incus/info.go:764
 msgid "MTU"
 msgstr ""
 
@@ -4817,7 +4829,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: cmd/incus/file.go:84 cmd/incus/file.go:85
+#: cmd/incus/file.go:86 cmd/incus/file.go:87
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4960,8 +4972,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom\" "
-"(user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5014,15 +5026,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: cmd/incus/info.go:708
+#: cmd/incus/info.go:719
 msgid "Memory (current)"
 msgstr ""
 
-#: cmd/incus/info.go:712
+#: cmd/incus/info.go:723
 msgid "Memory (peak)"
 msgstr ""
 
-#: cmd/incus/info.go:724
+#: cmd/incus/info.go:735
 msgid "Memory usage:"
 msgstr ""
 
@@ -5225,7 +5237,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:771
+#: cmd/incus/file.go:773
 msgid "Missing target directory"
 msgstr ""
 
@@ -5263,12 +5275,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:469
+#: cmd/incus/file.go:471
 #, fuzzy
 msgid "More than one file to download, but target is not a directory"
 msgstr "将下载多个文件, 但目标不是目录"
 
-#: cmd/incus/file.go:1152 cmd/incus/file.go:1153
+#: cmd/incus/file.go:1154 cmd/incus/file.go:1155
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5389,7 +5401,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:817 cmd/incus/info.go:868 cmd/incus/storage_volume.go:1474
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
 #: cmd/incus/storage_volume.go:1524
 msgid "Name"
 msgstr ""
@@ -5570,7 +5582,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: cmd/incus/info.go:774 cmd/incus/network.go:986
+#: cmd/incus/info.go:785 cmd/incus/network.go:986
 msgid "Network usage:"
 msgstr ""
 
@@ -5671,6 +5683,14 @@ msgstr ""
 msgid "Number of placement groups"
 msgstr ""
 
+#: cmd/incus/info.go:678
+msgid "OS"
+msgstr ""
+
+#: cmd/incus/info.go:679
+msgid "OS Version"
+msgstr ""
+
 #: cmd/incus/network.go:1028
 msgid "OVN:"
 msgstr ""
@@ -5708,12 +5728,16 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/info.go:677
+msgid "Operating System:"
+msgstr ""
+
 #: cmd/incus/operation.go:92
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:872 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5783,11 +5807,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: cmd/incus/info.go:758 cmd/incus/network.go:989
+#: cmd/incus/info.go:769 cmd/incus/network.go:989
 msgid "Packets received"
 msgstr ""
 
-#: cmd/incus/info.go:759 cmd/incus/network.go:990
+#: cmd/incus/info.go:770 cmd/incus/network.go:990
 msgid "Packets sent"
 msgstr ""
 
@@ -5800,7 +5824,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1353
+#: cmd/incus/file.go:1355
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5876,7 +5900,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1269
+#: cmd/incus/file.go:1271
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5910,7 +5934,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: cmd/incus/info.go:495 cmd/incus/info.go:677
+#: cmd/incus/info.go:495 cmd/incus/info.go:688
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -6054,20 +6078,20 @@ msgstr "发布实例为镜像"
 msgid "Publishing instance: %s"
 msgstr "正在发布实例: %s"
 
-#: cmd/incus/file.go:428 cmd/incus/file.go:429
+#: cmd/incus/file.go:430 cmd/incus/file.go:431
 msgid "Pull files from instances"
 msgstr "从实例拉取文件"
 
-#: cmd/incus/file.go:597 cmd/incus/file.go:934
+#: cmd/incus/file.go:599 cmd/incus/file.go:936
 #, fuzzy, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "正在从 %[2]s 拉取 %[1]s: %%s"
 
-#: cmd/incus/file.go:647 cmd/incus/file.go:648
+#: cmd/incus/file.go:649 cmd/incus/file.go:650
 msgid "Push files into instances"
 msgstr "向实例推送文件"
 
-#: cmd/incus/file.go:868 cmd/incus/file.go:1034
+#: cmd/incus/file.go:870 cmd/incus/file.go:1036
 #, fuzzy, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "正在向 %[2]s 推送 %[1]s: %%s"
@@ -6129,7 +6153,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:436 cmd/incus/file.go:654
+#: cmd/incus/file.go:438 cmd/incus/file.go:656
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "递归传输文件"
@@ -6363,7 +6387,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: cmd/incus/info.go:675
+#: cmd/incus/info.go:686
 msgid "Resources:"
 msgstr ""
 
@@ -6474,17 +6498,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1380
+#: cmd/incus/file.go:1382
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1397
+#: cmd/incus/file.go:1399
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1398
+#: cmd/incus/file.go:1400
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6598,7 +6622,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1162
+#: cmd/incus/file.go:1164
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6811,27 +6835,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: cmd/incus/file.go:142
+#: cmd/incus/file.go:144
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:657
+#: cmd/incus/file.go:659
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: cmd/incus/file.go:144
+#: cmd/incus/file.go:146
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:658
+#: cmd/incus/file.go:660
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: cmd/incus/file.go:143
+#: cmd/incus/file.go:145
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:656
+#: cmd/incus/file.go:658
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6899,7 +6923,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1160
+#: cmd/incus/file.go:1162
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7139,7 +7163,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:786 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
 msgid "Snapshots:"
 msgstr ""
 
@@ -7185,7 +7209,7 @@ msgstr ""
 msgid "Starting recovery..."
 msgstr ""
 
-#: cmd/incus/info.go:743
+#: cmd/incus/info.go:754
 msgid "State"
 msgstr ""
 
@@ -7194,7 +7218,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: cmd/incus/info.go:820
+#: cmd/incus/info.go:831
 msgid "Stateful"
 msgstr ""
 
@@ -7323,11 +7347,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: cmd/incus/info.go:716
+#: cmd/incus/info.go:727
 msgid "Swap (current)"
 msgstr ""
 
-#: cmd/incus/info.go:720
+#: cmd/incus/info.go:731
 msgid "Swap (peak)"
 msgstr ""
 
@@ -7339,7 +7363,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:164
+#: cmd/incus/file.go:166
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7368,16 +7392,16 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:818 cmd/incus/info.go:869 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1199
+#: cmd/incus/file.go:1201
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "目标路径和 --listen 标记不能一起使用"
 
-#: cmd/incus/file.go:1193
+#: cmd/incus/file.go:1195
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7401,7 +7425,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:130
+#: cmd/incus/console.go:134
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7432,7 +7456,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:379
+#: cmd/incus/console.go:383
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7637,7 +7661,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: cmd/incus/file.go:145
+#: cmd/incus/file.go:147
 msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
@@ -7687,7 +7711,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:217
+#: cmd/incus/console.go:221
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7703,7 +7727,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:560
+#: cmd/incus/file.go:562
 msgid "Too many links"
 msgstr ""
 
@@ -7767,7 +7791,7 @@ msgstr ""
 msgid "Try `incus info --show-log %s%s` for more info"
 msgstr ""
 
-#: cmd/incus/info.go:742
+#: cmd/incus/info.go:753
 msgid "Type"
 msgstr ""
 
@@ -7837,7 +7861,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:384
+#: cmd/incus/file.go:386
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7851,7 +7875,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1420
+#: cmd/incus/file.go:1422
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7873,12 +7897,12 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:160
+#: cmd/incus/console.go:164
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:974
+#: cmd/incus/file.go:976
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7888,7 +7912,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:109
+#: cmd/incus/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8054,7 +8078,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: cmd/incus/info.go:891
+#: cmd/incus/info.go:902
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -8124,7 +8148,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: cmd/incus/file.go:73
+#: cmd/incus/file.go:75
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -8590,24 +8614,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:359
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: cmd/incus/file.go:130
+#: cmd/incus/file.go:132
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:307
+#: cmd/incus/file.go:309
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:427
+#: cmd/incus/file.go:429
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1151
+#: cmd/incus/file.go:1153
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -9148,7 +9172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: cmd/incus/file.go:134
+#: cmd/incus/file.go:136
 msgid ""
 "incus file create foo/bar\n"
 "\t   To create a file /bar in the foo instance.\n"
@@ -9156,20 +9180,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1155
+#: cmd/incus/file.go:1157
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:431
+#: cmd/incus/file.go:433
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:650
+#: cmd/incus/file.go:652
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9609,16 +9633,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1309
+#: cmd/incus/file.go:1311
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1268
+#: cmd/incus/file.go:1270
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1221
+#: cmd/incus/file.go:1223
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/shared/api/instance_state.go
+++ b/shared/api/instance_state.go
@@ -65,6 +65,11 @@ type InstanceState struct {
 	//
 	// API extension: instance_state_started_at.
 	StartedAt time.Time `json:"started_at" yaml:"started_at"`
+
+	// OS information.
+	//
+	// API extension: instances_state_os_info.
+	OSInfo *InstanceStateOSInfo `json:"os_info" yaml:"os_info"`
 }
 
 // InstanceStateDisk represents the disk information section of an instance's state.
@@ -219,4 +224,31 @@ type InstanceStateNetworkCounters struct {
 	// Number of inbound packets dropped
 	// Example: 179
 	PacketsDroppedInbound int64 `json:"packets_dropped_inbound" yaml:"packets_dropped_inbound"`
+}
+
+// InstanceStateOSInfo represents the operating system information section of an instance's state.
+//
+// swagger:model
+//
+// API extension: instances_state_os_info.
+type InstanceStateOSInfo struct {
+	// Operating system running in the instance.
+	// Example: Debian GNU/Linux
+	OS string `json:"os" yaml:"os"`
+
+	// Version of the operating system.
+	// Example: 12 (bookworm)
+	OSVersion string `json:"os_version" yaml:"os_version"`
+
+	// Version of the kernel running in the instance.
+	// Example: 6.1.0-25-amd64
+	KernelVersion string `json:"kernel_version" yaml:"kernel_version"`
+
+	// Hostname of the instance.
+	// Example: myhost
+	Hostname string `json:"hostname" yaml:"hostname"`
+
+	// FQDN of the instance.
+	// Example: myhost.mydomain.local
+	FQDN string `json:"fqdn" yaml:"fqdn"`
 }


### PR DESCRIPTION
This adds operating system details to an instance's state. `incus-agent` has been extended to populate this information when running within a VM.

```
$ incus info debian
Name: debian
Status: RUNNING
Type: virtual-machine
Architecture: x86_64
PID: 658181
Created: 2024/09/13 16:13 MDT
Last Used: 2024/09/20 11:59 MDT
Started: 2024/09/20 11:59 MDT

Operating System:
  OS: Debian GNU/Linux
  OS Version: 12 (bookworm)
  Kernel Version: 6.1.0-25-amd64
  Hostname: debian
  FQDN: debian.testing.local

Resources:
  Processes: 16
[snip]
```