### PR TITLE
Add get-current to show current project

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: 2024-10-06 20:15+0000\n"
 "Last-Translator: Jan Mittelstädter <jan@mittelstaedter.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -545,7 +545,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern."
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1208,7 +1208,7 @@ msgid "Bad key/value pair: %s"
 msgstr "Ungültiges key/value Paar: %s"
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1590,7 +1590,7 @@ msgstr "Clustering aktiviert"
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1639,7 +1639,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the new network integration"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1660,7 +1660,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, fuzzy, c-format
@@ -1959,7 +1959,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 #, fuzzy
 msgid "Create projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -2011,7 +2011,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 #, fuzzy
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -2286,21 +2286,22 @@ msgstr ""
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2657,7 +2658,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2701,7 +2702,7 @@ msgstr "Alternatives config Verzeichnis."
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2781,7 +2782,7 @@ msgstr "Fehler beim Abrufen des Aliase/Namen: %w"
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
@@ -2803,7 +2804,7 @@ msgstr "Fehler beim Löschen der Parameter: %v"
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -3399,7 +3400,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3466,7 +3467,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3533,7 +3534,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3606,7 +3607,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3693,7 +3694,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3785,7 +3786,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr ""
 
@@ -4219,7 +4220,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr ""
 
@@ -4902,11 +4903,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -5436,8 +5437,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5697,9 +5698,9 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5836,7 +5837,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5847,11 +5848,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -5869,8 +5870,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -6298,7 +6299,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr ""
 
@@ -6430,7 +6431,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -6542,17 +6543,17 @@ msgstr "Profil %s erstellt\n"
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -6631,7 +6632,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr ""
 
@@ -6708,8 +6709,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -6747,7 +6748,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -6890,7 +6891,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -7085,7 +7086,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -7093,7 +7094,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -7345,12 +7346,12 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7489,7 +7490,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -7645,7 +7646,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr ""
 
@@ -7706,6 +7707,10 @@ msgid ""
 "machine\"."
 msgstr "Profil %s erstellt\n"
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid "Show the current project"
+msgstr ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr ""
@@ -7714,7 +7719,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
@@ -7983,7 +7988,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr ""
 
@@ -8215,7 +8220,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -8460,7 +8465,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8472,7 +8477,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -8489,7 +8494,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
@@ -8536,7 +8541,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -8652,7 +8657,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -8733,7 +8738,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -8824,7 +8829,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -9050,8 +9055,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -9105,7 +9110,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
@@ -10224,8 +10229,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -10233,7 +10238,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -10241,7 +10246,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -10249,7 +10254,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -10380,7 +10385,7 @@ msgstr ""
 msgid "application"
 msgstr "Eigenschaften:\n"
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
@@ -10794,7 +10799,7 @@ msgstr ""
 "   Automatisches Editieren eines Profils mithilfe der Konfigurationsdatei "
 "\"profile.yaml\""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 #, fuzzy
 msgid ""
 "incus project create p1\n"
@@ -10810,7 +10815,7 @@ msgstr ""
 "    Erstellt ein Projekt namens \"p1\" mit der Konfigurationsdatei \"config."
 "yaml\""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -11140,7 +11145,7 @@ msgstr "j"
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "ja"
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -546,7 +546,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1155,7 +1155,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1528,7 +1528,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1570,7 +1570,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Config key/value to apply to the new network integration"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1590,7 +1590,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1878,7 +1878,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid "Create projects"
 msgstr ""
 
@@ -1927,7 +1927,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid "Delete projects"
 msgstr ""
 
@@ -2198,21 +2198,22 @@ msgstr ""
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2548,7 +2549,7 @@ msgstr "Perfil %s creado"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2590,7 +2591,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2665,7 +2666,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
@@ -2687,7 +2688,7 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -3224,7 +3225,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3291,7 +3292,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3357,7 +3358,7 @@ msgstr "Acepta certificado"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3430,7 +3431,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3512,7 +3513,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3602,7 +3603,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr ""
 
@@ -4028,7 +4029,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr ""
 
@@ -4709,11 +4710,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -5216,8 +5217,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5474,9 +5475,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
@@ -5608,7 +5609,7 @@ msgstr ""
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5619,11 +5620,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -5641,8 +5642,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -6058,7 +6059,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr ""
 
@@ -6188,7 +6189,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -6299,17 +6300,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr "Perfil %s creado"
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -6384,7 +6385,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr ""
 
@@ -6460,8 +6461,8 @@ msgstr "Refrescando la imagen: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -6499,7 +6500,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -6635,7 +6636,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid "Rename projects"
 msgstr ""
 
@@ -6827,7 +6828,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6835,7 +6836,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -7074,11 +7075,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7211,7 +7212,7 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -7358,7 +7359,7 @@ msgstr "Perfil %s creado"
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr ""
 
@@ -7415,6 +7416,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid "Show the current project"
+msgstr ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr ""
@@ -7423,7 +7428,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Copiando la imagen: %s"
@@ -7682,7 +7687,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr ""
 
@@ -7911,7 +7916,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -8153,7 +8158,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8165,7 +8170,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -8180,7 +8185,7 @@ msgstr ""
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
@@ -8226,7 +8231,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -8338,7 +8343,7 @@ msgstr "Perfil %s creado"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -8416,7 +8421,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -8504,7 +8509,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8720,8 +8725,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8765,7 +8770,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
@@ -9458,23 +9463,23 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9554,7 +9559,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
@@ -9927,7 +9932,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9936,7 +9941,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -10182,7 +10187,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: 2024-03-08 16:01+0000\n"
 "Last-Translator: montag451 <montag451@laposte.net>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -551,7 +551,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1181,7 +1181,7 @@ msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Mauvaise association clef=valeur: %q"
@@ -1562,7 +1562,7 @@ msgstr "Clustering activé"
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1611,7 +1611,7 @@ msgstr "Configuration clé/valeur à associer à la nouvelle instance"
 msgid "Config key/value to apply to the new network integration"
 msgstr "Configuration clé/valeur à associer à la nouvelle intégration réseau"
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr "Configuration clef/valeur à associer au nouveau projet"
 
@@ -1630,7 +1630,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1962,7 +1962,7 @@ msgstr "Créer de nouveaux réseaux"
 msgid "Create profiles"
 msgstr "Créé : %s"
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 #, fuzzy
 msgid "Create projects"
 msgstr "Créé : %s"
@@ -2014,7 +2014,7 @@ msgstr "ADRESSE CIBLE PAR DÉFAUT"
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -2159,7 +2159,7 @@ msgstr "Supprime les réseaux"
 msgid "Delete profiles"
 msgstr "Supprime les profiles"
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 #, fuzzy
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
@@ -2295,21 +2295,22 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2662,7 +2663,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit profile configurations as YAML"
 msgstr "Modifier les configurations de profil au format YAML"
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2706,7 +2707,7 @@ msgstr "Clé de configuration invalide"
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2795,7 +2796,7 @@ msgstr "Erreur lors de la récupération des alias : %w"
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
@@ -2817,7 +2818,7 @@ msgstr "Erreur lors du déparamétrage des propriétés: %v"
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -3432,7 +3433,7 @@ msgstr "Forcer une action d'évacuation particulière"
 msgid "Force creating files or directories"
 msgstr "Forcer la création de fichiers ou de répertoires"
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3522,7 +3523,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3592,7 +3593,7 @@ msgstr "Ajouter de nouveaux certificat pour des clients de confiance"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr "Obtenir un résumé de l'allocation des ressources"
 
