### PR TITLE
Allow to use `dns.search` when only IPv4 is enabled

### DIFF
--- a/internal/server/network/driver_ovn.go
+++ b/internal/server/network/driver_ovn.go
@@ -2449,13 +2449,14 @@ func (n *ovn) setup(update bool) error {
 		}
 
 		opts := &networkOVN.OVNDHCPv4Opts{
-			ServerID:   routerIntPortIPv4,
-			ServerMAC:  routerMAC,
-			Router:     routerIntPortIPv4,
-			DomainName: n.getDomainName(),
-			LeaseTime:  time.Duration(time.Hour * 1),
-			MTU:        bridgeMTU,
-			Netmask:    dhcpV4Netmask,
+			ServerID:      routerIntPortIPv4,
+			ServerMAC:     routerMAC,
+			Router:        routerIntPortIPv4,
+			DomainName:    n.getDomainName(),
+			LeaseTime:     time.Duration(time.Hour * 1),
+			MTU:           bridgeMTU,
+			Netmask:       dhcpV4Netmask,
+			DNSSearchList: n.getDNSSearchList(),
 		}
 
 		if uplinkNet != nil {

--- a/internal/server/network/ovn/ovn_nb_actions.go
+++ b/internal/server/network/ovn/ovn_nb_actions.go
@@ -106,6 +106,7 @@ type OVNDHCPv4Opts struct {
 	LeaseTime          time.Duration
 	MTU                uint32
 	Netmask            string
+	DNSSearchList      []string
 }
 
 // OVNDHCPv6Opts IPv6 DHCP option set that can be created (and then applied to a switch port by resulting ID).
@@ -1252,6 +1253,11 @@ func (o *NB) UpdateLogicalSwitchDHCPv4Options(ctx context.Context, switchName OV
 
 	if opts.Router != nil {
 		dhcpOption.Options["router"] = opts.Router.String()
+	}
+
+	if len(opts.DNSSearchList) > 0 {
+		// Special quoting to allow domain names.
+		dhcpOption.Options["domain_search_list"] = fmt.Sprintf(`"%s"`, strings.Join(opts.DNSSearchList, ","))
 	}
 
 	if opts.RecursiveDNSServer != nil {


### PR DESCRIPTION
This PR fixes issue that `dns.search` network configuration was not honored when IPv6 was disabled. 