### PR TITLE
Add a GetOIDCTokens() method

### DIFF
--- a/client/incus_oidc.go
+++ b/client/incus_oidc.go
@@ -36,6 +36,17 @@ func (r *ProtocolIncus) setupOIDCClient(token *oidc.Tokens[*oidc.IDTokenClaims])
 	r.oidcClient.httpClient = r.http
 }
 
+// GetOIDCTokens returns the current OIDC tokens (if any) from the OIDC client.
+//
+// This should only be used by internal Incus tools when it's not possible to get the tokens from a Config struct.
+func (r *ProtocolIncus) GetOIDCTokens() *oidc.Tokens[*oidc.IDTokenClaims] {
+	if r.oidcClient == nil {
+		return nil
+	}
+
+	return r.oidcClient.tokens
+}
+
 // Custom transport that modifies requests to inject the audience field.
 type oidcTransport struct {
 	deviceAuthorizationEndpoint string


### PR DESCRIPTION
This adds a helper method to fetch the OIDC tokens (if any) from the OIDC client used to authenticate to an Incus server. In the vast majority of cases, the tokens are automatically saved/restored from the remote's configuration. However, when operating without a configuration file, such as a standalone tool, there's no way to save the tokens for later use. This results in an authentication prompt every time a new connection is established rather than being able to re-use a previously acquired token.