### PR TITLE
cmd/incus-migrate: Don't copy converted VM image

### DIFF
--- a/cmd/incus-migrate/transfer.go
+++ b/cmd/incus-migrate/transfer.go
@@ -88,7 +88,7 @@ func rsyncSendSetup(ctx context.Context, path string, rsyncArgs string, instance
 	}
 
 	if instanceType == api.InstanceTypeVM {
-		args = append(args, "--exclude", "root.img")
+		args = append(args, "--exclude", "*.img")
 	}
 
 	if rsync.AtLeast("3.1.3") {


### PR DESCRIPTION
If we convert a VM disk image when importing it, we shouldn't then copy that temporary image to the final storage location.