### PR TITLE
incusd/internal/server/instance/drivers:  support for Chimera Linux (qemu/edk2) pkg layout

### DIFF
--- a/internal/server/instance/drivers/edk2/driver_edk2.go
+++ b/internal/server/instance/drivers/edk2/driver_edk2.go
@@ -72,13 +72,16 @@ var architectureInstallations = map[int][]Installation{
 			GENERIC: {
 				{Code: "ovmf-x86_64-4m-code.bin", Vars: "ovmf-x86_64-4m-vars.bin"},
 				{Code: "ovmf-x86_64.bin", Vars: "ovmf-x86_64-code.bin"},
+				{Code: "edk2-x86_64-code.fd", Vars: "edk2-i386-vars.fd"},
 			},
 			SECUREBOOT: {
 				{Code: "ovmf-x86_64-ms-4m-vars.bin", Vars: "ovmf-x86_64-ms-4m-code.bin"},
 				{Code: "ovmf-x86_64-ms-code.bin", Vars: "ovmf-x86_64-ms-vars.bin"},
+				{Code: "edk2-x86_64-secure-code.fd", Vars: "edk2-i386-vars.fd"},
 			},
 			CSM: {
 				{Code: "seabios.bin", Vars: "seabios.bin"},
+				{Code: "bios.bin", Vars: "bios.bin"},
 			},
 		},
 	}, {


### PR DESCRIPTION
Incus is packaged for Chimera Linux; this addition provides support for edk2 filenames as packaged by Chimera Linux (these are the base filenames supplied by the qemu/edk2 package https://github.com/qemu/edk2).

Have built and tested on x86_64 arch / Chimera Linux (musl libc); both containers and virtual machines (security.secureboot=false) perform as expected.