@@ -3666,7 +3667,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get the key as a profile property"
 msgstr "Obtenir la clé en tant que propriété du profil"
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr "Obtenir la clé en tant que propriété du projet"
 
@@ -3755,7 +3756,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3851,7 +3852,7 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr "ID : %s"
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -4308,7 +4309,7 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr "LIMITE"
 
@@ -5051,11 +5052,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -5579,8 +5580,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5841,9 +5842,9 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5983,7 +5984,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5994,11 +5995,11 @@ msgstr "NOM"
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -6016,8 +6017,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr "NON"
@@ -6457,7 +6458,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr "PROFILS"
 
@@ -6589,7 +6590,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 #, fuzzy
@@ -6702,17 +6703,17 @@ msgstr "Profils : %s"
 msgid "Profiles: "
 msgstr "Profils : %s"
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -6790,7 +6791,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 #, fuzzy
 msgid "RESOURCE"
 msgstr "SOURCE"
@@ -6870,8 +6871,8 @@ msgstr "Récupération de l'image : %s"
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
@@ -6910,7 +6911,7 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -7053,7 +7054,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
@@ -7266,7 +7267,7 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 #, fuzzy
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -7275,7 +7276,7 @@ msgstr "ENSEMBLE DE STOCKAGE"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -7523,12 +7524,12 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7666,7 +7667,7 @@ msgstr "Clé de configuration invalide"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -7826,7 +7827,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
@@ -7886,6 +7887,11 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+#, fuzzy
+msgid "Show the current project"
+msgstr "impossible de supprimer le serveur distant par défaut"
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 #, fuzzy
 msgid "Show the default remote"
@@ -7895,7 +7901,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
@@ -8164,7 +8170,7 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -8405,7 +8411,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -8655,7 +8661,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8667,7 +8673,7 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -8684,7 +8690,7 @@ msgstr "Création du conteneur"
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -8731,7 +8737,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -8849,7 +8855,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -8930,7 +8936,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -9021,7 +9027,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 #, fuzzy
 msgid "User aborted delete operation"
@@ -9244,8 +9250,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr "OUI"
@@ -9298,7 +9304,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
@@ -10471,8 +10477,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -10480,7 +10486,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -10488,7 +10494,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -10496,7 +10502,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -10642,7 +10648,7 @@ msgstr ""
 msgid "application"
 msgstr "Propriétés :"
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -11039,7 +11045,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -11048,7 +11054,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -11296,7 +11302,7 @@ msgstr "o"
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "oui"
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -321,7 +321,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -895,7 +895,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1261,7 +1261,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid "Create projects"
 msgstr ""
 
@@ -1644,7 +1644,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -1774,7 +1774,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid "Delete projects"
 msgstr ""
 
@@ -1906,21 +1906,22 @@ msgstr ""
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2239,7 +2240,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2280,7 +2281,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2355,7 +2356,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
@@ -2377,7 +2378,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -2908,7 +2909,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -2974,7 +2975,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3039,7 +3040,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3103,7 +3104,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3176,7 +3177,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr ""
 
@@ -3674,7 +3675,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr ""
 
@@ -4341,11 +4342,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -4830,8 +4831,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5075,9 +5076,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 msgid "Missing project name"
 msgstr ""
 
@@ -5202,7 +5203,7 @@ msgstr ""
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5213,11 +5214,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -5235,8 +5236,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5650,7 +5651,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr ""
 
@@ -5779,7 +5780,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -5886,17 +5887,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -5971,7 +5972,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr ""
 
@@ -6045,8 +6046,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -6084,7 +6085,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -6210,7 +6211,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid "Rename projects"
 msgstr ""
 
@@ -6393,7 +6394,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6401,7 +6402,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -6632,11 +6633,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6761,7 +6762,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6898,7 +6899,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr ""
 
@@ -6951,6 +6952,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid "Show the current project"
+msgstr ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr ""
@@ -6959,7 +6964,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 msgid "Show the instance's access list"
 msgstr ""
 
@@ -7213,7 +7218,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr ""
 
@@ -7442,7 +7447,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -7681,7 +7686,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7693,7 +7698,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7708,7 +7713,7 @@ msgstr ""
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
@@ -7753,7 +7758,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -7854,7 +7859,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -7923,7 +7928,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -8008,7 +8013,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8223,8 +8228,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8266,7 +8271,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
@@ -8830,20 +8835,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -8908,7 +8913,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
@@ -9281,7 +9286,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9290,7 +9295,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9536,6 +9541,6 @@ msgstr ""
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-10-25 15:46-0400\n"
+        "POT-Creation-Date: 2024-11-06 08:30+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -300,7 +300,7 @@ msgid   "### This is a YAML representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 msgid   "### This is a YAML representation of the project.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -854,7 +854,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302 cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302 cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -1170,7 +1170,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092 cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421 cmd/incus/config_trust.go:610 cmd/incus/image.go:1093 cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072 cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:138 cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:687 cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904 cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548 cmd/incus/warning.go:93
+#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092 cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421 cmd/incus/config_trust.go:610 cmd/incus/image.go:1093 cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072 cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:138 cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:687 cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904 cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548 cmd/incus/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1203,7 +1203,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new network integration"
 msgstr  ""
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
@@ -1215,7 +1215,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714 cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804 cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405 cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300 cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714 cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804 cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405 cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300 cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1481,7 +1481,7 @@ msgstr  ""
 msgid   "Create profiles"
 msgstr  ""
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid   "Create projects"
 msgstr  ""
 
@@ -1521,7 +1521,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499 cmd/incus/config_trust.go:435 cmd/incus/image.go:1115 cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133 cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141 cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134 cmd/incus/network_zone.go:917 cmd/incus/operation.go:151 cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916 cmd/incus/storage_volume.go:1672
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499 cmd/incus/config_trust.go:435 cmd/incus/image.go:1115 cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133 cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141 cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134 cmd/incus/network_zone.go:917 cmd/incus/operation.go:151 cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916 cmd/incus/storage_volume.go:1672
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1648,7 +1648,7 @@ msgstr  ""
 msgid   "Delete profiles"
 msgstr  ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid   "Delete projects"
 msgstr  ""
 
@@ -1668,7 +1668,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:315 cmd/incus/file.go:393 cmd/incus/file.go:463 cmd/incus/file.go:682 cmd/incus/file.go:1187 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100 cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433 cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788 cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981 cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794 cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961 cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:315 cmd/incus/file.go:393 cmd/incus/file.go:463 cmd/incus/file.go:682 cmd/incus/file.go:1187 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104 cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437 cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792 cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985 cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794 cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961 cmd/incus/storage_volume.go:3127 cmd/incus/top.go:33 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
@@ -1952,7 +1952,7 @@ msgstr  ""
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
@@ -1983,7 +1983,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:631 cmd/incus/image.go:1133 cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113 cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:166 cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:722 cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925 cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658 cmd/incus/warning.go:236
+#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:631 cmd/incus/image.go:1133 cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113 cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:166 cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:722 cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925 cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658 cmd/incus/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -2043,7 +2043,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1539 cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595 cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548 cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083 cmd/incus/project.go:851 cmd/incus/storage.go:896 cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038 cmd/incus/storage_volume.go:2081
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1539 cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595 cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548 cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083 cmd/incus/project.go:855 cmd/incus/storage.go:896 cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038 cmd/incus/storage_volume.go:2081
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -2058,7 +2058,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013 cmd/incus/network.go:1533 cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662 cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622 cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230 cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013 cmd/incus/network.go:1533 cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662 cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622 cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230 cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2576,7 +2576,7 @@ msgstr  ""
 msgid   "Force creating files or directories"
 msgstr  ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid   "Force delete the project and everything it contains."
 msgstr  ""
 
