### PR TITLE
Implement `incus webui`

### DIFF
--- a/client/incus_oidc.go
+++ b/client/incus_oidc.go
@@ -18,6 +18,8 @@ import (
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"golang.org/x/oauth2"
+
+	"github.com/lxc/incus/v6/shared/util"
 )
 
 // ErrOIDCExpired is returned when the token is expired and we can't retry the request ourselves.
@@ -281,7 +283,7 @@ func (o *oidcClient) authenticate(issuer string, clientID string, audience strin
 	fmt.Printf("URL: %s\n", u.String())
 	fmt.Printf("Code: %s\n\n", resp.UserCode)
 
-	_ = openBrowser(u.String())
+	_ = util.OpenBrowser(u.String())
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT)
 	defer stop()

--- a/client/util.go
+++ b/client/util.go
@@ -7,9 +7,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 	"time"
 
@@ -252,35 +249,4 @@ type HTTPTransporter interface {
 
 	// Transport what this struct wraps
 	Transport() *http.Transport
-}
-
-func openBrowser(url string) error {
-	var err error
-
-	browser := os.Getenv("BROWSER")
-	if browser != "" {
-		if browser == "none" {
-			return nil
-		}
-
-		err = exec.Command(browser, url).Start()
-		return err
-	}
-
-	switch runtime.GOOS {
-	case "linux":
-		err = exec.Command("xdg-open", url).Start()
-	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
-	case "darwin":
-		err = exec.Command("open", url).Start()
-	default:
-		err = fmt.Errorf("unsupported platform")
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/cmd/incus/main.go
+++ b/cmd/incus/main.go
@@ -266,6 +266,10 @@ Custom commands can be defined through aliases, use "incus alias" to control tho
 	warningCmd := cmdWarning{global: &globalCmd}
 	app.AddCommand(warningCmd.Command())
 
+	// webui sub-command
+	webuiCmd := cmdWebui{global: &globalCmd}
+	app.AddCommand(webuiCmd.Command())
+
 	// Get help command
 	app.InitDefaultHelpCmd()
 	var help *cobra.Command

--- a/cmd/incus/top.go
+++ b/cmd/incus/top.go
@@ -28,7 +28,7 @@ type cmdTop struct {
 // Command is a method of the cmdTop structure that returns a new cobra Command for displaying resource usage per instance.
 func (c *cmdTop) Command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("top")
+	cmd.Use = usage("top", i18n.G("[<remote>:]"))
 	cmd.Short = i18n.G("Display resource usage info per instance")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Displays CPU usage, memory usage, and disk usage per instance`))

--- a/cmd/incus/webui.go
+++ b/cmd/incus/webui.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	cli "github.com/lxc/incus/v6/internal/cmd"
+	"github.com/lxc/incus/v6/internal/i18n"
+)
+
+type cmdWebui struct {
+	global *cmdGlobal
+}
+
+// Command is a method of the cmdWebui structure that returns a new cobra Command for displaying resource usage per instance.
+func (c *cmdWebui) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("webui", i18n.G("[<remote>:]"))
+	cmd.Short = i18n.G("Open the web interface")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Open the web interface`))
+
+	cmd.RunE = c.Run
+	return cmd
+}

