### PR TITLE
VM console log fixes

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -9346,7 +9346,7 @@ func (d *qemu) postCPUHotplug(monitor *qmp.Monitor) error {
 // ConsoleLog returns all output sent to the instance's console's ring buffer since startup.
 func (d *qemu) ConsoleLog() (string, error) {
 	// Setup a new operation.
-	op, err := operationlock.Create(d.Project().Name, d.Name(), d.op, operationlock.ActionConsoleRetrieve, false, false)
+	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), d.op, operationlock.ActionConsoleRetrieve, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore, operationlock.ActionMigrate}, false, true)
 	if err != nil {
 		return "", err
 	}

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -9361,6 +9361,13 @@ func (d *qemu) ConsoleLog() (string, error) {
 
 	logString, err := monitor.RingbufRead("console")
 	if err != nil {
+		// If a VM was started by an older version of Incus which was then upgraded, its
+		// console device won't be a ring buffer. We don't want to cause an error in this
+		// case, so just return an empty string.
+		if errors.Is(err, qmp.ErrNotARingbuf) {
+			return "", nil
+		}
+
 		return "", err
 	}
 

--- a/internal/server/instance/drivers/qmp/errors.go
+++ b/internal/server/instance/drivers/qmp/errors.go
@@ -7,5 +7,8 @@ import (
 // ErrMonitorDisconnect is returned when interacting with a disconnected Monitor.
 var ErrMonitorDisconnect = fmt.Errorf("Monitor is disconnected")
 
-// ErrMonitorBadConsole is retuned when the requested console doesn't exist.
+// ErrMonitorBadConsole is returned when the requested console doesn't exist.
 var ErrMonitorBadConsole = fmt.Errorf("Requested console couldn't be found")
+
+// ErrNotARingbuf is returned when the requested device isn't a ring buffer.
+var ErrNotARingbuf = fmt.Errorf("Requested device isn't a ring buffer")


### PR DESCRIPTION
* Don't return an error if VM's console device isn't a ringbuf
* Don't conflict with live migration operation