### PR TITLE
docs: mention alpine edge repository in alpine installation

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -297,6 +297,7 @@ UIDs
 unconfigured
 unevictable
 unixgram
+uncomment
 unmanaged
 unmount
 unmounting

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -33,7 +33,11 @@ Packages are available for a number of Linux distributions, either in their main
 ````{tabs}
 
 ```{group-tab} Alpine
-Incus and all of its dependencies are available in Alpine Linux's community repository as `incus`.
+Incus and all of its dependencies are available in Alpine Linux's edge main and community repository as `incus`.
+
+Uncomment the edge main and community repositories in `/etc/apk/repositories` and run:
+
+    apk update
 
 Install Incus with:
 


### PR DESCRIPTION
The alpine community repository `(http://dl-cdn.alpinelinux.org/alpine/v3.15/community)` does not contain the `incus` packages. It's only available in `http://dl-cdn.alpinelinux.org/alpine/edge/community` mirror (which is not enabled by default).