--- a/cmd/incus/webui_unix.go
+++ b/cmd/incus/webui_unix.go
@@ -1,0 +1,132 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/lxc/incus/v6/internal/i18n"
+	"github.com/lxc/incus/v6/shared/util"
+)
+
+// Run runs the actual command logic.
+func (c *cmdWebui) Run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	if exit {
+		return err
+	}
+
+	// Parse remote
+	remote := ""
+	if len(args) > 0 {
+		remote = args[0]
+	}
+
+	remoteName, _, err := c.global.conf.ParseRemote(remote)
+	if err != nil {
+		return err
+	}
+
+	s, err := c.global.conf.GetInstanceServer(remoteName)
+	if err != nil {
+		return err
+	}
+
+	// Create localhost socket.
+	server, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("Unable to setup TCP socket: %w", err)
+	}
+
+	// Get the connection info.
+	info, err := s.GetConnectionInfo()
+	if err != nil {
+		return err
+	}
+
+	uri, err := url.Parse(info.URL)
+	if err != nil {
+		return err
+	}
+
+	// Check that the target supports the UI.
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/ui/", info.URL), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.DoHTTP(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return errors.New(i18n.G("The server doesn't have a web UI installed"))
+	}
+
+	// Enable keep-alive for proxied connections.
+	httpClient, err := s.GetHTTPClient()
+	if err != nil {
+		return err
+	}
+
+	httpTransport, ok := httpClient.Transport.(*http.Transport)
+	if ok {
+		httpTransport.DisableKeepAlives = false
+	}
+
+	// Get server info.
+	api10, api10Etag, err := s.GetServer()
+	if err != nil {
+		return err
+	}
+
+	// Generate credentials.
+	token := uuid.New().String()
+
+	// Handle inbound connections.
+	transport := remoteProxyTransport{
+		s:       s,
+		baseURL: uri,
+	}
+
+	connections := uint64(0)
+	transactions := uint64(0)
+
+	handler := remoteProxyHandler{
+		s:         s,
+		transport: transport,
+		api10:     api10,
+		api10Etag: api10Etag,
+
+		mu:           &sync.RWMutex{},
+		connections:  &connections,
+		transactions: &transactions,
+
+		token: token,
+	}
+
+	// Print address.
+	uiURL := fmt.Sprintf("http://%s/ui?auth_token=%s", server.Addr().String(), token)
+	fmt.Printf(i18n.G("Web server running at: %s")+"\n", uiURL)
+
+	// Attempt to automatically open the web browser.
+	_ = util.OpenBrowser(uiURL)
+
+	// Start the server.
+	err = http.Serve(server, handler)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/incus/webui_windows.go
+++ b/cmd/incus/webui_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lxc/incus/v6/internal/i18n"
+)
+
+// Run runs the actual command logic.
+func (c *cmdWebui) Run(cmd *cobra.Command, args []string) error {
+	return errors.New(i18n.G("This command isn't supported on Windows"))
+}

--- a/cmd/incusd/api.go
+++ b/cmd/incusd/api.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"net/http"
 	"net/http/httputil"
