### PR TITLE
Don't return an error if console log file doesn't exist

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -9381,6 +9381,11 @@ func (d *qemu) ConsoleLog() (string, error) {
 	// Read and return the complete log for this instance.
 	fullLog, err := os.ReadFile(d.common.ConsoleBufferLogPath())
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// If there's no log file yet, such as right at VM creation, return an empty string.
+			return "", nil
+		}
+
 		return "", err
 	}
 


### PR DESCRIPTION
Right at VM creation, the ring buffer for the console is empty. If you try to access an interactive console, such as by running a command like `incus launch images:ubuntu/24.04 v1 --vm --console`, you'd get an error that the log file doesn't exist when attempting to save off the ring buffer contents prior to switching to the unix socket connection. We shouldn't return an error, but rather an empty string in this case.