### PR TITLE
Allow adding external interfaces to an OVN network

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2623,3 +2623,7 @@ This adds a `mode` configuration key on `macvlan` network interfaces which allow
 ## `storage_lvm_cluster_create`
 
 Allow for creating new LVM cluster pools by setting the `source` to the shared block device.
+
+## `network_ovn_external_interfaces`
+
+This adds support for `bridge.external_interfaces` on OVN networks.

--- a/doc/reference/network_ovn.md
+++ b/doc/reference/network_ovn.md
@@ -42,6 +42,7 @@ The following configuration options are available for the `ovn` network type:
 Key                                  | Type      | Condition             | Default                   | Description
 :--                                  | :--       | :--                   | :--                       | :--
 `network`                            | string    | -                     | -                         | Uplink network to use for external network access or `none` to keep isolated
+`bridge.external_interfaces`         | string    | -                     | -                         | Comma-separated list of unconfigured network interfaces to include in the bridge
 `bridge.hwaddr`                      | string    | -                     | -                         | MAC address for the bridge
 `bridge.mtu`                         | integer   | -                     | `1442`                    | Bridge MTU (default allows host to host Geneve tunnels)
 `dns.domain`                         | string    | -                     | `incus`                   | Domain to advertise to DHCP clients and use for DNS resolution