@@ -2627,7 +2627,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:609 cmd/incus/image.go:1094 cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073 cmd/incus/network.go:1272 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:859 cmd/incus/operation.go:136 cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902 cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561 cmd/incus/warning.go:94
+#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:609 cmd/incus/image.go:1094 cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073 cmd/incus/network.go:1272 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:859 cmd/incus/operation.go:136 cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902 cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561 cmd/incus/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2687,7 +2687,7 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
@@ -2751,7 +2751,7 @@ msgstr  ""
 msgid   "Get the key as a profile property"
 msgstr  ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid   "Get the key as a project property"
 msgstr  ""
 
@@ -2823,7 +2823,7 @@ msgstr  ""
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
@@ -2907,7 +2907,7 @@ msgstr  ""
 msgid   "ID: %s"
 msgstr  ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid   "IMAGES"
 msgstr  ""
 
@@ -3310,7 +3310,7 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid   "LIMIT"
 msgstr  ""
 
@@ -3948,11 +3948,11 @@ msgid   "List profiles\n"
         "u - Used By"
 msgstr  ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid   "List projects"
 msgstr  ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid   "List projects\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4577,7 +4577,7 @@ msgstr  ""
 msgid   "Missing profile name"
 msgstr  ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353 cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824 cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357 cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828 cmd/incus/project.go:956 cmd/incus/project.go:1087
 msgid   "Missing project name"
 msgstr  ""
 
@@ -4689,7 +4689,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:621 cmd/incus/list.go:583 cmd/incus/network.go:1093 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128 cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916 cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690 cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915 cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:621 cmd/incus/list.go:583 cmd/incus/network.go:1093 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128 cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916 cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694 cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915 cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
 msgid   "NAME"
 msgstr  ""
 
@@ -4697,11 +4697,11 @@ msgstr  ""
 msgid   "NAT"
 msgstr  ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid   "NETWORK ZONES"
 msgstr  ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid   "NETWORKS"
 msgstr  ""
 
@@ -4718,7 +4718,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: cmd/incus/network.go:1142 cmd/incus/operation.go:199 cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604 cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631 cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
+#: cmd/incus/network.go:1142 cmd/incus/operation.go:199 cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608 cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635 cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid   "NO"
 msgstr  ""
 
@@ -5123,7 +5123,7 @@ msgstr  ""
 msgid   "PROCESSES"
 msgstr  ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid   "PROFILES"
 msgstr  ""
 
@@ -5240,7 +5240,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:478 cmd/incus/network.go:803 cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805 cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406 cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301 cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:478 cmd/incus/network.go:803 cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805 cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406 cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301 cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -5345,17 +5345,17 @@ msgstr  ""
 msgid   "Profiles: "
 msgstr  ""
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid   "Project %s created"
 msgstr  ""
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
@@ -5430,7 +5430,7 @@ msgstr  ""
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid   "RESOURCE"
 msgstr  ""
 
@@ -5498,7 +5498,7 @@ msgstr  ""
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927 cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -5536,7 +5536,7 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid   "Remove %s and everything it contains (instances, images, volumes, networks, ...) (yes/no): "
 msgstr  ""
@@ -5658,7 +5658,7 @@ msgstr  ""
 msgid   "Rename profiles"
 msgstr  ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid   "Rename projects"
 msgstr  ""
 
@@ -5838,7 +5838,7 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
@@ -5846,7 +5846,7 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
@@ -6053,11 +6053,11 @@ msgid   "Set profile configuration keys\n"
         "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -6172,7 +6172,7 @@ msgstr  ""
 msgid   "Set the key as a profile property"
 msgstr  ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid   "Set the key as a project property"
 msgstr  ""
 
@@ -6308,7 +6308,7 @@ msgstr  ""
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid   "Show project options"
 msgstr  ""
 
@@ -6356,6 +6356,10 @@ msgid   "Show storage volume state information\n"
         "Supported values for type are \"custom\", \"container\" and \"virtual-machine\"."
 msgstr  ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid   "Show the current project"
+msgstr  ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid   "Show the default remote"
 msgstr  ""
@@ -6364,7 +6368,7 @@ msgstr  ""
 msgid   "Show the expanded configuration"
 msgstr  ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 msgid   "Show the instance's access list"
 msgstr  ""
 
@@ -6615,7 +6619,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid   "Switch the current project"
 msgstr  ""
 
@@ -6827,7 +6831,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, c-format
 msgid   "The property %q does not exist on the project %q: %v"
 msgstr  ""
@@ -7049,7 +7053,7 @@ msgstr  ""
 msgid   "Type: %s"
 msgstr  ""
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid   "UNLIMITED"
 msgstr  ""
 
@@ -7061,7 +7065,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid   "USAGE"
 msgstr  ""
 
@@ -7073,7 +7077,7 @@ msgstr  ""
 msgid   "USB devices:"
 msgstr  ""
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452 cmd/incus/network_zone.go:135 cmd/incus/profile.go:748 cmd/incus/project.go:556 cmd/incus/storage.go:712 cmd/incus/storage_volume.go:1674
+#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452 cmd/incus/network_zone.go:135 cmd/incus/profile.go:748 cmd/incus/project.go:560 cmd/incus/storage.go:712 cmd/incus/storage_volume.go:1674
 msgid   "USED BY"
 msgstr  ""
 
@@ -7109,7 +7113,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455 cmd/incus/config_trust.go:637 cmd/incus/image.go:1141 cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119 cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:172 cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:728 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664 cmd/incus/warning.go:244
+#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455 cmd/incus/config_trust.go:637 cmd/incus/image.go:1141 cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119 cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:172 cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:728 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664 cmd/incus/warning.go:244
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -7206,7 +7210,7 @@ msgstr  ""
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 msgid   "Unset project configuration keys"
 msgstr  ""
 
@@ -7273,7 +7277,7 @@ msgstr  ""
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid   "Unset the key as a project property"
 msgstr  ""
 
@@ -7354,7 +7358,7 @@ msgstr  ""
 msgid   "User aborted configuration"
 msgstr  ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224 cmd/incus/snapshot.go:257
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228 cmd/incus/snapshot.go:257
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -7556,7 +7560,7 @@ msgstr  ""
 msgid   "Would you like to use clustering?"
 msgstr  ""
 
-#: cmd/incus/network.go:1139 cmd/incus/operation.go:202 cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606 cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633 cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
+#: cmd/incus/network.go:1139 cmd/incus/operation.go:202 cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610 cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637 cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid   "YES"
 msgstr  ""
 