@@ -71,7 +72,7 @@ func restServer(d *Daemon) *http.Server {
 	mux.UseEncodedPath() // Allow encoded values in path segments.
 
 	uiPath := os.Getenv("INCUS_UI")
-	uiEnabled := uiPath != "" && util.PathExists(uiPath)
+	uiEnabled := uiPath != "" && util.PathExists(fmt.Sprintf("%s/index.html", uiPath))
 	if uiEnabled {
 		uiHttpDir := uiHttpDir{http.Dir(uiPath)}
 		mux.PathPrefix("/ui/").Handler(http.StripPrefix("/ui/", http.FileServer(uiHttpDir)))

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: 2024-10-06 20:15+0000\n"
 "Last-Translator: Jan Mittelstädter <jan@mittelstaedter.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -1598,11 +1598,11 @@ msgstr "Clustering aktiviert"
 msgid "Columns"
 msgstr "Spalten"
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid "Command line client for Incus"
 msgstr "Kommandozeilen-Client für Incus"
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -2223,7 +2223,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2325,7 +2325,7 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
@@ -2525,7 +2525,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr ""
 
@@ -3428,7 +3428,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3836,7 +3836,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -4138,7 +4138,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -6235,6 +6235,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+#, fuzzy
+msgid "Open the web interface"
+msgstr "Anhalten des Containers fehlgeschlagen!"
+
 #: cmd/incus/info.go:677
 #, fuzzy
 msgid "Operating System:"
@@ -6249,7 +6254,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr ""
 
@@ -6329,7 +6334,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -6435,7 +6440,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -6443,7 +6448,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -6991,7 +6996,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -7519,11 +7524,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -7578,7 +7583,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance snapshot configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr ""
 
@@ -8273,6 +8278,10 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -8296,7 +8305,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8304,6 +8313,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -8345,7 +8358,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8792,7 +8805,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8915,6 +8928,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -9088,7 +9106,8 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1536,12 +1536,12 @@ msgstr ""
 msgid "Columns"
 msgstr "Columnas"
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 #, fuzzy
 msgid "Command line client for Incus"
 msgstr "Cliente de Linea de Comandos para LXD"
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -2135,7 +2135,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2237,7 +2237,7 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Descripción"
 
@@ -2427,7 +2427,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgstr "Creando el contenedor"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3653,7 +3653,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3952,7 +3952,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -5998,6 +5998,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+#, fuzzy
+msgid "Open the web interface"
+msgstr "Aliases:"
+
 #: cmd/incus/info.go:677
 msgid "Operating System:"
 msgstr ""
@@ -6011,7 +6016,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr ""
 
@@ -6089,7 +6094,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -6193,7 +6198,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -6201,7 +6206,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -6733,7 +6738,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -7239,11 +7244,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -7293,7 +7298,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr ""
 
@@ -7969,6 +7974,10 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -7990,7 +7999,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7998,6 +8007,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -8037,7 +8050,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8472,7 +8485,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8591,6 +8604,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -8748,7 +8766,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "No se puede proveer el nombre del container a la lista"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -1570,11 +1570,11 @@ msgstr "Clustering activé"
 msgid "Columns"
 msgstr "Colonnes"
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid "Command line client for Incus"
 msgstr "Client en ligne de commande pour Incus"
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -2232,7 +2232,7 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2334,7 +2334,7 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Description"
 
@@ -2531,7 +2531,7 @@ msgstr "Voulez-vous continuer sans provisionnement virtuel?"
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr "Ne pas afficher les informations sur l'état d'avancement"
 
@@ -3464,7 +3464,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Force the removal of running instances"
 msgstr "Forcer la suppression des conteneurs arrêtés"
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
@@ -3906,7 +3906,7 @@ msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "Si l'instantané de l'image existe déjà, le supprimer d'abord puis le recréer"
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 #, fuzzy
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
@@ -4230,7 +4230,7 @@ msgstr ""
 "Nom invalide dans \"%s\", la chaîne vide n'est autorisée que lorsque "
 "maxWidth est défini."
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -6393,6 +6393,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+#, fuzzy
+msgid "Open the web interface"
+msgstr "L'arrêt du conteneur a échoué !"
+
 #: cmd/incus/info.go:677
 #, fuzzy
 msgid "Operating System:"
@@ -6407,7 +6412,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 #, fuzzy
 msgid "Override the source project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6489,7 +6494,7 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -6595,7 +6600,7 @@ msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -6603,7 +6608,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -7170,7 +7175,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -7696,11 +7701,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -7755,7 +7760,7 @@ msgstr "Afficher des informations supplémentaires"
 msgid "Show instance snapshot configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -8466,6 +8471,10 @@ msgstr ""
 "Le pool de stockage demandé \"%s\" existe déjà. Veuillez choisir un autre "
 "nom."
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -8487,7 +8496,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\". Vouliez-vous un alias ?"
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8495,6 +8504,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -8537,7 +8550,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 #, fuzzy
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
@@ -8989,7 +9002,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -9109,6 +9122,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -9281,7 +9299,8 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<serveur distant>:]"
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1269,11 +1269,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1843,7 +1843,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -1945,7 +1945,7 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
@@ -2124,7 +2124,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2936,7 +2936,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3312,7 +3312,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3602,7 +3602,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -5591,6 +5591,10 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+msgid "Open the web interface"
+msgstr ""
+
 #: cmd/incus/info.go:677
 msgid "Operating System:"
 msgstr ""
@@ -5604,7 +5608,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr ""
 
@@ -5682,7 +5686,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5785,7 +5789,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -5793,7 +5797,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -6302,7 +6306,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -6789,11 +6793,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -6841,7 +6845,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr ""
 
@@ -7501,6 +7505,10 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -7522,7 +7530,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7530,6 +7538,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -7568,7 +7580,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -7978,7 +7990,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8096,6 +8108,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -8250,7 +8267,8 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-10-18 14:09-0400\n"
+        "POT-Creation-Date: 2024-10-25 15:46-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1174,11 +1174,11 @@ msgstr  ""
 msgid   "Columns"
 msgstr  ""
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid   "Command line client for Incus"
 msgstr  ""
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid   "Command line client for Incus\n"
         "\n"
         "All of Incus's features can be driven through the various commands below.\n"
@@ -1668,7 +1668,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:315 cmd/incus/file.go:393 cmd/incus/file.go:463 cmd/incus/file.go:682 cmd/incus/file.go:1187 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794 cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961 cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:315 cmd/incus/file.go:393 cmd/incus/file.go:463 cmd/incus/file.go:682 cmd/incus/file.go:1187 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794 cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961 cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
@@ -1841,7 +1841,7 @@ msgstr  ""
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid   "Don't show progress information"
 msgstr  ""
 
@@ -2604,7 +2604,7 @@ msgstr  ""
 msgid   "Force the removal of running instances"
 msgstr  ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid   "Force using the local unix socket"
 msgstr  ""
 
@@ -2956,7 +2956,7 @@ msgstr  ""
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid   "If this is your first time running Incus on this machine, you should also run: incus admin init"
 msgstr  ""
 
@@ -3240,7 +3240,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -5064,6 +5064,10 @@ msgstr  ""
 msgid   "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr  ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+msgid   "Open the web interface"
+msgstr  ""
+
 #: cmd/incus/info.go:677
 msgid   "Operating System:"
 msgstr  ""
@@ -5077,7 +5081,7 @@ msgstr  ""
 msgid   "Optimized Storage"
 msgstr  ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid   "Override the source project"
 msgstr  ""
 
@@ -5151,7 +5155,7 @@ msgstr  ""
 msgid   "Partitions:"
 msgstr  ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -5244,7 +5248,7 @@ msgstr  ""
 msgid   "Pretty rendering (short for --format=pretty)"
 msgstr  ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid   "Print help"
 msgstr  ""
 
@@ -5252,7 +5256,7 @@ msgstr  ""
 msgid   "Print the raw response"
 msgstr  ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid   "Print version number"
 msgstr  ""
 
@@ -5749,7 +5753,7 @@ msgstr  ""
 msgid   "Role (admin or read-only)"
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid   "Rows affected: %d"
 msgstr  ""
@@ -6200,11 +6204,11 @@ msgstr  ""
 msgid   "Setup loop based storage with SIZE in GiB"
 msgstr  ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid   "Show all debug messages"
 msgstr  ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid   "Show all information messages"
 msgstr  ""
 
@@ -6252,7 +6256,7 @@ msgstr  ""
 msgid   "Show instance snapshot configuration"
 msgstr  ""
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -6881,6 +6885,10 @@ msgstr  ""
 msgid   "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr  ""
 
+#: cmd/incus/webui_unix.go:73
+msgid   "The server doesn't have a web UI installed"
+msgstr  ""
+
 #: cmd/incus/info.go:394
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
@@ -6901,11 +6909,15 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid   "This client hasn't been configured to use a remote server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote server.\n"
         "\n"
         "If you already added a remote server, make it the default with \"incus remote switch NAME\"."
+msgstr  ""
+
+#: cmd/incus/webui_windows.go:15
+msgid   "This command isn't supported on Windows"
 msgstr  ""
 
 #: cmd/incus/admin_recover.go:63
@@ -6944,7 +6956,7 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid   "To start your first container, try: incus launch images:ubuntu/22.04\n"
         "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr  ""
@@ -7325,7 +7337,7 @@ msgstr  ""
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
@@ -7436,6 +7448,11 @@ msgid   "We detected that you are running inside an unprivileged container.\n"
         "Doing so makes your nested containers slightly less safe as they could\n"
         "in theory attack their parent container and gain more privileges than\n"
         "they otherwise would."
+msgstr  ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid   "Web server running at: %s"
 msgstr  ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -7575,7 +7592,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070 cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31 cmd/incus/network.go:1050 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505 cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070 cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31 cmd/incus/network.go:1050 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505 cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20 cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid   "[<remote>:]"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -1531,11 +1531,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Colonne"
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -2128,7 +2128,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2230,7 +2230,7 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr ""
 
@@ -3247,7 +3247,7 @@ msgstr "Creazione del container in corso"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3642,7 +3642,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3940,7 +3940,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -5991,6 +5991,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+#, fuzzy
+msgid "Open the web interface"
+msgstr "Creazione del container in corso"
+
 #: cmd/incus/info.go:677
 msgid "Operating System:"
 msgstr ""
@@ -6004,7 +6009,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr ""
 
@@ -6084,7 +6089,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -6189,7 +6194,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -6197,7 +6202,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -6729,7 +6734,7 @@ msgstr "Il nome del container è: %s"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -7231,11 +7236,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -7285,7 +7290,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr ""
 
@@ -7965,6 +7970,10 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -7986,7 +7995,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7994,6 +8003,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -8033,7 +8046,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8466,7 +8479,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8585,6 +8598,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -8746,7 +8764,8 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Creazione del container in corso"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -1545,11 +1545,11 @@ msgstr "クラスタリングが有効になりました"
 msgid "Columns"
 msgstr "カラムレイアウト"
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid "Command line client for Incus"
 msgstr "incus のコマンドラインクライアント"
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -2153,7 +2153,7 @@ msgstr "警告を削除します"
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2255,7 +2255,7 @@ msgstr "警告を削除します"
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "説明"
 
@@ -2447,7 +2447,7 @@ msgstr "Thin provisioning なしで続けますか?"
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
@@ -3317,7 +3317,7 @@ msgstr "インスタンスを強制停止します"
 msgid "Force the removal of running instances"
 msgstr "稼働中のインスタンスを強制的に削除します"
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
@@ -3733,7 +3733,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 #, fuzzy
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
@@ -4042,7 +4042,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -6735,6 +6735,11 @@ msgstr ""
 "指定できるのは、--storage-create-device もしくは --storage-create-loop のいず"
 "れか一方のみです"
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+#, fuzzy
+msgid "Open the web interface"
+msgstr "ホストインターフェース"
+
 #: cmd/incus/info.go:677
 #, fuzzy
 msgid "Operating System:"
@@ -6749,7 +6754,7 @@ msgstr "バックグラウンド操作 %s を削除しました"
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr "プロジェクトを指定します"
 
@@ -6830,7 +6835,7 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -6936,7 +6941,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr "Pretty レンダリング（--format=pretty の短縮系）"
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr "ヘルプを表示します"
 
@@ -6944,7 +6949,7 @@ msgstr "ヘルプを表示します"
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
@@ -7475,7 +7480,7 @@ msgstr "クラスターメンバーに join するためのトークンを失効
 msgid "Role (admin or read-only)"
 msgstr "ロール（admin または read-only）"
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr "影響を受ける行: %d"
@@ -8061,11 +8066,11 @@ msgstr "DEVICE を使ってストレージベースのデバイスをセット�
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr "サイズ GiB で loop ベースのストレージをセットアップします"
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr "デバッグメッセージをすべて表示します"
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
@@ -8114,7 +8119,7 @@ msgstr "インスタンスもしくはサーバの情報を表示します"
 msgid "Show instance snapshot configuration"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -8829,6 +8834,10 @@ msgstr ""
 "入力したストレージプール \"%s\" はすでに存在しています。他の名前を入力してく"
 "ださい。"
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
@@ -8852,7 +8861,7 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 #, fuzzy
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
@@ -8871,6 +8880,11 @@ msgstr ""
 "うにデフォルトを設定してください。\n"
 "仮想マシン上にローカルな LXD サーバを簡単にセットアップするには、https://"
 "multipass.run の使用を検討してください。"
+
+#: cmd/incus/webui_windows.go:15
+#, fuzzy
+msgid "This command isn't supported on Windows"
+msgstr "入力したバックエンド '%s' は、この初期化ではサポートされていません"
 
 #: cmd/incus/admin_recover.go:63
 msgid "This server currently has the following storage pools:"
@@ -8915,7 +8929,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 #, fuzzy
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
@@ -9353,7 +9367,7 @@ msgstr ""
 "最適化された形でストレージドライバを使います (同様のプール上にのみリストアで"
 "きます)"
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
@@ -9487,6 +9501,11 @@ msgstr ""
 "この問題を回避するには、コンテナ自身への割当を再利用できます。再利用す\n"
 "ると理論的には、そうしない場合に比べて、親コンテナを攻撃してより多くの\n"
 "特権を得られる可能性があるため、安全性は若干低くなります。"
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
+msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
 msgid "What IP address or DNS name should be used to reach this server?"
@@ -9653,7 +9672,8 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -1276,11 +1276,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1850,7 +1850,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -1952,7 +1952,7 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3320,7 +3320,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3610,7 +3610,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -5599,6 +5599,10 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+msgid "Open the web interface"
+msgstr ""
+
 #: cmd/incus/info.go:677
 msgid "Operating System:"
 msgstr ""
@@ -5612,7 +5616,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr ""
 
@@ -5690,7 +5694,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5793,7 +5797,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -5801,7 +5805,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -6310,7 +6314,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -6797,11 +6801,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -6849,7 +6853,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr ""
 
@@ -7509,6 +7513,10 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -7530,7 +7538,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7538,6 +7546,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -7576,7 +7588,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -7986,7 +7998,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8104,6 +8116,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -8258,7 +8275,8 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -1559,11 +1559,11 @@ msgstr "Clustering aan"
 msgid "Columns"
 msgstr "Kolommen"
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid "Command line client for Incus"
 msgstr "Lijncommando client voor Incus"
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -2141,7 +2141,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2243,7 +2243,7 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
@@ -2422,7 +2422,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr "Toon geen voortgang indicator/informatie"
 
@@ -3234,7 +3234,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3610,7 +3610,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3900,7 +3900,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -5889,6 +5889,10 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+msgid "Open the web interface"
+msgstr ""
+
 #: cmd/incus/info.go:677
 msgid "Operating System:"
 msgstr ""
@@ -5902,7 +5906,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr ""
 
@@ -5980,7 +5984,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -6083,7 +6087,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -6091,7 +6095,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -6600,7 +6604,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -7089,11 +7093,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -7141,7 +7145,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr ""
 
@@ -7801,6 +7805,10 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -7822,7 +7830,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7830,6 +7838,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -7868,7 +7880,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8279,7 +8291,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8397,6 +8409,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -8551,7 +8568,8 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1269,11 +1269,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1843,7 +1843,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -1945,7 +1945,7 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
@@ -2124,7 +2124,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2936,7 +2936,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3312,7 +3312,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3602,7 +3602,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -5591,6 +5591,10 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+msgid "Open the web interface"
+msgstr ""
+
 #: cmd/incus/info.go:677
 msgid "Operating System:"
 msgstr ""
@@ -5604,7 +5608,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr ""
 
@@ -5682,7 +5686,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5785,7 +5789,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -5793,7 +5797,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -6302,7 +6306,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -6789,11 +6793,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -6841,7 +6845,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr ""
 
@@ -7501,6 +7505,10 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -7522,7 +7530,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7530,6 +7538,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -7568,7 +7580,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -7978,7 +7990,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8096,6 +8108,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -8250,7 +8267,8 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1544,12 +1544,12 @@ msgstr "Clustering ativado"
 msgid "Columns"
 msgstr "Colunas"
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 #, fuzzy
 msgid "Command line client for Incus"
 msgstr "Cliente de linha de comando para LXD"
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 #, fuzzy
 msgid ""
 "Command line client for Incus\n"
@@ -2167,7 +2167,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2269,7 +2269,7 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Descrição"
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr ""
 
@@ -3292,7 +3292,7 @@ msgstr "Ignorar o estado do container"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3694,7 +3694,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3992,7 +3992,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -6045,6 +6045,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+#, fuzzy
+msgid "Open the web interface"
+msgstr "Criando %s"
+
 #: cmd/incus/info.go:677
 msgid "Operating System:"
 msgstr ""
@@ -6058,7 +6063,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr ""
 
@@ -6138,7 +6143,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -6242,7 +6247,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -6250,7 +6255,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -6796,7 +6801,7 @@ msgstr "Nome de membro do cluster"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -7308,11 +7313,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -7367,7 +7372,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance snapshot configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr ""
 
@@ -8049,6 +8054,10 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -8070,7 +8079,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8078,6 +8087,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -8117,7 +8130,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8561,7 +8574,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8680,6 +8693,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -8837,7 +8855,8 @@ msgstr "Criar perfis"
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1557,11 +1557,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Столбцы"
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -2163,7 +2163,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2265,7 +2265,7 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
@@ -2456,7 +2456,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr ""
 
@@ -3288,7 +3288,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3989,7 +3989,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -6058,6 +6058,11 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+#, fuzzy
+msgid "Open the web interface"
+msgstr "Псевдонимы:"
+
 #: cmd/incus/info.go:677
 msgid "Operating System:"
 msgstr ""
@@ -6071,7 +6076,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr ""
 
@@ -6151,7 +6156,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -6255,7 +6260,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -6263,7 +6268,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -6795,7 +6800,7 @@ msgstr "Копирование образа: %s"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -7303,11 +7308,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -7359,7 +7364,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr ""
 
@@ -8043,6 +8048,10 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -8064,7 +8073,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8072,6 +8081,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -8111,7 +8124,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8550,7 +8563,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8669,6 +8682,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -8833,7 +8851,8 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-18 14:09-0400\n"
+"POT-Creation-Date: 2024-10-25 15:46-0400\n"
 "PO-Revision-Date: 2024-08-14 07:23+0000\n"
 "Last-Translator: Kwok Guy <kwokjuy@163.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -1430,11 +1430,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:84
+#: cmd/incus/main.go:85
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:85
+#: cmd/incus/main.go:86
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -2004,7 +2004,7 @@ msgstr ""
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
 #: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
 #: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:85
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2106,7 +2106,7 @@ msgstr ""
 #: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
 #: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
-#: cmd/incus/warning.go:304 cmd/incus/warning.go:358
+#: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Don't show progress information"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:101
+#: cmd/incus/main.go:102
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3473,7 +3473,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:446
+#: cmd/incus/main.go:451
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3763,7 +3763,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:542 cmd/incus/storage.go:134
+#: cmd/incus/main.go:547 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -5753,6 +5753,10 @@ msgid ""
 "Only one of --storage-create-device or --storage-create-loop can be specified"
 msgstr ""
 
+#: cmd/incus/webui.go:18 cmd/incus/webui.go:19
+msgid "Open the web interface"
+msgstr ""
+
 #: cmd/incus/info.go:677
 msgid "Operating System:"
 msgstr ""
@@ -5766,7 +5770,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:102
+#: cmd/incus/main.go:103
 msgid "Override the source project"
 msgstr ""
 
@@ -5844,7 +5848,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:407
+#: cmd/incus/main.go:412
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5947,7 +5951,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:100
+#: cmd/incus/main.go:101
 msgid "Print help"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:99
+#: cmd/incus/main.go:100
 msgid "Print version number"
 msgstr ""
 
@@ -6473,7 +6477,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: cmd/incus/admin_sql.go:145
+#: cmd/incus/admin_sql.go:148
 #, c-format
 msgid "Rows affected: %d"
 msgstr ""
@@ -6960,11 +6964,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:103
+#: cmd/incus/main.go:104
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:104
+#: cmd/incus/main.go:105
 msgid "Show all information messages"
 msgstr ""
 
@@ -7012,7 +7016,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:279 cmd/incus/main.go:280
+#: cmd/incus/main.go:284 cmd/incus/main.go:285
 msgid "Show less common commands"
 msgstr ""
 
@@ -7673,6 +7677,10 @@ msgid ""
 "The requested storage pool \"%s\" already exists. Please choose another name."
 msgstr ""
 
+#: cmd/incus/webui_unix.go:73
+msgid "The server doesn't have a web UI installed"
+msgstr ""
+
 #: cmd/incus/info.go:394
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
@@ -7694,7 +7702,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:306
+#: cmd/incus/main.go:311
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7702,6 +7710,10 @@ msgid ""
 "\n"
 "If you already added a remote server, make it the default with \"incus "
 "remote switch NAME\"."
+msgstr ""
+
+#: cmd/incus/webui_windows.go:15
+msgid "This command isn't supported on Windows"
 msgstr ""
 
 #: cmd/incus/admin_recover.go:63
@@ -7740,7 +7752,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:451
+#: cmd/incus/main.go:456
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8150,7 +8162,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8268,6 +8280,11 @@ msgid ""
 "Doing so makes your nested containers slightly less safe as they could\n"
 "in theory attack their parent container and gain more privileges than\n"
 "they otherwise would."
+msgstr ""
+
+#: cmd/incus/webui_unix.go:120
+#, c-format
+msgid "Web server running at: %s"
 msgstr ""
 
 #: cmd/incus/admin_init_interactive.go:151
@@ -8422,7 +8439,8 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
-#: cmd/incus/storage.go:662 cmd/incus/version.go:20 cmd/incus/warning.go:69
+#: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
+#: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
 

--- a/shared/util/browser.go
+++ b/shared/util/browser.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// OpenBrowser opens the provided URL in the default web browser.
+func OpenBrowser(url string) error {
+	var err error
+
+	browser := os.Getenv("BROWSER")
+	if browser != "" {
+		if browser == "none" {
+			return nil
+		}
+
+		err = exec.Command(browser, url).Start()
+		return err
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		err = fmt.Errorf("unsupported platform")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This implements a new `incus webui` command which will:
 - Check if the server has the web UI installed
 - Spawn a tiny web server for HTTP requests on localhost
 - Generate an authentication token to avoid other clients on the machine from accessing Incus
 - Open the user's web browser with a URL including that token

The result is that running `incus webui` will open your current web browser to the Incus UI without requiring Incus itself to listen on the network, or have to deal with Incus' TLS authentication and TLS certificate verification.