### PR TITLE
Run cluster evacuate and restore in parallel

### DIFF
--- a/cmd/incusd/api_cluster.go
+++ b/cmd/incusd/api_cluster.go
@@ -2894,7 +2894,7 @@ func clusterNodeStatePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		run := func(op *operations.Operation) error {
-			return evacuateClusterMember(context.Background(), s, d.gateway, op, name, req.Mode, stopFunc, migrateFunc)
+			return evacuateClusterMember(context.Background(), s, op, name, req.Mode, stopFunc, migrateFunc)
 		}
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ClusterMemberEvacuate, nil, nil, run, nil, nil, r)


### PR DESCRIPTION
Sequentially evacuating or restoring a server can be slow when there are several instances running. This switches to running migrations in parallel, based on the number of detected CPUs available.