@@ -7592,7 +7596,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070 cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31 cmd/incus/network.go:1050 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505 cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20 cmd/incus/warning.go:69 cmd/incus/webui.go:17
+#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070 cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31 cmd/incus/network.go:1050 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509 cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20 cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -8116,19 +8120,19 @@ msgstr  ""
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295 cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299 cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 msgid   "[<remote>:]<project>"
 msgstr  ""
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 msgid   "[<remote>:]<project> <key>"
 msgstr  ""
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 msgid   "[<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
@@ -8192,7 +8196,7 @@ msgstr  ""
 msgid   "application"
 msgstr  ""
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid   "current"
 msgstr  ""
 
@@ -8507,7 +8511,7 @@ msgid   "incus profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid   "incus project create p1\n"
         "    Create a project named p1\n"
         "\n"
@@ -8515,7 +8519,7 @@ msgid   "incus project create p1\n"
         "    Create a project named p1 with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid   "incus project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
@@ -8721,7 +8725,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493 cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978 cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493 cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978 cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid   "yes"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -550,7 +550,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1154,7 +1154,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1523,7 +1523,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid "Create projects"
 msgstr ""
 
@@ -1920,7 +1920,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -2057,7 +2057,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid "Delete projects"
 msgstr ""
 
@@ -2191,21 +2191,22 @@ msgstr ""
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2542,7 +2543,7 @@ msgstr "Il nome del container è: %s"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2584,7 +2585,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2659,7 +2660,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
@@ -2681,7 +2682,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -3218,7 +3219,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3285,7 +3286,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3351,7 +3352,7 @@ msgstr "Accetta certificato"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3422,7 +3423,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3503,7 +3504,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3593,7 +3594,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr ""
 
@@ -4017,7 +4018,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr ""
 
@@ -4699,11 +4700,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -5211,8 +5212,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5468,9 +5469,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
@@ -5602,7 +5603,7 @@ msgstr ""
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5613,11 +5614,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -5635,8 +5636,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -6053,7 +6054,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr ""
 
@@ -6184,7 +6185,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -6293,17 +6294,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -6379,7 +6380,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr ""
 
@@ -6455,8 +6456,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
@@ -6494,7 +6495,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -6631,7 +6632,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid "Rename projects"
 msgstr ""
 
@@ -6823,7 +6824,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6831,7 +6832,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -7068,11 +7069,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7203,7 +7204,7 @@ msgstr "Il nome del container è: %s"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -7350,7 +7351,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr ""
 
@@ -7407,6 +7408,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid "Show the current project"
+msgstr ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr ""
@@ -7415,7 +7420,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Creazione del container in corso"
@@ -7676,7 +7681,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr ""
 
@@ -7907,7 +7912,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Il nome del container è: %s"
@@ -8148,7 +8153,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8160,7 +8165,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -8177,7 +8182,7 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
@@ -8224,7 +8229,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -8334,7 +8339,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -8409,7 +8414,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -8498,7 +8503,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8715,8 +8720,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8763,7 +8768,7 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
@@ -9456,23 +9461,23 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
@@ -9552,7 +9557,7 @@ msgstr "Creazione del container in corso"
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
@@ -9925,7 +9930,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9934,7 +9939,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -10181,7 +10186,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -542,7 +542,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1160,7 +1160,7 @@ msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %q"
@@ -1537,7 +1537,7 @@ msgstr "クラスタリングが有効になりました"
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1584,7 +1584,7 @@ msgstr "新しいインスタンスに適用するキー/値の設定"
 msgid "Config key/value to apply to the new network integration"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
@@ -1603,7 +1603,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1902,7 +1902,7 @@ msgstr "新たにネットワークを作成します"
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid "Create projects"
 msgstr "プロジェクトを作成します"
 
@@ -1950,7 +1950,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -2084,7 +2084,7 @@ msgstr "ネットワークを削除します"
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
@@ -2216,21 +2216,22 @@ msgstr "警告を削除します"
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2565,7 +2566,7 @@ msgstr "ネットワークゾーンレコードをYAMLで編集します"
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
@@ -2606,7 +2607,7 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2691,7 +2692,7 @@ msgstr "エイリアスの取得に失敗しました: %w"
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
@@ -2713,7 +2714,7 @@ msgstr "プロパティの削除でエラーが発生しました: %v"
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -3288,7 +3289,7 @@ msgstr "特定の待避アクションを強制します"
 msgid "Force creating files or directories"
 msgstr "強制的にファイルまたはディレクトリーを作成します"
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr "プロジェクトとプロジェクトに含まれるすべてを強制的に削除します。"
 
@@ -3370,7 +3371,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3436,7 +3437,7 @@ msgstr "新たに信頼済みのクライアント証明書を追加します"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
@@ -3510,7 +3511,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Get the key as a profile property"
 msgstr "key をプロファイルプロパティとして取得します"
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr "key をプロジェクトプロパティとして取得します"
 
@@ -3588,7 +3589,7 @@ msgstr "ネットワークゾーンレコードの設定値を取得します"
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
@@ -3679,7 +3680,7 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -4118,7 +4119,7 @@ msgstr "LAST SEEN"
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr "LIMIT"
 
@@ -5269,11 +5270,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 #, fuzzy
 msgid ""
 "List projects\n"
@@ -5929,8 +5930,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -6179,9 +6180,9 @@ msgstr "ストレージプール名を指定する必要があります"
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
@@ -6331,7 +6332,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -6342,11 +6343,11 @@ msgstr "NAME"
 msgid "NAT"
 msgstr "NAT"
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr "NETWORK ZONES"
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
@@ -6364,8 +6365,8 @@ msgid "NICs:"
 msgstr "NICs:"
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr "NO"
@@ -6798,7 +6799,7 @@ msgstr "PORTS"
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr "PROFILES"
 
@@ -6929,7 +6930,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -7038,17 +7039,17 @@ msgstr "プロファイル:"
 msgid "Profiles: "
 msgstr "プロファイル: "
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid "Project %s created"
 msgstr "プロジェクト %s を作成しました"
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
@@ -7123,7 +7124,7 @@ msgstr "query のパスは / で始める必要があります"
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
@@ -7207,8 +7208,8 @@ msgstr "イメージの更新中: %s"
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
@@ -7247,7 +7248,7 @@ msgstr "リムーバブルディスク: %v"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -7377,7 +7378,7 @@ msgstr "ネットワーク名を変更します"
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
@@ -7570,7 +7571,7 @@ msgstr "STATIC"
 msgid "STATUS"
 msgstr "STATUS"
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
@@ -7578,7 +7579,7 @@ msgstr "STORAGE BUCKETS"
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
@@ -7870,11 +7871,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 #, fuzzy
 msgid ""
 "Set project configuration keys\n"
@@ -8030,7 +8031,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Set the key as a profile property"
 msgstr "プロファイルプロパティとして設定します"
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr "プロジェクトプロパティとして設定します"
 
@@ -8173,7 +8174,7 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
@@ -8231,6 +8232,11 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+#, fuzzy
+msgid "Show the current project"
+msgstr "現在のプロジェクトを切り替えます"
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
@@ -8239,7 +8245,7 @@ msgstr "デフォルトのリモートを表示します"
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "インスタンスログの最後の 100 行を表示しますか?"
@@ -8499,7 +8505,7 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
@@ -8761,7 +8767,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -9038,7 +9044,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
@@ -9050,7 +9056,7 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr "USAGE"
 
