### PR TITLE
Allows the VM's limits.memory configuration to be set to a percentage value

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -1133,24 +1133,9 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 
 		// Configure the memory limits
 		if memory != "" {
-			var valueInt int64
-			if strings.HasSuffix(memory, "%") {
-				percent, err := strconv.ParseInt(strings.TrimSuffix(memory, "%"), 10, 64)
-				if err != nil {
-					return nil, err
-				}
-
-				memoryTotal, err := linux.DeviceTotalMemory()
-				if err != nil {
-					return nil, err
-				}
-
-				valueInt = int64((memoryTotal / 100) * percent)
-			} else {
-				valueInt, err = units.ParseByteSizeString(memory)
-				if err != nil {
-					return nil, err
-				}
+			valueInt, err := ParseMemoryStr(memory)
+			if err != nil {
+				return nil, err
 			}
 
 			if memoryEnforce == "soft" {
@@ -4804,20 +4789,8 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 				// Parse memory
 				if memory == "" {
 					memoryInt = -1
-				} else if strings.HasSuffix(memory, "%") {
-					percent, err := strconv.ParseInt(strings.TrimSuffix(memory, "%"), 10, 64)
-					if err != nil {
-						return err
-					}
-
-					memoryTotal, err := linux.DeviceTotalMemory()
-					if err != nil {
-						return err
-					}
-
-					memoryInt = int64((memoryTotal / 100) * percent)
 				} else {
-					memoryInt, err = units.ParseByteSizeString(memory)
+					memoryInt, err = ParseMemoryStr(memory)
 					if err != nil {
 						return err
 					}

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -1118,7 +1118,7 @@ func (d *qemu) checkStateStorage() error {
 		memoryLimitStr = d.expandedConfig["limits.memory"]
 	}
 
-	memoryLimit, err := units.ParseByteSizeString(memoryLimitStr)
+	memoryLimit, err := ParseMemoryStr(memoryLimitStr)
 	if err != nil {
 		return err
 	}
@@ -3821,7 +3821,7 @@ func (d *qemu) addCPUMemoryConfig(cfg *[]cfgSection, cpuInfo *cpuTopology) error
 		memSize = qemudefault.MemSize // Default if no memory limit specified.
 	}
 
-	memSizeBytes, err := units.ParseByteSizeString(memSize)
+	memSizeBytes, err := ParseMemoryStr(memSize)
 	if err != nil {
 		return fmt.Errorf("limits.memory invalid: %w", err)
 	}

--- a/internal/server/instance/drivers/util.go
+++ b/internal/server/instance/drivers/util.go
@@ -8,12 +8,16 @@ import (
 	"io/fs"
 	"os"
 	"slices"
+	"strconv"
+	"strings"
 
+	"github.com/lxc/incus/v6/internal/linux"
 	"github.com/lxc/incus/v6/internal/server/db"
 	"github.com/lxc/incus/v6/internal/server/instance/instancetype"
 	"github.com/lxc/incus/v6/internal/server/state"
 	internalUtil "github.com/lxc/incus/v6/internal/util"
 	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/units"
 )
 
 // GetClusterCPUFlags returns the list of shared CPU flags across.
@@ -98,4 +102,27 @@ func GetClusterCPUFlags(ctx context.Context, s *state.State, servers []string, a
 	}
 
 	return flags, nil
+}
+
+// ParseMemoryStr parses a human representation of memory value as int64 type.
+func ParseMemoryStr(memory string) (valueInt int64, err error) {
+	if strings.HasSuffix(memory, "%") {
+		var percent, memoryTotal int64
+
+		percent, err = strconv.ParseInt(strings.TrimSuffix(memory, "%"), 10, 64)
+		if err != nil {
+			return 0, err
+		}
+
+		memoryTotal, err = linux.DeviceTotalMemory()
+		if err != nil {
+			return 0, err
+		}
+
+		valueInt = (memoryTotal / 100) * percent
+	} else {
+		valueInt, err = units.ParseByteSizeString(memory)
+	}
+
+	return valueInt, err
 }


### PR DESCRIPTION
fix https://github.com/lxc/incus/issues/1261

Just extract the logic of driver_lxc.go for the memory percentage value into a function and apply it to driver_qemu.go