### PR TITLE
incusd/instance/lxc: Remove restrictions on /run

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -2377,7 +2377,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 
 		// Mount /run as a tmpfs if it exists and isn't already mounted.
 		if !slices.Contains(lxcMounts, "/run") {
-			err := lxcSetConfigItem(cc, "lxc.mount.entry", "none run tmpfs none,nosuid,nodev,noexec,mode=755,optional")
+			err := lxcSetConfigItem(cc, "lxc.mount.entry", "none run tmpfs none,mode=755,optional")
 			if err != nil {
 				return "", nil, err
 			}


### PR DESCRIPTION
Apparently some containers put executables in /run...