@@ -9067,7 +9073,7 @@ msgstr "上位デバイス"
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr "USED BY"
@@ -9113,7 +9119,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -9216,7 +9222,7 @@ msgstr "ネットワークゾーンレコードの設定を削除します"
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
@@ -9293,7 +9299,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Unset the key as a profile property"
 msgstr "プロファイルプロパティの設定を削除します"
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr "プロジェクトプロパティの設定を削除します"
 
@@ -9386,7 +9392,7 @@ msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 msgid "User aborted configuration"
 msgstr "ユーザが削除操作を中断しました"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
@@ -9625,8 +9631,8 @@ msgid "Would you like to use clustering?"
 msgstr "クラスタリングを使用しますか?"
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr "YES"
@@ -9671,7 +9677,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
@@ -10272,20 +10278,20 @@ msgstr "[<remote>:]<profile> <new-name>"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 msgid "[<remote>:]<project>"
 msgstr "[<remote>:]<project>"
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 msgid "[<remote>:]<project> <key>"
 msgstr "[<remote>:]<project> <key>"
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
@@ -10351,7 +10357,7 @@ msgstr "[[<remote>:]<member>]"
 msgid "application"
 msgstr "operation"
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr "現在値"
 
@@ -10927,7 +10933,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 #, fuzzy
 msgid ""
 "incus project create p1\n"
@@ -10941,7 +10947,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 #, fuzzy
 msgid ""
 "incus project edit <project> < project.yaml\n"
@@ -11265,7 +11271,7 @@ msgstr "y"
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "yes"
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -328,7 +328,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -902,7 +902,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1268,7 +1268,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1307,7 +1307,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1603,7 +1603,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid "Create projects"
 msgstr ""
 
@@ -1651,7 +1651,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -1781,7 +1781,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid "Delete projects"
 msgstr ""
 
@@ -1913,21 +1913,22 @@ msgstr ""
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2246,7 +2247,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2287,7 +2288,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2362,7 +2363,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
@@ -2384,7 +2385,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -2915,7 +2916,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -2981,7 +2982,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3046,7 +3047,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3110,7 +3111,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3183,7 +3184,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3271,7 +3272,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr ""
 
@@ -3682,7 +3683,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr ""
 
@@ -4349,11 +4350,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -4838,8 +4839,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5083,9 +5084,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 msgid "Missing project name"
 msgstr ""
 
@@ -5210,7 +5211,7 @@ msgstr ""
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5221,11 +5222,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -5243,8 +5244,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5658,7 +5659,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr ""
 
@@ -5787,7 +5788,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -5894,17 +5895,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -5979,7 +5980,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr ""
 
@@ -6053,8 +6054,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -6092,7 +6093,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -6218,7 +6219,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid "Rename projects"
 msgstr ""
 
@@ -6401,7 +6402,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6409,7 +6410,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -6640,11 +6641,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6769,7 +6770,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6906,7 +6907,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr ""
 
@@ -6959,6 +6960,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid "Show the current project"
+msgstr ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr ""
@@ -6967,7 +6972,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 msgid "Show the instance's access list"
 msgstr ""
 
@@ -7221,7 +7226,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr ""
 
@@ -7450,7 +7455,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -7689,7 +7694,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7701,7 +7706,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7716,7 +7721,7 @@ msgstr ""
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
@@ -7761,7 +7766,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -7862,7 +7867,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -7931,7 +7936,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -8016,7 +8021,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8231,8 +8236,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8274,7 +8279,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
@@ -8838,20 +8843,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -8916,7 +8921,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
@@ -9289,7 +9294,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9298,7 +9303,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9544,6 +9549,6 @@ msgstr "j"
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "ja"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -561,7 +561,7 @@ msgstr ""
 "###\n"
 "### Merk op dat de getoonde naam (name) niet kan worden aangepast"
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1183,7 +1183,7 @@ msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Ongeldig sleutel=waarde paar: %q"
@@ -1551,7 +1551,7 @@ msgstr "Clustering aan"
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1598,7 +1598,7 @@ msgstr "Configuratie sleutel/waarde toe te passen op de nieuwe instantiatie"
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1617,7 +1617,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1894,7 +1894,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid "Create projects"
 msgstr ""
 
@@ -1942,7 +1942,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -2072,7 +2072,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid "Delete projects"
 msgstr ""
 
@@ -2204,21 +2204,22 @@ msgstr ""
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2537,7 +2538,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2578,7 +2579,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2653,7 +2654,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
@@ -2675,7 +2676,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -3206,7 +3207,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3272,7 +3273,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3337,7 +3338,7 @@ msgstr "Genereer het client certificaat"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3401,7 +3402,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3474,7 +3475,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3561,7 +3562,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr ""
 
@@ -3972,7 +3973,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr ""
 
@@ -4639,11 +4640,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -5128,8 +5129,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5373,9 +5374,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 msgid "Missing project name"
 msgstr ""
 
@@ -5500,7 +5501,7 @@ msgstr ""
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5511,11 +5512,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -5533,8 +5534,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5948,7 +5949,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr ""
 
@@ -6077,7 +6078,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -6184,17 +6185,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -6269,7 +6270,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr ""
 
@@ -6343,8 +6344,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -6382,7 +6383,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -6508,7 +6509,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid "Rename projects"
 msgstr ""
 
@@ -6691,7 +6692,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6699,7 +6700,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -6930,11 +6931,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7061,7 +7062,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -7198,7 +7199,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr ""
 
@@ -7251,6 +7252,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid "Show the current project"
+msgstr ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr ""
@@ -7259,7 +7264,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 msgid "Show the instance's access list"
 msgstr ""
 
@@ -7513,7 +7518,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr ""
 
@@ -7742,7 +7747,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -7981,7 +7986,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7993,7 +7998,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -8008,7 +8013,7 @@ msgstr ""
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
@@ -8053,7 +8058,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -8154,7 +8159,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -8224,7 +8229,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -8309,7 +8314,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8524,8 +8529,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8567,7 +8572,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
@@ -9131,20 +9136,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -9209,7 +9214,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
@@ -9582,7 +9587,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9591,7 +9596,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9844,7 +9849,7 @@ msgstr "j"
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "ja"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -321,7 +321,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -895,7 +895,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1261,7 +1261,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid "Create projects"
 msgstr ""
 
@@ -1644,7 +1644,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -1774,7 +1774,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid "Delete projects"
 msgstr ""
 
@@ -1906,21 +1906,22 @@ msgstr ""
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2239,7 +2240,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2280,7 +2281,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2355,7 +2356,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
@@ -2377,7 +2378,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -2908,7 +2909,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -2974,7 +2975,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3039,7 +3040,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3103,7 +3104,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3176,7 +3177,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr ""
 
@@ -3674,7 +3675,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr ""
 
@@ -4341,11 +4342,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -4830,8 +4831,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5075,9 +5076,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 msgid "Missing project name"
 msgstr ""
 
@@ -5202,7 +5203,7 @@ msgstr ""
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5213,11 +5214,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -5235,8 +5236,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5650,7 +5651,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr ""
 
@@ -5779,7 +5780,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -5886,17 +5887,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -5971,7 +5972,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr ""
 
@@ -6045,8 +6046,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -6084,7 +6085,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -6210,7 +6211,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid "Rename projects"
 msgstr ""
 
