### PR TITLE
Added ability for user to specify the macvlan mode using the mode key…

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2615,3 +2615,7 @@ This extension adds a pointer to an `InstanceStateOSInfo` struct to the instance
 
 This adds a new `/1.0/networks/NAME/load-balancers/IP/state` API endpoint
 which returns load-balancer health check information (when configured).
+
+## `instance_nic_macvlan_mode`
+
+This adds a `mode` configuration key on `macvlan` network interfaces which allows for configuring the Macvlan mode.

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -118,6 +118,7 @@ Key                     | Type    | Default           | Managed | Description
 `boot.priority`         | integer | -                 | no      | Boot priority for VMs (higher value boots first)
 `gvrp`                  | bool    | `false`           | no      | Register VLAN using GARP VLAN Registration Protocol
 `hwaddr`                | string  | randomly assigned | no      | The MAC address of the new interface
+`mode`                  | string  | `bridge`          | no      | Macvlan mode (one of `bridge`, `vepa`, `passthrough` or `private`)
 `mtu`                   | integer | parent MTU        | yes     | The MTU of the new interface
 `name`                  | string  | kernel assigned   | no      | The name of the interface inside the instance
 `network`               | string  | -                 | no      | The managed network to link the device to (instead of specifying the `nictype` directly)

--- a/internal/server/device/nic.go
+++ b/internal/server/device/nic.go
@@ -52,6 +52,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		"security.acls.default.ingress.logged": validate.Optional(validate.IsBool),
 		"security.acls.default.egress.logged":  validate.Optional(validate.IsBool),
 		"security.promiscuous":                 validate.Optional(validate.IsBool),
+		"mode":                                 validate.Optional(validate.IsOneOf("bridge", "vepa", "passthrough", "private")),
 	}
 
 	validators := map[string]func(value string) error{}

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -444,6 +444,7 @@ var APIExtensions = []string{
 	"ovn_nic_ip_address_none",
 	"instances_state_os_info",
 	"network_load_balancer_state",
+	"instance_nic_macvlan_mode",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Currently the Incus code is hard coded to configure MACVLAN interfaces with a mode of "bridge". This change allows the user to specify the mode as either bridge, vepa, passthru or private. If nothing is entered then a default setting of bridge (as it is currently) is defined. 

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.