### PR TITLE
fix live update VM's limits.memory configuration when use a percentage value

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -6005,7 +6005,7 @@ func (d *qemu) updateMemoryLimit(newLimit string) error {
 	}
 
 	// Check new size string is valid and convert to bytes.
-	newSizeBytes, err := units.ParseByteSizeString(newLimit)
+	newSizeBytes, err := ParseMemoryStr(newLimit)
 	if err != nil {
 		return fmt.Errorf("Invalid memory size: %w", err)
 	}


### PR DESCRIPTION
The previous submission  https://github.com/lxc/incus/pull/1270 only applied to newly created or shut down virtual machines. This submission fixes the `limits.memory` update for running virtual machines.