@@ -6393,7 +6394,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6401,7 +6402,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -6632,11 +6633,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6761,7 +6762,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6898,7 +6899,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr ""
 
@@ -6951,6 +6952,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid "Show the current project"
+msgstr ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr ""
@@ -6959,7 +6964,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 msgid "Show the instance's access list"
 msgstr ""
 
@@ -7213,7 +7218,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr ""
 
@@ -7442,7 +7447,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -7681,7 +7686,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7693,7 +7698,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7708,7 +7713,7 @@ msgstr ""
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
@@ -7753,7 +7758,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -7854,7 +7859,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -7923,7 +7928,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -8008,7 +8013,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8223,8 +8228,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8266,7 +8271,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
@@ -8830,20 +8835,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -8908,7 +8913,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
@@ -9281,7 +9286,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9290,7 +9295,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9536,6 +9541,6 @@ msgstr ""
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -539,7 +539,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado"
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1165,7 +1165,7 @@ msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1536,7 +1536,7 @@ msgstr "Clustering ativado"
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1586,7 +1586,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Config key/value to apply to the new network integration"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1606,7 +1606,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1903,7 +1903,7 @@ msgstr "Criar novas redes"
 msgid "Create profiles"
 msgstr "Criar perfis"
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid "Create projects"
 msgstr "Criar projetos"
 
@@ -1952,7 +1952,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
@@ -2230,21 +2230,22 @@ msgstr ""
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2588,7 +2589,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
@@ -2632,7 +2633,7 @@ msgstr "Editar configurações de perfil como YAML"
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2707,7 +2708,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
@@ -2729,7 +2730,7 @@ msgstr "Editar propriedades da imagem"
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -3263,7 +3264,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3330,7 +3331,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3396,7 +3397,7 @@ msgstr "Adicionar novos clientes confiáveis"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3470,7 +3471,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3556,7 +3557,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3645,7 +3646,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr ""
 
@@ -4068,7 +4069,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr ""
 
@@ -4748,11 +4749,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -5263,8 +5264,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5521,9 +5522,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 msgid "Missing project name"
 msgstr ""
 
@@ -5655,7 +5656,7 @@ msgstr ""
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5666,11 +5667,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -5688,8 +5689,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -6107,7 +6108,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr ""
 
@@ -6237,7 +6238,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -6349,17 +6350,17 @@ msgstr "Copiar perfis"
 msgid "Profiles: "
 msgstr "Copiar perfis"
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -6435,7 +6436,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr ""
 
@@ -6511,8 +6512,8 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -6551,7 +6552,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -6693,7 +6694,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid "Rename projects"
 msgstr ""
 
@@ -6890,7 +6891,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6898,7 +6899,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -7141,12 +7142,12 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7279,7 +7280,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -7434,7 +7435,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr ""
 
@@ -7492,6 +7493,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid "Show the current project"
+msgstr ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr ""
@@ -7500,7 +7505,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Ignorar o estado do container"
@@ -7761,7 +7766,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr ""
 
@@ -7991,7 +7996,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nome de membro do cluster"
@@ -8232,7 +8237,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8244,7 +8249,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -8261,7 +8266,7 @@ msgstr "Editar arquivos no container"
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
@@ -8308,7 +8313,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -8425,7 +8430,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -8504,7 +8509,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -8593,7 +8598,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "Editar configurações de perfil como YAML"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8810,8 +8815,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8854,7 +8859,7 @@ msgstr "Criar perfis"
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
@@ -9490,21 +9495,21 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Criar projetos"
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -9578,7 +9583,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
@@ -9951,7 +9956,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9960,7 +9965,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -10206,7 +10211,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "sim"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -563,7 +563,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1179,7 +1179,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1549,7 +1549,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1588,7 +1588,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1607,7 +1607,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1901,7 +1901,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid "Create projects"
 msgstr ""
 
@@ -1952,7 +1952,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid "Delete projects"
 msgstr ""
 
@@ -2226,21 +2226,22 @@ msgstr ""
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2578,7 +2579,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2620,7 +2621,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2695,7 +2696,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, fuzzy, c-format
@@ -2717,7 +2718,7 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -3259,7 +3260,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3326,7 +3327,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3392,7 +3393,7 @@ msgstr "Принять сертификат"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3465,7 +3466,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3549,7 +3550,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3639,7 +3640,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr ""
 
@@ -4065,7 +4066,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr ""
 
@@ -4748,11 +4749,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -5269,8 +5270,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5528,9 +5529,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
@@ -5662,7 +5663,7 @@ msgstr ""
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5673,11 +5674,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -5695,8 +5696,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -6120,7 +6121,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr ""
 
@@ -6250,7 +6251,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -6357,17 +6358,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -6442,7 +6443,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr ""
 
@@ -6520,8 +6521,8 @@ msgstr "Копирование образа: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -6559,7 +6560,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -6696,7 +6697,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid "Rename projects"
 msgstr ""
 
@@ -6889,7 +6890,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6897,7 +6898,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -7136,11 +7137,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -7273,7 +7274,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -7425,7 +7426,7 @@ msgstr "Копирование образа: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr ""
 
@@ -7483,6 +7484,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid "Show the current project"
+msgstr ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr ""
@@ -7491,7 +7496,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 #, fuzzy
 msgid "Show the instance's access list"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -7756,7 +7761,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr ""
 
@@ -7985,7 +7990,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Копирование образа: %s"
@@ -8226,7 +8231,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -8238,7 +8243,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -8255,7 +8260,7 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
@@ -8301,7 +8306,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -8413,7 +8418,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -8491,7 +8496,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -8582,7 +8587,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8799,8 +8804,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8850,7 +8855,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
@@ -9934,8 +9939,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -9943,7 +9948,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -9951,7 +9956,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -9959,7 +9964,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -10084,7 +10089,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
@@ -10457,7 +10462,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -10466,7 +10471,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -10712,7 +10717,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr "да"
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-10-25 15:46-0400\n"
+"POT-Creation-Date: 2024-11-06 08:30+0100\n"
 "PO-Revision-Date: 2024-08-14 07:23+0000\n"
 "Last-Translator: Kwok Guy <kwokjuy@163.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -482,7 +482,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: cmd/incus/project.go:317
+#: cmd/incus/project.go:321
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1056,7 +1056,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
-#: cmd/incus/network_integration.go:145 cmd/incus/project.go:167
+#: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1422,7 +1422,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
 #: cmd/incus/network_zone.go:115 cmd/incus/operation.go:138
-#: cmd/incus/profile.go:725 cmd/incus/project.go:527 cmd/incus/remote.go:750
+#: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
 #: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
@@ -1461,7 +1461,7 @@ msgstr ""
 msgid "Config key/value to apply to the new network integration"
 msgstr ""
 
-#: cmd/incus/project.go:108
+#: cmd/incus/project.go:112
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1480,7 +1480,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312
 #: cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
-#: cmd/incus/profile.go:600 cmd/incus/project.go:399 cmd/incus/storage.go:368
+#: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
 #: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
 #, c-format
@@ -1757,7 +1757,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: cmd/incus/project.go:99 cmd/incus/project.go:100
+#: cmd/incus/project.go:103 cmd/incus/project.go:104
 msgid "Create projects"
 msgstr ""
 