--- a/internal/server/network/driver_bridge.go
+++ b/internal/server/network/driver_bridge.go
@@ -163,47 +163,10 @@ func (n *bridge) Validate(config map[string]string) error {
 		"bgp.ipv4.nexthop": validate.Optional(validate.IsNetworkAddressV4),
 		"bgp.ipv6.nexthop": validate.Optional(validate.IsNetworkAddressV6),
 
-		"bridge.driver": validate.Optional(validate.IsOneOf("native", "openvswitch")),
-		"bridge.external_interfaces": validate.Optional(func(value string) error {
-			for _, entry := range strings.Split(value, ",") {
-				entry = strings.TrimSpace(entry)
-
-				// Test for extended configuration of external interface.
-				entryParts := strings.Split(entry, "/")
-				if len(entryParts) == 3 {
-					// The first part is the interface name.
-					entry = strings.TrimSpace(entryParts[0])
-				}
-
-				err := validate.IsInterfaceName(entry)
-				if err != nil {
-					return fmt.Errorf("Invalid interface name %q: %w", entry, err)
-				}
-
-				if len(entryParts) == 3 {
-					// Check if the parent interface is valid.
-					parent := strings.TrimSpace(entryParts[1])
-					err := validate.IsInterfaceName(parent)
-					if err != nil {
-						return fmt.Errorf("Invalid interface name %q: %w", parent, err)
-					}
-
-					// Check if the VLAN ID is valid.
-					vlanID, err := strconv.Atoi(entryParts[2])
-					if err != nil {
-						return fmt.Errorf("Invalid VLAN ID %q: %w", entryParts[2], err)
-					}
-
-					if vlanID < 1 || vlanID > 4094 {
-						return fmt.Errorf("Invalid VLAN ID %q", entryParts[2])
-					}
-				}
-			}
-
-			return nil
-		}),
-		"bridge.hwaddr": validate.Optional(validate.IsNetworkMAC),
-		"bridge.mtu":    validate.Optional(validate.IsNetworkMTU),
+		"bridge.driver":              validate.Optional(validate.IsOneOf("native", "openvswitch")),
+		"bridge.external_interfaces": validate.Optional(validateExternalInterfaces),
+		"bridge.hwaddr":              validate.Optional(validate.IsNetworkMAC),
+		"bridge.mtu":                 validate.Optional(validate.IsNetworkMTU),
 
 		"ipv4.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf("none", "auto")(value) == nil {

--- a/internal/server/network/network_utils.go
+++ b/internal/server/network/network_utils.go
@@ -1442,3 +1442,42 @@ func ProxyParseAddr(data string) (*deviceConfig.ProxyAddress, error) {
 
 	return newProxyAddr, nil
 }
+
+func validateExternalInterfaces(value string) error {
+	for _, entry := range strings.Split(value, ",") {
+		entry = strings.TrimSpace(entry)
+
+		// Test for extended configuration of external interface.
+		entryParts := strings.Split(entry, "/")
+		if len(entryParts) == 3 {
+			// The first part is the interface name.
+			entry = strings.TrimSpace(entryParts[0])
+		}
+
+		err := validate.IsInterfaceName(entry)
+		if err != nil {
+			return fmt.Errorf("Invalid interface name %q: %w", entry, err)
+		}
+
+		if len(entryParts) == 3 {
+			// Check if the parent interface is valid.
+			parent := strings.TrimSpace(entryParts[1])
+			err := validate.IsInterfaceName(parent)
+			if err != nil {
+				return fmt.Errorf("Invalid interface name %q: %w", parent, err)
+			}
+
+			// Check if the VLAN ID is valid.
+			vlanID, err := strconv.Atoi(entryParts[2])
+			if err != nil {
+				return fmt.Errorf("Invalid VLAN ID %q: %w", entryParts[2], err)
+			}
+
+			if vlanID < 1 || vlanID > 4094 {
+				return fmt.Errorf("Invalid VLAN ID %q", entryParts[2])
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -446,6 +446,7 @@ var APIExtensions = []string{
 	"network_load_balancer_state",
 	"instance_nic_macvlan_mode",
 	"storage_lvm_cluster_create",
+	"network_ovn_external_interfaces",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
## Description

- Allow adding external interfaces to an OVN network
- close #937

## Details

- OS: Ubuntu 24.04
- Arch: x86_64

### Test result

**create OVN network with `bridge.external_interfaces`**

```
# incus network create ext-ifac-ovn bridge.external_interfaces=ens18.10/ens18/10 --type=ovn network=test-network --debug
Network ext-ifac-ovn created

# incus network ls
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
|     NAME     |   TYPE   | MANAGED |      IPV4       |           IPV6            | DESCRIPTION | USED BY |  STATE  |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| br-int       | bridge   | NO      |                 |                           |             | 0       |         |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| ens18        | physical | NO      |                 |                           |             | 0       |         |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| ens18.10     | vlan     | NO      |                 |                           |             | 0       |         |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| ext-ifac-ovn | ovn      | YES     | 10.6.133.1/24   | fd42:3332:1564:37bd::1/64 |             | 0       | CREATED |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| incusbr0     | bridge   | YES     | 10.46.82.1/24   | fd42:a560:1040:84ee::1/64 |             | 2       | CREATED |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| incusovn2    | bridge   | NO      |                 |                           |             | 0       |         |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| incusovn2a   | unknown  | NO      |                 |                           |             | 0       |         |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| incusovn2b   | unknown  | NO      |                 |                           |             | 0       |         |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| isolated-ovn | ovn      | YES     | 10.168.199.1/24 | fd42:5d7e:c084:dcb0::1/64 |             | 0       | CREATED |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| lo           | loopback | NO      |                 |                           |             | 0       |         |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| lxcbr0       | bridge   | NO      |                 |                           |             | 0       |         |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| ovn-network  | ovn      | YES     | 10.71.151.1/24  | fd42:69ae:dc4b:fb01::1/64 |             | 0       | CREATED |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| ovs-system   | unknown  | NO      |                 |                           |             | 0       |         |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+
| test-network | bridge   | YES     | 10.97.209.1/24  | fd42:f32:39dc:32b::1/64   |             | 2       | CREATED |
+--------------+----------+---------+-----------------+---------------------------+-------------+---------+---------+

# incus network info ext-ifac-ovn
Name: ext-ifac-ovn
MAC address: 00:16:3e:33:66:9b
MTU: 1500
State: up
Type: broadcast

IP addresses:
  inet  10.6.133.1/24 (link)
  inet6 fd42:3332:1564:37bd::1/64 (link)

Network usage:
  Bytes received: 0B
  Bytes sent: 0B
  Packets received: 0
  Packets sent: 0

OVN:
  Chassis: playground
  Logical router: incus-net39-lr


# ovn-nbctl lsp-get-addresses ens18.10-lsp-router
unknown
```

**delete OVN network with `bridge.external_interfaces`**
```
# incus network delete ext-ifac-ovn
Network ext-ifac-ovn deleted

# ovn-nbctl lsp-get-addresses ens18.10-lsp-router
ovn-nbctl: ens18.10-lsp-router: port name not found
```