### PR TITLE
cleanup: Replace use of os.IsNotExist(err) with errors.Is(err, fs.ErrNotExist)

### DIFF
--- a/cmd/incus-agent/exec.go
+++ b/cmd/incus-agent/exec.go
@@ -360,7 +360,7 @@ func (s *execWs) Do(op *operations.Operation) error {
 	if err != nil {
 		exitStatus := -1
 
-		if errors.Is(err, exec.ErrNotFound) || os.IsNotExist(err) {
+		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
 			exitStatus = 127
 		} else if errors.Is(err, fs.ErrPermission) {
 			exitStatus = 126

--- a/cmd/incus-agent/network.go
+++ b/cmd/incus-agent/network.go
@@ -3,6 +3,8 @@ package main
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"net"
 	"os"
 	"path/filepath"
@@ -65,7 +67,7 @@ func reconfigureNetworkInterfaces() {
 	nicDirEntries, err := os.ReadDir(deviceConfig.NICConfigDir)
 	if err != nil {
 		// Abort if configuration folder does not exist (nothing to do), otherwise log and return.
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return
 		}
 

--- a/cmd/incus-simplestreams/main_add.go
+++ b/cmd/incus-simplestreams/main_add.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 	"time"
@@ -291,7 +293,7 @@ func (c *cmdAdd) Run(cmd *cobra.Command, args []string) error {
 
 	body, err = os.ReadFile("streams/v1/images.json")
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 

--- a/cmd/incus-simplestreams/main_remove.go
+++ b/cmd/incus-simplestreams/main_remove.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -39,7 +41,7 @@ func (c *cmdRemove) remove(path string) error {
 	}
 
 	err := os.Remove(path)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 
@@ -97,7 +99,7 @@ func (c *cmdRemove) Run(cmd *cobra.Command, args []string) error {
 				} else if metaEntry.CombinedSha256SquashFs == image.Fingerprint {
 					// Deleting a container image.
 					err = c.remove(version.Items["squashfs"].Path)
-					if err != nil && !os.IsNotExist(err) {
+					if err != nil && !errors.Is(err, fs.ErrNotExist) {
 						return err
 					}
 

--- a/cmd/incus-simplestreams/main_verify.go
+++ b/cmd/incus-simplestreams/main_verify.go
@@ -3,8 +3,10 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -47,7 +49,7 @@ func (c *cmdVerify) Run(cmd *cobra.Command, args []string) error {
 
 	body, err := os.ReadFile("streams/v1/images.json")
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 
@@ -67,7 +69,7 @@ func (c *cmdVerify) Run(cmd *cobra.Command, args []string) error {
 				// Open the data.
 				dataFile, err := os.Open(item.Path)
 				if err != nil {
-					if os.IsNotExist(err) {
+					if errors.Is(err, fs.ErrNotExist) {
 						return fmt.Errorf("Missing image file %q", item.Path)
 					}
 

--- a/cmd/incus/file.go
+++ b/cmd/incus/file.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math/rand"
 	"net"
 	"os"
@@ -451,7 +453,7 @@ func (c *cmdFilePull) Run(cmd *cobra.Command, args []string) error {
 
 	targetIsDir := false
 	sb, err := os.Stat(target)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 

--- a/cmd/incusd/api.go
+++ b/cmd/incusd/api.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -423,10 +425,11 @@ type uiHttpDir struct {
 	http.FileSystem
 }
 
-func (fs uiHttpDir) Open(name string) (http.File, error) {
-	fsFile, err := fs.FileSystem.Open(name)
-	if err != nil && os.IsNotExist(err) {
-		return fs.FileSystem.Open("index.html")
+// Open is part of the http.FileSystem interface.
+func (httpFS uiHttpDir) Open(name string) (http.File, error) {
+	fsFile, err := httpFS.FileSystem.Open(name)
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		return httpFS.FileSystem.Open("index.html")
 	}
 
 	return fsFile, err
@@ -436,10 +439,11 @@ type documentationHttpDir struct {
 	http.FileSystem
 }
 
-func (fs documentationHttpDir) Open(name string) (http.File, error) {
-	fsFile, err := fs.FileSystem.Open(name)
-	if err != nil && os.IsNotExist(err) {
-		return fs.FileSystem.Open("index.html")
+// Open is part of the http.FileSystem interface.
+func (httpFS documentationHttpDir) Open(name string) (http.File, error) {
+	fsFile, err := httpFS.FileSystem.Open(name)
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		return httpFS.FileSystem.Open("index.html")
 	}
 
 	return fsFile, err

--- a/cmd/incusd/images.go
+++ b/cmd/incusd/images.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"math/rand"
 	"mime"
@@ -2623,14 +2624,14 @@ func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Oper
 		// Remove main image file.
 		fname := filepath.Join(s.OS.VarDir, "images", fingerprint)
 		err = os.Remove(fname)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("Error deleting image file %q: %w", fname, err)
 		}
 
 		// Remove the rootfs file for the image.
 		fname = filepath.Join(s.OS.VarDir, "images", fingerprint) + ".rootfs"
 		err = os.Remove(fname)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("Error deleting image file %q: %w", fname, err)
 		}
 
@@ -2856,7 +2857,7 @@ func imageDeleteFromDisk(fingerprint string) {
 	fname := internalUtil.VarPath("images", fingerprint)
 	if util.PathExists(fname) {
 		err := os.Remove(fname)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			logger.Errorf("Error deleting image file %s: %s", fname, err)
 		}
 	}
@@ -2865,7 +2866,7 @@ func imageDeleteFromDisk(fingerprint string) {
 	fname = internalUtil.VarPath("images", fingerprint) + ".rootfs"
 	if util.PathExists(fname) {
 		err := os.Remove(fname)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			logger.Errorf("Error deleting image file %s: %s", fname, err)
 		}
 	}

--- a/cmd/incusd/instances.go
+++ b/cmd/incusd/instances.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -326,12 +328,12 @@ func instancesOnDisk(s *state.State) ([]instance.Instance, error) {
 	instanceTypeNames := make(map[instancetype.Type][]os.DirEntry, 2)
 
 	instanceTypeNames[instancetype.Container], err = os.ReadDir(instancePaths[instancetype.Container])
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 
 	instanceTypeNames[instancetype.VM], err = os.ReadDir(instancePaths[instancetype.VM])
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 

--- a/cmd/incusd/main_forkproxy.go
+++ b/cmd/incusd/main_forkproxy.go
@@ -241,8 +241,10 @@ void forkproxy(void)
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"os"
 	"os/signal"
@@ -453,7 +455,7 @@ func (c *cmdForkproxy) Run(cmd *cobra.Command, args []string) error {
 
 		if lAddr.ConnType == "unix" && !lAddr.Abstract {
 			err := os.Remove(lAddr.Address)
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return err
 			}
 		}

--- a/cmd/lxd-to-incus/main.go
+++ b/cmd/lxd-to-incus/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -575,19 +577,19 @@ Instead this tool will be providing specific commands for each of the servers.`)
 	_, _ = logFile.WriteString("Wiping the target server\n")
 
 	err = os.RemoveAll(targetPaths.logs)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		_, _ = logFile.WriteString(fmt.Sprintf("ERROR: %v\n", err))
 		return fmt.Errorf("Failed to remove %q: %w", targetPaths.logs, err)
 	}
 
 	err = os.RemoveAll(targetPaths.cache)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		_, _ = logFile.WriteString(fmt.Sprintf("ERROR: %v\n", err))
 		return fmt.Errorf("Failed to remove %q: %w", targetPaths.cache, err)
 	}
 
 	err = os.RemoveAll(targetPaths.daemon)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		_, _ = logFile.WriteString(fmt.Sprintf("ERROR: %v\n", err))
 		return fmt.Errorf("Failed to remove %q: %w", targetPaths.daemon, err)
 	}
@@ -713,7 +715,7 @@ Instead this tool will be providing specific commands for each of the servers.`)
 
 		_ = unix.Unmount(filepath.Join(targetPaths.daemon, dir), unix.MNT_DETACH)
 		err = os.RemoveAll(filepath.Join(targetPaths.daemon, dir))
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			_, _ = logFile.WriteString(fmt.Sprintf("ERROR: %v\n", err))
 			return fmt.Errorf("Failed to delete %q: %w", dir, err)
 		}
@@ -722,7 +724,7 @@ Instead this tool will be providing specific commands for each of the servers.`)
 	for _, dir := range []string{"containers", "containers-snapshots", "snapshots", "virtual-machines", "virtual-machines-snapshots"} {
 		entries, err := os.ReadDir(filepath.Join(targetPaths.daemon, dir))
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 

--- a/internal/server/apparmor/apparmor.go
+++ b/internal/server/apparmor/apparmor.go
@@ -2,8 +2,10 @@ package apparmor
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,7 +116,7 @@ func deleteNamespace(sysOS *sys.OS, name string) error {
 
 	p := filepath.Join("/sys/kernel/security/apparmor/policy/namespaces", name)
 	err := os.Remove(p)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 
@@ -195,12 +197,12 @@ func deleteProfile(sysOS *sys.OS, fullName string, name string) error {
 	}
 
 	err = os.Remove(filepath.Join(aaCacheDir, name))
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to remove %s: %w", filepath.Join(aaCacheDir, name), err)
 	}
 
 	err = os.Remove(filepath.Join(aaPath, "profiles", name))
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to remove %s: %w", filepath.Join(aaPath, "profiles", name), err)
 	}
 

--- a/internal/server/apparmor/instance.go
+++ b/internal/server/apparmor/instance.go
@@ -1,7 +1,9 @@
 package apparmor
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,7 +125,7 @@ func instanceProfileGenerate(sysOS *sys.OS, inst instance, extraBinaries []strin
 	 */
 	profile := filepath.Join(aaPath, "profiles", instanceProfileFilename(inst))
 	content, err := os.ReadFile(profile)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 

--- a/internal/server/apparmor/instance_forkproxy.go
+++ b/internal/server/apparmor/instance_forkproxy.go
@@ -1,7 +1,9 @@
 package apparmor
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -170,7 +172,7 @@ func ForkproxyLoad(sysOS *sys.OS, inst instance, dev device) error {
 	 */
 	profile := filepath.Join(aaPath, "profiles", forkproxyProfileFilename(inst, dev))
 	content, err := os.ReadFile(profile)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 

--- a/internal/server/apparmor/network.go
+++ b/internal/server/apparmor/network.go
@@ -1,6 +1,8 @@
 package apparmor
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -30,7 +32,7 @@ func NetworkLoad(sysOS *sys.OS, n network) error {
 	// dnsmasq
 	profile := filepath.Join(aaPath, "profiles", dnsmasqProfileFilename(n))
 	content, err := os.ReadFile(profile)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 

--- a/internal/server/apparmor/qemuimg.go
+++ b/internal/server/apparmor/qemuimg.go
@@ -3,8 +3,10 @@ package apparmor
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -153,7 +155,7 @@ func qemuImgProfileLoad(sysOS *sys.OS, imgPath string, dstPath string, allowedCm
 	profileName := profileName("qemu-img", name)
 	profilePath := filepath.Join(aaPath, "profiles", profileName)
 	content, err := os.ReadFile(profilePath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return "", err
 	}
 

--- a/internal/server/cgroup/abstraction.go
+++ b/internal/server/cgroup/abstraction.go
@@ -3,7 +3,9 @@ package cgroup
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"slices"
 	"strconv"
@@ -762,7 +764,7 @@ func (cg *CGroup) SetHugepagesLimit(pageType string, limit int64) error {
 
 		// Apply the reserved limit.
 		err = cg.rw.Set(version, "hugetlb", fmt.Sprintf("hugetlb.%s.rsvd.limit_in_bytes", pageType), fmt.Sprintf("%d", limit))
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 
@@ -777,7 +779,7 @@ func (cg *CGroup) SetHugepagesLimit(pageType string, limit int64) error {
 
 			// Apply the reserved limit.
 			err = cg.rw.Set(version, "hugetlb", fmt.Sprintf("hugetlb.%s.rsvd.max", pageType), "max")
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return err
 			}
 
@@ -792,7 +794,7 @@ func (cg *CGroup) SetHugepagesLimit(pageType string, limit int64) error {
 
 		// Apply the reserved limit.
 		err = cg.rw.Set(version, "hugetlb", fmt.Sprintf("hugetlb.%s.rsvd.max", pageType), fmt.Sprintf("%d", limit))
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 

--- a/internal/server/cgroup/init.go
+++ b/internal/server/cgroup/init.go
@@ -2,6 +2,8 @@ package cgroup
 
 import (
 	"bufio"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -331,7 +333,7 @@ func Init() {
 	// Go through the list of resource controllers for Incus.
 	selfCg, err := os.Open("/proc/self/cgroup")
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			logger.Warnf("System doesn't appear to support CGroups")
 		} else {
 			logger.Errorf("Unable to load list of cgroups: %v", err)
@@ -370,14 +372,14 @@ func Init() {
 
 		controllers, err := os.Open(hybridPath)
 		if err != nil {
-			if !os.IsNotExist(err) {
+			if !errors.Is(err, fs.ErrNotExist) {
 				logger.Errorf("Unable to load cgroup.controllers")
 				return
 			}
 
 			dedicatedPath = filepath.Join(cgPath, "cgroup.controllers")
 			controllers, err = os.Open(dedicatedPath)
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				logger.Errorf("Unable to load cgroup.controllers")
 				return
 			}

--- a/internal/server/cluster/upgrade_test.go
+++ b/internal/server/cluster/upgrade_test.go
@@ -3,7 +3,9 @@ package cluster_test
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -138,7 +140,7 @@ func TestMaybeUpdate_NothingToDo(t *testing.T) {
 	_ = cluster.MaybeUpdate(state)
 
 	_, err = os.Stat(stamp)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
 func TestUpgradeMembersWithoutRole(t *testing.T) {

--- a/internal/server/db/cluster/open_test.go
+++ b/internal/server/db/cluster/open_test.go
@@ -3,7 +3,9 @@ package cluster_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -199,7 +201,7 @@ func newDir(t *testing.T) (string, func()) {
 	cleanup := func() {
 		_, err := os.Stat(dir)
 		if err != nil {
-			assert.True(t, os.IsNotExist(err))
+			assert.True(t, errors.Is(err, fs.ErrNotExist))
 		} else {
 			assert.NoError(t, os.RemoveAll(dir))
 		}

--- a/internal/server/db/testing.go
+++ b/internal/server/db/testing.go
@@ -4,7 +4,9 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"path/filepath"
@@ -144,7 +146,7 @@ func newDir(t *testing.T) (string, func()) {
 	cleanup := func() {
 		_, err := os.Stat(dir)
 		if err != nil {
-			assert.True(t, os.IsNotExist(err))
+			assert.True(t, errors.Is(err, fs.ErrNotExist))
 		} else {
 			assert.NoError(t, os.RemoveAll(dir))
 		}

--- a/internal/server/device/device_utils_unix.go
+++ b/internal/server/device/device_utils_unix.go
@@ -1,7 +1,9 @@
 package device
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -266,7 +268,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 	// Load all existing host devices.
 	dents, err := os.ReadDir(devicesPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 	}
@@ -384,7 +386,7 @@ func unixDeviceRemove(devicesPath string, typePrefix string, deviceName string, 
 	// Load all devices.
 	dents, err := os.ReadDir(devicesPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 	}
@@ -490,7 +492,7 @@ func unixDeviceDeleteFiles(s *state.State, devicesPath string, typePrefix string
 	// Load all devices.
 	dents, err := os.ReadDir(devicesPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 	}

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"os/exec"
@@ -678,7 +679,7 @@ func (d *disk) validateEnvironmentSourcePath() error {
 	// safely later).
 	_, err := os.Lstat(sourceHostPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return diskSourceNotFoundError{msg: fmt.Sprintf("Missing source path %q", d.config["source"])}
 		}
 

--- a/internal/server/device/gpu_mdev.go
+++ b/internal/server/device/gpu_mdev.go
@@ -1,7 +1,9 @@
 package device
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -128,7 +130,7 @@ func (d *gpuMdev) startVM() (*deviceConfig.RunConfig, error) {
 
 			err = os.WriteFile(filepath.Join(fmt.Sprintf("/sys/bus/pci/devices/%s/mdev_supported_types/%s/create", pciAddress, d.config["mdev"])), []byte(mdevUUID), 0200)
 			if err != nil {
-				if os.IsNotExist(err) {
+				if errors.Is(err, fs.ErrNotExist) {
 					return nil, fmt.Errorf("The requested profile %q does not exist", d.config["mdev"])
 				}
 

--- a/internal/server/device/gpu_physical.go
+++ b/internal/server/device/gpu_physical.go
@@ -1,7 +1,9 @@
 package device
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -419,7 +421,7 @@ func (d *gpuPhysical) deviceNumStringToUint32(devNum string) (uint32, uint32, er
 func (d *gpuPhysical) getNvidiaNonCardDevices() ([]nvidiaNonCardDevice, error) {
 	nvidiaEnts, err := os.ReadDir("/dev")
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, err
 		}
 	}

--- a/internal/server/device/nic_macvlan.go
+++ b/internal/server/device/nic_macvlan.go
@@ -1,10 +1,11 @@
 package device
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
-	"os"
 	"strconv"
 
 	"github.com/lxc/incus/v6/internal/revert"
@@ -231,7 +232,7 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 	if d.inst.Type() == instancetype.VM {
 		// Disable IPv6 on host interface to avoid getting IPv6 link-local addresses unnecessarily.
 		err = localUtil.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/disable_ipv6", link.Name), "1")
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("Failed to disable IPv6 on host interface %q: %w", link.Name, err)
 		}
 	}

--- a/internal/server/device/nic_ovn.go
+++ b/internal/server/device/nic_ovn.go
@@ -3,7 +3,9 @@ package device
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
 	"os"
@@ -1208,7 +1210,7 @@ func (d *nicOVN) setupHostNIC(hostName string, ovnPortName ovn.OVNSwitchPort) (r
 	// Disable IPv6 on host-side veth interface (prevents host-side interface getting link-local address and
 	// accepting router advertisements) as not needed because the host-side interface is connected to a bridge.
 	err := localUtil.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/disable_ipv6", hostName), "1")
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 

--- a/internal/server/device/nic_p2p.go
+++ b/internal/server/device/nic_p2p.go
@@ -1,8 +1,9 @@
 package device
 
 import (
+	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 
 	"github.com/lxc/incus/v6/internal/revert"
 	deviceConfig "github.com/lxc/incus/v6/internal/server/device/config"
@@ -117,7 +118,7 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 
 	// Attempt to disable router advertisement acceptance.
 	err = localUtil.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", saveData["host_name"]), "0")
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 

--- a/internal/server/device/nic_routed.go
+++ b/internal/server/device/nic_routed.go
@@ -2,9 +2,10 @@ package device
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
-	"os"
 	"strings"
 	"time"
 
@@ -354,13 +355,13 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 
 	// Attempt to disable IPv6 router advertisement acceptance from instance.
 	err = localUtil.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", saveData["host_name"]), "0")
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 
 	// Prevent source address spoofing by requiring a return path.
 	err = localUtil.SysctlSet(fmt.Sprintf("net/ipv4/conf/%s/rp_filter", saveData["host_name"]), "1")
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 

--- a/internal/server/device/unix_common.go
+++ b/internal/server/device/unix_common.go
@@ -1,8 +1,9 @@
 package device
 
 import (
+	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -168,7 +169,7 @@ func (d *unixCommon) Register() error {
 			// Get the file type and ensure it matches what the user was expecting.
 			dType, _, _, err := unixDeviceAttributes(e.Path)
 			if err != nil {
-				if os.IsNotExist(err) {
+				if errors.Is(err, fs.ErrNotExist) {
 					// Skip if host side source device doesn't exist.
 					// This could be an event for the parent directory being added.
 					return nil, nil

--- a/internal/server/device/usb.go
+++ b/internal/server/device/usb.go
@@ -1,7 +1,9 @@
 package device
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"strings"
@@ -303,7 +305,7 @@ func (d *usb) loadUsb() ([]USBEvent, error) {
 	if err != nil {
 		/* if there are no USB devices, let's render an empty list,
 		 * i.e. no usb devices */
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return result, nil
 		}
 
@@ -313,7 +315,7 @@ func (d *usb) loadUsb() ([]USBEvent, error) {
 	for _, ent := range ents {
 		values, err := d.loadRawValues(path.Join(usbDevPath, ent.Name()))
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 
@@ -339,7 +341,7 @@ func (d *usb) loadUsb() ([]USBEvent, error) {
 			0,
 		)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 
@@ -365,7 +367,7 @@ func (d *usb) loadRawValues(p string) (map[string]string, error) {
 	for k := range values {
 		v, err := os.ReadFile(path.Join(p, k))
 		if err != nil {
-			if k == "serial" && os.IsNotExist(err) {
+			if k == "serial" && errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 

--- a/internal/server/dnsmasq/dhcpalloc/dhcpalloc.go
+++ b/internal/server/dnsmasq/dhcpalloc/dhcpalloc.go
@@ -5,10 +5,10 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io/fs"
 	"math"
 	"math/big"
 	"net"
-	"os"
 
 	"github.com/mdlayher/netx/eui64"
 
@@ -346,7 +346,7 @@ func AllocateTask(opts *Options, f func(*Transaction) error) error {
 	// Read current static IP allocation configured from dnsmasq host config (if exists).
 	deviceStaticFileName := dnsmasq.StaticAllocationFileName(opts.ProjectName, opts.HostName, opts.DeviceName)
 	t.currentDHCPMAC, t.currentDHCPv4, t.currentDHCPv6, err = dnsmasq.DHCPStaticAllocation(opts.Network.Name(), deviceStaticFileName)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 

--- a/internal/server/dnsmasq/dnsmasq.go
+++ b/internal/server/dnsmasq/dnsmasq.go
@@ -2,7 +2,9 @@ package dnsmasq
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"strings"
@@ -64,7 +66,7 @@ func UpdateStaticEntry(network string, projectName string, instanceName string, 
 func RemoveStaticEntry(network string, projectName string, instanceName string, deviceName string) error {
 	deviceStaticFileName := StaticAllocationFileName(projectName, instanceName, deviceName)
 	err := os.Remove(internalUtil.VarPath("networks", network, "dnsmasq.hosts", deviceStaticFileName))
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 
@@ -189,7 +191,7 @@ func DHCPAllAllocations(network string) (map[[4]byte]DHCPAllocation, map[[16]byt
 
 	// First read all statically allocated IPs.
 	files, err := os.ReadDir(internalUtil.VarPath("networks", network, "dnsmasq.hosts"))
-	if err != nil && os.IsNotExist(err) {
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		return nil, nil, err
 	}
 

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -2022,7 +2022,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	if util.PathExists(logfile) {
 		_ = os.Remove(logfile + ".old")
 		err := os.Rename(logfile, logfile+".old")
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return "", nil, err
 		}
 	}
@@ -3955,7 +3955,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 
 		// Remove the state from the parent container; we only keep this in snapshots.
 		err2 := os.RemoveAll(d.StatePath())
-		if err2 != nil && !os.IsNotExist(err) {
+		if err2 != nil && !errors.Is(err, fs.ErrNotExist) {
 			op.Done(err)
 			return err
 		}
@@ -5088,7 +5088,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	}
 
 	err = d.UpdateBackupFile()
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to write backup file: %w", err)
 	}
 

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -1223,7 +1223,7 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 		if util.PathExists(logfile) {
 			_ = os.Remove(logfile + ".old")
 			err := os.Rename(logfile, logfile+".old")
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				op.Done(err)
 				return err
 			}
@@ -1596,7 +1596,7 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 	} else if d.stateful {
 		// Stateless start requested but state is present, delete it.
 		err := os.Remove(d.StatePath())
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			op.Done(err)
 			return err
 		}
@@ -2112,7 +2112,7 @@ func (d *qemu) setupNvram() error {
 	// Cleanup existing variables.
 	for _, firmwarePair := range edk2.GetAchitectureFirmwarePairs(d.architecture) {
 		err := os.Remove(filepath.Join(d.Path(), filepath.Base(firmwarePair.Vars)))
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 	}
@@ -4886,7 +4886,7 @@ func (d *qemu) pidFilePath() string {
 // pid gets the PID of the running qemu process. Returns 0 if PID file or process not found, and -1 if err non-nil.
 func (d *qemu) pid() (int, error) {
 	pidStr, err := os.ReadFile(d.pidFilePath())
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return 0, nil // PID file has gone.
 	}
 
@@ -5917,7 +5917,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	}
 
 	err = d.UpdateBackupFile()
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to write backup file: %w", err)
 	}
 
@@ -8918,7 +8918,7 @@ func (d *qemu) checkFeatures(hostArch int, qemuPath string) (map[string]any, err
 
 		// Check if SEV/SEV-ES are enabled
 		sev, err := os.ReadFile("/sys/module/kvm_amd/parameters/sev")
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return nil, err
 		} else if strings.TrimSpace(string(sev)) == "Y" {
 			// Host supports SEV, check if QEMU supports it as well.

--- a/internal/server/instance/drivers/util.go
+++ b/internal/server/instance/drivers/util.go
@@ -3,7 +3,9 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"slices"
 
@@ -42,7 +44,7 @@ func GetClusterCPUFlags(ctx context.Context, s *state.State, servers []string, a
 
 		data, err := os.ReadFile(resourcesPath)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
 	"os"
@@ -1155,7 +1156,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 
 				// If IPv6 router acceptance is enabled (set to 1) then we now set it to 2.
 				err = localUtil.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/accept_ra", entry.Name()), "2")
-				if err != nil && !os.IsNotExist(err) {
+				if err != nil && !errors.Is(err, fs.ErrNotExist) {
 					return err
 				}
 			}
@@ -1163,7 +1164,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 			// Then set forwarding for all of them.
 			for _, entry := range entries {
 				err = localUtil.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/forwarding", entry.Name()), "1")
-				if err != nil && !os.IsNotExist(err) {
+				if err != nil && !errors.Is(err, fs.ErrNotExist) {
 					return err
 				}
 			}

--- a/internal/server/network/network_utils.go
+++ b/internal/server/network/network_utils.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	cryptoRand "crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io/fs"
 	"math/big"
 	"math/rand"
 	"net"
@@ -469,7 +471,7 @@ func UpdateDNSMasqStatic(s *state.State, networkName string) error {
 			if (util.IsTrue(d["security.ipv4_filtering"]) && d["ipv4.address"] == "") || (util.IsTrue(d["security.ipv6_filtering"]) && d["ipv6.address"] == "") {
 				deviceStaticFileName := dnsmasq.StaticAllocationFileName(inst.Project().Name, inst.Name(), deviceName)
 				_, curIPv4, curIPv6, err := dnsmasq.DHCPStaticAllocation(d["parent"], deviceStaticFileName)
-				if err != nil && !os.IsNotExist(err) {
+				if err != nil && !errors.Is(err, fs.ErrNotExist) {
 					return err
 				}
 

--- a/internal/server/resources/cpu.go
+++ b/internal/server/resources/cpu.go
@@ -2,7 +2,9 @@ package resources
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -136,7 +138,7 @@ func getCPUCache(path string) ([]api.ResourcesCPUCache, error) {
 		// Get the cache size
 		content, err := os.ReadFile(filepath.Join(entryPath, "size"))
 		if err != nil {
-			if !os.IsNotExist(err) {
+			if !errors.Is(err, fs.ErrNotExist) {
 				return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "size"), err)
 			}
 		} else {
@@ -160,7 +162,7 @@ func getCPUCache(path string) ([]api.ResourcesCPUCache, error) {
 		// Get the cache type
 		cacheType, err := os.ReadFile(filepath.Join(entryPath, "type"))
 		if err != nil {
-			if !os.IsNotExist(err) {
+			if !errors.Is(err, fs.ErrNotExist) {
 				return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "type"), err)
 			}
 		} else {
@@ -267,17 +269,17 @@ func GetCPU() (*api.ResourcesCPU, error) {
 
 		// Get topology
 		cpuSocket, err := readInt(filepath.Join(entryPath, "topology", "physical_package_id"))
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "topology", "physical_package_id"), err)
 		}
 
 		cpuCore, err := readInt(filepath.Join(entryPath, "topology", "core_id"))
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "topology", "core_id"), err)
 		}
 
 		cpuDie, err := readInt(filepath.Join(entryPath, "topology", "die_id"))
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("Failed to read %q: %w", filepath.Join(entryPath, "topology", "die_id"), err)
 		}
 

--- a/internal/server/resources/network.go
+++ b/internal/server/resources/network.go
@@ -1,7 +1,9 @@
 package resources
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
 	"os"
@@ -713,7 +715,7 @@ func GetNetworkCounters(name string) (*api.NetworkStateCounters, error) {
 	// Get counters
 	content, err := os.ReadFile("/proc/net/dev")
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return &counters, nil
 		}
 

--- a/internal/server/resources/storage.go
+++ b/internal/server/resources/storage.go
@@ -2,7 +2,9 @@ package resources
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -165,7 +167,7 @@ func GetStorage() (*api.ResourcesStorage, error) {
 			// Device node
 			diskDev, err := os.ReadFile(filepath.Join(entryPath, "dev"))
 			if err != nil {
-				if os.IsNotExist(err) {
+				if errors.Is(err, fs.ErrNotExist) {
 					// This happens on multipath devices, just skip as we only care about the main node.
 					continue
 				}

--- a/internal/server/resources/utils.go
+++ b/internal/server/resources/utils.go
@@ -2,7 +2,9 @@ package resources
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -206,7 +208,7 @@ func getDeviceDir(devicePath string) (string, error) {
 	for {
 		deviceDir := filepath.Join(devicePath, "device")
 		fileInfo, err := os.Stat(deviceDir)
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			break
 		} else if err != nil {
 			return "", fmt.Errorf("Unable to get file info for %q: %w", deviceDir, err)

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -404,7 +404,7 @@ func (b *backend) Delete(clientType request.ClientType, op *operations.Operation
 
 	// Delete the mountpoint.
 	err = os.Remove(path)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to remove directory %q: %w", path, err)
 	}
 

--- a/internal/server/storage/drivers/driver_btrfs.go
+++ b/internal/server/storage/drivers/driver_btrfs.go
@@ -1,7 +1,9 @@
 package drivers
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -236,7 +238,7 @@ func (d *btrfs) Create() error {
 
 				// Delete the current directory to replace by subvolume.
 				err := os.Remove(cleanSource)
-				if err != nil && !os.IsNotExist(err) {
+				if err != nil && !errors.Is(err, fs.ErrNotExist) {
 					return fmt.Errorf("Failed to remove %q: %w", cleanSource, err)
 				}
 			}
@@ -311,7 +313,7 @@ func (d *btrfs) Delete(op *operations.Operation) error {
 	// Delete any loop file we may have used.
 	loopPath := loopFilePath(d.name)
 	err = os.Remove(loopPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed removing loop file %q: %w", loopPath, err)
 	}
 

--- a/internal/server/storage/drivers/driver_ceph_utils.go
+++ b/internal/server/storage/drivers/driver_ceph_utils.go
@@ -2,8 +2,10 @@ package drivers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"os/exec"
@@ -1065,7 +1067,7 @@ func (d *ceph) parseClone(clone string) (string, string, string, bool, error) {
 func (d *ceph) getRBDMappedDevPath(vol Volume, mapIfMissing bool) (bool, string, error) {
 	// List all RBD devices.
 	files, err := os.ReadDir("/sys/devices/rbd")
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return false, "", err
 	}
 
@@ -1088,7 +1090,7 @@ func (d *ceph) getRBDMappedDevPath(vol Volume, mapIfMissing bool) (bool, string,
 		devPoolName, err := os.ReadFile(fmt.Sprintf("/sys/devices/rbd/%s/pool", fName))
 		if err != nil {
 			// Skip if no pool file.
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 
@@ -1104,7 +1106,7 @@ func (d *ceph) getRBDMappedDevPath(vol Volume, mapIfMissing bool) (bool, string,
 		devName, err := os.ReadFile(fmt.Sprintf("/sys/devices/rbd/%s/name", fName))
 		if err != nil {
 			// Skip if no name file.
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 
@@ -1123,7 +1125,7 @@ func (d *ceph) getRBDMappedDevPath(vol Volume, mapIfMissing bool) (bool, string,
 
 		// Get the snapshot name for the RBD device (if exists).
 		devSnap, err := os.ReadFile(fmt.Sprintf("/sys/devices/rbd/%s/current_snap", fName))
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return false, "", err
 		}
 

--- a/internal/server/storage/drivers/driver_ceph_volumes.go
+++ b/internal/server/storage/drivers/driver_ceph_volumes.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"strings"
@@ -749,7 +751,7 @@ func (d *ceph) DeleteVolume(vol Volume, op *operations.Operation) error {
 		}
 
 		err = os.Remove(mountPath)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("Failed to remove '%s': %w", mountPath, err)
 		}
 	}
@@ -1561,7 +1563,7 @@ func (d *ceph) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 		}
 
 		err = os.Remove(mountPath)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("Failed to remove '%s': %w", mountPath, err)
 		}
 	}

--- a/internal/server/storage/drivers/driver_cephfs.go
+++ b/internal/server/storage/drivers/driver_cephfs.go
@@ -1,7 +1,9 @@
 package drivers
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -350,7 +352,7 @@ func (d *cephfs) Delete(op *operations.Operation) error {
 		// Delete the path itself.
 		if fsPath != "" && fsPath != "/" {
 			err = os.Remove(filepath.Join(mountPoint, fsPath))
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("Failed to remove directory '%s': %w", filepath.Join(mountPoint, fsPath), err)
 			}
 		}

--- a/internal/server/storage/drivers/driver_cephfs_volumes.go
+++ b/internal/server/storage/drivers/driver_cephfs_volumes.go
@@ -1,8 +1,10 @@
 package drivers
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -261,7 +263,7 @@ func (d *cephfs) DeleteVolume(vol Volume, op *operations.Operation) error {
 
 	// Remove the volume from the storage device.
 	err = os.RemoveAll(volPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to delete '%s': %w", volPath, err)
 	}
 
@@ -270,7 +272,7 @@ func (d *cephfs) DeleteVolume(vol Volume, op *operations.Operation) error {
 	snapshotDir := GetVolumeSnapshotDir(d.name, vol.volType, vol.name)
 
 	err = os.RemoveAll(snapshotDir)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to delete '%s': %w", snapshotDir, err)
 	}
 
@@ -522,14 +524,14 @@ func (d *cephfs) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) 
 	cephSnapPath := filepath.Join(sourcePath, ".snap", snapName)
 
 	err := os.Remove(cephSnapPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to remove '%s': %w", cephSnapPath, err)
 	}
 
 	// Remove the symlink.
 	snapPath := snapVol.MountPath()
 	err = os.Remove(snapPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to remove '%s': %w", snapPath, err)
 	}
 
@@ -602,7 +604,7 @@ func (d *cephfs) RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op
 	// Re-generate the snapshot symlink.
 	oldPath := snapVol.MountPath()
 	err = os.Remove(oldPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to remove '%s': %w", oldPath, err)
 	}
 

--- a/internal/server/storage/drivers/driver_dir_volumes.go
+++ b/internal/server/storage/drivers/driver_dir_volumes.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -198,7 +199,7 @@ func (d *dir) DeleteVolume(vol Volume, op *operations.Operation) error {
 
 	// Remove the volume from the storage device.
 	err = forceRemoveAll(volPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to remove '%s': %w", volPath, err)
 	}
 
@@ -493,7 +494,7 @@ func (d *dir) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 
 	// Remove the snapshot from the storage device.
 	err := forceRemoveAll(snapPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to remove '%s': %w", snapPath, err)
 	}
 

--- a/internal/server/storage/drivers/driver_lvm.go
+++ b/internal/server/storage/drivers/driver_lvm.go
@@ -1,7 +1,9 @@
 package drivers
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"os/exec"
@@ -548,7 +550,7 @@ func (d *lvm) Delete(op *operations.Operation) error {
 
 		// This is a loop file so deconfigure the associated loop device.
 		err = os.Remove(d.config["source"])
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("Error removing LVM pool loop file %q: %w", d.config["source"], err)
 		}
 

--- a/internal/server/storage/drivers/driver_lvm_volumes.go
+++ b/internal/server/storage/drivers/driver_lvm_volumes.go
@@ -2,8 +2,10 @@ package drivers
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"os/exec"
@@ -227,7 +229,7 @@ func (d *lvm) DeleteVolume(vol Volume, op *operations.Operation) error {
 		// Remove the volume from the storage device.
 		mountPath := vol.MountPath()
 		err = os.RemoveAll(mountPath)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("Error removing LVM logical volume mount path %q: %w", mountPath, err)
 		}
 
@@ -1021,7 +1023,7 @@ func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	// Remove the snapshot mount path from the storage device.
 	snapPath := snapVol.MountPath()
 	err = os.RemoveAll(snapPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Error removing LVM snapshot mount path %q: %w", snapPath, err)
 	}
 

--- a/internal/server/storage/drivers/driver_zfs.go
+++ b/internal/server/storage/drivers/driver_zfs.go
@@ -1,7 +1,9 @@
 package drivers
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -452,7 +454,7 @@ func (d *zfs) Delete(op *operations.Operation) error {
 	// Delete any loop file we may have used
 	loopPath := loopFilePath(d.name)
 	err = os.Remove(loopPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to remove '%s': %w", loopPath, err)
 	}
 

--- a/internal/server/storage/drivers/driver_zfs_volumes.go
+++ b/internal/server/storage/drivers/driver_zfs_volumes.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1533,13 +1534,13 @@ func (d *zfs) deleteVolume(vol Volume, op *operations.Operation) error {
 	if vol.contentType == ContentTypeFS {
 		// Delete the mountpoint if present.
 		err := os.Remove(vol.MountPath())
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("Failed to remove '%s': %w", vol.MountPath(), err)
 		}
 
 		// Delete the snapshot storage.
 		err = os.RemoveAll(GetVolumeSnapshotDir(d.name, vol.volType, vol.name))
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("Failed to remove '%s': %w", GetVolumeSnapshotDir(d.name, vol.volType, vol.name), err)
 		}
 	}
@@ -2942,7 +2943,7 @@ func (d *zfs) DeleteVolumeSnapshot(vol Volume, op *operations.Operation) error {
 
 	// Delete the mountpoint.
 	err = os.Remove(vol.MountPath())
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("Failed to remove '%s': %w", vol.MountPath(), err)
 	}
 

--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -2,8 +2,10 @@ package drivers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,7 +107,7 @@ func genericVFSVolumeSnapshots(d Driver, vol Volume, op *operations.Operation) (
 	ents, err := os.ReadDir(snapshotDir)
 	if err != nil {
 		// If the snapshots directory doesn't exist, there are no snapshots.
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return snapshots, nil
 		}
 
@@ -453,7 +455,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 func genericVFSHasVolume(vol Volume) (bool, error) {
 	_, err := os.Lstat(vol.MountPath())
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}
 
@@ -591,7 +593,7 @@ func genericVFSBackupVolume(d Driver, vol Volume, tarWriter *instancewriter.Inst
 
 				return filepath.Walk(mountPath, func(srcPath string, fi os.FileInfo, err error) error {
 					if err != nil {
-						if os.IsNotExist(err) {
+						if errors.Is(err, fs.ErrNotExist) {
 							logger.Warnf("File vanished during export: %q, skipping", srcPath)
 							return nil
 						}

--- a/internal/server/storage/drivers/utils.go
+++ b/internal/server/storage/drivers/utils.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -36,7 +37,7 @@ func wipeDirectory(path string) error {
 	// List all entries.
 	entries, err := os.ReadDir(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 
@@ -47,7 +48,7 @@ func wipeDirectory(path string) error {
 	for _, entry := range entries {
 		entryPath := filepath.Join(path, entry.Name())
 		err := os.RemoveAll(entryPath)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("Failed removing %q: %w", entryPath, err)
 		}
 	}
@@ -293,7 +294,7 @@ func deleteParentSnapshotDirIfEmpty(poolName string, volType VolumeType, volName
 
 		if isEmpty {
 			err := os.Remove(snapshotsPath)
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("Failed to remove '%s': %w", snapshotsPath, err)
 			}
 		}

--- a/internal/server/storage/quota/projectquota.go
+++ b/internal/server/storage/quota/projectquota.go
@@ -158,7 +158,9 @@ import "C"
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -242,7 +244,7 @@ func GetProject(path string) (uint32, error) {
 func SetProject(path string, id uint32) error {
 	err := filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				return nil
 			}
 

--- a/internal/server/storage/utils.go
+++ b/internal/server/storage/utils.go
@@ -3,7 +3,9 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -616,7 +618,7 @@ func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, sys
 
 	// Validate the target.
 	fileInfo, err := os.Stat(destBlockFile)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return -1, err
 	}
 

--- a/internal/server/sys/fs.go
+++ b/internal/server/sys/fs.go
@@ -3,7 +3,9 @@
 package sys
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
@@ -68,7 +70,7 @@ func (s *OS) initDirs() error {
 			}
 
 			err = os.Chmod(dir.path, dir.mode)
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("Failed to chmod dir %q: %w", dir.path, err)
 			}
 		}
@@ -95,7 +97,7 @@ func (s *OS) initStorageDirs() error {
 			}
 
 			err = os.Chmod(dir.path, dir.mode)
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("Failed to chmod storage dir %q: %w", dir.path, err)
 			}
 		}

--- a/internal/usbid/load.go
+++ b/internal/usbid/load.go
@@ -16,6 +16,8 @@
 package usbid
 
 import (
+	"errors"
+	"io/fs"
 	"log"
 	"os"
 )
@@ -37,7 +39,7 @@ func Load() {
 
 	usbids, err := os.Open(usbidFile)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			log.Printf("usbid: failed to load: %s", err)
 		}
 

--- a/shared/osarch/release.go
+++ b/shared/osarch/release.go
@@ -1,7 +1,9 @@
 package osarch
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 )
@@ -9,7 +11,7 @@ import (
 // GetLSBRelease returns a map with Linux distribution information.
 func GetLSBRelease() (map[string]string, error) {
 	osRelease, err := getLSBRelease("/etc/os-release")
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return getLSBRelease("/usr/lib/os-release")
 	}
 
@@ -21,7 +23,7 @@ func getLSBRelease(filename string) (map[string]string, error) {
 
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return osRelease, nil
 		}
 

--- a/shared/util/filesystem.go
+++ b/shared/util/filesystem.go
@@ -1,12 +1,14 @@
 package util
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 )
 
 func PathExists(name string) bool {
 	_, err := os.Lstat(name)
-	if err != nil && os.IsNotExist(err) {
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		return false
 	}
 


### PR DESCRIPTION
`os.IsNotExist(err)`  is [deprecated](https://pkg.go.dev/os#IsNotExist) in favor of `errors.Is(err, fs.ErrNotExist)`.