@@ -1805,7 +1805,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
-#: cmd/incus/profile.go:747 cmd/incus/project.go:555 cmd/incus/storage.go:710
+#: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
 #: cmd/incus/storage_volume.go:1672
 msgid "DESCRIPTION"
@@ -1935,7 +1935,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: cmd/incus/project.go:198 cmd/incus/project.go:199
+#: cmd/incus/project.go:202 cmd/incus/project.go:203
 msgid "Delete projects"
 msgstr ""
 
@@ -2067,21 +2067,22 @@ msgstr ""
 #: cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634
 #: cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956
 #: cmd/incus/profile.go:1016 cmd/incus/profile.go:1105
-#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:100
-#: cmd/incus/project.go:199 cmd/incus/project.go:297 cmd/incus/project.go:433
-#: cmd/incus/project.go:508 cmd/incus/project.go:723 cmd/incus/project.go:788
-#: cmd/incus/project.go:876 cmd/incus/project.go:920 cmd/incus/project.go:981
-#: cmd/incus/project.go:1049 cmd/incus/publish.go:32 cmd/incus/query.go:34
-#: cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109
-#: cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724
-#: cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044
-#: cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21
-#: cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203
-#: cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449
-#: cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37
-#: cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270
-#: cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665
-#: cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024
+#: cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104
+#: cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437
+#: cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792
+#: cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985
+#: cmd/incus/project.go:1053 cmd/incus/project.go:1163 cmd/incus/publish.go:32
+#: cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44
+#: cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685
+#: cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979
+#: cmd/incus/remote.go:1044 cmd/incus/remote.go:1092
+#: cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31
+#: cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294
+#: cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510
+#: cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100
+#: cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402
+#: cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826
+#: cmd/incus/storage.go:930 cmd/incus/storage.go:1024
 #: cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96
 #: cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262
 #: cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479
@@ -2400,7 +2401,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: cmd/incus/project.go:296 cmd/incus/project.go:297
+#: cmd/incus/project.go:300 cmd/incus/project.go:301
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2441,7 +2442,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
 #: cmd/incus/network_zone.go:147 cmd/incus/operation.go:166
-#: cmd/incus/profile.go:763 cmd/incus/project.go:565 cmd/incus/remote.go:773
+#: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
 #: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
@@ -2516,7 +2517,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
-#: cmd/incus/project.go:851 cmd/incus/storage.go:896
+#: cmd/incus/project.go:855 cmd/incus/storage.go:896
 #: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
 #: cmd/incus/storage_volume.go:2081
 #, c-format
@@ -2538,7 +2539,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
-#: cmd/incus/profile.go:1077 cmd/incus/project.go:845 cmd/incus/storage.go:890
+#: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
 #: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
 #: cmd/incus/storage_volume.go:2075
 #, c-format
@@ -3069,7 +3070,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: cmd/incus/project.go:202
+#: cmd/incus/project.go:206
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
@@ -3135,7 +3136,7 @@ msgstr ""
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
 #: cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113
 #: cmd/incus/network_zone.go:859 cmd/incus/operation.go:136
-#: cmd/incus/profile.go:726 cmd/incus/project.go:529 cmd/incus/project.go:1052
+#: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
 #: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
@@ -3200,7 +3201,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: cmd/incus/project.go:1048 cmd/incus/project.go:1049
+#: cmd/incus/project.go:1052 cmd/incus/project.go:1053
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3264,7 +3265,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:437
+#: cmd/incus/project.go:441
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3337,7 +3338,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:432 cmd/incus/project.go:433
+#: cmd/incus/project.go:436 cmd/incus/project.go:437
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3424,7 +3425,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: cmd/incus/project.go:549
+#: cmd/incus/project.go:553
 msgid "IMAGES"
 msgstr ""
 
@@ -3835,7 +3836,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: cmd/incus/project.go:1142
+#: cmd/incus/project.go:1146
 msgid "LIMIT"
 msgstr ""
 
@@ -4502,11 +4503,11 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: cmd/incus/project.go:507
+#: cmd/incus/project.go:511
 msgid "List projects"
 msgstr ""
 
-#: cmd/incus/project.go:508
+#: cmd/incus/project.go:512
 msgid ""
 "List projects\n"
 "\n"
@@ -4991,8 +4992,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5236,9 +5237,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: cmd/incus/project.go:154 cmd/incus/project.go:251 cmd/incus/project.go:353
-#: cmd/incus/project.go:470 cmd/incus/project.go:755 cmd/incus/project.go:824
-#: cmd/incus/project.go:952 cmd/incus/project.go:1083
+#: cmd/incus/project.go:158 cmd/incus/project.go:255 cmd/incus/project.go:357
+#: cmd/incus/project.go:474 cmd/incus/project.go:759 cmd/incus/project.go:828
+#: cmd/incus/project.go:956 cmd/incus/project.go:1087
 msgid "Missing project name"
 msgstr ""
 
@@ -5364,7 +5365,7 @@ msgstr ""
 #: cmd/incus/network.go:1093 cmd/incus/network_acl.go:168
 #: cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128
 #: cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916
-#: cmd/incus/profile.go:745 cmd/incus/project.go:548 cmd/incus/project.go:690
+#: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
 #: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
@@ -5375,11 +5376,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: cmd/incus/project.go:554
+#: cmd/incus/project.go:558
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: cmd/incus/project.go:553
+#: cmd/incus/project.go:557
 msgid "NETWORKS"
 msgstr ""
 
@@ -5397,8 +5398,8 @@ msgid "NICs:"
 msgstr ""
 
 #: cmd/incus/network.go:1142 cmd/incus/operation.go:199
-#: cmd/incus/project.go:586 cmd/incus/project.go:595 cmd/incus/project.go:604
-#: cmd/incus/project.go:613 cmd/incus/project.go:622 cmd/incus/project.go:631
+#: cmd/incus/project.go:590 cmd/incus/project.go:599 cmd/incus/project.go:608
+#: cmd/incus/project.go:617 cmd/incus/project.go:626 cmd/incus/project.go:635
 #: cmd/incus/remote.go:823 cmd/incus/remote.go:832 cmd/incus/remote.go:841
 msgid "NO"
 msgstr ""
@@ -5812,7 +5813,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: cmd/incus/list.go:586 cmd/incus/project.go:550
+#: cmd/incus/list.go:586 cmd/incus/project.go:554
 msgid "PROFILES"
 msgstr ""
 
@@ -5941,7 +5942,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313
 #: cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
-#: cmd/incus/profile.go:601 cmd/incus/project.go:400 cmd/incus/storage.go:369
+#: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
 #: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -6048,17 +6049,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: cmd/incus/project.go:180
+#: cmd/incus/project.go:184
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: cmd/incus/project.go:273
+#: cmd/incus/project.go:277
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: cmd/incus/project.go:770
+#: cmd/incus/project.go:774
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -6133,7 +6134,7 @@ msgstr "查询路径必须以 / 开头"
 msgid "Query virtual machine images"
 msgstr "查询虚拟机镜像"
 
-#: cmd/incus/project.go:1141
+#: cmd/incus/project.go:1145
 msgid "RESOURCE"
 msgstr ""
 
@@ -6210,8 +6211,8 @@ msgstr "正在刷新镜像: %s"
 msgid "Remote %s already exists"
 msgstr "远程 %s 已存在"
 
-#: cmd/incus/project.go:1015 cmd/incus/remote.go:927 cmd/incus/remote.go:1008
-#: cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
+#: cmd/incus/project.go:1019 cmd/incus/project.go:1183 cmd/incus/remote.go:927
+#: cmd/incus/remote.go:1008 cmd/incus/remote.go:1073 cmd/incus/remote.go:1121
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "远程 %s 不存在"
@@ -6251,7 +6252,7 @@ msgstr "是否可移除: %v"
 msgid "Remove %s (yes/no): "
 msgstr "移除 %s (yes/no): "
 
-#: cmd/incus/project.go:219
+#: cmd/incus/project.go:223
 #, c-format
 msgid ""
 "Remove %s and everything it contains (instances, images, volumes, "
@@ -6381,7 +6382,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: cmd/incus/project.go:722 cmd/incus/project.go:723
+#: cmd/incus/project.go:726 cmd/incus/project.go:727
 msgid "Rename projects"
 msgstr ""
 
@@ -6564,7 +6565,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: cmd/incus/project.go:552
+#: cmd/incus/project.go:556
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -6572,7 +6573,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: cmd/incus/project.go:551
+#: cmd/incus/project.go:555
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -6803,11 +6804,11 @@ msgid ""
 "    incus profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: cmd/incus/project.go:787
+#: cmd/incus/project.go:791
 msgid "Set project configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:788
+#: cmd/incus/project.go:792
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6932,7 +6933,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:795
+#: cmd/incus/project.go:799
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -7069,7 +7070,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: cmd/incus/project.go:919 cmd/incus/project.go:920
+#: cmd/incus/project.go:923 cmd/incus/project.go:924
 msgid "Show project options"
 msgstr ""
 
@@ -7122,6 +7123,10 @@ msgid ""
 "machine\"."
 msgstr ""
 
+#: cmd/incus/project.go:1162 cmd/incus/project.go:1163
+msgid "Show the current project"
+msgstr ""
+
 #: cmd/incus/remote.go:684 cmd/incus/remote.go:685
 msgid "Show the default remote"
 msgstr ""
@@ -7130,7 +7135,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: cmd/incus/info.go:45 cmd/incus/project.go:1051
+#: cmd/incus/info.go:45 cmd/incus/project.go:1055
 msgid "Show the instance's access list"
 msgstr ""
 
@@ -7384,7 +7389,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: cmd/incus/project.go:980 cmd/incus/project.go:981
+#: cmd/incus/project.go:984 cmd/incus/project.go:985
 msgid "Switch the current project"
 msgstr ""
 
@@ -7614,7 +7619,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: cmd/incus/project.go:483
+#: cmd/incus/project.go:487
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -7853,7 +7858,7 @@ msgstr ""
 msgid "Type: %s"
 msgstr ""
 
-#: cmd/incus/project.go:1113
+#: cmd/incus/project.go:1117
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7865,7 +7870,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1143 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
 msgid "USAGE"
 msgstr ""
 
@@ -7880,7 +7885,7 @@ msgstr ""
 #: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
-#: cmd/incus/project.go:556 cmd/incus/storage.go:712
+#: cmd/incus/project.go:560 cmd/incus/storage.go:712
 #: cmd/incus/storage_volume.go:1674
 msgid "USED BY"
 msgstr ""
@@ -7925,7 +7930,7 @@ msgstr ""
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
 #: cmd/incus/network_zone.go:153 cmd/incus/operation.go:172
-#: cmd/incus/profile.go:769 cmd/incus/project.go:571 cmd/incus/remote.go:779
+#: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
 #: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
@@ -8026,7 +8031,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: cmd/incus/project.go:875 cmd/incus/project.go:876
+#: cmd/incus/project.go:879 cmd/incus/project.go:880
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -8095,7 +8100,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: cmd/incus/project.go:880
+#: cmd/incus/project.go:884
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -8180,7 +8185,7 @@ msgstr ""
 msgid "User aborted configuration"
 msgstr ""
 
-#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:224
+#: cmd/incus/cluster.go:728 cmd/incus/delete.go:53 cmd/incus/project.go:228
 #: cmd/incus/snapshot.go:257
 msgid "User aborted delete operation"
 msgstr ""
@@ -8395,8 +8400,8 @@ msgid "Would you like to use clustering?"
 msgstr ""
 
 #: cmd/incus/network.go:1139 cmd/incus/operation.go:202
-#: cmd/incus/project.go:588 cmd/incus/project.go:597 cmd/incus/project.go:606
-#: cmd/incus/project.go:615 cmd/incus/project.go:624 cmd/incus/project.go:633
+#: cmd/incus/project.go:592 cmd/incus/project.go:601 cmd/incus/project.go:610
+#: cmd/incus/project.go:619 cmd/incus/project.go:628 cmd/incus/project.go:637
 #: cmd/incus/remote.go:825 cmd/incus/remote.go:834 cmd/incus/remote.go:843
 msgid "YES"
 msgstr ""
@@ -8438,7 +8443,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
-#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:505
+#: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
 #: cmd/incus/storage.go:662 cmd/incus/top.go:31 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
@@ -9002,20 +9007,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: cmd/incus/project.go:98 cmd/incus/project.go:196 cmd/incus/project.go:295
-#: cmd/incus/project.go:918 cmd/incus/project.go:979 cmd/incus/project.go:1047
+#: cmd/incus/project.go:102 cmd/incus/project.go:200 cmd/incus/project.go:299
+#: cmd/incus/project.go:922 cmd/incus/project.go:983 cmd/incus/project.go:1051
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: cmd/incus/project.go:431 cmd/incus/project.go:874
+#: cmd/incus/project.go:435 cmd/incus/project.go:878
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: cmd/incus/project.go:786
+#: cmd/incus/project.go:790
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/project.go:720
+#: cmd/incus/project.go:724
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -9080,7 +9085,7 @@ msgstr ""
 msgid "application"
 msgstr ""
 
-#: cmd/incus/project.go:692 cmd/incus/remote.go:794
+#: cmd/incus/project.go:696 cmd/incus/remote.go:794
 msgid "current"
 msgstr ""
 
@@ -9453,7 +9458,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:102
+#: cmd/incus/project.go:106
 msgid ""
 "incus project create p1\n"
 "    Create a project named p1\n"
@@ -9462,7 +9467,7 @@ msgid ""
 "    Create a project named p1 with configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/project.go:299
+#: cmd/incus/project.go:303
 msgid ""
 "incus project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9708,7 +9713,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:727 cmd/incus/config_trust.go:493
 #: cmd/incus/delete.go:52 cmd/incus/image.go:973 cmd/incus/image.go:978
-#: cmd/incus/image.go:1178 cmd/incus/project.go:223 cmd/incus/snapshot.go:256
+#: cmd/incus/image.go:1178 cmd/incus/project.go:227 cmd/incus/snapshot.go:256
 msgid "yes"
 msgstr ""
 

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -65,7 +65,7 @@ test_projects_crud() {
   incus project delete bar
 
   # We're back to the default project
-  incus project list | grep -q "default (current)"
+  [ "$(incus project get-current)" = "default" ]
 }
 
 # Use containers in a project.


### PR DESCRIPTION
This pull requests adds a new command to show the current project.

```
$ incus project get-current
default

$ incus project create foo
$ incus project switch foo
$ incus project get-current
foo
```