### PR TITLE
Add refresh-exclude-older flag to only transfer new snapshots during instance/volume refresh

### DIFF
--- a/client/incus_instances.go
+++ b/client/incus_instances.go
@@ -782,6 +782,10 @@ func (r *ProtocolIncus) CopyInstance(source InstanceServer, instance api.Instanc
 			}
 		}
 
+		if args.RefreshExcludeOlder && !source.HasExtension("custom_volume_refresh_exclude_older_snapshots") {
+			return nil, fmt.Errorf("The source server is missing the required \"custom_volume_refresh_exclude_older_snapshots\" API extension")
+		}
+
 		if args.AllowInconsistent {
 			if !r.HasExtension("instance_allow_inconsistent_copy") {
 				return nil, fmt.Errorf("The source server is missing the required \"instance_allow_inconsistent_copy\" API extension")
@@ -796,6 +800,7 @@ func (r *ProtocolIncus) CopyInstance(source InstanceServer, instance api.Instanc
 		req.Source.Live = args.Live
 		req.Source.InstanceOnly = args.InstanceOnly
 		req.Source.Refresh = args.Refresh
+		req.Source.RefreshExcludeOlder = args.RefreshExcludeOlder
 		req.Source.AllowInconsistent = args.AllowInconsistent
 	}
 
@@ -868,6 +873,7 @@ func (r *ProtocolIncus) CopyInstance(source InstanceServer, instance api.Instanc
 		req.Source.Type = "migration"
 		req.Source.Mode = "push"
 		req.Source.Refresh = args.Refresh
+		req.Source.RefreshExcludeOlder = args.RefreshExcludeOlder
 
 		op, err := r.CreateInstance(req)
 		if err != nil {

--- a/client/incus_storage_volumes.go
+++ b/client/incus_storage_volumes.go
@@ -529,15 +529,20 @@ func (r *ProtocolIncus) CopyStoragePoolVolume(pool string, source InstanceServer
 		return nil, fmt.Errorf("The target server is missing the required \"custom_volume_refresh\" API extension")
 	}
 
+	if args != nil && args.RefreshExcludeOlder && !r.HasExtension("custom_volume_refresh_exclude_older_snapshots") {
+		return nil, fmt.Errorf("The target server is missing the required \"custom_volume_refresh_exclude_older_snapshots\" API extension")
+	}
+
 	req := api.StorageVolumesPost{
 		Name: args.Name,
 		Type: volume.Type,
 		Source: api.StorageVolumeSource{
-			Name:       volume.Name,
-			Type:       "copy",
-			Pool:       sourcePool,
-			VolumeOnly: args.VolumeOnly,
-			Refresh:    args.Refresh,
+			Name:                volume.Name,
+			Type:                "copy",
+			Pool:                sourcePool,
+			VolumeOnly:          args.VolumeOnly,
+			Refresh:             args.Refresh,
+			RefreshExcludeOlder: args.RefreshExcludeOlder,
 		},
 	}
 

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -522,6 +522,9 @@ type StoragePoolVolumeCopyArgs struct {
 
 	// API extension: custom_volume_refresh
 	Refresh bool
+
+	// API extension: custom_volume_refresh_exclude_older_snapshots
+	RefreshExcludeOlder bool
 }
 
 // The StoragePoolVolumeMoveArgs struct is used to pass additional options
@@ -572,6 +575,9 @@ type InstanceCopyArgs struct {
 	// API extension: container_incremental_copy
 	// Perform an incremental copy
 	Refresh bool
+
+	// API extension: custom_volume_refresh_exclude_older_snapshots
+	RefreshExcludeOlder bool
 
 	// API extension: instance_allow_inconsistent_copy
 	AllowInconsistent bool

--- a/cmd/incus/copy.go
+++ b/cmd/incus/copy.go
@@ -17,19 +17,20 @@ import (
 type cmdCopy struct {
 	global *cmdGlobal
 
-	flagNoProfiles        bool
-	flagProfile           []string
-	flagConfig            []string
-	flagDevice            []string
-	flagEphemeral         bool
-	flagInstanceOnly      bool
-	flagMode              string
-	flagStateless         bool
-	flagStorage           string
-	flagTarget            string
-	flagTargetProject     string
-	flagRefresh           bool
-	flagAllowInconsistent bool
+	flagNoProfiles          bool
+	flagProfile             []string
+	flagConfig              []string
+	flagDevice              []string
+	flagEphemeral           bool
+	flagInstanceOnly        bool
+	flagMode                string
+	flagStateless           bool
+	flagStorage             string
+	flagTarget              string
+	flagTargetProject       string
+	flagRefresh             bool
+	flagRefreshExcludeOlder bool
+	flagAllowInconsistent   bool
 }
 
 func (c *cmdCopy) Command() *cobra.Command {
@@ -61,6 +62,7 @@ The pull transfer mode is the default as it is compatible with all server versio
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
 	cmd.Flags().BoolVar(&c.flagNoProfiles, "no-profiles", false, i18n.G("Create the instance with no profiles applied"))
 	cmd.Flags().BoolVar(&c.flagRefresh, "refresh", false, i18n.G("Perform an incremental copy"))
+	cmd.Flags().BoolVar(&c.flagRefreshExcludeOlder, "refresh-exclude-older", false, i18n.G("During incremental copy, exclude source snapshots earlier than latest target snapshot"))
 	cmd.Flags().BoolVar(&c.flagAllowInconsistent, "allow-inconsistent", false, i18n.G("Ignore copy errors for volatile files"))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -256,12 +258,13 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 	} else {
 		// Prepare the instance creation request
 		args := incus.InstanceCopyArgs{
-			Name:              destName,
-			Live:              stateful,
-			InstanceOnly:      instanceOnly,
-			Mode:              mode,
-			Refresh:           c.flagRefresh,
-			AllowInconsistent: c.flagAllowInconsistent,
+			Name:                destName,
+			Live:                stateful,
+			InstanceOnly:        instanceOnly,
+			Mode:                mode,
+			Refresh:             c.flagRefresh,
+			RefreshExcludeOlder: c.flagRefreshExcludeOlder,
+			AllowInconsistent:   c.flagAllowInconsistent,
 		}
 
 		// Copy of an instance into a new instance

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -347,10 +347,11 @@ type cmdStorageVolumeCopy struct {
 	storage       *cmdStorage
 	storageVolume *cmdStorageVolume
 
-	flagMode          string
-	flagVolumeOnly    bool
-	flagTargetProject string
-	flagRefresh       bool
+	flagMode                string
+	flagVolumeOnly          bool
+	flagTargetProject       string
+	flagRefresh             bool
+	flagRefreshExcludeOlder bool
 }
 
 func (c *cmdStorageVolumeCopy) Command() *cobra.Command {
@@ -367,6 +368,7 @@ func (c *cmdStorageVolumeCopy) Command() *cobra.Command {
 	cmd.Flags().BoolVar(&c.flagVolumeOnly, "volume-only", false, i18n.G("Copy the volume without its snapshots"))
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")
 	cmd.Flags().BoolVar(&c.flagRefresh, "refresh", false, i18n.G("Refresh and update the existing storage volume copies"))
+	cmd.Flags().BoolVar(&c.flagRefreshExcludeOlder, "refresh-exclude-older", false, i18n.G("During refresh, exclude source snapshots earlier than latest target snapshot"))
 	cmd.RunE = c.Run
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -514,6 +516,7 @@ func (c *cmdStorageVolumeCopy) Run(cmd *cobra.Command, args []string) error {
 		args.Mode = mode
 		args.VolumeOnly = c.flagVolumeOnly
 		args.Refresh = c.flagRefresh
+		args.RefreshExcludeOlder = c.flagRefreshExcludeOlder
 
 		if c.flagTargetProject != "" {
 			dstServer = dstServer.UseProject(c.flagTargetProject)

--- a/cmd/incusd/instance.go
+++ b/cmd/incusd/instance.go
@@ -290,6 +290,7 @@ type instanceCreateAsCopyOpts struct {
 	targetInstance       db.InstanceArgs   // Configuration for new instance.
 	instanceOnly         bool              // Only copy the instance and not it's snapshots.
 	refresh              bool              // Refresh an existing target instance.
+	refreshExcludeOlder  bool              // During refresh, exclude source snapshots earlier than latest target snapshot
 	applyTemplateTrigger bool              // Apply deferred TemplateTriggerCopy.
 	allowInconsistent    bool              // Ignore some copy errors
 }
@@ -372,7 +373,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 				})
 			}
 
-			syncSourceSnapshotIndexes, deleteTargetSnapshotIndexes := storagePools.CompareSnapshots(sourceSnapshotComparable, targetSnapshotsComparable)
+			syncSourceSnapshotIndexes, deleteTargetSnapshotIndexes := storagePools.CompareSnapshots(sourceSnapshotComparable, targetSnapshotsComparable, opts.refreshExcludeOlder)
 
 			// Delete extra snapshots first.
 			for _, deleteTargetSnapIndex := range deleteTargetSnapshotIndexes {

--- a/cmd/incusd/instances_post.go
+++ b/cmd/incusd/instances_post.go
@@ -362,6 +362,7 @@ func createFromMigration(ctx context.Context, s *state.State, r *http.Request, p
 		InstanceOnly:          instanceOnly,
 		ClusterMoveSourceName: clusterMoveSourceName,
 		Refresh:               req.Source.Refresh,
+		RefreshExcludeOlder:   req.Source.RefreshExcludeOlder,
 	}
 
 	sink, err := newMigrationSink(&migrationArgs)

--- a/cmd/incusd/instances_post.go
+++ b/cmd/incusd/instances_post.go
@@ -549,6 +549,7 @@ func createFromCopy(ctx context.Context, s *state.State, r *http.Request, projec
 			targetInstance:       args,
 			instanceOnly:         req.Source.InstanceOnly,
 			refresh:              req.Source.Refresh,
+			refreshExcludeOlder:  req.Source.RefreshExcludeOlder,
 			applyTemplateTrigger: true,
 			allowInconsistent:    req.Source.AllowInconsistent,
 		}, op)

--- a/cmd/incusd/migrate.go
+++ b/cmd/incusd/migrate.go
@@ -185,6 +185,7 @@ type migrationSink struct {
 	push                  bool
 	clusterMoveSourceName string
 	refresh               bool
+	refreshExcludeOlder   bool
 }
 
 // MigrationSinkArgs arguments to configure migration sink.
@@ -201,6 +202,7 @@ type migrationSinkArgs struct {
 	Idmap                 *idmap.Set
 	Live                  bool
 	Refresh               bool
+	RefreshExcludeOlder   bool
 	ClusterMoveSourceName string
 	Snapshots             []*migration.Snapshot
 

--- a/cmd/incusd/migrate_instance.go
+++ b/cmd/incusd/migrate_instance.go
@@ -169,6 +169,7 @@ func newMigrationSink(args *migrationSinkArgs) (*migrationSink, error) {
 		clusterMoveSourceName: args.ClusterMoveSourceName,
 		push:                  args.Push,
 		refresh:               args.Refresh,
+		refreshExcludeOlder:   args.RefreshExcludeOlder,
 	}
 
 	secretNames := []string{api.SecretNameControl, api.SecretNameFilesystem}
@@ -275,8 +276,9 @@ func (c *migrationSink) Do(state *state.State, instOp *operationlock.InstanceOpe
 			},
 			ClusterMoveSourceName: c.clusterMoveSourceName,
 		},
-		InstanceOperation: instOp,
-		Refresh:           c.refresh,
+		InstanceOperation:   instOp,
+		Refresh:             c.refresh,
+		RefreshExcludeOlder: c.refreshExcludeOlder,
 	})
 	if err != nil {
 		l.Error("Failed migration on target", logger.Ctx{"err": err})

--- a/cmd/incusd/migrate_storage_volumes.go
+++ b/cmd/incusd/migrate_storage_volumes.go
@@ -322,16 +322,16 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 	// with the new storage layer.
 	myTarget = func(conn io.ReadWriteCloser, op *operations.Operation, args migrationSinkArgs) error {
 		volTargetArgs := localMigration.VolumeTargetArgs{
-			IndexHeaderVersion: respHeader.GetIndexHeaderVersion(),
-			Name:               req.Name,
-			Config:             req.Config,
-			Description:        req.Description,
-			MigrationType:      respTypes[0],
-			TrackProgress:      true,
-			ContentType:        req.ContentType,
-			Refresh:            args.Refresh,
+			IndexHeaderVersion:  respHeader.GetIndexHeaderVersion(),
+			Name:                req.Name,
+			Config:              req.Config,
+			Description:         req.Description,
+			MigrationType:       respTypes[0],
+			TrackProgress:       true,
+			ContentType:         req.ContentType,
+			Refresh:             args.Refresh,
 			RefreshExcludeOlder: args.RefreshExcludeOlder,
-			VolumeOnly:         args.VolumeOnly,
+			VolumeOnly:          args.VolumeOnly,
 		}
 
 		// A zero length Snapshots slice indicates volume only migration in
@@ -421,10 +421,11 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 			// as part of MigrationSinkArgs below.
 			rsyncFeatures := respHeader.GetRsyncFeaturesSlice()
 			args := migrationSinkArgs{
-				RsyncFeatures: rsyncFeatures,
-				Snapshots:     respHeader.Snapshots,
-				VolumeOnly:    c.volumeOnly,
-				Refresh:       c.refresh,
+				RsyncFeatures:       rsyncFeatures,
+				Snapshots:           respHeader.Snapshots,
+				VolumeOnly:          c.volumeOnly,
+				Refresh:             c.refresh,
+				RefreshExcludeOlder: c.refreshExcludeOlder,
 			}
 
 			fsConn, err := c.conns[api.SecretNameFilesystem].WebsocketIO(state.ShutdownCtx)

--- a/cmd/incusd/migrate_storage_volumes.go
+++ b/cmd/incusd/migrate_storage_volumes.go
@@ -208,9 +208,10 @@ func newStorageMigrationSink(args *migrationSinkArgs) (*migrationSink, error) {
 		migrationFields: migrationFields{
 			volumeOnly: args.VolumeOnly,
 		},
-		url:     args.URL,
-		push:    args.Push,
-		refresh: args.Refresh,
+		url:                 args.URL,
+		push:                args.Push,
+		refresh:             args.Refresh,
+		refreshExcludeOlder: args.RefreshExcludeOlder,
 	}
 
 	secretNames := []string{api.SecretNameControl, api.SecretNameFilesystem}
@@ -329,6 +330,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 			TrackProgress:      true,
 			ContentType:        req.ContentType,
 			Refresh:            args.Refresh,
+			RefreshExcludeOlder: args.RefreshExcludeOlder,
 			VolumeOnly:         args.VolumeOnly,
 		}
 
@@ -373,7 +375,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 		}
 
 		// Compare the two sets.
-		syncSourceSnapshotIndexes, deleteTargetSnapshotIndexes := storagePools.CompareSnapshots(sourceSnapshotComparable, targetSnapshotsComparable)
+		syncSourceSnapshotIndexes, deleteTargetSnapshotIndexes := storagePools.CompareSnapshots(sourceSnapshotComparable, targetSnapshotsComparable, c.refreshExcludeOlder)
 
 		// Delete the extra local snapshots first.
 		for _, deleteTargetSnapshotIndex := range deleteTargetSnapshotIndexes {

--- a/cmd/incusd/storage_volumes.go
+++ b/cmd/incusd/storage_volumes.go
@@ -829,7 +829,7 @@ func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName s
 			return fmt.Errorf("No source volume name supplied")
 		}
 
-		err = pool.RefreshCustomVolume(projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
+		err = pool.RefreshCustomVolume(projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, req.Source.RefreshExcludeOlder, op)
 		if err != nil {
 			return err
 		}

--- a/cmd/incusd/storage_volumes.go
+++ b/cmd/incusd/storage_volumes.go
@@ -940,10 +940,11 @@ func doVolumeMigration(s *state.State, r *http.Request, requestProjectName strin
 			NetDialContext:   localtls.RFC3493Dialer,
 			HandshakeTimeout: time.Second * 5,
 		},
-		Secrets:    req.Source.Websockets,
-		Push:       push,
-		VolumeOnly: req.Source.VolumeOnly,
-		Refresh:    req.Source.Refresh,
+		Secrets:             req.Source.Websockets,
+		Push:                push,
+		VolumeOnly:          req.Source.VolumeOnly,
+		Refresh:             req.Source.Refresh,
+		RefreshExcludeOlder: req.Source.RefreshExcludeOlder,
 	}
 
 	sink, err := newStorageMigrationSink(&migrationArgs)

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2642,3 +2642,7 @@ As part of this, the following configuration options have been added:
 * `cluster.rebalance.cooldown`
 * `cluster.rebalance.interval`
 * `cluster.rebalance.threshold`
+
+## `custom_volume_refresh_exclude_older_snapshots`
+
+This adds support for excluding source snapshots earlier than latest target snapshot.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2111,6 +2111,11 @@ definitions:
                 example: false
                 type: boolean
                 x-go-name: Refresh
+            refresh_exclude_older:
+                description: Whether to exclude source snapshots earlier than latest target snapshot
+                example: false
+                type: boolean
+                x-go-name: RefreshExcludeOlder
             secret:
                 description: Remote server secret (for remote private images)
                 example: RANDOM-STRING
@@ -6504,6 +6509,11 @@ definitions:
                 example: false
                 type: boolean
                 x-go-name: Refresh
+            refresh_exclude_older:
+                description: Whether to exclude source snapshots earlier than latest target snapshot
+                example: false
+                type: boolean
+                x-go-name: RefreshExcludeOlder
             secrets:
                 additionalProperties:
                     type: string

--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -6206,7 +6206,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		}
 
 		// Compare the two sets.
-		syncSourceSnapshotIndexes, deleteTargetSnapshotIndexes := storagePools.CompareSnapshots(sourceSnapshotComparable, targetSnapshotsComparable)
+		syncSourceSnapshotIndexes, deleteTargetSnapshotIndexes := storagePools.CompareSnapshots(sourceSnapshotComparable, targetSnapshotsComparable, args.RefreshExcludeOlder)
 
 		// Delete the extra local snapshots first.
 		for _, deleteTargetSnapshotIndex := range deleteTargetSnapshotIndexes {

--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -7315,7 +7315,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		}
 
 		// Compare the two sets.
-		syncSourceSnapshotIndexes, deleteTargetSnapshotIndexes := storagePools.CompareSnapshots(sourceSnapshotComparable, targetSnapshotsComparable)
+		syncSourceSnapshotIndexes, deleteTargetSnapshotIndexes := storagePools.CompareSnapshots(sourceSnapshotComparable, targetSnapshotsComparable, args.RefreshExcludeOlder)
 
 		// Delete the extra local snapshots first.
 		for _, deleteTargetSnapshotIndex := range deleteTargetSnapshotIndexes {

--- a/internal/server/instance/instance_interface.go
+++ b/internal/server/instance/instance_interface.go
@@ -238,6 +238,7 @@ type MigrateSendArgs struct {
 type MigrateReceiveArgs struct {
 	MigrateArgs
 
-	InstanceOperation *operationlock.InstanceOperation
-	Refresh           bool
+	InstanceOperation   *operationlock.InstanceOperation
+	Refresh             bool
+	RefreshExcludeOlder bool
 }

--- a/internal/server/migration/migration_volumes.go
+++ b/internal/server/migration/migration_volumes.go
@@ -73,6 +73,7 @@ type VolumeTargetArgs struct {
 	MigrationType         Type
 	TrackProgress         bool
 	Refresh               bool
+	RefreshExcludeOlder   bool
 	Live                  bool
 	VolumeSize            int64
 	ContentType           string

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -1227,7 +1227,7 @@ func (b *backend) CreateInstanceFromCopy(inst instance.Instance, src instance.In
 // RefreshCustomVolume refreshes custom volumes (and optionally snapshots) during the custom volume copy operations.
 // Snapshots that are not present in the source but are in the destination are removed from the
 // destination if snapshots are included in the synchronization.
-func (b *backend) RefreshCustomVolume(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error {
+func (b *backend) RefreshCustomVolume(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, excludeOlder bool, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "srcProjectName": srcProjectName, "volName": volName, "desc": desc, "config": config, "srcPoolName": srcPoolName, "srcVolName": srcVolName, "snapshots": snapshots})
 	l.Debug("RefreshCustomVolume started")
 	defer l.Debug("RefreshCustomVolume finished")
@@ -1327,7 +1327,7 @@ func (b *backend) RefreshCustomVolume(projectName string, srcProjectName string,
 			})
 		}
 
-		syncSourceSnapshotIndexes, deleteTargetSnapshotIndexes := CompareSnapshots(sourceSnapshotComparable, targetSnapshotsComparable)
+		syncSourceSnapshotIndexes, deleteTargetSnapshotIndexes := CompareSnapshots(sourceSnapshotComparable, targetSnapshotsComparable, excludeOlder)
 
 		// Delete extra snapshots first.
 		for _, deleteTargetSnapIndex := range deleteTargetSnapshotIndexes {

--- a/internal/server/storage/backend_mock.go
+++ b/internal/server/storage/backend_mock.go
@@ -172,7 +172,8 @@ func (b *mockBackend) CleanupInstancePaths(inst instance.Instance, op *operation
 	return nil
 }
 
-func (b *mockBackend) RefreshCustomVolume(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
+// RefreshCustomVolume refresh a custom volume.
+func (b *mockBackend) RefreshCustomVolume(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, excludeOlder bool, op *operations.Operation) error {
 	return nil
 }
 

--- a/internal/server/storage/pool_interface.go
+++ b/internal/server/storage/pool_interface.go
@@ -126,7 +126,7 @@ type Pool interface {
 	MountCustomVolume(projectName string, volName string, op *operations.Operation) (*MountInfo, error)
 	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
 	ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
-	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
+	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, excludeOlder bool, op *operations.Operation) error
 	GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
 	CreateCustomVolumeFromISO(projectName string, volName string, srcData io.ReadSeeker, size int64, op *operations.Operation) error
 

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -449,6 +449,7 @@ var APIExtensions = []string{
 	"network_ovn_external_interfaces",
 	"instances_scriptlet_get_instances_count",
 	"cluster_rebalance",
+	"custom_volume_refresh_exclude_older_snapshots",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2024-10-06 20:15+0000\n"
 "Last-Translator: Jan Mittelstädter <jan@mittelstaedter.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -87,7 +87,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -680,7 +680,7 @@ msgstr "--empty kann nicht mit einem image namen kombiniert werden"
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 "--instance-only kann nicht verwendet werden, wenn die Quelle ein Snapshot ist"
@@ -690,7 +690,7 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -700,7 +700,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Instanzen verwendet werden"
 
@@ -1029,7 +1029,7 @@ msgstr ""
 "Alle existierenden Dateien sind verloren, wenn sie dem Cluster beitreten, "
 "Vorgang fortsetzen?"
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid "All projects"
 msgstr "Alle Projekte"
 
@@ -1178,17 +1178,17 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Backing up storage bucket: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr "Backup erfolgreich exportiert!"
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr "Sicherungen:"
 
@@ -1207,14 +1207,14 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "Ungültiges key/value Paar: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Ungültiges key=value Paar: %s"
@@ -1262,7 +1262,7 @@ msgstr "ABBRECHBAR"
 msgid "COMMON NAME"
 msgstr "ALLGEMEINER NAME"
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr "INHALTS-TYP"
 
@@ -1270,7 +1270,7 @@ msgstr "INHALTS-TYP"
 msgid "COUNT"
 msgstr "ANZAHL"
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 #, fuzzy
 msgid "CPU TIME(s)"
 msgstr "Prozessorauslastung (%s):"
@@ -1362,7 +1362,7 @@ msgstr "Kann --project nicht zusammen mit --all-projects angeben"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1409,19 +1409,19 @@ msgstr ""
 "\"Kann Konfiguration für Gerät %q nicht überschreiben: Gerät in den "
 "Profilgeräten nicht gefunden.\""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "Kann --destination-target nicht setzen, wenn der Zielserver nicht im Cluster "
 "ist"
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "\"Kann --target nicht setzen, wenn der Quellserver nicht im Cluster ist"
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "Kann --volume-only nicht setzen, wenn ein Snapshot kopiert wird"
 
@@ -1540,7 +1540,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1566,15 +1566,15 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr "Cluster-Mitgliedsname"
 
@@ -1593,8 +1593,8 @@ msgstr "Clustering aktiviert"
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1629,7 +1629,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1662,7 +1662,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -1675,7 +1675,7 @@ msgstr ""
 msgid "Configure the daemon"
 msgstr ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 #, fuzzy
 msgid "Configure the refresh delay in seconds"
 msgstr "Legen Sie eine Verzögerungszeit angegeben in Sekunden fest:"
@@ -1685,11 +1685,11 @@ msgstr "Legen Sie eine Verzögerungszeit angegeben in Sekunden fest:"
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1699,7 +1699,7 @@ msgstr "Erstellt: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1707,7 +1707,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr "Kopiere Aliasse von der Quelle"
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1724,12 +1724,12 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 #, fuzzy
 msgid "Copy instances within or in between servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1753,18 +1753,18 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 #, fuzzy
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1777,7 +1777,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1915,7 +1915,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1974,13 +1974,13 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -2018,11 +2018,11 @@ msgstr ""
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr ""
 
@@ -2057,11 +2057,11 @@ msgstr "Erstellt: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr ""
 
@@ -2077,7 +2077,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2170,7 +2170,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2216,7 +2216,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -2317,40 +2317,40 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Storage Volumes zu Profilen hinzufügen"
@@ -2483,7 +2483,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display images from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2498,7 +2498,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display profiles from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2575,6 +2575,17 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr ""
@@ -2589,7 +2600,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "ABLAUFDATUM"
@@ -2698,11 +2709,11 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 #, fuzzy
 msgid ""
 "Edit storage volume configurations as YAML\n"
@@ -2728,8 +2739,8 @@ msgstr "Alternatives config Verzeichnis."
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2752,7 +2763,7 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
@@ -2760,7 +2771,7 @@ msgstr ""
 "Stellen Sie eine Sortiermethode ein ('a' für Alphabetisch, 'c' für CPU/"
 "Prozessor, 'm' für Memory/RAM, 'd' für Festplatte (disk):"
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr "Legen Sie eine Verzögerungszeit angegeben in Sekunden fest:"
 
@@ -2774,7 +2785,7 @@ msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 "Festzulegende Umgebungsvariable (Environment variable) (z.B. HOME=/home/foo)"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Kurzlebiger Container"
@@ -2806,8 +2817,8 @@ msgstr "Fehler beim Abrufen des Aliase/Namen: %w"
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim Festlegen der Parameter: %v"
@@ -2828,8 +2839,8 @@ msgstr "Fehler beim Löschen der Parameter: %v"
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Fehler beim Löschen des Parameters: %v"
@@ -2960,8 +2971,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 #, fuzzy
 msgid "Expires at"
 msgstr "Wird gelöscht am"
@@ -2992,7 +3003,7 @@ msgstr ""
 "angegeben wird, wird die resultierende Datei im derzeit aktiven Ordner/Pfad "
 "gespeichert."
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid "Export custom storage volume"
 msgstr "Storage Volume exportieren"
 
@@ -3014,7 +3025,7 @@ msgstr "Storage Buckets exportieren"
 msgid "Export storage buckets as tarball."
 msgstr "Storage Buckets als Dateien (.tar) exportieren."
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid "Export the volume without its snapshots"
 msgstr "Storage Volume ohne Snapshots exportieren"
 
@@ -3023,7 +3034,7 @@ msgstr "Storage Volume ohne Snapshots exportieren"
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Backup des Storage Bucket %s wird exportiert"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Backup %s wird exportiert"
@@ -3106,7 +3117,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, fuzzy, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3245,7 +3256,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3260,7 +3271,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3300,7 +3311,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to read from stdin: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3493,7 +3504,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3506,7 +3517,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid "Format (table|compact)"
 msgstr ""
 
@@ -3648,7 +3659,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3735,11 +3746,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 #, fuzzy
 msgid ""
 "Get values for storage volume configuration keys\n"
@@ -3752,7 +3763,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3817,7 +3828,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr ""
 
@@ -3860,7 +3871,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3874,11 +3885,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3935,12 +3946,12 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3966,15 +3977,15 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Import storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3983,7 +3994,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -4060,7 +4071,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Ungültige Quelle %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Ungültiges Ziel %s"
@@ -4081,7 +4092,7 @@ msgid "Invalid arguments"
 msgstr "Ungültiges Ziel %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -4121,7 +4132,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid expiration date: %w"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Ungültiges Ziel %s"
@@ -4131,7 +4142,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid format: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr ""
 
@@ -4191,19 +4202,19 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 #, fuzzy
 msgid "Invalid sorting type"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 #, fuzzy
 msgid "Invalid sorting type provided"
 msgstr "Ungültiges Ziel %s"
@@ -4263,7 +4274,7 @@ msgstr ""
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -5015,12 +5026,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5034,12 +5045,12 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -5152,7 +5163,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5227,7 +5238,7 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -5455,7 +5466,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage storage pools and volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5711,15 +5722,15 @@ msgstr "Fehlende Zusammenfassung."
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5746,12 +5757,12 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5792,7 +5803,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5806,7 +5817,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5837,11 +5848,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5872,7 +5883,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr ""
 
@@ -5927,8 +5938,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr ""
 
@@ -5993,7 +6004,7 @@ msgid "Name of the storage pool:"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -6136,7 +6147,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6161,7 +6172,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -6186,11 +6197,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6239,11 +6250,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -6255,7 +6266,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -6283,7 +6294,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6338,7 +6349,7 @@ msgstr ""
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -6391,7 +6402,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -6439,15 +6450,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -6465,7 +6476,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6550,7 +6561,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Profile to apply to the new image"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6717,7 +6728,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6726,7 +6737,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -6890,7 +6901,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -6932,17 +6943,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Herunterfahren des Containers erzwingen."
@@ -6986,7 +6997,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -7420,12 +7431,12 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -7536,7 +7547,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -7696,12 +7707,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 #, fuzzy
 msgid ""
 "Show storage volume configurations\n"
@@ -7714,22 +7725,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 #, fuzzy
 msgid ""
 "Show storage volume state information\n"
@@ -7809,16 +7820,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr ""
 
@@ -7832,7 +7843,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -7956,7 +7967,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 #, fuzzy
 msgid "Storage pool name"
@@ -7967,27 +7978,27 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Storage pool to use or create"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Profil %s gelöscht\n"
@@ -8036,7 +8047,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8052,12 +8063,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid "Taken at"
 msgstr ""
 
@@ -8182,7 +8193,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -8271,12 +8282,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8328,7 +8339,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -8406,7 +8417,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -8415,7 +8426,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -8431,7 +8442,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8439,11 +8450,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -8456,7 +8467,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -8496,7 +8507,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -8513,7 +8524,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -8531,7 +8542,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr ""
 
@@ -8580,8 +8591,8 @@ msgstr "Unbekannter Befehl %s für Abbild"
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8707,12 +8718,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 #, fuzzy
 msgid ""
 "Unset storage volume configuration keys\n"
@@ -8788,7 +8799,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -8821,7 +8832,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -8836,12 +8847,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8932,7 +8943,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Version: %v"
 msgstr "Fehler: %v\n"
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr ""
 
@@ -9110,12 +9121,12 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -9125,7 +9136,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -9147,7 +9158,7 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
@@ -9972,7 +9983,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -10048,7 +10059,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -10056,7 +10067,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -10064,7 +10075,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -10080,7 +10091,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -10089,7 +10100,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -10098,7 +10109,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -10107,7 +10118,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -10116,7 +10127,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -10124,7 +10135,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -10133,7 +10144,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -10141,8 +10152,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -10150,7 +10161,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -10158,7 +10169,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -10166,7 +10177,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -10175,7 +10186,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10183,7 +10194,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10298,7 +10309,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -10997,7 +11008,7 @@ msgstr ""
 "    Automatisches Editieren der Konfiguration des storage pool mit den "
 "Konfigurationsdetails aus der Datei \"pool.yaml\"."
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 #, fuzzy
 msgid ""
 "incus storage volume create default foo\n"
@@ -11016,7 +11027,7 @@ msgstr ""
 "\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
 "yaml\"."
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 #, fuzzy
 msgid ""
 "incus storage volume edit default container/c1\n"
@@ -11035,7 +11046,7 @@ msgstr ""
 "\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
 "yaml\"."
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -11045,7 +11056,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -11055,7 +11066,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -11065,7 +11076,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -11075,7 +11086,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -11089,7 +11100,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 #, fuzzy
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
@@ -11108,7 +11119,7 @@ msgstr ""
 "\"snap0\" mit den Konfigurationsdetails aus der angegebenen Datei \"config."
 "yaml\"."
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -91,7 +91,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -674,7 +674,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
@@ -684,7 +684,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--network-port can't be used without --network-address"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
@@ -693,7 +693,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -993,7 +993,7 @@ msgstr "Aliases:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid "All projects"
 msgstr ""
 
@@ -1127,17 +1127,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backing up storage bucket: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr ""
 
@@ -1154,14 +1154,14 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 #, fuzzy
 msgid "CPU TIME(s)"
 msgstr "CPU (%s):"
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1353,16 +1353,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1478,7 +1478,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1504,15 +1504,15 @@ msgstr "Perfil %s eliminado de %s"
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1531,8 +1531,8 @@ msgstr ""
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
 
@@ -1560,7 +1560,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1592,7 +1592,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "Configure the daemon"
 msgstr ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
@@ -1614,11 +1614,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1628,7 +1628,7 @@ msgstr "Auto actualización: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "Perfil %s creado"
@@ -1653,11 +1653,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1681,16 +1681,16 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1704,7 +1704,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1839,7 +1839,7 @@ msgstr "Perfil %s creado"
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1890,12 +1890,12 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1933,11 +1933,11 @@ msgstr ""
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr ""
 
@@ -1972,11 +1972,11 @@ msgstr "Auto actualización: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr ""
 
@@ -1992,7 +1992,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2081,7 +2081,7 @@ msgstr "Perfil %s creado"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2127,7 +2127,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -2228,40 +2228,40 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Descripción"
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2384,7 +2384,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display images from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2399,7 +2399,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display profiles from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr ""
 
@@ -2408,7 +2408,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2472,6 +2472,17 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr ""
@@ -2486,7 +2497,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "FECHA DE EXPIRACIÓN"
@@ -2588,11 +2599,11 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2616,8 +2627,8 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2640,13 +2651,13 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
 msgstr ""
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr ""
 
@@ -2658,7 +2669,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2689,8 +2700,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2711,8 +2722,8 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2793,8 +2804,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2819,7 +2830,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2843,7 +2854,7 @@ msgstr "Aliases:"
 msgid "Export storage buckets as tarball."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2852,7 +2863,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2933,7 +2944,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -3072,7 +3083,7 @@ msgstr "Acepta certificado"
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Acepta certificado"
@@ -3087,7 +3098,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Acepta certificado"
@@ -3127,7 +3138,7 @@ msgstr "Acepta certificado"
 msgid "Failed to read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -3317,7 +3328,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3330,7 +3341,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid "Format (table|compact)"
 msgstr ""
 
@@ -3470,7 +3481,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3552,11 +3563,11 @@ msgstr "Perfil %s creado"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3568,7 +3579,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3633,7 +3644,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr ""
 
@@ -3676,7 +3687,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3690,11 +3701,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3749,11 +3760,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Perfil %s creado"
@@ -3779,15 +3790,15 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Import storage bucket"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3796,7 +3807,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3875,7 +3886,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Nombre del contenedor es: %s"
@@ -3896,7 +3907,7 @@ msgid "Invalid arguments"
 msgstr "Nombre del contenedor es: %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3934,7 +3945,7 @@ msgstr ""
 msgid "Invalid expiration date: %w"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3944,7 +3955,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid format: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr ""
 
@@ -4003,19 +4014,19 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 #, fuzzy
 msgid "Invalid sorting type"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 #, fuzzy
 msgid "Invalid sorting type provided"
 msgstr "Nombre del contenedor es: %s"
@@ -4071,7 +4082,7 @@ msgstr ""
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4820,12 +4831,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4839,11 +4850,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4956,7 +4967,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5025,7 +5036,7 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -5235,7 +5246,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Nombre del contenedor es: %s"
@@ -5488,15 +5499,15 @@ msgstr "Nombre del contenedor es: %s"
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 msgid "Missing pool name"
 msgstr ""
 
@@ -5522,11 +5533,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
@@ -5567,7 +5578,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5580,7 +5591,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Aliases:"
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Aliases:"
@@ -5609,11 +5620,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -5643,7 +5654,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr ""
 
@@ -5698,8 +5709,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr ""
 
@@ -5760,7 +5771,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5901,7 +5912,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5924,7 +5935,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5948,11 +5959,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6001,11 +6012,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -6017,7 +6028,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -6044,7 +6055,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6097,7 +6108,7 @@ msgstr ""
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -6149,7 +6160,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -6196,15 +6207,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -6222,7 +6233,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6307,7 +6318,7 @@ msgstr "Perfil %s renombrado a %s"
 msgid "Profile to apply to the new image"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -6469,7 +6480,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6477,7 +6488,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6635,7 +6646,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6675,17 +6686,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6729,7 +6740,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -7146,11 +7157,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7256,7 +7267,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -7408,11 +7419,11 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7424,21 +7435,21 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7515,15 +7526,15 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr ""
 
@@ -7537,7 +7548,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -7658,7 +7669,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7668,25 +7679,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Perfil %s eliminado"
@@ -7734,7 +7745,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7750,12 +7761,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid "Taken at"
 msgstr ""
 
@@ -7878,7 +7889,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -7966,12 +7977,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8023,7 +8034,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -8097,7 +8108,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -8106,7 +8117,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -8122,7 +8133,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8130,11 +8141,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -8147,7 +8158,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8188,7 +8199,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -8205,7 +8216,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -8221,7 +8232,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr ""
 
@@ -8269,8 +8280,8 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8391,11 +8402,11 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8469,7 +8480,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8501,7 +8512,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -8515,12 +8526,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8607,7 +8618,7 @@ msgstr "Versión de CUDA: %v"
 msgid "Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr ""
 
@@ -8778,11 +8789,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8790,7 +8801,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8806,7 +8817,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
@@ -9317,7 +9328,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9365,17 +9376,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9385,68 +9396,68 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9519,7 +9530,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -10068,7 +10079,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10078,7 +10089,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10088,7 +10099,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10098,7 +10109,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10108,7 +10119,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10118,7 +10129,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10128,7 +10139,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10142,7 +10153,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10152,7 +10163,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2024-11-11 22:00+0000\n"
 "Last-Translator: \"Laterria.Severino\" <Laterria.Severino@openmail.pro>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -84,7 +84,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -684,7 +684,7 @@ msgstr "--empty ne peut être combiné avec le nom d'une image"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only ne peut être utilisé lorsque la source est un snapshot"
 
@@ -692,7 +692,7 @@ msgstr "--instance-only ne peut être utilisé lorsque la source est un snapshot
 msgid "--network-port can't be used without --network-address"
 msgstr "--network-port ne peut pas être utilisé sans --network-address"
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 
@@ -700,7 +700,7 @@ msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 msgid "--project cannot be used with the query command"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
@@ -1014,7 +1014,7 @@ msgstr ""
 "Toutes les données seront perdues après avoir rejoint le cluster, voulez-"
 "vous continuer ?"
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid "All projects"
 msgstr "Tous les projets"
 
@@ -1152,17 +1152,17 @@ msgstr "Sauvegarder l'instance : %s"
 msgid "Backing up storage bucket: %s"
 msgstr "Sauvegarder le bucket de stockage : %s"
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Sauvegarder le volume de stockage : %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr "Export de la sauvegarde réussie !"
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr "Sauvegardes:"
 
@@ -1181,14 +1181,14 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "Mauvaise paire clé/valeur: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Mauvaise association clef=valeur: %q"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Mauvaise paire clé=valeur: %s"
@@ -1236,7 +1236,7 @@ msgstr "ANNULABLE"
 msgid "COMMON NAME"
 msgstr "NOM COMMUN"
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr "Type de contenu"
 
@@ -1244,7 +1244,7 @@ msgstr "Type de contenu"
 msgid "COUNT"
 msgstr "NOMBRE"
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 #, fuzzy
 msgid "CPU TIME(s)"
 msgstr "TEMPS CPU(s)"
@@ -1337,7 +1337,7 @@ msgstr "Impossible de spécifier --project avec --all-projects"
 msgid "Can't specify a different remote for rename"
 msgstr "Impossible de spécifier un autre serveur distant pour un renommage"
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1382,20 +1382,20 @@ msgstr ""
 "Impossible de surcharger l'appareil %q : Appareil introuvable dans les "
 "profils"
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "Impossible d'utiliser --destination-target quand le serveur distant n'est "
 "pas dans un cluster"
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "Impossible de mettre --target quand le server source n'est pas dans un "
 "cluster"
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "Impossible de mettre --volume-only lors de la copie d'une sauvegarde"
 
@@ -1513,7 +1513,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Le membre du cluster %s est supprimé du groupe %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1539,15 +1539,15 @@ msgstr "Le membre du cluster %s est supprimé du groupe %s"
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr "Nom du membre du cluster"
 
@@ -1566,8 +1566,8 @@ msgstr "Clustering activé"
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1603,7 +1603,7 @@ msgstr "Algorithme de compression à utiliser (`none` pour ne pas compresser)"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Algorithme de compression à utiliser (`none` pour ne pas compresser)"
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuration clé/valeur à associer à la nouvelle instance"
 
@@ -1633,7 +1633,7 @@ msgstr "L'option de configuration doit être dans le format CLÉ=VALEUR"
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -1646,7 +1646,7 @@ msgstr "Fanions de configuration nécessite --auto"
 msgid "Configure the daemon"
 msgstr "Configurer le démon"
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 #, fuzzy
 msgid "Configure the refresh delay in seconds"
 msgstr "Configurer le démon"
@@ -1656,11 +1656,11 @@ msgstr "Configurer le démon"
 msgid "Connecting to the daemon (attempt %d)"
 msgstr "Connexion au démon (tentative %d)"
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr "Type de contenu, bloc ou système de fichier"
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Content type: %s"
 msgstr "Type de contenu : %s"
@@ -1670,7 +1670,7 @@ msgstr "Type de contenu : %s"
 msgid "Control: %s (%s)"
 msgstr "Contrôle: %s (%s)"
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr "Copie une instance avec état"
 
@@ -1678,7 +1678,7 @@ msgstr "Copie une instance avec état"
 msgid "Copy aliases from source"
 msgstr "Copier les alias depuis la source"
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 msgid "Copy custom storage volumes"
 msgstr "Copie de volumes de stockage personnalisés"
 
@@ -1698,11 +1698,11 @@ msgstr ""
 "Le fanion auto-update indique au serveur que l'image doit restée à jour.\n"
 "Cela nécessite que la source soit un alias et d'être publique."
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid "Copy instances within or in between servers"
 msgstr "Copier des instances au sein d'un même serveur ou entre serveurs"
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1740,16 +1740,16 @@ msgstr ""
 msgid "Copy profiles"
 msgstr "Copier les profiles"
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr "Copier l'instance sans ses instantanés"
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr "Copier le volume sans ses instantanés"
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr "Copie dans un projet différent de la source"
 
@@ -1762,7 +1762,7 @@ msgstr "Copier des images de machines virtuelles"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie du volume de stockage : %s"
@@ -1918,7 +1918,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1978,13 +1978,13 @@ msgstr "Créé : %s"
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -2022,11 +2022,11 @@ msgstr "ADRESSE CIBLE PAR DÉFAUT"
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr "DISQUE"
 
@@ -2061,12 +2061,12 @@ msgstr "État : %s"
 msgid "Default VLAN ID"
 msgstr "ID VLAN par défaut"
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr "Supprime un groupe de serveurs"
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2179,7 +2179,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete storage pools"
 msgstr "Supprime les pool de stockage"
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2226,7 +2226,7 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -2327,40 +2327,40 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Description"
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Détacher les volumes de stockage des profils"
@@ -2489,7 +2489,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display images from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2504,7 +2504,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display profiles from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr "Afficher l'utilisation des ressources par instance"
 
@@ -2513,7 +2513,7 @@ msgstr "Afficher l'utilisation des ressources par instance"
 msgid "Display storage pool buckets from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2578,6 +2578,17 @@ msgstr "Pilote: %v (%v)"
 msgid "Dump YAML config to stdout"
 msgstr "Copié de la configuration YAML vers stdout"
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr "ENTRÉES"
@@ -2592,7 +2603,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr "EXISTANT: %q (principal=%q, source=%q)"
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATE D'EXPIRATION"
@@ -2705,11 +2716,11 @@ msgstr "Modifier la clé du bucket de stockage au format YAML"
 msgid "Edit storage pool configurations as YAML"
 msgstr "Modifier les configurations du pool de stockage au format YAML"
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr "Modifier les configurations de volume de stockage au format YAML"
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2734,8 +2745,8 @@ msgstr "Clé de configuration invalide"
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2771,7 +2782,7 @@ msgstr ""
 "définir une valeur\n"
 "  pour l'adresse si elle n'est pas encore paramétrée."
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 #, fuzzy
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
@@ -2780,7 +2791,7 @@ msgstr ""
 "Entrez le type de tri souhaité ('a' pour alphabétique, 'c' pour CPU, 'm' "
 "pour mémoire ou 'd' pour disque) :"
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr ""
 
@@ -2792,7 +2803,7 @@ msgstr "Entrée TTL"
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 #, fuzzy
 msgid "Ephemeral instance"
 msgstr "Conteneur éphémère"
@@ -2824,8 +2835,8 @@ msgstr "Erreur lors de la récupération des alias : %w"
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "Erreur lors du paramétrages des propriétés: %v"
@@ -2846,8 +2857,8 @@ msgstr "Erreur lors du déparamétrage des propriétés: %v"
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "Erreur dans le déparamétrage de la propriété: %v"
@@ -2983,8 +2994,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "Attendait une struct, a obtenu un %v"
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -3015,7 +3026,7 @@ msgstr ""
 "La cible de sortie est facultative et par défaut dans le répertoire de "
 "travail."
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -3040,7 +3051,7 @@ msgstr "Copie de l'image : %s"
 msgid "Export storage buckets as tarball."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
@@ -3050,7 +3061,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -3138,7 +3149,7 @@ msgstr ""
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Échec de la suppression de l'instance %q dans le projet %q : %w"
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Échec de la suppression du volume source après la copie : %w"
@@ -3279,7 +3290,7 @@ msgstr "Échec de la création de la sauvegarde : %v"
 msgid "Failed to create certificate: %w"
 msgstr "Échec de la création du certificat : %w"
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Échec de la création de la sauvegarde du volume de stockage : %w"
@@ -3295,7 +3306,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Échec de la récupération de la sauvegarde de l'unité de stockage : %w"
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3336,7 +3347,7 @@ msgstr "Échec de l'analyse du preseed : %w"
 msgid "Failed to read from stdin: %w"
 msgstr "Échec de la lecture à partir de l'entrée standard : %w"
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec du rafraîchissement de l'instance cible '%s' : %v"
@@ -3555,7 +3566,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 #, fuzzy
 msgid "Format (csv|json|table|yaml|compact)"
@@ -3571,7 +3582,7 @@ msgstr "Format (json|pretty|yaml)"
 msgid "Format (man|md|rest|yaml)"
 msgstr "Format (man|md|rest|yaml)"
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 #, fuzzy
 msgid "Format (table|compact)"
 msgstr "Format (csv|json|table|yaml|compact)"
@@ -3715,7 +3726,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -3804,11 +3815,11 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr "Obtenir les valeurs des clés de configuration du pool de stockage"
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr "Obtenir les valeurs des clés de configuration du volume de stockage"
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3820,7 +3831,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3890,7 +3901,7 @@ msgstr "ID : %s"
 msgid "IMAGES"
 msgstr "IMAGES"
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr "NOM DE L'INSTANCE"
 
@@ -3936,7 +3947,7 @@ msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 "Si l'alias de l'image existe déjà, le supprimer d'abord puis le recréer"
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "Si l'instantané de l'image existe déjà, le supprimer d'abord puis le recréer"
@@ -3954,12 +3965,12 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "Ignorer toute expiration automatique configurée pour l'instance"
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 "Ignorer toute expiration automatique configurée pour le volume de stockage"
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr "Ignorer les erreurs de copie pour les fichiers non permanents"
 
@@ -4018,12 +4029,12 @@ msgstr "Importer des sauvegardes d'instances, y compris leurs instantanés."
 msgid "Import backups of storage buckets."
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Copie de l'image : %s"
@@ -4054,16 +4065,16 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Import storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr "Le type d'importation doit être \"backup\" ou \"iso\""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 #, fuzzy
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr "Type d'importation : \"backup\" ou \"iso\" (par défaut \"backup\")"
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr "L'importation d'images ISO nécessite la définition d'un nom de volume"
 
@@ -4072,7 +4083,7 @@ msgstr "L'importation d'images ISO nécessite la définition d'un nom de volume"
 msgid "Importing bucket: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -4156,7 +4167,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Le nom du conteneur est : %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Cible invalide %s"
@@ -4177,7 +4188,7 @@ msgid "Invalid arguments"
 msgstr "Cible invalide %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, fuzzy, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "Segment de nom de sauvegarde non valide dans le chemin %q : %w"
@@ -4217,7 +4228,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid expiration date: %w"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Cible invalide %s"
@@ -4227,7 +4238,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid format: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 #, fuzzy
 msgid "Invalid input, please enter a positive number"
 msgstr "Entrée invalide, veuillez entrer un entier positif"
@@ -4292,19 +4303,19 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 #, fuzzy
 msgid "Invalid sorting type"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 #, fuzzy
 msgid "Invalid sorting type provided"
 msgstr "Cible invalide %s"
@@ -4361,7 +4372,7 @@ msgstr "ADRESSE D’ÉCOUTE"
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr "LOCALISATION"
 
@@ -5173,12 +5184,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -5192,12 +5203,12 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -5310,7 +5321,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5381,7 +5392,7 @@ msgstr "GÉRÉ"
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -5607,7 +5618,7 @@ msgstr "Copie de l'image : %s"
 msgid "Manage storage pools and volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Copie de l'image : %s"
@@ -5864,15 +5875,15 @@ msgstr "Résumé manquant."
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5899,12 +5910,12 @@ msgstr "Résumé manquant."
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -5947,7 +5958,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
@@ -5962,7 +5973,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -5993,11 +6004,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -6028,7 +6039,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr "NOM"
 
@@ -6083,8 +6094,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -6150,7 +6161,7 @@ msgid "Name of the storage pool:"
 msgstr "Copie de l'image : %s"
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -6293,7 +6304,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -6317,7 +6328,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
@@ -6342,11 +6353,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6397,13 +6408,13 @@ msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -6419,7 +6430,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
@@ -6450,7 +6461,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6506,7 +6517,7 @@ msgstr "PROFILS"
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -6560,7 +6571,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -6607,15 +6618,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -6633,7 +6644,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -6719,7 +6730,7 @@ msgstr "Profil %s ajouté à %s"
 msgid "Profile to apply to the new image"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -6887,7 +6898,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
@@ -6897,7 +6908,7 @@ msgstr "Copie de l'image : %s"
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -7063,7 +7074,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -7104,17 +7115,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Forcer le conteneur à s'arrêter"
@@ -7174,7 +7185,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -7607,12 +7618,12 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7722,7 +7733,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7887,12 +7898,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7904,22 +7915,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -8000,16 +8011,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -8023,7 +8034,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Certaines instances n'ont pas réussi à %s"
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -8148,7 +8159,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -8158,27 +8169,27 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Storage pool to use or create"
 msgstr "Le réseau %s a été créé"
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Profil %s supprimé"
@@ -8229,7 +8240,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8245,12 +8256,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -8382,7 +8393,7 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -8471,12 +8482,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8531,7 +8542,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -8610,7 +8621,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -8619,7 +8630,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -8635,7 +8646,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8643,11 +8654,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -8660,7 +8671,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -8701,7 +8712,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -8718,7 +8729,7 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -8736,7 +8747,7 @@ msgstr "Création du conteneur"
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -8785,8 +8796,8 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8915,12 +8926,12 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8995,7 +9006,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -9028,7 +9039,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -9043,12 +9054,12 @@ msgstr "Publié : %s"
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -9136,7 +9147,7 @@ msgstr "Version CUDA : %v"
 msgid "Version: %v"
 msgstr "Version CUDA : %v"
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr ""
 
@@ -9314,12 +9325,12 @@ msgstr "Il est impossible de passer -t et -T simultanément"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "impossible de copier vers le même nom de conteneur"
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -9328,7 +9339,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom d'image ou utilisez --empty"
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -9350,7 +9361,7 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<serveur distant>:]"
@@ -10208,7 +10219,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -10287,7 +10298,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -10295,7 +10306,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -10303,7 +10314,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -10319,7 +10330,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -10331,7 +10342,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -10343,7 +10354,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -10355,7 +10366,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -10367,7 +10378,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -10375,7 +10386,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -10387,7 +10398,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -10395,8 +10406,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -10404,7 +10415,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -10412,7 +10423,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -10420,7 +10431,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -10432,7 +10443,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10440,7 +10451,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10555,7 +10566,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -11191,7 +11202,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -11201,7 +11212,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -11211,7 +11222,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -11221,7 +11232,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -11231,7 +11242,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -11241,7 +11252,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -11251,7 +11262,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -11265,7 +11276,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -11275,7 +11286,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2024-11-09 07:00+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -61,7 +61,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -435,7 +435,7 @@ msgstr "--empty tidak bisa dikombinasikan dengan nama image"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded tidak bisa dipakai dengan server"
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -451,7 +451,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr "Alias:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid "All projects"
 msgstr "Semua proyek"
 
@@ -871,17 +871,17 @@ msgstr ""
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr "Cadangan:"
 
@@ -898,14 +898,14 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -953,7 +953,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NAMA UMUM"
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -961,7 +961,7 @@ msgstr ""
 msgid "COUNT"
 msgstr "CACAH"
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 msgid "CPU TIME(s)"
 msgstr ""
 
@@ -1051,7 +1051,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1091,16 +1091,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1241,15 +1241,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr ""
 
@@ -1268,8 +1268,8 @@ msgstr ""
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Kolom"
 
@@ -1296,7 +1296,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1325,7 +1325,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Configure the daemon"
 msgstr ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
@@ -1347,11 +1347,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 msgid "Copy custom storage volumes"
 msgstr ""
 
@@ -1385,11 +1385,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1413,16 +1413,16 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1435,7 +1435,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1612,12 +1612,12 @@ msgstr "Buat proyek"
 msgid "Create storage pools"
 msgstr "Buat pool penyimpanan"
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr "Dibuat: %s"
@@ -1654,11 +1654,11 @@ msgstr ""
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr "DESKRIPSI"
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr "DISK"
 
@@ -1693,11 +1693,11 @@ msgstr "Tanggal: %s"
 msgid "Default VLAN ID"
 msgstr "ID VLAN baku"
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr "Tundaan:"
 
@@ -1713,7 +1713,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 msgid "Delete custom storage volumes"
 msgstr ""
 
@@ -1794,7 +1794,7 @@ msgstr "Hapus bucket penyimpanan"
 msgid "Delete storage pools"
 msgstr "Hapus pool penyimpanan"
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 msgid "Delete storage volume snapshots"
 msgstr ""
 
@@ -1839,7 +1839,7 @@ msgstr "Hapus peringatan"
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -1940,38 +1940,38 @@ msgstr "Hapus peringatan"
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Deskripsi"
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, c-format
 msgid "Description: %s"
 msgstr "Deskripsi: %s"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -2101,7 +2101,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr ""
 
@@ -2109,7 +2109,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2173,6 +2173,17 @@ msgstr "Driver: %v (%v)"
 msgid "Dump YAML config to stdout"
 msgstr ""
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr "ENTRI"
@@ -2187,7 +2198,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 msgid "EXPIRES AT"
 msgstr "KEDALUWARSA PADA"
 
@@ -2282,11 +2293,11 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2310,8 +2321,8 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2334,13 +2345,13 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
 msgstr ""
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr ""
 
@@ -2352,7 +2363,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2383,8 +2394,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2405,8 +2416,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2486,8 +2497,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 msgid "Expires at"
 msgstr "Kedaluwarsa pada"
 
@@ -2511,7 +2522,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2531,7 +2542,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2540,7 +2551,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2621,7 +2632,7 @@ msgstr ""
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -2760,7 +2771,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2775,7 +2786,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -2815,7 +2826,7 @@ msgstr ""
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -3004,7 +3015,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3017,7 +3028,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid "Format (table|compact)"
 msgstr ""
 
@@ -3146,7 +3157,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3219,11 +3230,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3235,7 +3246,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3298,7 +3309,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr ""
 
@@ -3339,7 +3350,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3353,11 +3364,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3411,11 +3422,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3438,15 +3449,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3455,7 +3466,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3530,7 +3541,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3550,7 +3561,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3588,7 +3599,7 @@ msgstr ""
 msgid "Invalid expiration date: %w"
 msgstr ""
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -3598,7 +3609,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr ""
 
@@ -3656,17 +3667,17 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 msgid "Invalid sorting type"
 msgstr ""
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 msgid "Invalid sorting type provided"
 msgstr ""
 
@@ -3721,7 +3732,7 @@ msgstr ""
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4455,11 +4466,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4473,11 +4484,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4589,7 +4600,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4657,7 +4668,7 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -4854,7 +4865,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -5093,15 +5104,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 msgid "Missing pool name"
 msgstr ""
 
@@ -5125,11 +5136,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -5167,7 +5178,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5179,7 +5190,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
@@ -5207,11 +5218,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -5241,7 +5252,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr ""
 
@@ -5296,8 +5307,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr ""
 
@@ -5358,7 +5369,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5499,7 +5510,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5522,7 +5533,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5546,11 +5557,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5598,11 +5609,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5614,7 +5625,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5640,7 +5651,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5693,7 +5704,7 @@ msgstr ""
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5745,7 +5756,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -5791,15 +5802,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -5817,7 +5828,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5901,7 +5912,7 @@ msgstr "Profil %s diganti nama menjadi %s"
 msgid "Profile to apply to the new image"
 msgstr "Profil yang akan diterapkan ke image baru"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr "Profil yang akan diterapkan ke instansi baru"
 
@@ -6058,7 +6069,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6066,7 +6077,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -6218,7 +6229,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 msgid "Rename custom storage volumes"
 msgstr ""
 
@@ -6254,16 +6265,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6304,7 +6315,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6707,11 +6718,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6809,7 +6820,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6950,11 +6961,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -6966,19 +6977,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7053,15 +7064,15 @@ msgstr "Ukuran: %.2fMiB"
 msgid "Size: %s"
 msgstr "Ukuran: %s"
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 msgid "Snapshot storage volumes"
 msgstr "Volume penyimpanan snapshot"
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "Snapshot itu hanya-baca dan tidak bisa diubah konfigurasinya"
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr "Snapshot:"
 
@@ -7075,7 +7086,7 @@ msgstr "Soket %d:"
 msgid "Some instances failed to %s"
 msgstr "Beberapa instansi gagal %s"
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr "Metode Pengurutan:"
 
@@ -7195,7 +7206,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7204,25 +7215,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7269,7 +7280,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7285,12 +7296,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid "Taken at"
 msgstr ""
 
@@ -7413,7 +7424,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -7501,12 +7512,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7558,7 +7569,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7631,7 +7642,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7640,7 +7651,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7656,7 +7667,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7664,11 +7675,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -7681,7 +7692,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -7720,7 +7731,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7737,7 +7748,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -7753,7 +7764,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr ""
 
@@ -7800,8 +7811,8 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7910,11 +7921,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -7979,7 +7990,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8010,7 +8021,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -8024,12 +8035,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8115,7 +8126,7 @@ msgstr "Versi: %s"
 msgid "Version: %v"
 msgstr "Versi: %v"
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr "Hanya Volume"
 
@@ -8285,11 +8296,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8297,7 +8308,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profil> [<nama perangkat>]"
 
@@ -8311,7 +8322,7 @@ msgstr "[<remote:>]<pool> <volume> <profil> [<nama perangkat>] [<path>]"
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -8728,7 +8739,7 @@ msgstr "[<remote>:]<pool>"
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "[<remote>:]<pool> <berkas cadangan> [<bucket>]"
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <berkas cadangan> [<volume nama>]"
 
@@ -8767,15 +8778,15 @@ msgstr "[<remote>:]<pool> <kunci>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <kunci> <nilai>"
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "[<remote>:]<pool> <nama lama> <nama baru>"
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instansi> [<nama perangkat>]"
 
@@ -8783,56 +8794,56 @@ msgstr "[<remote>:]<pool> <volume> <instansi> [<nama perangkat>]"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instansi> [<nama perangkat>] [<path>]"
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot lama> <snapshot baru>"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -8891,7 +8902,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -9426,7 +9437,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9436,7 +9447,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9446,7 +9457,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9456,7 +9467,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9466,7 +9477,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9476,7 +9487,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9486,7 +9497,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9500,7 +9511,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9510,7 +9521,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-11-13 16:23-0500\n"
+        "POT-Creation-Date: 2024-11-14 01:18-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,7 +56,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -409,7 +409,7 @@ msgstr  ""
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid   "--instance-only can't be passed when the source is a snapshot"
 msgstr  ""
 
@@ -417,7 +417,7 @@ msgstr  ""
 msgid   "--network-port can't be used without --network-address"
 msgstr  ""
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 msgid   "--no-profiles cannot be used with --refresh"
 msgstr  ""
 
@@ -425,7 +425,7 @@ msgstr  ""
 msgid   "--project cannot be used with the query command"
 msgstr  ""
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
@@ -703,7 +703,7 @@ msgstr  ""
 msgid   "All existing data is lost when joining a cluster, continue?"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid   "All projects"
 msgstr  ""
 
@@ -831,16 +831,16 @@ msgstr  ""
 msgid   "Backing up storage bucket: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539 cmd/incus/storage_volume.go:3110
+#: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539 cmd/incus/storage_volume.go:3113
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid   "Backups:"
 msgstr  ""
 
@@ -854,12 +854,12 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302 cmd/incus/network_integration.go:145 cmd/incus/project.go:171
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302 cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: cmd/incus/publish.go:191 cmd/incus/storage.go:169 cmd/incus/storage_volume.go:651
+#: cmd/incus/publish.go:191 cmd/incus/storage.go:169 cmd/incus/storage_volume.go:654
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -907,7 +907,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -915,7 +915,7 @@ msgstr  ""
 msgid   "COUNT"
 msgstr  ""
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 msgid   "CPU TIME(s)"
 msgstr  ""
 
@@ -1004,7 +1004,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683 cmd/incus/warning.go:225
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686 cmd/incus/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -1042,15 +1042,15 @@ msgstr  ""
 msgid   "Cannot override config for device %q: Device not found in profile devices"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid   "Cannot set --volume-only when copying a snapshot"
 msgstr  ""
 
@@ -1162,7 +1162,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60 cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64 cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1471 cmd/incus/network.go:1564 cmd/incus/network.go:1636 cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520 cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826 cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997 cmd/incus/network_load_balancer.go:255 cmd/incus/network_load_balancer.go:336 cmd/incus/network_load_balancer.go:507 cmd/incus/network_load_balancer.go:642 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:895 cmd/incus/network_load_balancer.go:971 cmd/incus/network_load_balancer.go:1084 cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108 cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832 cmd/incus/storage.go:934 cmd/incus/storage.go:1027 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738 cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903 cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337 cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560 cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966 cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325 cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126 cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876 cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537 cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61 cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64 cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920 cmd/incus/network.go:1471 cmd/incus/network.go:1564 cmd/incus/network.go:1636 cmd/incus/network_forward.go:251 cmd/incus/network_forward.go:332 cmd/incus/network_forward.go:520 cmd/incus/network_forward.go:672 cmd/incus/network_forward.go:826 cmd/incus/network_forward.go:915 cmd/incus/network_forward.go:997 cmd/incus/network_load_balancer.go:255 cmd/incus/network_load_balancer.go:336 cmd/incus/network_load_balancer.go:507 cmd/incus/network_load_balancer.go:642 cmd/incus/network_load_balancer.go:807 cmd/incus/network_load_balancer.go:895 cmd/incus/network_load_balancer.go:971 cmd/incus/network_load_balancer.go:1084 cmd/incus/network_load_balancer.go:1158 cmd/incus/storage.go:108 cmd/incus/storage.go:405 cmd/incus/storage.go:488 cmd/incus/storage.go:832 cmd/incus/storage.go:934 cmd/incus/storage.go:1027 cmd/incus/storage_bucket.go:103 cmd/incus/storage_bucket.go:203 cmd/incus/storage_bucket.go:266 cmd/incus/storage_bucket.go:397 cmd/incus/storage_bucket.go:645 cmd/incus/storage_bucket.go:738 cmd/incus/storage_bucket.go:804 cmd/incus/storage_bucket.go:903 cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136 cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337 cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560 cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587 cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969 cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328 cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873 cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129 cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335 cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713 cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879 cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1170,7 +1170,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092 cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421 cmd/incus/config_trust.go:610 cmd/incus/image.go:1093 cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072 cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:138 cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:687 cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904 cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548 cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092 cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421 cmd/incus/config_trust.go:610 cmd/incus/image.go:1093 cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072 cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:138 cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:687 cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904 cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551 cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1195,7 +1195,7 @@ msgstr  ""
 msgid   "Compression algorithm to use (none for uncompressed)"
 msgstr  ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
@@ -1215,7 +1215,7 @@ msgstr  ""
 msgid   "Config option should be in the format KEY=VALUE"
 msgstr  ""
 
-#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714 cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804 cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405 cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300 cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/cluster.go:962 cmd/incus/cluster_group.go:413 cmd/incus/config.go:276 cmd/incus/config.go:351 cmd/incus/config_metadata.go:154 cmd/incus/config_trust.go:353 cmd/incus/image.go:477 cmd/incus/network.go:802 cmd/incus/network_acl.go:714 cmd/incus/network_forward.go:790 cmd/incus/network_integration.go:312 cmd/incus/network_load_balancer.go:771 cmd/incus/network_peer.go:804 cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405 cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368 cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300 cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1228,7 +1228,7 @@ msgstr  ""
 msgid   "Configure the daemon"
 msgstr  ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 msgid   "Configure the refresh delay in seconds"
 msgstr  ""
 
@@ -1237,11 +1237,11 @@ msgstr  ""
 msgid   "Connecting to the daemon (attempt %d)"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1251,7 +1251,7 @@ msgstr  ""
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
@@ -1259,7 +1259,7 @@ msgstr  ""
 msgid   "Copy aliases from source"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 msgid   "Copy custom storage volumes"
 msgstr  ""
 
@@ -1274,11 +1274,11 @@ msgid   "Copy images between servers\n"
         "It requires the source to be an alias and for it to be public."
 msgstr  ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid   "Copy instances within or in between servers"
 msgstr  ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid   "Copy instances within or in between servers\n"
         "\n"
         "Transfer modes (--mode):\n"
@@ -1297,15 +1297,15 @@ msgstr  ""
 msgid   "Copy profiles"
 msgstr  ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65 cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65 cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1318,7 +1318,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -1445,7 +1445,7 @@ msgstr  ""
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1493,11 +1493,11 @@ msgstr  ""
 msgid   "Create storage pools"
 msgstr  ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: cmd/incus/image.go:999 cmd/incus/info.go:663 cmd/incus/storage_volume.go:1443
+#: cmd/incus/image.go:999 cmd/incus/info.go:663 cmd/incus/storage_volume.go:1446
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1525,11 +1525,11 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499 cmd/incus/config_trust.go:435 cmd/incus/image.go:1115 cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133 cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141 cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134 cmd/incus/network_zone.go:917 cmd/incus/operation.go:151 cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916 cmd/incus/storage_volume.go:1672
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499 cmd/incus/config_trust.go:435 cmd/incus/image.go:1115 cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133 cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141 cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134 cmd/incus/network_zone.go:917 cmd/incus/operation.go:151 cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916 cmd/incus/storage_volume.go:1675
 msgid   "DESCRIPTION"
 msgstr  ""
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid   "DISK"
 msgstr  ""
 
@@ -1564,11 +1564,11 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid   "Delay:"
 msgstr  ""
 
@@ -1584,7 +1584,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 msgid   "Delete custom storage volumes"
 msgstr  ""
 
@@ -1664,7 +1664,7 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 msgid   "Delete storage volume snapshots"
 msgstr  ""
 
@@ -1672,24 +1672,24 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470 cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104 cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437 cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792 cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985 cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576 cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759 cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954 cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314 cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559 cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867 cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110 cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273 cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550 cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794 cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961 cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470 cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:321 cmd/incus/image.go:376 cmd/incus/image.go:511 cmd/incus/image.go:679 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:86 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104 cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437 cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792 cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985 cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762 cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957 cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317 cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562 cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113 cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797 cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964 cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 msgid   "Destination cluster member name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 msgid   "Detach custom storage volumes from instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 msgid   "Detach custom storage volumes from profiles"
 msgstr  ""
 
@@ -1801,7 +1801,7 @@ msgstr  ""
 msgid   "Display images from all projects"
 msgstr  ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 msgid   "Display instances from all projects"
 msgstr  ""
 
@@ -1813,7 +1813,7 @@ msgstr  ""
 msgid   "Display profiles from all projects"
 msgstr  ""
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid   "Display resource usage info per instance"
 msgstr  ""
 
@@ -1821,7 +1821,7 @@ msgstr  ""
 msgid   "Display storage pool buckets from all projects"
 msgstr  ""
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid   "Displays CPU usage, memory usage, and disk usage per instance\n"
         "\n"
         "Default column layout: numD\n"
@@ -1884,6 +1884,14 @@ msgstr  ""
 msgid   "Dump YAML config to stdout"
 msgstr  ""
 
+#: cmd/incus/copy.go:65
+msgid   "During incremental copy, exclude source snapshots earlier than latest target snapshot"
+msgstr  ""
+
+#: cmd/incus/storage_volume.go:371
+msgid   "During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr  ""
+
 #: cmd/incus/network_zone.go:918
 msgid   "ENTRIES"
 msgstr  ""
@@ -1897,7 +1905,7 @@ msgstr  ""
 msgid   "EXISTING: %q (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623 cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623 cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 msgid   "EXPIRES AT"
 msgstr  ""
 
@@ -1989,11 +1997,11 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid   "Edit storage volume configurations as YAML\n"
         "\n"
         "If the type is not specified, incus assumes the type is \"custom\".\n"
@@ -2004,7 +2012,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:631 cmd/incus/image.go:1133 cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113 cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:166 cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:722 cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925 cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658 cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:631 cmd/incus/image.go:1133 cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113 cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:166 cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:722 cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925 cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661 cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -2024,11 +2032,11 @@ msgid   "Enable clustering on a single non-clustered server\n"
         "  for the address if not yet set."
 msgstr  ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid   "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' for disk):"
 msgstr  ""
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid   "Enter new delay in seconds:"
 msgstr  ""
 
@@ -2040,7 +2048,7 @@ msgstr  ""
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid   "Ephemeral instance"
 msgstr  ""
 
@@ -2064,7 +2072,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1539 cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595 cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548 cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083 cmd/incus/project.go:855 cmd/incus/storage.go:896 cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038 cmd/incus/storage_volume.go:2081
+#: cmd/incus/cluster.go:562 cmd/incus/cluster_group.go:1019 cmd/incus/config.go:641 cmd/incus/config.go:673 cmd/incus/network.go:1539 cmd/incus/network_acl.go:540 cmd/incus/network_forward.go:595 cmd/incus/network_integration.go:668 cmd/incus/network_load_balancer.go:582 cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548 cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083 cmd/incus/project.go:855 cmd/incus/storage.go:896 cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041 cmd/incus/storage_volume.go:2084
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -2079,7 +2087,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013 cmd/incus/network.go:1533 cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662 cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622 cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230 cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032 cmd/incus/storage_volume.go:2075
+#: cmd/incus/cluster.go:556 cmd/incus/cluster_group.go:1013 cmd/incus/network.go:1533 cmd/incus/network_acl.go:534 cmd/incus/network_forward.go:589 cmd/incus/network_integration.go:662 cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622 cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230 cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890 cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035 cmd/incus/storage_volume.go:2078
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2155,7 +2163,7 @@ msgstr  ""
 msgid   "Expected a struct, got a %v"
 msgstr  ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476 cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479 cmd/incus/storage_volume.go:1529
 msgid   "Expires at"
 msgstr  ""
 
@@ -2178,7 +2186,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -2198,7 +2206,7 @@ msgstr  ""
 msgid   "Export storage buckets as tarball."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
@@ -2207,7 +2215,7 @@ msgstr  ""
 msgid   "Exporting backup of storage bucket: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2287,7 +2295,7 @@ msgstr  ""
 msgid   "Failed deleting instance %q in project %q: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid   "Failed deleting source volume after copy: %w"
 msgstr  ""
@@ -2426,7 +2434,7 @@ msgstr  ""
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, c-format
 msgid   "Failed to create storage volume backup: %w"
 msgstr  ""
@@ -2441,7 +2449,7 @@ msgstr  ""
 msgid   "Failed to fetch storage bucket backup: %w"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, c-format
 msgid   "Failed to fetch storage volume backup file: %w"
 msgstr  ""
@@ -2481,7 +2489,7 @@ msgstr  ""
 msgid   "Failed to read from stdin: %w"
 msgstr  ""
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid   "Failed to refresh target instance '%s': %v"
 msgstr  ""
@@ -2648,7 +2656,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:609 cmd/incus/image.go:1094 cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073 cmd/incus/network.go:1272 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:859 cmd/incus/operation.go:136 cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902 cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561 cmd/incus/warning.go:94
+#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:609 cmd/incus/image.go:1094 cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073 cmd/incus/network.go:1272 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:859 cmd/incus/operation.go:136 cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902 cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2660,7 +2668,7 @@ msgstr  ""
 msgid   "Format (man|md|rest|yaml)"
 msgstr  ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid   "Format (table|compact)"
 msgstr  ""
 
@@ -2788,7 +2796,7 @@ msgstr  ""
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
@@ -2860,11 +2868,11 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid   "Get values for storage volume configuration keys\n"
         "\n"
         "If the type is not specified, incus assumes the type is \"custom\".\n"
@@ -2873,7 +2881,7 @@ msgid   "Get values for storage volume configuration keys\n"
         "For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine)."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
@@ -2936,7 +2944,7 @@ msgstr  ""
 msgid   "IMAGES"
 msgstr  ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid   "INSTANCE NAME"
 msgstr  ""
 
@@ -2977,7 +2985,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2989,11 +2997,11 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid   "Ignore copy errors for volatile files"
 msgstr  ""
 
@@ -3047,11 +3055,11 @@ msgstr  ""
 msgid   "Import backups of storage buckets."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 msgid   "Import custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 msgid   "Import custom storage volumes."
 msgstr  ""
 
@@ -3073,15 +3081,15 @@ msgstr  ""
 msgid   "Import storage bucket"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid   "Import type needs to be \"backup\" or \"iso\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid   "Importing ISO images requires a volume name to be set"
 msgstr  ""
 
@@ -3090,7 +3098,7 @@ msgstr  ""
 msgid   "Importing bucket: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -3164,7 +3172,7 @@ msgstr  ""
 msgid   "Invalid IP address or DNS name"
 msgstr  ""
 
-#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490 cmd/incus/storage_volume.go:3061
+#: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490 cmd/incus/storage_volume.go:3064
 #, c-format
 msgid   "Invalid URL %q: %w"
 msgstr  ""
@@ -3183,7 +3191,7 @@ msgstr  ""
 msgid   "Invalid arguments"
 msgstr  ""
 
-#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495 cmd/incus/storage_volume.go:3066
+#: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495 cmd/incus/storage_volume.go:3069
 #, c-format
 msgid   "Invalid backup name segment in path %q: %w"
 msgstr  ""
@@ -3221,7 +3229,7 @@ msgstr  ""
 msgid   "Invalid expiration date: %w"
 msgstr  ""
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, c-format
 msgid   "Invalid format %q"
 msgstr  ""
@@ -3231,7 +3239,7 @@ msgstr  ""
 msgid   "Invalid format: %s"
 msgstr  ""
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid   "Invalid input, please enter a positive number"
 msgstr  ""
 
@@ -3288,15 +3296,15 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242 cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015 cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245 cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018 cmd/incus/storage_volume.go:2924
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 msgid   "Invalid sorting type"
 msgstr  ""
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 msgid   "Invalid sorting type provided"
 msgstr  ""
 
@@ -3348,7 +3356,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: cmd/incus/list.go:617 cmd/incus/network.go:1296 cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143 cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516 cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/list.go:617 cmd/incus/network.go:1296 cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143 cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516 cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -4053,11 +4061,11 @@ msgid   "List storage buckets\n"
         "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 msgid   "List storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid   "List storage volume snapshots\n"
         "\n"
         "	The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4070,11 +4078,11 @@ msgid   "List storage volume snapshots\n"
         "		E - Expiry"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 msgid   "List storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -4181,7 +4189,7 @@ msgstr  ""
 msgid   "Load:"
 msgstr  ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -4249,7 +4257,7 @@ msgstr  ""
 msgid   "MEMBERS"
 msgstr  ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid   "MEMORY"
 msgstr  ""
 
@@ -4441,7 +4449,7 @@ msgstr  ""
 msgid   "Manage storage pools and volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 msgid   "Manage storage volume snapshots"
 msgstr  ""
 
@@ -4599,7 +4607,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970 cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668 cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969 cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157 cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615 cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799 cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014 cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606 cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998 cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380 cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596 cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834 cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage.go:244 cmd/incus/storage.go:322 cmd/incus/storage.go:440 cmd/incus/storage.go:518 cmd/incus/storage.go:864 cmd/incus/storage.go:970 cmd/incus/storage_bucket.go:125 cmd/incus/storage_bucket.go:225 cmd/incus/storage_bucket.go:301 cmd/incus/storage_bucket.go:420 cmd/incus/storage_bucket.go:580 cmd/incus/storage_bucket.go:668 cmd/incus/storage_bucket.go:760 cmd/incus/storage_bucket.go:969 cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157 cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359 cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203 cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618 cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802 cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017 cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609 cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001 cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383 cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599 cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837 cmd/incus/storage_volume.go:2914
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -4619,11 +4627,11 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 msgid   "Missing storage pool name"
 msgstr  ""
 
@@ -4659,7 +4667,7 @@ msgid   "Monitor a local or remote server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: cmd/incus/network.go:562 cmd/incus/network.go:659 cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/network.go:562 cmd/incus/network.go:659 cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -4671,7 +4679,7 @@ msgstr  ""
 msgid   "Mount files from instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 msgid   "Move custom storage volumes between pools"
 msgstr  ""
 
@@ -4694,11 +4702,11 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
@@ -4719,7 +4727,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:621 cmd/incus/list.go:583 cmd/incus/network.go:1093 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128 cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916 cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694 cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915 cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/cluster.go:171 cmd/incus/cluster.go:1111 cmd/incus/cluster_group.go:497 cmd/incus/config_trust.go:431 cmd/incus/config_trust.go:621 cmd/incus/list.go:583 cmd/incus/network.go:1093 cmd/incus/network_acl.go:168 cmd/incus/network_integration.go:449 cmd/incus/network_peer.go:128 cmd/incus/network_zone.go:133 cmd/incus/network_zone.go:916 cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694 cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708 cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915 cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid   "NAME"
 msgstr  ""
 
@@ -4770,7 +4778,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474 cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477 cmd/incus/storage_volume.go:1527
 msgid   "Name"
 msgstr  ""
 
@@ -4829,7 +4837,7 @@ msgstr  ""
 msgid   "Name of the storage pool:"
 msgstr  ""
 
-#: cmd/incus/info.go:633 cmd/incus/network.go:969 cmd/incus/storage_volume.go:1414
+#: cmd/incus/info.go:633 cmd/incus/network.go:969 cmd/incus/storage_volume.go:1417
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -4969,7 +4977,7 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
@@ -4992,7 +5000,7 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 msgid   "No device found for this storage volume"
 msgstr  ""
 
@@ -5016,11 +5024,11 @@ msgstr  ""
 msgid   "No storage backends available"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -5066,11 +5074,11 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -5082,7 +5090,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
@@ -5107,7 +5115,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -5157,7 +5165,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092 cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132 cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513 cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76 cmd/incus/warning.go:213
+#: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092 cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132 cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513 cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77 cmd/incus/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -5208,7 +5216,7 @@ msgstr  ""
 msgid   "Pause instances"
 msgstr  ""
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid   "Perform an incremental copy"
 msgstr  ""
 
@@ -5254,15 +5262,15 @@ msgstr  ""
 msgid   "Pre-seed mode, expects YAML config from stdin"
 msgstr  ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid   "Press 'd' + ENTER to change delay"
 msgstr  ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid   "Press 's' + ENTER to change sorting method"
 msgstr  ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid   "Press CTRL-C to exit"
 msgstr  ""
 
@@ -5270,7 +5278,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:478 cmd/incus/network.go:803 cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805 cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406 cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301 cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/cluster.go:963 cmd/incus/cluster_group.go:414 cmd/incus/config.go:277 cmd/incus/config.go:352 cmd/incus/config_metadata.go:155 cmd/incus/config_template.go:254 cmd/incus/config_trust.go:354 cmd/incus/image.go:478 cmd/incus/network.go:803 cmd/incus/network_acl.go:715 cmd/incus/network_forward.go:791 cmd/incus/network_integration.go:313 cmd/incus/network_load_balancer.go:772 cmd/incus/network_peer.go:805 cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406 cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369 cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301 cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -5354,7 +5362,7 @@ msgstr  ""
 msgid   "Profile to apply to the new image"
 msgstr  ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
@@ -5505,7 +5513,7 @@ msgstr  ""
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
@@ -5513,7 +5521,7 @@ msgstr  ""
 msgid   "Refresh images"
 msgstr  ""
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, c-format
 msgid   "Refreshing instance: %s"
 msgstr  ""
@@ -5660,7 +5668,7 @@ msgstr  ""
 msgid   "Rename aliases"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 msgid   "Rename custom storage volumes"
 msgstr  ""
 
@@ -5696,16 +5704,16 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 msgid   "Rename storage volume snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, c-format
 msgid   "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr  ""
@@ -5745,7 +5753,7 @@ msgstr  ""
 msgid   "Restore instance snapshots"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -6116,11 +6124,11 @@ msgid   "Set storage pool configuration keys\n"
         "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -6214,7 +6222,7 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -6354,11 +6362,11 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid   "Show storage volume configurations\n"
         "\n"
         "If the type is not specified, Incus assumes the type is \"custom\".\n"
@@ -6367,19 +6375,19 @@ msgid   "Show storage volume configurations\n"
         "For snapshots, add the snapshot name (only if type is one of custom, container or virtual-machine)."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 msgid   "Show storage volume snapshhot configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 msgid   "Show storage volume snapshot configurations"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid   "Show storage volume state information\n"
         "\n"
         "If the type is not specified, Incus assumes the type is \"custom\".\n"
@@ -6452,15 +6460,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -6474,7 +6482,7 @@ msgstr  ""
 msgid   "Some instances failed to %s"
 msgstr  ""
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid   "Sorting Method:"
 msgstr  ""
 
@@ -6592,7 +6600,7 @@ msgstr  ""
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34 cmd/incus/move.go:63
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34 cmd/incus/move.go:63
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -6600,25 +6608,25 @@ msgstr  ""
 msgid   "Storage pool to use or create"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, c-format
 msgid   "Storage volume snapshot %s deleted from %s"
 msgstr  ""
@@ -6665,7 +6673,7 @@ msgstr  ""
 msgid   "System:"
 msgstr  ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid   "TAKEN AT"
 msgstr  ""
 
@@ -6677,11 +6685,11 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123 cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094 cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73 cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131 cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670 cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123 cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094 cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73 cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131 cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673 cmd/incus/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid   "Taken at"
 msgstr  ""
 
@@ -6792,7 +6800,7 @@ msgstr  ""
 msgid   "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr  ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid   "The minimum refresh rate is 10s"
 msgstr  ""
 
@@ -6880,12 +6888,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
@@ -6931,7 +6939,7 @@ msgstr  ""
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: cmd/incus/network.go:576 cmd/incus/network.go:673 cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/network.go:576 cmd/incus/network.go:673 cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -6999,7 +7007,7 @@ msgid   "To start your first container, try: incus launch images:ubuntu/22.04\n"
         "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr  ""
 
-#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386 cmd/incus/network.go:957 cmd/incus/storage.go:524
+#: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702 cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386 cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -7007,7 +7015,7 @@ msgstr  ""
 msgid   "Too many links"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -7022,7 +7030,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -7030,11 +7038,11 @@ msgstr  ""
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid   "Transfer mode. One of pull, push or relay"
 msgstr  ""
 
@@ -7047,7 +7055,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -7082,7 +7090,7 @@ msgstr  ""
 msgid   "Type of peer (local or remote)"
 msgstr  ""
 
-#: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433 cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973 cmd/incus/storage_volume.go:1423
+#: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433 cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973 cmd/incus/storage_volume.go:1426
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -7099,7 +7107,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid   "USAGE"
 msgstr  ""
 
@@ -7111,7 +7119,7 @@ msgstr  ""
 msgid   "USB devices:"
 msgstr  ""
 
-#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452 cmd/incus/network_zone.go:135 cmd/incus/profile.go:748 cmd/incus/project.go:560 cmd/incus/storage.go:712 cmd/incus/storage_volume.go:1674
+#: cmd/incus/network.go:1099 cmd/incus/network_acl.go:170 cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452 cmd/incus/network_zone.go:135 cmd/incus/profile.go:748 cmd/incus/project.go:560 cmd/incus/storage.go:712 cmd/incus/storage_volume.go:1677
 msgid   "USED BY"
 msgstr  ""
 
@@ -7147,7 +7155,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455 cmd/incus/config_trust.go:637 cmd/incus/image.go:1141 cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119 cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:172 cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:728 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664 cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455 cmd/incus/config_trust.go:637 cmd/incus/image.go:1141 cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119 cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:172 cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:728 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667 cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -7256,11 +7264,11 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid   "Unset storage volume configuration keys\n"
         "\n"
         "If the type is not specified, Incus assumes the type is \"custom\".\n"
@@ -7323,7 +7331,7 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -7352,7 +7360,7 @@ msgstr  ""
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid   "Updated interval to %v"
 msgstr  ""
@@ -7366,12 +7374,12 @@ msgstr  ""
 msgid   "Upper devices"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -7452,7 +7460,7 @@ msgstr  ""
 msgid   "Version: %v"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid   "Volume Only"
 msgstr  ""
 
@@ -7610,11 +7618,11 @@ msgstr  ""
 msgid   "You can't pass -t or -T at the same time as --mode"
 msgstr  ""
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 msgid   "You must specify a source instance name"
 msgstr  ""
 
@@ -7622,7 +7630,7 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
@@ -7630,7 +7638,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070 cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31 cmd/incus/network.go:1050 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509 cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20 cmd/incus/warning.go:69 cmd/incus/webui.go:17
+#: cmd/incus/cluster.go:127 cmd/incus/cluster.go:1070 cmd/incus/cluster_group.go:454 cmd/incus/config_trust.go:397 cmd/incus/config_trust.go:588 cmd/incus/monitor.go:31 cmd/incus/network.go:1050 cmd/incus/network_acl.go:91 cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88 cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509 cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20 cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -8014,7 +8022,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -8050,15 +8058,15 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 msgid   "[<remote>:]<pool> <old name> <new name>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 msgid   "[<remote>:]<pool> <volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr  ""
 
@@ -8066,55 +8074,55 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 msgid   "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 msgid   "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 msgid   "[<remote>:]<pool> [<filter>...]"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312 cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315 cmd/incus/storage_volume.go:2111
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
@@ -8170,7 +8178,7 @@ msgstr  ""
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 msgid   "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
@@ -8627,7 +8635,7 @@ msgid   "incus storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid   "incus storage volume create default foo\n"
         "    Create custom storage volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8635,7 +8643,7 @@ msgid   "incus storage volume create default foo\n"
         "    Create custom storage volume \"foo\" in pool \"default\" with configuration from config.yaml"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid   "incus storage volume edit default container/c1\n"
         "    Edit container storage volume \"c1\" in pool \"default\"\n"
         "\n"
@@ -8643,7 +8651,7 @@ msgid   "incus storage volume edit default container/c1\n"
         "    Edit custom storage volume \"foo\" in pool \"default\" using the content of volume.yaml"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid   "incus storage volume get default data size\n"
         "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
         "\n"
@@ -8651,7 +8659,7 @@ msgid   "incus storage volume get default data size\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid   "incus storage volume import default backup0.tar.gz\n"
         "    Create a new custom volume using backup0.tar.gz as the source\n"
         "\n"
@@ -8659,7 +8667,7 @@ msgid   "incus storage volume import default backup0.tar.gz\n"
         "    Create a new custom volume storing some-installer.iso for use as a CD-ROM image"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid   "incus storage volume info default foo\n"
         "    Returns state information for a custom volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8667,7 +8675,7 @@ msgid   "incus storage volume info default foo\n"
         "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid   "incus storage volume set default data size=1GiB\n"
         "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
         "\n"
@@ -8675,7 +8683,7 @@ msgid   "incus storage volume set default data size=1GiB\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days"
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid   "incus storage volume show default foo\n"
         "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
         "\n"
@@ -8686,7 +8694,7 @@ msgid   "incus storage volume show default foo\n"
         "    Will show the properties of the container volume \"c1\" in pool \"default\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid   "incus storage volume snapshot create default foo snap0\n"
         "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
         "\n"
@@ -8694,7 +8702,7 @@ msgid   "incus storage volume snapshot create default foo snap0\n"
         "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\" with the configuration from \"config.yaml\""
 msgstr  ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid   "incus storage volume unset default foo size\n"
         "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"
         "\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -90,7 +90,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -677,7 +677,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -693,7 +693,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr "Alias:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid "All projects"
 msgstr ""
 
@@ -1126,17 +1126,17 @@ msgstr "Creazione del container in corso"
 msgid "Backing up storage bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr ""
 
@@ -1153,14 +1153,14 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1208,7 +1208,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1216,7 +1216,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 #, fuzzy
 msgid "CPU TIME(s)"
 msgstr "Utilizzo CPU:"
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1348,16 +1348,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1499,15 +1499,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr ""
 
@@ -1526,8 +1526,8 @@ msgstr ""
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
 
@@ -1554,7 +1554,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1584,7 +1584,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1597,7 +1597,7 @@ msgstr ""
 msgid "Configure the daemon"
 msgstr ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
@@ -1606,11 +1606,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1620,7 +1620,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1628,7 +1628,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "Creazione del container in corso"
@@ -1645,11 +1645,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1673,16 +1673,16 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1695,7 +1695,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1831,7 +1831,7 @@ msgstr "Il nome del container è: %s"
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1883,12 +1883,12 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1926,11 +1926,11 @@ msgstr ""
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr ""
 
@@ -1965,11 +1965,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr ""
 
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Creazione del container in corso"
@@ -2074,7 +2074,7 @@ msgstr "Il nome del container è: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Creazione del container in corso"
@@ -2120,7 +2120,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -2221,40 +2221,40 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Creazione del container in corso"
@@ -2378,7 +2378,7 @@ msgstr "Creazione del container in corso"
 msgid "Display images from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Creazione del container in corso"
@@ -2393,7 +2393,7 @@ msgstr "Creazione del container in corso"
 msgid "Display profiles from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr ""
 
@@ -2402,7 +2402,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2466,6 +2466,17 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr ""
@@ -2480,7 +2491,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DI SCADENZA"
@@ -2582,11 +2593,11 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2610,8 +2621,8 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2634,13 +2645,13 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
 msgstr ""
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr ""
 
@@ -2652,7 +2663,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2683,8 +2694,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2705,8 +2716,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2787,8 +2798,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 msgid "Expires at"
 msgstr ""
 
@@ -2812,7 +2823,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2836,7 +2847,7 @@ msgstr "Creazione del container in corso"
 msgid "Export storage buckets as tarball."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2845,7 +2856,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2926,7 +2937,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -3065,7 +3076,7 @@ msgstr "Accetta certificato"
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Accetta certificato"
@@ -3080,7 +3091,7 @@ msgstr "Accetta certificato"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Accetta certificato"
@@ -3120,7 +3131,7 @@ msgstr "Accetta certificato"
 msgid "Failed to read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -3311,7 +3322,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3324,7 +3335,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid "Format (table|compact)"
 msgstr ""
 
@@ -3462,7 +3473,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3543,11 +3554,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3559,7 +3570,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3624,7 +3635,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr ""
 
@@ -3665,7 +3676,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3679,11 +3690,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3739,11 +3750,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Creazione del container in corso"
@@ -3769,15 +3780,15 @@ msgstr "Creazione del container in corso"
 msgid "Import storage bucket"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3786,7 +3797,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3863,7 +3874,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Il nome del container è: %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Proprietà errata: %s"
@@ -3884,7 +3895,7 @@ msgid "Invalid arguments"
 msgstr "Proprietà errata: %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3922,7 +3933,7 @@ msgstr ""
 msgid "Invalid expiration date: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Proprietà errata: %s"
@@ -3932,7 +3943,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid format: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr ""
 
@@ -3992,19 +4003,19 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 #, fuzzy
 msgid "Invalid sorting type"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 #, fuzzy
 msgid "Invalid sorting type provided"
 msgstr "Proprietà errata: %s"
@@ -4060,7 +4071,7 @@ msgstr ""
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4810,12 +4821,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4829,11 +4840,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4946,7 +4957,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5016,7 +5027,7 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -5230,7 +5241,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Creazione del container in corso"
@@ -5482,15 +5493,15 @@ msgstr "Il nome del container è: %s"
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 msgid "Missing pool name"
 msgstr ""
 
@@ -5516,11 +5527,11 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
@@ -5561,7 +5572,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5574,7 +5585,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Creazione del container in corso"
@@ -5603,11 +5614,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -5637,7 +5648,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr ""
 
@@ -5692,8 +5703,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr ""
 
@@ -5754,7 +5765,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5895,7 +5906,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5918,7 +5929,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5942,11 +5953,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5994,11 +6005,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -6010,7 +6021,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -6037,7 +6048,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6092,7 +6103,7 @@ msgstr ""
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -6145,7 +6156,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -6192,15 +6203,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -6218,7 +6229,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6303,7 +6314,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6464,7 +6475,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6472,7 +6483,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
@@ -6631,7 +6642,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Creazione del container in corso"
@@ -6671,17 +6682,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6725,7 +6736,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -7140,11 +7151,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7248,7 +7259,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -7400,11 +7411,11 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7416,21 +7427,21 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7508,15 +7519,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr ""
 
@@ -7530,7 +7541,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -7652,7 +7663,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7661,25 +7672,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Creazione del container in corso"
@@ -7728,7 +7739,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7744,12 +7755,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -7873,7 +7884,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -7962,12 +7973,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8019,7 +8030,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -8093,7 +8104,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -8102,7 +8113,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -8118,7 +8129,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8126,11 +8137,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -8143,7 +8154,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -8183,7 +8194,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -8200,7 +8211,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -8218,7 +8229,7 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr ""
 
@@ -8267,8 +8278,8 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8387,11 +8398,11 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8462,7 +8473,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8494,7 +8505,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -8509,12 +8520,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8601,7 +8612,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr ""
 
@@ -8773,12 +8784,12 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -8788,7 +8799,7 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -8804,7 +8815,7 @@ msgstr "Creazione del container in corso"
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
@@ -9315,7 +9326,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -9363,17 +9374,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -9383,68 +9394,68 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
@@ -9517,7 +9528,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Creazione del container in corso"
@@ -10066,7 +10077,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10076,7 +10087,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10086,7 +10097,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10096,7 +10107,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10106,7 +10117,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10116,7 +10127,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10126,7 +10137,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10140,7 +10151,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10150,7 +10161,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -83,7 +83,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -669,7 +669,7 @@ msgstr "--empty はイメージ名と同時に指定できません"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only はコピー元がスナップショットの場合は指定できません"
 
@@ -677,7 +677,7 @@ msgstr "--instance-only はコピー元がスナップショットの場合は�
 msgid "--network-port can't be used without --network-address"
 msgstr "--network-port を使うには --network-address を指定しなければなりません"
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles と --refresh は同時に指定できません"
 
@@ -685,7 +685,7 @@ msgstr "--no-profiles と --refresh は同時に指定できません"
 msgid "--project cannot be used with the query command"
 msgstr "--project は query コマンドでは使えません"
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
@@ -993,7 +993,7 @@ msgstr "エイリアス:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr "クラスターに join すると、すべてのデータが削除されます。続けますか?"
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1130,17 +1130,17 @@ msgstr "インスタンスのバックアップ中: %s"
 msgid "Backing up storage bucket: %s"
 msgstr "ストレージバケット %s のバックアップを行います"
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1159,14 +1159,14 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %q"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1214,7 +1214,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1222,7 +1222,7 @@ msgstr "CONTENT-TYPE"
 msgid "COUNT"
 msgstr "COUNT"
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 #, fuzzy
 msgid "CPU TIME(s)"
 msgstr "CPU (%s):"
@@ -1315,7 +1315,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスターでない場合はカラムとして L は指定できません"
@@ -1357,19 +1357,19 @@ msgstr ""
 "デバイス %q の設定を上書きできません: プロファイルのデバイス内にデバイスが見"
 "つかりません"
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr "スナップショットをコピーするときに --volume-only は指定できません"
 
@@ -1487,7 +1487,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1513,15 +1513,15 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr "クラスターメンバ名"
 
@@ -1540,8 +1540,8 @@ msgstr "クラスタリングが有効になりました"
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1575,7 +1575,7 @@ msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `n
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない場合は none)"
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
@@ -1605,7 +1605,7 @@ msgstr "設定は KEY=VALUE のフォーマットである必要があります"
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
@@ -1618,7 +1618,7 @@ msgstr "設定オプションに --auto が必要です"
 msgid "Configure the daemon"
 msgstr "デーモンの設定"
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 #, fuzzy
 msgid "Configure the refresh delay in seconds"
 msgstr "更新間隔を秒単位で入力:"
@@ -1628,11 +1628,11 @@ msgstr "更新間隔を秒単位で入力:"
 msgid "Connecting to the daemon (attempt %d)"
 msgstr "デーモンに接続しています (試行 %d)"
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1642,7 +1642,7 @@ msgstr "コンテンツタイプ: %s"
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
@@ -1650,7 +1650,7 @@ msgstr "ステートフルなインスタンスをステートレスにコピー
 msgid "Copy aliases from source"
 msgstr "ソースからエイリアスをコピーしました"
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
@@ -1671,11 +1671,11 @@ msgstr ""
 "自動更新フラグは、このイメージを最新に保つようにサーバに指示します。\n"
 "ソースはエイリアスで、かつパブリックである必要があります。"
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid "Copy instances within or in between servers"
 msgstr "サーバ内、またはサーバ間でインスタンスをコピーします"
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1711,16 +1711,16 @@ msgstr "プロファイルに継承されたデバイスをコピーし、設定
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1733,7 +1733,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1866,7 +1866,7 @@ msgstr "新たにネットワークピアリングを作成します"
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1915,12 +1915,12 @@ msgstr "プロジェクトを作成します"
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1957,11 +1957,11 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr "ディスク"
 
@@ -1997,11 +1997,11 @@ msgstr "状態: %s"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 #, fuzzy
 msgid "Delay:"
 msgstr "Down delay"
@@ -2018,7 +2018,7 @@ msgstr "クラスターグループを削除します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "ストレージボリュームを削除します"
@@ -2101,7 +2101,7 @@ msgstr "ストレージバケットを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 msgid "Delete storage volume snapshots"
 msgstr "ストレージボリュームのスナップショットを削除します"
 
@@ -2146,7 +2146,7 @@ msgstr "警告を削除します"
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -2247,39 +2247,39 @@ msgstr "警告を削除します"
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "説明"
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
@@ -2406,7 +2406,7 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Display images from all projects"
 msgstr "すべてのプロジェクトのイメージを表示します"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
@@ -2420,7 +2420,7 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Display profiles from all projects"
 msgstr "すべてのプロジェクトのイメージを表示します"
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr "インスタンスごとのリソース消費状況を表示する"
 
@@ -2429,7 +2429,7 @@ msgstr "インスタンスごとのリソース消費状況を表示する"
 msgid "Display storage pool buckets from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 #, fuzzy
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
@@ -2518,6 +2518,17 @@ msgstr "ドライバ: %v (%v)"
 msgid "Dump YAML config to stdout"
 msgstr "YAML 形式で設定を stdout に出力します"
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr "ENTRIES"
@@ -2532,7 +2543,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr "既存: %q (バックエンド=%q, ソース=%q)"
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 msgid "EXPIRES AT"
 msgstr "EXPIRES AT"
 
@@ -2630,11 +2641,11 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2658,8 +2669,8 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2692,13 +2703,13 @@ msgstr ""
 "  これは 'incus config get core.https_address' コマンドでチェックできます。\n"
 "  まだ使用可能でない場合は、アドレスを設定することもできます。"
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
 msgstr "ソートタイプを入力する（'a' はアルファベット、'c' CPU、'd' ディスク）"
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr "更新間隔を秒単位で入力:"
 
@@ -2710,7 +2721,7 @@ msgstr "TTLを指定します"
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr "Ephemeral インスタンス"
 
@@ -2741,8 +2752,8 @@ msgstr "エイリアスの取得に失敗しました: %w"
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, c-format
 msgid "Error setting properties: %v"
 msgstr "プロパティの設定でエラーが発生しました: %v"
@@ -2763,8 +2774,8 @@ msgstr "プロパティの削除でエラーが発生しました: %v"
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr "プロパティの設定解除エラー: %v"
@@ -2884,8 +2895,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr "構造体を期待しましたが、%v が返されました"
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2912,7 +2923,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2932,7 +2943,7 @@ msgstr "ストレージバケットをエクスポートします"
 msgid "Export storage buckets as tarball."
 msgstr "ストレージバケットを tarball 形式でエクスポートします。"
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
@@ -2942,7 +2953,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "ストレージバケット %s のバックアップをエクスポートします"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -3023,7 +3034,7 @@ msgstr "join トークンのトークン変換操作に失敗しました: %w"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "インスタンス %q （プロジェクト %q 内）の削除に失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "コピー後のソースボリュームの削除に失敗しました: %w"
@@ -3162,7 +3173,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "ストレージボリュームのバックアップ作成に失敗しました: %w"
@@ -3177,7 +3188,7 @@ msgstr "移動元のインスタンスをコピーしたあとの削除に失敗
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "ストレージボリュームのバックアップファイルの取得に失敗しました: %w"
@@ -3217,7 +3228,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
@@ -3422,7 +3433,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
@@ -3435,7 +3446,7 @@ msgstr "フォーマット (json|pretty|yaml)"
 msgid "Format (man|md|rest|yaml)"
 msgstr "フォーマット (man|md|rest|yaml)"
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 #, fuzzy
 msgid "Format (table|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
@@ -3578,7 +3589,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -3654,11 +3665,11 @@ msgstr "ストレージバケットの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 #, fuzzy
 msgid ""
 "Get values for storage volume configuration keys\n"
@@ -3673,7 +3684,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
@@ -3737,7 +3748,7 @@ msgstr "ID: %s"
 msgid "IMAGES"
 msgstr "IMAGES"
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr "インスタンス名"
 
@@ -3781,7 +3792,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -3798,11 +3809,11 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr "コピー中にファイルが更新された場合のエラーを無視します"
 
@@ -3858,11 +3869,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "新たにカスタムストレージボリュームをインポートします"
@@ -3891,16 +3902,16 @@ msgstr "インスタンスのバックアップをインポートします"
 msgid "Import storage bucket"
 msgstr "ストレージバケットを一覧表示します"
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 "インポートするタイプは \"backup\" もしくは \"iso\" である必要があります"
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr "インポートするタイプ。backup もしくは iso (デフォルト \\\"backup\\\")"
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr "ISO イメージをインポートするには、ボリューム名を設定する必要があります"
 
@@ -3909,7 +3920,7 @@ msgstr "ISO イメージをインポートするには、ボリューム名を�
 msgid "Importing bucket: %s"
 msgstr "インスタンスのインポート中: %s"
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3987,7 +3998,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "不正なスナップショット名"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "不正なフォーマット %q"
@@ -4008,7 +4019,7 @@ msgid "Invalid arguments"
 msgstr "不正な引数 %q"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr "パス %q に不正なバックアップ名のセグメントがあります: %w"
@@ -4048,7 +4059,7 @@ msgstr "不正な送り先 %s"
 msgid "Invalid expiration date: %w"
 msgstr "不正なインスタンス名: %s"
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "不正なフォーマット %s"
@@ -4058,7 +4069,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid format: %s"
 msgstr "不正なフォーマット %s"
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr "入力が無効です。正の値を入力してください"
 
@@ -4120,18 +4131,18 @@ msgstr "不正な送り先 %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 #, fuzzy
 msgid "Invalid sorting type"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 #, fuzzy
 msgid "Invalid sorting type provided"
 msgstr "不正な送り先 %s"
@@ -4188,7 +4199,7 @@ msgstr "LISTEN ADDRESS"
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -5481,12 +5492,12 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 #, fuzzy
 msgid ""
 "List storage volume snapshots\n"
@@ -5525,11 +5536,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -5692,7 +5703,7 @@ msgstr "バックグラウンド操作の一覧表示、表示、削除を行い
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -5760,7 +5771,7 @@ msgstr "MANAGED"
 msgid "MEMBERS"
 msgstr "MEMBERS"
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 #, fuzzy
 msgid "MEMORY"
 msgstr "MEMORY USAGE"
@@ -5975,7 +5986,7 @@ msgstr "ストレージバケットを管理します。"
 msgid "Manage storage pools and volumes"
 msgstr "ストレージプール、ストレージボリュームを管理します"
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "ストレージボリュームを管理します"
@@ -6220,15 +6231,15 @@ msgstr "ピア名を指定する必要があります"
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -6253,11 +6264,11 @@ msgstr "プロファイル名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -6301,7 +6312,7 @@ msgstr ""
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
@@ -6315,7 +6326,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
@@ -6357,11 +6368,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
@@ -6393,7 +6404,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr "NAME"
 
@@ -6448,8 +6459,8 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr "名前"
 
@@ -6514,7 +6525,7 @@ msgid "Name of the storage pool:"
 msgstr "ストレージプールを作成します"
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -6657,7 +6668,7 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
@@ -6681,7 +6692,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
@@ -6705,11 +6716,11 @@ msgstr "マッチするルールが見つかりません"
 msgid "No storage backends available"
 msgstr "利用可能なストレージバックエンドがありません"
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -6762,11 +6773,11 @@ msgstr "OVN:"
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -6779,7 +6790,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
@@ -6809,7 +6820,7 @@ msgstr "バックグラウンド操作 %s を削除しました"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -6864,7 +6875,7 @@ msgstr "PROFILES"
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
@@ -6917,7 +6928,7 @@ msgstr "既存のブロックデバイスのパス:"
 msgid "Pause instances"
 msgstr "インスタンスを一時停止します"
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
@@ -6964,15 +6975,15 @@ msgstr "ポート:"
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr "Pre-seed モード。標準入力から YAML で設定を入力します"
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -6990,7 +7001,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -7076,7 +7087,7 @@ msgstr "プロファイル名 %s を %s に変更しました"
 msgid "Profile to apply to the new image"
 msgstr "新しいイメージに適用するプロファイル"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
@@ -7243,7 +7254,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
@@ -7251,7 +7262,7 @@ msgstr "既存のストレージボリュームのコピーの再読込と更新
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
@@ -7404,7 +7415,7 @@ msgstr "クラスターメンバの名前を変更します"
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "ストレージボリューム名を変更します"
@@ -7444,17 +7455,17 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -7500,7 +7511,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "スナップショットからインスタンスをリストアします"
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -7983,11 +7994,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -8103,7 +8114,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -8248,11 +8259,11 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 #, fuzzy
 msgid ""
 "Show storage volume configurations\n"
@@ -8267,21 +8278,21 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -8359,15 +8370,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -8381,7 +8392,7 @@ msgstr "ソケット %d:"
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -8503,7 +8514,7 @@ msgstr "ストレージプール %s を削除しました"
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr "ストレージプール名"
@@ -8513,25 +8524,25 @@ msgstr "ストレージプール名"
 msgid "Storage pool to use or create"
 msgstr "ストレージプール %s を作成しました"
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "ストレージボリューム %s を削除しました"
@@ -8579,7 +8590,7 @@ msgstr "シンボリックリンクのターゲットパスは \"symlink\" タ�
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -8595,12 +8606,12 @@ msgstr "TOKEN"
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -8756,7 +8767,7 @@ msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:' を試してみてください。"
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -8844,12 +8855,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8911,7 +8922,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -9008,7 +9019,7 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -9019,7 +9030,7 @@ msgstr ""
 msgid "Too many links"
 msgstr "リンクが多すぎます"
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -9035,7 +9046,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -9043,11 +9054,11 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr "転送モード。pull, push, relay のいずれか"
 
@@ -9060,7 +9071,7 @@ msgstr "転送モード。pull, push, relay のいずれか。"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -9101,7 +9112,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -9118,7 +9129,7 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr "USAGE"
 
@@ -9136,7 +9147,7 @@ msgstr "上位デバイス"
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -9184,8 +9195,8 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -9296,11 +9307,11 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -9375,7 +9386,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -9409,7 +9420,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -9423,12 +9434,12 @@ msgstr "アップロード日時: %s"
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -9519,7 +9530,7 @@ msgstr "CUDA バージョン: %v"
 msgid "Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -9711,12 +9722,12 @@ msgstr "-t と -T は同時に指定できません"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "--mode と同時に -t または -T は指定できません"
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -9726,7 +9737,7 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
@@ -9740,7 +9751,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -10185,7 +10196,7 @@ msgstr "[<remote>:]<pool>"
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -10225,17 +10236,17 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
@@ -10243,62 +10254,62 @@ msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
@@ -10357,7 +10368,7 @@ msgstr "[<remote>:]<project> <key>=<value>..."
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 
@@ -11143,7 +11154,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 #, fuzzy
 msgid ""
 "incus storage volume create default foo\n"
@@ -11158,7 +11169,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 #, fuzzy
 msgid ""
 "incus storage volume edit default container/c1\n"
@@ -11171,7 +11182,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 #, fuzzy
 msgid ""
 "incus storage volume get default data size\n"
@@ -11184,7 +11195,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -11194,7 +11205,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 #, fuzzy
 msgid ""
 "incus storage volume info default foo\n"
@@ -11207,7 +11218,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 #, fuzzy
 msgid ""
 "incus storage volume set default data size=1GiB\n"
@@ -11220,7 +11231,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 #, fuzzy
 msgid ""
 "incus storage volume show default foo\n"
@@ -11242,7 +11253,7 @@ msgstr ""
 "    \"default\" プール内のコンテナ \"data\" のファイルシステムプロパティを表"
 "示します。"
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 #, fuzzy
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
@@ -11257,7 +11268,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 #, fuzzy
 msgid ""
 "incus storage volume unset default foo size\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -61,7 +61,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -439,7 +439,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -447,7 +447,7 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -455,7 +455,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid "All projects"
 msgstr ""
 
@@ -874,17 +874,17 @@ msgstr ""
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr ""
 
@@ -901,14 +901,14 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -956,7 +956,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -964,7 +964,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 msgid "CPU TIME(s)"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1094,16 +1094,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1244,15 +1244,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr ""
 
@@ -1271,8 +1271,8 @@ msgstr ""
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1299,7 +1299,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1328,7 +1328,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1341,7 +1341,7 @@ msgstr ""
 msgid "Configure the daemon"
 msgstr ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
@@ -1350,11 +1350,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1372,7 +1372,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 msgid "Copy custom storage volumes"
 msgstr ""
 
@@ -1388,11 +1388,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1416,16 +1416,16 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1438,7 +1438,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1615,12 +1615,12 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1657,11 +1657,11 @@ msgstr ""
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr ""
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr ""
 
@@ -1696,11 +1696,11 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 msgid "Delete custom storage volumes"
 msgstr ""
 
@@ -1797,7 +1797,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 msgid "Delete storage volume snapshots"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -1943,38 +1943,38 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr ""
 
@@ -2112,7 +2112,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2176,6 +2176,17 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr ""
@@ -2190,7 +2201,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2285,11 +2296,11 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2313,8 +2324,8 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2337,13 +2348,13 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
 msgstr ""
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr ""
 
@@ -2355,7 +2366,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2386,8 +2397,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2408,8 +2419,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2489,8 +2500,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 msgid "Expires at"
 msgstr ""
 
@@ -2514,7 +2525,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2534,7 +2545,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2543,7 +2554,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2624,7 +2635,7 @@ msgstr ""
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -2763,7 +2774,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2778,7 +2789,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -2818,7 +2829,7 @@ msgstr ""
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -3007,7 +3018,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3020,7 +3031,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid "Format (table|compact)"
 msgstr ""
 
@@ -3149,7 +3160,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3222,11 +3233,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3238,7 +3249,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3302,7 +3313,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr ""
 
@@ -3343,7 +3354,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3357,11 +3368,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3415,11 +3426,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3442,15 +3453,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3459,7 +3470,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3534,7 +3545,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3554,7 +3565,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3592,7 +3603,7 @@ msgstr ""
 msgid "Invalid expiration date: %w"
 msgstr ""
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -3602,7 +3613,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr ""
 
@@ -3660,17 +3671,17 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 msgid "Invalid sorting type"
 msgstr ""
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 msgid "Invalid sorting type provided"
 msgstr ""
 
@@ -3725,7 +3736,7 @@ msgstr ""
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4459,11 +4470,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4477,11 +4488,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4593,7 +4604,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4661,7 +4672,7 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -4858,7 +4869,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -5097,15 +5108,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 msgid "Missing pool name"
 msgstr ""
 
@@ -5129,11 +5140,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -5171,7 +5182,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5183,7 +5194,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
@@ -5211,11 +5222,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -5245,7 +5256,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr ""
 
@@ -5300,8 +5311,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr ""
 
@@ -5362,7 +5373,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5503,7 +5514,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5526,7 +5537,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5550,11 +5561,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5602,11 +5613,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5618,7 +5629,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5644,7 +5655,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5697,7 +5708,7 @@ msgstr ""
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5749,7 +5760,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -5795,15 +5806,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -5821,7 +5832,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5905,7 +5916,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6062,7 +6073,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6070,7 +6081,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -6222,7 +6233,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 msgid "Rename custom storage volumes"
 msgstr ""
 
@@ -6258,16 +6269,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6308,7 +6319,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6711,11 +6722,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6813,7 +6824,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6954,11 +6965,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -6970,19 +6981,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7057,15 +7068,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr ""
 
@@ -7079,7 +7090,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -7199,7 +7210,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7208,25 +7219,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7273,7 +7284,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7289,12 +7300,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid "Taken at"
 msgstr ""
 
@@ -7417,7 +7428,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -7505,12 +7516,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7562,7 +7573,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7635,7 +7646,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7644,7 +7655,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7660,7 +7671,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7668,11 +7679,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -7685,7 +7696,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -7724,7 +7735,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7741,7 +7752,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -7757,7 +7768,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr ""
 
@@ -7804,8 +7815,8 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7914,11 +7925,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -7983,7 +7994,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8014,7 +8025,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -8028,12 +8039,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8119,7 +8130,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr ""
 
@@ -8289,11 +8300,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8301,7 +8312,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8315,7 +8326,7 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
@@ -8732,7 +8743,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -8771,15 +8782,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -8787,56 +8798,56 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -8895,7 +8906,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -9430,7 +9441,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9440,7 +9451,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9450,7 +9461,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9460,7 +9471,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9470,7 +9481,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9480,7 +9491,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9490,7 +9501,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9504,7 +9515,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9514,7 +9525,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -84,7 +84,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -697,7 +697,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded kan niet gebruikt worden voor een server"
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 "--instance-only kan niet worden doorgegeven, als de bron een snapshot is"
@@ -706,7 +706,7 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr "--network-port kan niet gebruikt worden zonder --network-address"
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles kan niet gebruikt worden met --refresh"
 
@@ -714,7 +714,7 @@ msgstr "--no-profiles kan niet gebruikt worden met --refresh"
 msgid "--project cannot be used with the query command"
 msgstr "--project kan niet gebruikt worden met de query command"
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kan alleen worden gebruikt bij geïnstantieerden (instances)"
 
@@ -1018,7 +1018,7 @@ msgstr ""
 "Alle huidige gegevens gaan verloren bij het lid worden (joining) van een "
 "cluster, doorgaan?"
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid "All projects"
 msgstr "Alle projecten"
 
@@ -1155,17 +1155,17 @@ msgstr "Backup aan het maken van instantiatie (instance): %s"
 msgid "Backing up storage bucket: %s"
 msgstr "Back-uppen van opslag emmer (storage bucket): %s"
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Backup aan het maken van opslagvolume (storage volume): %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr "Backup is geëxporteerd met succes!"
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr "Backups:"
 
@@ -1182,14 +1182,14 @@ msgstr "Ongeldige device override syntax, verwacht: <device>,<key>=<value>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "Ongeldig sleutel/waarde paar: %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Ongeldig sleutel=waarde paar: %q"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "Ongeldig sleutel=waarde paar: %s"
@@ -1237,7 +1237,7 @@ msgstr "ONDERBREEKBAAR"
 msgid "COMMON NAME"
 msgstr "GEWONE NAAM"
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr "INHOUDSTYPE"
 
@@ -1245,7 +1245,7 @@ msgstr "INHOUDSTYPE"
 msgid "COUNT"
 msgstr "SOM"
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 msgid "CPU TIME(s)"
 msgstr "CPU TIJD(s)"
 
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1377,16 +1377,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1501,7 +1501,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1527,15 +1527,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr ""
 
@@ -1554,8 +1554,8 @@ msgstr "Clustering aan"
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Kolommen"
 
@@ -1590,7 +1590,7 @@ msgstr "Compressie algoritme om te gebruiken (`none` is geen compressie)"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Compressie algoritme om te gebruiken (none is zonder compressie)"
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuratie sleutel/waarde toe te passen op de nieuwe instantiatie"
 
@@ -1619,7 +1619,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1632,7 +1632,7 @@ msgstr ""
 msgid "Configure the daemon"
 msgstr ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
@@ -1641,11 +1641,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1655,7 +1655,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 msgid "Copy custom storage volumes"
 msgstr "Kopieer aangepaste opslag volumes"
 
@@ -1679,11 +1679,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1707,16 +1707,16 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1857,7 +1857,7 @@ msgstr "Creëer netwerk integraties"
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1906,12 +1906,12 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1948,11 +1948,11 @@ msgstr ""
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr ""
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr "Datum: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 msgid "Delete custom storage volumes"
 msgstr "Verwijder aangepaste opslag volumes (storage volume)"
 
@@ -2088,7 +2088,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 msgid "Delete storage volume snapshots"
 msgstr ""
 
@@ -2133,7 +2133,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -2234,38 +2234,38 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 msgid "Detach custom storage volumes from instances"
 msgstr "Ontkoppel aangepaste opslag volumes van een instantiatie (instance)"
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 msgid "Detach custom storage volumes from profiles"
 msgstr "Ontkoppel aangepaste opslag volumes van profielen (profiles)"
 
@@ -2383,7 +2383,7 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -2395,7 +2395,7 @@ msgstr "Toon netwerk zones van alle projecten"
 msgid "Display profiles from all projects"
 msgstr "Toon profielen van alle projecten"
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr "Toon resource gebruik per instantiatie"
 
@@ -2403,7 +2403,7 @@ msgstr "Toon resource gebruik per instantiatie"
 msgid "Display storage pool buckets from all projects"
 msgstr "Toon opslag pool emmers (buckets) van alle projecten"
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2467,6 +2467,17 @@ msgstr "Stuurprogramma: %v (%v)"
 msgid "Dump YAML config to stdout"
 msgstr "Dump YAML configuratie naar standaard uitvoer (stdout)"
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr ""
@@ -2481,7 +2492,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2576,11 +2587,11 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2604,8 +2615,8 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2628,13 +2639,13 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
 msgstr ""
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr ""
 
@@ -2646,7 +2657,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2677,8 +2688,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2699,8 +2710,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2780,8 +2791,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 msgid "Expires at"
 msgstr ""
 
@@ -2805,7 +2816,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2825,7 +2836,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2834,7 +2845,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Exporteren van de backup van opslag (storage) emmer (bucket): %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2915,7 +2926,7 @@ msgstr ""
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -3054,7 +3065,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -3069,7 +3080,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -3109,7 +3120,7 @@ msgstr ""
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -3298,7 +3309,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3311,7 +3322,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid "Format (table|compact)"
 msgstr ""
 
@@ -3440,7 +3451,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3513,11 +3524,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3529,7 +3540,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3592,7 +3603,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr ""
 
@@ -3633,7 +3644,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3647,11 +3658,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3705,11 +3716,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 msgid "Import custom storage volumes."
 msgstr "Importeer aangepaste opslag volumes (storage volume)."
 
@@ -3732,15 +3743,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3749,7 +3760,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3824,7 +3835,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3844,7 +3855,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3882,7 +3893,7 @@ msgstr ""
 msgid "Invalid expiration date: %w"
 msgstr ""
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -3892,7 +3903,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr ""
 
@@ -3950,17 +3961,17 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 msgid "Invalid sorting type"
 msgstr ""
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 msgid "Invalid sorting type provided"
 msgstr ""
 
@@ -4015,7 +4026,7 @@ msgstr ""
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4749,11 +4760,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4767,11 +4778,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4883,7 +4894,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4951,7 +4962,7 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -5148,7 +5159,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -5387,15 +5398,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 msgid "Missing pool name"
 msgstr ""
 
@@ -5419,11 +5430,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -5461,7 +5472,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5473,7 +5484,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
@@ -5501,11 +5512,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -5535,7 +5546,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr ""
 
@@ -5590,8 +5601,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr ""
 
@@ -5652,7 +5663,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5793,7 +5804,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5816,7 +5827,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5840,11 +5851,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5892,11 +5903,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5908,7 +5919,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5934,7 +5945,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5987,7 +5998,7 @@ msgstr ""
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -6039,7 +6050,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -6085,15 +6096,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -6111,7 +6122,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6195,7 +6206,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6352,7 +6363,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6360,7 +6371,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -6512,7 +6523,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 msgid "Rename custom storage volumes"
 msgstr "Hernoem aangepaste opslag volumes"
 
@@ -6548,16 +6559,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6598,7 +6609,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -7001,11 +7012,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7105,7 +7116,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -7246,11 +7257,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7262,19 +7273,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7349,15 +7360,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr ""
 
@@ -7371,7 +7382,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -7491,7 +7502,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7500,25 +7511,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7565,7 +7576,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7581,12 +7592,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid "Taken at"
 msgstr ""
 
@@ -7709,7 +7720,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -7797,12 +7808,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7854,7 +7865,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7927,7 +7938,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7936,7 +7947,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7952,7 +7963,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7960,11 +7971,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -7977,7 +7988,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -8016,7 +8027,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -8033,7 +8044,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -8049,7 +8060,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr ""
 
@@ -8096,8 +8107,8 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8206,11 +8217,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8276,7 +8287,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8307,7 +8318,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -8321,12 +8332,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8412,7 +8423,7 @@ msgstr "Versie: %s"
 msgid "Version: %v"
 msgstr "Versie: %v"
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr ""
 
@@ -8582,11 +8593,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8594,7 +8605,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8608,7 +8619,7 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
@@ -9025,7 +9036,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -9064,15 +9075,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -9080,56 +9091,56 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -9188,7 +9199,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -9723,7 +9734,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9733,7 +9744,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9743,7 +9754,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9753,7 +9764,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9763,7 +9774,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9773,7 +9784,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9783,7 +9794,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9797,7 +9808,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9807,7 +9818,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -58,7 +58,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -432,7 +432,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -448,7 +448,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid "All projects"
 msgstr ""
 
@@ -867,17 +867,17 @@ msgstr ""
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr ""
 
@@ -894,14 +894,14 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -949,7 +949,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 msgid "CPU TIME(s)"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1087,16 +1087,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1211,7 +1211,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1237,15 +1237,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr ""
 
@@ -1264,8 +1264,8 @@ msgstr ""
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1292,7 +1292,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1321,7 +1321,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Configure the daemon"
 msgstr ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
@@ -1343,11 +1343,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1357,7 +1357,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 msgid "Copy custom storage volumes"
 msgstr ""
 
@@ -1381,11 +1381,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1409,16 +1409,16 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1559,7 +1559,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1608,12 +1608,12 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1650,11 +1650,11 @@ msgstr ""
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr ""
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr ""
 
@@ -1709,7 +1709,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 msgid "Delete custom storage volumes"
 msgstr ""
 
@@ -1790,7 +1790,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 msgid "Delete storage volume snapshots"
 msgstr ""
 
@@ -1835,7 +1835,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -1936,38 +1936,38 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
@@ -2085,7 +2085,7 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -2097,7 +2097,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr ""
 
@@ -2105,7 +2105,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2169,6 +2169,17 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr ""
@@ -2183,7 +2194,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2278,11 +2289,11 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2306,8 +2317,8 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2330,13 +2341,13 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
 msgstr ""
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr ""
 
@@ -2348,7 +2359,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2379,8 +2390,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2401,8 +2412,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2482,8 +2493,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 msgid "Expires at"
 msgstr ""
 
@@ -2507,7 +2518,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2527,7 +2538,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2536,7 +2547,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2617,7 +2628,7 @@ msgstr ""
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -2756,7 +2767,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2771,7 +2782,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -2811,7 +2822,7 @@ msgstr ""
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -3000,7 +3011,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3013,7 +3024,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid "Format (table|compact)"
 msgstr ""
 
@@ -3142,7 +3153,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3215,11 +3226,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3231,7 +3242,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3294,7 +3305,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr ""
 
@@ -3335,7 +3346,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3349,11 +3360,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3407,11 +3418,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3434,15 +3445,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3451,7 +3462,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3526,7 +3537,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3546,7 +3557,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3584,7 +3595,7 @@ msgstr ""
 msgid "Invalid expiration date: %w"
 msgstr ""
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -3594,7 +3605,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr ""
 
@@ -3652,17 +3663,17 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 msgid "Invalid sorting type"
 msgstr ""
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 msgid "Invalid sorting type provided"
 msgstr ""
 
@@ -3717,7 +3728,7 @@ msgstr ""
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4451,11 +4462,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4469,11 +4480,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4585,7 +4596,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4653,7 +4664,7 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -4850,7 +4861,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -5089,15 +5100,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 msgid "Missing pool name"
 msgstr ""
 
@@ -5121,11 +5132,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -5163,7 +5174,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5175,7 +5186,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
@@ -5203,11 +5214,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -5237,7 +5248,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr ""
 
@@ -5292,8 +5303,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr ""
 
@@ -5354,7 +5365,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5495,7 +5506,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5518,7 +5529,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5542,11 +5553,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5594,11 +5605,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5610,7 +5621,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5636,7 +5647,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5689,7 +5700,7 @@ msgstr ""
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5741,7 +5752,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -5787,15 +5798,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -5813,7 +5824,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5897,7 +5908,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6054,7 +6065,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6062,7 +6073,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -6214,7 +6225,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 msgid "Rename custom storage volumes"
 msgstr ""
 
@@ -6250,16 +6261,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6300,7 +6311,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6703,11 +6714,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6805,7 +6816,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6946,11 +6957,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -6962,19 +6973,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7049,15 +7060,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr ""
 
@@ -7071,7 +7082,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -7191,7 +7202,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7200,25 +7211,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7265,7 +7276,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7281,12 +7292,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid "Taken at"
 msgstr ""
 
@@ -7409,7 +7420,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -7497,12 +7508,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7554,7 +7565,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7627,7 +7638,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7636,7 +7647,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7652,7 +7663,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7660,11 +7671,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -7677,7 +7688,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -7716,7 +7727,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7733,7 +7744,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -7749,7 +7760,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr ""
 
@@ -7796,8 +7807,8 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7906,11 +7917,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -7975,7 +7986,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8006,7 +8017,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -8020,12 +8031,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8111,7 +8122,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr ""
 
@@ -8281,11 +8292,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8293,7 +8304,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8307,7 +8318,7 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
@@ -8724,7 +8735,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -8763,15 +8774,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -8779,56 +8790,56 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -8887,7 +8898,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -9422,7 +9433,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9432,7 +9443,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9442,7 +9453,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9452,7 +9463,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9462,7 +9473,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9472,7 +9483,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9482,7 +9493,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9496,7 +9507,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9506,7 +9517,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -85,7 +85,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -672,7 +672,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
@@ -682,7 +682,7 @@ msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 msgid "--network-port can't be used without --network-address"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh só pode ser usado com containers"
@@ -692,7 +692,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -997,7 +997,7 @@ msgstr "Aliases:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -1137,17 +1137,17 @@ msgstr "Editar arquivos no container"
 msgid "Backing up storage bucket: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr ""
 
@@ -1164,14 +1164,14 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1219,7 +1219,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1227,7 +1227,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 #, fuzzy
 msgid "CPU TIME(s)"
 msgstr "Utilização do CPU:"
@@ -1321,7 +1321,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
@@ -1361,16 +1361,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1486,7 +1486,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1512,15 +1512,15 @@ msgstr "Dispositivo %s removido de %s"
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1539,8 +1539,8 @@ msgstr "Clustering ativado"
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1576,7 +1576,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 #, fuzzy
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1608,7 +1608,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -1621,7 +1621,7 @@ msgstr ""
 msgid "Configure the daemon"
 msgstr ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
@@ -1630,11 +1630,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1644,7 +1644,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr "Aliases de cópia da fonte"
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "Criar novas redes"
@@ -1669,12 +1669,12 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 #, fuzzy
 msgid "Copy instances within or in between servers"
 msgstr "Copiar imagens entre servidores"
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1698,16 +1698,16 @@ msgstr ""
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1721,7 +1721,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1859,7 +1859,7 @@ msgstr "Criar novas redes"
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1915,12 +1915,12 @@ msgstr "Criar projetos"
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1958,11 +1958,11 @@ msgstr ""
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr ""
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr ""
 
@@ -1997,12 +1997,12 @@ msgstr "Criado: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr ""
 
@@ -2019,7 +2019,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Apagar nomes alternativos da imagem"
@@ -2113,7 +2113,7 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Apagar nomes alternativos da imagem"
@@ -2159,7 +2159,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -2260,40 +2260,40 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -2418,7 +2418,7 @@ msgstr "Criar projetos"
 msgid "Display images from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -2432,7 +2432,7 @@ msgstr "Criar projetos"
 msgid "Display profiles from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr ""
 
@@ -2441,7 +2441,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr "Criar projetos"
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2505,6 +2505,17 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr ""
@@ -2519,7 +2530,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DE VALIDADE"
@@ -2629,11 +2640,11 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2658,8 +2669,8 @@ msgstr "Editar configurações de perfil como YAML"
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2682,13 +2693,13 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
 msgstr ""
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr ""
 
@@ -2700,7 +2711,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2731,8 +2742,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2753,8 +2764,8 @@ msgstr "Editar propriedades da imagem"
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2835,8 +2846,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 msgid "Expires at"
 msgstr ""
 
@@ -2860,7 +2871,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2882,7 +2893,7 @@ msgstr "Apagar projetos"
 msgid "Export storage buckets as tarball."
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2891,7 +2902,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Criar novas redes"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2972,7 +2983,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -3111,7 +3122,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Aceitar certificado"
@@ -3126,7 +3137,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Aceitar certificado"
@@ -3166,7 +3177,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -3356,7 +3367,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3369,7 +3380,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid "Format (table|compact)"
 msgstr ""
 
@@ -3510,7 +3521,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -3597,11 +3608,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3613,7 +3624,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3676,7 +3687,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr ""
 
@@ -3717,7 +3728,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3731,11 +3742,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3792,11 +3803,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Criar novas redes"
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Criar novas redes"
@@ -3821,15 +3832,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr "Apagar projetos"
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3838,7 +3849,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3915,7 +3926,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Editar arquivos no container"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Editar arquivos no container"
@@ -3936,7 +3947,7 @@ msgid "Invalid arguments"
 msgstr "Editar arquivos no container"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3974,7 +3985,7 @@ msgstr ""
 msgid "Invalid expiration date: %w"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Editar arquivos no container"
@@ -3984,7 +3995,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid format: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr ""
 
@@ -4043,19 +4054,19 @@ msgstr "Editar arquivos no container"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 #, fuzzy
 msgid "Invalid sorting type"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 #, fuzzy
 msgid "Invalid sorting type provided"
 msgstr "Editar arquivos no container"
@@ -4111,7 +4122,7 @@ msgstr ""
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4858,12 +4869,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4877,11 +4888,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4993,7 +5004,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5063,7 +5074,7 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -5282,7 +5293,7 @@ msgstr "Criar novas redes"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Criar novas redes"
@@ -5535,15 +5546,15 @@ msgstr "Nome de membro do cluster"
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 msgid "Missing pool name"
 msgstr ""
 
@@ -5568,11 +5579,11 @@ msgstr "Nome de membro do cluster"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
@@ -5613,7 +5624,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5626,7 +5637,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -5656,11 +5667,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -5690,7 +5701,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr ""
 
@@ -5745,8 +5756,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr ""
 
@@ -5807,7 +5818,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5948,7 +5959,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5971,7 +5982,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5995,11 +6006,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6048,11 +6059,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -6064,7 +6075,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -6091,7 +6102,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6146,7 +6157,7 @@ msgstr ""
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -6198,7 +6209,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -6245,15 +6256,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -6271,7 +6282,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6356,7 +6367,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 #, fuzzy
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -6520,7 +6531,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6528,7 +6539,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
@@ -6692,7 +6703,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -6733,17 +6744,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -6792,7 +6803,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -7214,11 +7225,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7324,7 +7335,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -7484,11 +7495,11 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7500,22 +7511,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7594,15 +7605,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr ""
 
@@ -7616,7 +7627,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -7736,7 +7747,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7746,25 +7757,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr "Clustering ativado"
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Desconectar volumes de armazenamento dos containers"
@@ -7813,7 +7824,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7829,12 +7840,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid "Taken at"
 msgstr ""
 
@@ -7958,7 +7969,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -8046,12 +8057,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8103,7 +8114,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -8177,7 +8188,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -8186,7 +8197,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -8202,7 +8213,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8210,11 +8221,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -8227,7 +8238,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -8267,7 +8278,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -8284,7 +8295,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -8302,7 +8313,7 @@ msgstr "Editar arquivos no container"
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr ""
 
@@ -8351,8 +8362,8 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8479,11 +8490,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8557,7 +8568,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8589,7 +8600,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -8604,12 +8615,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8696,7 +8707,7 @@ msgstr "Versão CUDA: %v"
 msgid "Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr ""
 
@@ -8868,11 +8879,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8880,7 +8891,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8895,7 +8906,7 @@ msgstr "Criar perfis"
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
@@ -9364,7 +9375,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -9409,17 +9420,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -9428,65 +9439,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
@@ -9548,7 +9559,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -10092,7 +10103,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10102,7 +10113,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10112,7 +10123,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10122,7 +10133,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10132,7 +10143,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10142,7 +10153,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10152,7 +10163,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10166,7 +10177,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10176,7 +10187,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -90,7 +90,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -692,7 +692,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -708,7 +708,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr "Псевдонимы:"
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -1151,17 +1151,17 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Backing up storage bucket: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr ""
 
@@ -1178,14 +1178,14 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1233,7 +1233,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1241,7 +1241,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 #, fuzzy
 msgid "CPU TIME(s)"
 msgstr " Использование ЦП:"
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1374,16 +1374,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1499,7 +1499,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1525,15 +1525,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr ""
 
@@ -1552,8 +1552,8 @@ msgstr ""
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1580,7 +1580,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1609,7 +1609,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1622,7 +1622,7 @@ msgstr ""
 msgid "Configure the daemon"
 msgstr ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
@@ -1631,11 +1631,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1645,7 +1645,7 @@ msgstr "Авто-обновление: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1653,7 +1653,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr "Копировать псевдонимы из источника"
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 #, fuzzy
 msgid "Copy custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1670,11 +1670,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1698,16 +1698,16 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1721,7 +1721,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1857,7 +1857,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1914,13 +1914,13 @@ msgstr ""
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 #, fuzzy
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1958,11 +1958,11 @@ msgstr ""
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr ""
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr ""
 
@@ -1997,11 +1997,11 @@ msgstr "Авто-обновление: %s"
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr ""
 
@@ -2017,7 +2017,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 #, fuzzy
 msgid "Delete custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -2109,7 +2109,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 #, fuzzy
 msgid "Delete storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -2155,7 +2155,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -2256,40 +2256,40 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 #, fuzzy
 msgid "Detach custom storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 #, fuzzy
 msgid "Detach custom storage volumes from profiles"
 msgstr "Копирование образа: %s"
@@ -2413,7 +2413,7 @@ msgstr "Копирование образа: %s"
 msgid "Display images from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 #, fuzzy
 msgid "Display instances from all projects"
 msgstr "Копирование образа: %s"
@@ -2428,7 +2428,7 @@ msgstr "Копирование образа: %s"
 msgid "Display profiles from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr ""
 
@@ -2437,7 +2437,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2501,6 +2501,17 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr ""
@@ -2515,7 +2526,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2618,11 +2629,11 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2646,8 +2657,8 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2670,13 +2681,13 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
 msgstr ""
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr ""
 
@@ -2688,7 +2699,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2719,8 +2730,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2741,8 +2752,8 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2826,8 +2837,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 msgid "Expires at"
 msgstr ""
 
@@ -2852,7 +2863,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2877,7 +2888,7 @@ msgstr "Копирование образа: %s"
 msgid "Export storage buckets as tarball."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
@@ -2887,7 +2898,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting backup of storage bucket: %s"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2968,7 +2979,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, fuzzy, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Копирование образа: %s"
@@ -3107,7 +3118,7 @@ msgstr "Принять сертификат"
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, fuzzy, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr "Принять сертификат"
@@ -3122,7 +3133,7 @@ msgstr "Принять сертификат"
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, fuzzy, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr "Принять сертификат"
@@ -3162,7 +3173,7 @@ msgstr "Принять сертификат"
 msgid "Failed to read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -3352,7 +3363,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3365,7 +3376,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid "Format (table|compact)"
 msgstr ""
 
@@ -3506,7 +3517,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -3589,11 +3600,11 @@ msgstr "Копирование образа: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3605,7 +3616,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3670,7 +3681,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr ""
 
@@ -3711,7 +3722,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3725,11 +3736,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3785,12 +3796,12 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 #, fuzzy
 msgid "Import custom storage volumes."
 msgstr "Копирование образа: %s"
@@ -3817,15 +3828,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Import storage bucket"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3834,7 +3845,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3912,7 +3923,7 @@ msgid "Invalid IP address or DNS name"
 msgstr "Имя контейнера: %s"
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, fuzzy, c-format
 msgid "Invalid URL %q: %w"
 msgstr "Имя контейнера: %s"
@@ -3933,7 +3944,7 @@ msgid "Invalid arguments"
 msgstr "Имя контейнера: %s"
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3971,7 +3982,7 @@ msgstr ""
 msgid "Invalid expiration date: %w"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Имя контейнера: %s"
@@ -3981,7 +3992,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid format: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr ""
 
@@ -4040,19 +4051,19 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 #, fuzzy
 msgid "Invalid sorting type"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 #, fuzzy
 msgid "Invalid sorting type provided"
 msgstr "Имя контейнера: %s"
@@ -4108,7 +4119,7 @@ msgstr ""
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4860,12 +4871,12 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 #, fuzzy
 msgid "List storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4879,12 +4890,12 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4997,7 +5008,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -5067,7 +5078,7 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -5287,7 +5298,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage storage pools and volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 #, fuzzy
 msgid "Manage storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -5542,15 +5553,15 @@ msgstr "Имя контейнера: %s"
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 msgid "Missing pool name"
 msgstr ""
 
@@ -5576,12 +5587,12 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
@@ -5621,7 +5632,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5634,7 +5645,7 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 #, fuzzy
 msgid "Move custom storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -5663,11 +5674,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -5697,7 +5708,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr ""
 
@@ -5752,8 +5763,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr ""
 
@@ -5818,7 +5829,7 @@ msgid "Name of the storage pool:"
 msgstr "Копирование образа: %s"
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5961,7 +5972,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5984,7 +5995,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
@@ -6009,11 +6020,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -6061,11 +6072,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -6077,7 +6088,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -6104,7 +6115,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -6159,7 +6170,7 @@ msgstr ""
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -6211,7 +6222,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -6258,15 +6269,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -6284,7 +6295,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6368,7 +6379,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6527,7 +6538,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
@@ -6537,7 +6548,7 @@ msgstr "Копирование образа: %s"
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6696,7 +6707,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 #, fuzzy
 msgid "Rename custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -6736,17 +6747,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 #, fuzzy
 msgid "Rename storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, fuzzy, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr "Копирование образа: %s"
@@ -6790,7 +6801,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -7208,11 +7219,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -7319,7 +7330,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -7475,11 +7486,11 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7491,22 +7502,22 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 #, fuzzy
 msgid "Show storage volume snapshhot configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 #, fuzzy
 msgid "Show storage volume snapshot configurations"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7585,16 +7596,16 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr ""
 
@@ -7608,7 +7619,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -7731,7 +7742,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7741,25 +7752,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr " Использование сети:"
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, fuzzy, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr "Копирование образа: %s"
@@ -7808,7 +7819,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7824,12 +7835,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid "Taken at"
 msgstr ""
 
@@ -7952,7 +7963,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -8040,12 +8051,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -8097,7 +8108,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -8171,7 +8182,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -8180,7 +8191,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -8196,7 +8207,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -8204,11 +8215,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -8221,7 +8232,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -8261,7 +8272,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -8278,7 +8289,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -8296,7 +8307,7 @@ msgstr "Копирование образа: %s"
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr ""
 
@@ -8344,8 +8355,8 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8466,11 +8477,11 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8545,7 +8556,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -8578,7 +8589,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -8593,12 +8604,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8685,7 +8696,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr ""
 
@@ -8857,11 +8868,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8869,7 +8880,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -8891,7 +8902,7 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 #, fuzzy
 msgid "[<remote>:]"
@@ -9688,7 +9699,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -9763,7 +9774,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 #, fuzzy
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
@@ -9771,7 +9782,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -9779,7 +9790,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -9795,7 +9806,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
@@ -9803,7 +9814,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -9811,7 +9822,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -9819,7 +9830,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -9827,7 +9838,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -9835,7 +9846,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
@@ -9843,7 +9854,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -9851,8 +9862,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -9860,7 +9871,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -9868,7 +9879,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -9876,7 +9887,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -9884,7 +9895,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -9892,7 +9903,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -10007,7 +10018,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 #, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
@@ -10598,7 +10609,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -10608,7 +10619,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -10618,7 +10629,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -10628,7 +10639,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -10638,7 +10649,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -10648,7 +10659,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -10658,7 +10669,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -10672,7 +10683,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -10682,7 +10693,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-13 16:23-0500\n"
+"POT-Creation-Date: 2024-11-14 01:18-0500\n"
 "PO-Revision-Date: 2024-08-14 07:23+0000\n"
 "Last-Translator: Kwok Guy <kwokjuy@163.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -83,7 +83,7 @@ msgstr ""
 "###   source: default\n"
 "###   zfs.pool_name: default"
 
-#: cmd/incus/storage_volume.go:985
+#: cmd/incus/storage_volume.go:988
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -593,7 +593,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: cmd/incus/copy.go:167
+#: cmd/incus/copy.go:169
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -601,7 +601,7 @@ msgstr ""
 msgid "--network-port can't be used without --network-address"
 msgstr ""
 
-#: cmd/incus/copy.go:101
+#: cmd/incus/copy.go:103
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: cmd/incus/copy.go:178
+#: cmd/incus/copy.go:180
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgstr ""
 msgid "All existing data is lost when joining a cluster, continue?"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1558 cmd/incus/storage_volume.go:2549
+#: cmd/incus/storage_volume.go:1561 cmd/incus/storage_volume.go:2552
 msgid "All projects"
 msgstr ""
 
@@ -1028,17 +1028,17 @@ msgstr ""
 msgid "Backing up storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3033
+#: cmd/incus/storage_volume.go:3036
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
 #: cmd/incus/export.go:191 cmd/incus/storage_bucket.go:1539
-#: cmd/incus/storage_volume.go:3110
+#: cmd/incus/storage_volume.go:3113
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1489
+#: cmd/incus/info.go:844 cmd/incus/storage_volume.go:1492
 msgid "Backups:"
 msgstr ""
 
@@ -1055,14 +1055,14 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:150 cmd/incus/create.go:242 cmd/incus/move.go:302
+#: cmd/incus/copy.go:152 cmd/incus/create.go:242 cmd/incus/move.go:302
 #: cmd/incus/network_integration.go:145 cmd/incus/project.go:171
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
 #: cmd/incus/publish.go:191 cmd/incus/storage.go:169
-#: cmd/incus/storage_volume.go:651
+#: cmd/incus/storage_volume.go:654
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1110,7 +1110,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1673
+#: cmd/incus/storage_volume.go:1676
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: cmd/incus/top.go:78
+#: cmd/incus/top.go:79
 msgid "CPU TIME(s)"
 msgstr ""
 
@@ -1208,7 +1208,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1683
+#: cmd/incus/list.go:621 cmd/incus/storage_volume.go:1686
 #: cmd/incus/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
@@ -1248,16 +1248,16 @@ msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:457
+#: cmd/incus/storage_volume.go:459
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:411
+#: cmd/incus/storage_volume.go:413
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:432
+#: cmd/incus/storage_volume.go:434
 msgid "Cannot set --volume-only when copying a snapshot"
 msgstr ""
 
@@ -1372,7 +1372,7 @@ msgid "Cluster member %s removed from group %s"
 msgstr ""
 
 #: cmd/incus/config.go:101 cmd/incus/config.go:393 cmd/incus/config.go:537
-#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:60
+#: cmd/incus/config.go:755 cmd/incus/config.go:886 cmd/incus/copy.go:61
 #: cmd/incus/create.go:59 cmd/incus/info.go:48 cmd/incus/move.go:64
 #: cmd/incus/network.go:347 cmd/incus/network.go:839 cmd/incus/network.go:920
 #: cmd/incus/network.go:1471 cmd/incus/network.go:1564
@@ -1398,15 +1398,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1036 cmd/incus/storage_bucket.go:1136
 #: cmd/incus/storage_bucket.go:1201 cmd/incus/storage_bucket.go:1337
 #: cmd/incus/storage_bucket.go:1411 cmd/incus/storage_bucket.go:1560
-#: cmd/incus/storage_volume.go:365 cmd/incus/storage_volume.go:584
-#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:966
-#: cmd/incus/storage_volume.go:1192 cmd/incus/storage_volume.go:1325
-#: cmd/incus/storage_volume.go:1778 cmd/incus/storage_volume.go:1870
-#: cmd/incus/storage_volume.go:1962 cmd/incus/storage_volume.go:2126
-#: cmd/incus/storage_volume.go:2226 cmd/incus/storage_volume.go:2332
-#: cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2710
-#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2876
-#: cmd/incus/storage_volume.go:2968 cmd/incus/storage_volume.go:3134
+#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:587
+#: cmd/incus/storage_volume.go:692 cmd/incus/storage_volume.go:969
+#: cmd/incus/storage_volume.go:1195 cmd/incus/storage_volume.go:1328
+#: cmd/incus/storage_volume.go:1781 cmd/incus/storage_volume.go:1873
+#: cmd/incus/storage_volume.go:1965 cmd/incus/storage_volume.go:2129
+#: cmd/incus/storage_volume.go:2229 cmd/incus/storage_volume.go:2335
+#: cmd/incus/storage_volume.go:2461 cmd/incus/storage_volume.go:2713
+#: cmd/incus/storage_volume.go:2799 cmd/incus/storage_volume.go:2879
+#: cmd/incus/storage_volume.go:2971 cmd/incus/storage_volume.go:3137
 msgid "Cluster member name"
 msgstr ""
 
@@ -1425,8 +1425,8 @@ msgstr ""
 #: cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750
 #: cmd/incus/snapshot.go:316 cmd/incus/storage.go:687
 #: cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904
-#: cmd/incus/storage_volume.go:1557 cmd/incus/storage_volume.go:2548
-#: cmd/incus/top.go:63 cmd/incus/warning.go:93
+#: cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551
+#: cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1453,7 +1453,7 @@ msgstr ""
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
-#: cmd/incus/copy.go:52 cmd/incus/create.go:51
+#: cmd/incus/copy.go:53 cmd/incus/create.go:51
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:710 cmd/incus/network_zone.go:1405
 #: cmd/incus/profile.go:600 cmd/incus/project.go:403 cmd/incus/storage.go:368
 #: cmd/incus/storage_bucket.go:361 cmd/incus/storage_bucket.go:1300
-#: cmd/incus/storage_volume.go:1111 cmd/incus/storage_volume.go:1143
+#: cmd/incus/storage_volume.go:1114 cmd/incus/storage_volume.go:1146
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1495,7 +1495,7 @@ msgstr ""
 msgid "Configure the daemon"
 msgstr ""
 
-#: cmd/incus/top.go:65
+#: cmd/incus/top.go:66
 msgid "Configure the refresh delay in seconds"
 msgstr ""
 
@@ -1504,11 +1504,11 @@ msgstr ""
 msgid "Connecting to the daemon (attempt %d)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:585
+#: cmd/incus/storage_volume.go:588
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1429
+#: cmd/incus/storage_volume.go:1432
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: cmd/incus/copy.go:58 cmd/incus/move.go:62
+#: cmd/incus/copy.go:59 cmd/incus/move.go:62
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:360 cmd/incus/storage_volume.go:361
+#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:362
 msgid "Copy custom storage volumes"
 msgstr ""
 
@@ -1542,11 +1542,11 @@ msgid ""
 "It requires the source to be an alias and for it to be public."
 msgstr ""
 
-#: cmd/incus/copy.go:39
+#: cmd/incus/copy.go:40
 msgid "Copy instances within or in between servers"
 msgstr ""
 
-#: cmd/incus/copy.go:40
+#: cmd/incus/copy.go:41
 msgid ""
 "Copy instances within or in between servers\n"
 "\n"
@@ -1570,16 +1570,16 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: cmd/incus/copy.go:57
+#: cmd/incus/copy.go:58
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:367
+#: cmd/incus/storage_volume.go:368
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: cmd/incus/copy.go:61 cmd/incus/image.go:160 cmd/incus/move.go:65
-#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:368
+#: cmd/incus/copy.go:62 cmd/incus/image.go:160 cmd/incus/move.go:65
+#: cmd/incus/profile.go:277 cmd/incus/storage_volume.go:369
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1592,7 +1592,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:479
+#: cmd/incus/storage_volume.go:481
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1720,7 +1720,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:575 cmd/incus/storage_volume.go:576
+#: cmd/incus/storage_volume.go:578 cmd/incus/storage_volume.go:579
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1769,12 +1769,12 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: cmd/incus/copy.go:62 cmd/incus/create.go:60
+#: cmd/incus/copy.go:63 cmd/incus/create.go:60
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
 #: cmd/incus/image.go:999 cmd/incus/info.go:663
-#: cmd/incus/storage_volume.go:1443
+#: cmd/incus/storage_volume.go:1446
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1811,11 +1811,11 @@ msgstr ""
 #: cmd/incus/network_zone.go:917 cmd/incus/operation.go:151
 #: cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710
 #: cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916
-#: cmd/incus/storage_volume.go:1672
+#: cmd/incus/storage_volume.go:1675
 msgid "DESCRIPTION"
 msgstr ""
 
-#: cmd/incus/top.go:80
+#: cmd/incus/top.go:81
 msgid "DISK"
 msgstr ""
 
@@ -1850,11 +1850,11 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2967
+#: cmd/incus/storage_bucket.go:1410 cmd/incus/storage_volume.go:2970
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: cmd/incus/top.go:446
+#: cmd/incus/top.go:447
 msgid "Delay:"
 msgstr ""
 
@@ -1870,7 +1870,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:685 cmd/incus/storage_volume.go:686
+#: cmd/incus/storage_volume.go:688 cmd/incus/storage_volume.go:689
 msgid "Delete custom storage volumes"
 msgstr ""
 
@@ -1951,7 +1951,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2454 cmd/incus/storage_volume.go:2455
+#: cmd/incus/storage_volume.go:2457 cmd/incus/storage_volume.go:2458
 msgid "Delete storage volume snapshots"
 msgstr ""
 
@@ -1996,7 +1996,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:40
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
@@ -2097,38 +2097,38 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404
 #: cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56
 #: cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254
-#: cmd/incus/storage_volume.go:361 cmd/incus/storage_volume.go:576
-#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:759
-#: cmd/incus/storage_volume.go:857 cmd/incus/storage_volume.go:954
-#: cmd/incus/storage_volume.go:1178 cmd/incus/storage_volume.go:1314
-#: cmd/incus/storage_volume.go:1475 cmd/incus/storage_volume.go:1559
-#: cmd/incus/storage_volume.go:1774 cmd/incus/storage_volume.go:1867
-#: cmd/incus/storage_volume.go:1947 cmd/incus/storage_volume.go:2110
-#: cmd/incus/storage_volume.go:2215 cmd/incus/storage_volume.go:2273
-#: cmd/incus/storage_volume.go:2322 cmd/incus/storage_volume.go:2455
-#: cmd/incus/storage_volume.go:2544 cmd/incus/storage_volume.go:2550
-#: cmd/incus/storage_volume.go:2707 cmd/incus/storage_volume.go:2794
-#: cmd/incus/storage_volume.go:2874 cmd/incus/storage_volume.go:2961
-#: cmd/incus/storage_volume.go:3127 cmd/incus/top.go:42 cmd/incus/version.go:22
+#: cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579
+#: cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762
+#: cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957
+#: cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317
+#: cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562
+#: cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870
+#: cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113
+#: cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276
+#: cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458
+#: cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553
+#: cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797
+#: cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22
 #: cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263
 #: cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid "Description"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1416
+#: cmd/incus/storage_volume.go:1419
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:366 cmd/incus/storage_volume.go:1779
+#: cmd/incus/storage_volume.go:367 cmd/incus/storage_volume.go:1782
 msgid "Destination cluster member name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:758 cmd/incus/storage_volume.go:759
+#: cmd/incus/storage_volume.go:761 cmd/incus/storage_volume.go:762
 msgid "Detach custom storage volumes from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:856 cmd/incus/storage_volume.go:857
+#: cmd/incus/storage_volume.go:859 cmd/incus/storage_volume.go:860
 msgid "Detach custom storage volumes from profiles"
 msgstr ""
 
@@ -2246,7 +2246,7 @@ msgstr ""
 msgid "Display images from all projects"
 msgstr ""
 
-#: cmd/incus/list.go:137 cmd/incus/top.go:62
+#: cmd/incus/list.go:137 cmd/incus/top.go:63
 msgid "Display instances from all projects"
 msgstr ""
 
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: cmd/incus/top.go:41
+#: cmd/incus/top.go:42
 msgid "Display resource usage info per instance"
 msgstr ""
 
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Display storage pool buckets from all projects"
 msgstr ""
 
-#: cmd/incus/top.go:42
+#: cmd/incus/top.go:43
 msgid ""
 "Displays CPU usage, memory usage, and disk usage per instance\n"
 "\n"
@@ -2330,6 +2330,17 @@ msgstr ""
 msgid "Dump YAML config to stdout"
 msgstr ""
 
+#: cmd/incus/copy.go:65
+msgid ""
+"During incremental copy, exclude source snapshots earlier than latest target "
+"snapshot"
+msgstr ""
+
+#: cmd/incus/storage_volume.go:371
+msgid ""
+"During refresh, exclude source snapshots earlier than latest target snapshot"
+msgstr ""
+
 #: cmd/incus/network_zone.go:918
 msgid "ENTRIES"
 msgstr ""
@@ -2344,7 +2355,7 @@ msgid "EXISTING: %q (backend=%q, source=%q)"
 msgstr ""
 
 #: cmd/incus/cluster.go:1113 cmd/incus/config_trust.go:623
-#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2650
+#: cmd/incus/snapshot.go:337 cmd/incus/storage_volume.go:2653
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2439,11 +2450,11 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:953
+#: cmd/incus/storage_volume.go:956
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:954
+#: cmd/incus/storage_volume.go:957
 msgid ""
 "Edit storage volume configurations as YAML\n"
 "\n"
@@ -2467,8 +2478,8 @@ msgstr ""
 #: cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773
 #: cmd/incus/snapshot.go:346 cmd/incus/storage.go:722
 #: cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925
-#: cmd/incus/storage_volume.go:1700 cmd/incus/storage_volume.go:2658
-#: cmd/incus/top.go:89 cmd/incus/warning.go:236
+#: cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661
+#: cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2491,13 +2502,13 @@ msgid ""
 "  for the address if not yet set."
 msgstr ""
 
-#: cmd/incus/top.go:289
+#: cmd/incus/top.go:290
 msgid ""
 "Enter a sorting type ('a' for alphabetical, 'c' for CPU, 'm' for memory, 'd' "
 "for disk):"
 msgstr ""
 
-#: cmd/incus/top.go:270
+#: cmd/incus/top.go:271
 msgid "Enter new delay in seconds:"
 msgstr ""
 
@@ -2509,7 +2520,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: cmd/incus/copy.go:55 cmd/incus/create.go:54
+#: cmd/incus/copy.go:56 cmd/incus/create.go:54
 msgid "Ephemeral instance"
 msgstr ""
 
@@ -2540,8 +2551,8 @@ msgstr ""
 #: cmd/incus/network_peer.go:628 cmd/incus/network_zone.go:548
 #: cmd/incus/network_zone.go:1236 cmd/incus/profile.go:1083
 #: cmd/incus/project.go:855 cmd/incus/storage.go:896
-#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2038
-#: cmd/incus/storage_volume.go:2081
+#: cmd/incus/storage_bucket.go:706 cmd/incus/storage_volume.go:2041
+#: cmd/incus/storage_volume.go:2084
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2562,8 +2573,8 @@ msgstr ""
 #: cmd/incus/network_load_balancer.go:576 cmd/incus/network_peer.go:622
 #: cmd/incus/network_zone.go:542 cmd/incus/network_zone.go:1230
 #: cmd/incus/profile.go:1077 cmd/incus/project.go:849 cmd/incus/storage.go:890
-#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2032
-#: cmd/incus/storage_volume.go:2075
+#: cmd/incus/storage_bucket.go:700 cmd/incus/storage_volume.go:2035
+#: cmd/incus/storage_volume.go:2078
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2643,8 +2654,8 @@ msgstr ""
 msgid "Expected a struct, got a %v"
 msgstr ""
 
-#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1476
-#: cmd/incus/storage_volume.go:1526
+#: cmd/incus/info.go:830 cmd/incus/info.go:881 cmd/incus/storage_volume.go:1479
+#: cmd/incus/storage_volume.go:1529
 msgid "Expires at"
 msgstr ""
 
@@ -2668,7 +2679,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2960 cmd/incus/storage_volume.go:2961
+#: cmd/incus/storage_volume.go:2963 cmd/incus/storage_volume.go:2964
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2688,7 +2699,7 @@ msgstr ""
 msgid "Export storage buckets as tarball."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2964
+#: cmd/incus/storage_volume.go:2967
 msgid "Export the volume without its snapshots"
 msgstr ""
 
@@ -2697,7 +2708,7 @@ msgstr ""
 msgid "Exporting backup of storage bucket: %s"
 msgstr ""
 
-#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3093
+#: cmd/incus/export.go:151 cmd/incus/storage_volume.go:3096
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2778,7 +2789,7 @@ msgstr ""
 msgid "Failed deleting instance %q in project %q: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:556
+#: cmd/incus/storage_volume.go:559
 #, c-format
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
@@ -2917,7 +2928,7 @@ msgstr ""
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3028
+#: cmd/incus/storage_volume.go:3031
 #, c-format
 msgid "Failed to create storage volume backup: %w"
 msgstr ""
@@ -2932,7 +2943,7 @@ msgstr ""
 msgid "Failed to fetch storage bucket backup: %w"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3107
+#: cmd/incus/storage_volume.go:3110
 #, c-format
 msgid "Failed to fetch storage volume backup file: %w"
 msgstr ""
@@ -2972,7 +2983,7 @@ msgstr ""
 msgid "Failed to read from stdin: %w"
 msgstr ""
 
-#: cmd/incus/copy.go:372
+#: cmd/incus/copy.go:375
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -3161,7 +3172,7 @@ msgstr ""
 #: cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056
 #: cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689
 #: cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902
-#: cmd/incus/storage_volume.go:1575 cmd/incus/storage_volume.go:2561
+#: cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564
 #: cmd/incus/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -3174,7 +3185,7 @@ msgstr ""
 msgid "Format (man|md|rest|yaml)"
 msgstr ""
 
-#: cmd/incus/top.go:64
+#: cmd/incus/top.go:65
 msgid "Format (table|compact)"
 msgstr ""
 
@@ -3303,7 +3314,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1193
+#: cmd/incus/storage_volume.go:1196
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -3376,11 +3387,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1177
+#: cmd/incus/storage_volume.go:1180
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1178
+#: cmd/incus/storage_volume.go:1181
 msgid ""
 "Get values for storage volume configuration keys\n"
 "\n"
@@ -3392,7 +3403,7 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:440
+#: cmd/incus/storage_volume.go:442
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3455,7 +3466,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: cmd/incus/top.go:77
+#: cmd/incus/top.go:78
 msgid "INSTANCE NAME"
 msgstr ""
 
@@ -3496,7 +3507,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2331
+#: cmd/incus/snapshot.go:91 cmd/incus/storage_volume.go:2334
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3510,11 +3521,11 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2330
+#: cmd/incus/storage_volume.go:2333
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: cmd/incus/copy.go:64 cmd/incus/move.go:66
+#: cmd/incus/copy.go:66 cmd/incus/move.go:66
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3568,11 +3579,11 @@ msgstr ""
 msgid "Import backups of storage buckets."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3126
+#: cmd/incus/storage_volume.go:3129
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3127
+#: cmd/incus/storage_volume.go:3130
 msgid "Import custom storage volumes."
 msgstr ""
 
@@ -3595,15 +3606,15 @@ msgstr ""
 msgid "Import storage bucket"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3201
+#: cmd/incus/storage_volume.go:3204
 msgid "Import type needs to be \"backup\" or \"iso\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3136
+#: cmd/incus/storage_volume.go:3139
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3206
+#: cmd/incus/storage_volume.go:3209
 msgid "Importing ISO images requires a volume name to be set"
 msgstr ""
 
@@ -3612,7 +3623,7 @@ msgstr ""
 msgid "Importing bucket: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3210
+#: cmd/incus/storage_volume.go:3213
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3687,7 +3698,7 @@ msgid "Invalid IP address or DNS name"
 msgstr ""
 
 #: cmd/incus/export.go:113 cmd/incus/storage_bucket.go:1490
-#: cmd/incus/storage_volume.go:3061
+#: cmd/incus/storage_volume.go:3064
 #, c-format
 msgid "Invalid URL %q: %w"
 msgstr ""
@@ -3707,7 +3718,7 @@ msgid "Invalid arguments"
 msgstr ""
 
 #: cmd/incus/export.go:118 cmd/incus/storage_bucket.go:1495
-#: cmd/incus/storage_volume.go:3066
+#: cmd/incus/storage_volume.go:3069
 #, c-format
 msgid "Invalid backup name segment in path %q: %w"
 msgstr ""
@@ -3745,7 +3756,7 @@ msgstr ""
 msgid "Invalid expiration date: %w"
 msgstr ""
 
-#: cmd/incus/top.go:166
+#: cmd/incus/top.go:167
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -3755,7 +3766,7 @@ msgstr ""
 msgid "Invalid format: %s"
 msgstr ""
 
-#: cmd/incus/top.go:281
+#: cmd/incus/top.go:282
 msgid "Invalid input, please enter a positive number"
 msgstr ""
 
@@ -3813,17 +3824,17 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1025 cmd/incus/storage_volume.go:1242
-#: cmd/incus/storage_volume.go:1370 cmd/incus/storage_volume.go:2015
-#: cmd/incus/storage_volume.go:2921
+#: cmd/incus/storage_volume.go:1028 cmd/incus/storage_volume.go:1245
+#: cmd/incus/storage_volume.go:1373 cmd/incus/storage_volume.go:2018
+#: cmd/incus/storage_volume.go:2924
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: cmd/incus/top.go:359
+#: cmd/incus/top.go:360
 msgid "Invalid sorting type"
 msgstr ""
 
-#: cmd/incus/top.go:310
+#: cmd/incus/top.go:311
 msgid "Invalid sorting type provided"
 msgstr ""
 
@@ -3878,7 +3889,7 @@ msgstr ""
 #: cmd/incus/list.go:617 cmd/incus/network.go:1296
 #: cmd/incus/network_forward.go:136 cmd/incus/network_load_balancer.go:143
 #: cmd/incus/operation.go:155 cmd/incus/storage_bucket.go:516
-#: cmd/incus/storage_volume.go:1679 cmd/incus/warning.go:221
+#: cmd/incus/storage_volume.go:1682 cmd/incus/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -4612,11 +4623,11 @@ msgid ""
 "  L - Location of the storage bucket (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2543 cmd/incus/storage_volume.go:2544
+#: cmd/incus/storage_volume.go:2546 cmd/incus/storage_volume.go:2547
 msgid "List storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2550
+#: cmd/incus/storage_volume.go:2553
 msgid ""
 "List storage volume snapshots\n"
 "\n"
@@ -4630,11 +4641,11 @@ msgid ""
 "\t\tE - Expiry"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1554
+#: cmd/incus/storage_volume.go:1557
 msgid "List storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1559
+#: cmd/incus/storage_volume.go:1562
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4746,7 +4757,7 @@ msgstr ""
 msgid "Load:"
 msgstr ""
 
-#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1432
+#: cmd/incus/info.go:655 cmd/incus/storage_volume.go:1435
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4814,7 +4825,7 @@ msgstr ""
 msgid "MEMBERS"
 msgstr ""
 
-#: cmd/incus/top.go:79
+#: cmd/incus/top.go:80
 msgid "MEMORY"
 msgstr ""
 
@@ -5011,7 +5022,7 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2272 cmd/incus/storage_volume.go:2273
+#: cmd/incus/storage_volume.go:2275 cmd/incus/storage_volume.go:2276
 msgid "Manage storage volume snapshots"
 msgstr ""
 
@@ -5250,15 +5261,15 @@ msgstr ""
 #: cmd/incus/storage_bucket.go:1060 cmd/incus/storage_bucket.go:1157
 #: cmd/incus/storage_bucket.go:1236 cmd/incus/storage_bucket.go:1359
 #: cmd/incus/storage_bucket.go:1434 cmd/incus/storage_volume.go:203
-#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:615
-#: cmd/incus/storage_volume.go:722 cmd/incus/storage_volume.go:799
-#: cmd/incus/storage_volume.go:897 cmd/incus/storage_volume.go:1014
-#: cmd/incus/storage_volume.go:1231 cmd/incus/storage_volume.go:1606
-#: cmd/incus/storage_volume.go:1904 cmd/incus/storage_volume.go:1998
-#: cmd/incus/storage_volume.go:2160 cmd/incus/storage_volume.go:2380
-#: cmd/incus/storage_volume.go:2495 cmd/incus/storage_volume.go:2596
-#: cmd/incus/storage_volume.go:2749 cmd/incus/storage_volume.go:2834
-#: cmd/incus/storage_volume.go:2911
+#: cmd/incus/storage_volume.go:294 cmd/incus/storage_volume.go:618
+#: cmd/incus/storage_volume.go:725 cmd/incus/storage_volume.go:802
+#: cmd/incus/storage_volume.go:900 cmd/incus/storage_volume.go:1017
+#: cmd/incus/storage_volume.go:1234 cmd/incus/storage_volume.go:1609
+#: cmd/incus/storage_volume.go:1907 cmd/incus/storage_volume.go:2001
+#: cmd/incus/storage_volume.go:2163 cmd/incus/storage_volume.go:2383
+#: cmd/incus/storage_volume.go:2498 cmd/incus/storage_volume.go:2599
+#: cmd/incus/storage_volume.go:2752 cmd/incus/storage_volume.go:2837
+#: cmd/incus/storage_volume.go:2914
 msgid "Missing pool name"
 msgstr ""
 
@@ -5282,11 +5293,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:403 cmd/incus/storage_volume.go:1814
+#: cmd/incus/storage_volume.go:405 cmd/incus/storage_volume.go:1817
 msgid "Missing source volume name"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1359
+#: cmd/incus/storage_volume.go:1362
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -5324,7 +5335,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/network.go:562 cmd/incus/network.go:659
-#: cmd/incus/storage_volume.go:819 cmd/incus/storage_volume.go:916
+#: cmd/incus/storage_volume.go:822 cmd/incus/storage_volume.go:919
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -5337,7 +5348,7 @@ msgstr "将下载多个文件, 但目标不是目录"
 msgid "Mount files from instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1773 cmd/incus/storage_volume.go:1774
+#: cmd/incus/storage_volume.go:1776 cmd/incus/storage_volume.go:1777
 msgid "Move custom storage volumes between pools"
 msgstr ""
 
@@ -5365,11 +5376,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1780
+#: cmd/incus/storage_volume.go:1783
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:483
+#: cmd/incus/storage_volume.go:485
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -5399,7 +5410,7 @@ msgstr ""
 #: cmd/incus/profile.go:745 cmd/incus/project.go:552 cmd/incus/project.go:694
 #: cmd/incus/remote.go:759 cmd/incus/snapshot.go:335 cmd/incus/storage.go:708
 #: cmd/incus/storage_bucket.go:514 cmd/incus/storage_bucket.go:915
-#: cmd/incus/storage_volume.go:1671 cmd/incus/storage_volume.go:2648
+#: cmd/incus/storage_volume.go:1674 cmd/incus/storage_volume.go:2651
 msgid "NAME"
 msgstr ""
 
@@ -5454,8 +5465,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1474
-#: cmd/incus/storage_volume.go:1524
+#: cmd/incus/info.go:828 cmd/incus/info.go:879 cmd/incus/storage_volume.go:1477
+#: cmd/incus/storage_volume.go:1527
 msgid "Name"
 msgstr ""
 
@@ -5516,7 +5527,7 @@ msgid "Name of the storage pool:"
 msgstr ""
 
 #: cmd/incus/info.go:633 cmd/incus/network.go:969
-#: cmd/incus/storage_volume.go:1414
+#: cmd/incus/storage_volume.go:1417
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -5657,7 +5668,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: cmd/incus/copy.go:53 cmd/incus/create.go:53 cmd/incus/move.go:57
+#: cmd/incus/copy.go:54 cmd/incus/create.go:53 cmd/incus/move.go:57
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -5680,7 +5691,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:828 cmd/incus/storage_volume.go:925
+#: cmd/incus/storage_volume.go:831 cmd/incus/storage_volume.go:928
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -5704,11 +5715,11 @@ msgstr ""
 msgid "No storage backends available"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:417 cmd/incus/storage_volume.go:1823
+#: cmd/incus/storage_volume.go:419 cmd/incus/storage_volume.go:1826
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:467 cmd/incus/storage_volume.go:1834
+#: cmd/incus/storage_volume.go:469 cmd/incus/storage_volume.go:1837
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -5756,11 +5767,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3015
+#: cmd/incus/storage_volume.go:3018
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2393
+#: cmd/incus/storage_volume.go:2396
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -5772,7 +5783,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1377
+#: cmd/incus/storage_volume.go:1380
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -5798,7 +5809,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1528
+#: cmd/incus/info.go:883 cmd/incus/storage_volume.go:1531
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5851,7 +5862,7 @@ msgstr ""
 #: cmd/incus/image.go:1116 cmd/incus/list.go:577 cmd/incus/network.go:1092
 #: cmd/incus/network_acl.go:174 cmd/incus/network_zone.go:132
 #: cmd/incus/profile.go:746 cmd/incus/storage_bucket.go:513
-#: cmd/incus/storage_volume.go:1690 cmd/incus/top.go:76
+#: cmd/incus/storage_volume.go:1693 cmd/incus/top.go:77
 #: cmd/incus/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5903,7 +5914,7 @@ msgstr ""
 msgid "Pause instances"
 msgstr ""
 
-#: cmd/incus/copy.go:63
+#: cmd/incus/copy.go:64
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -5949,15 +5960,15 @@ msgstr ""
 msgid "Pre-seed mode, expects YAML config from stdin"
 msgstr ""
 
-#: cmd/incus/top.go:442
+#: cmd/incus/top.go:443
 msgid "Press 'd' + ENTER to change delay"
 msgstr ""
 
-#: cmd/incus/top.go:443
+#: cmd/incus/top.go:444
 msgid "Press 's' + ENTER to change sorting method"
 msgstr ""
 
-#: cmd/incus/top.go:444
+#: cmd/incus/top.go:445
 msgid "Press CTRL-C to exit"
 msgstr ""
 
@@ -5975,7 +5986,7 @@ msgstr ""
 #: cmd/incus/network_zone.go:711 cmd/incus/network_zone.go:1406
 #: cmd/incus/profile.go:601 cmd/incus/project.go:404 cmd/incus/storage.go:369
 #: cmd/incus/storage_bucket.go:362 cmd/incus/storage_bucket.go:1301
-#: cmd/incus/storage_volume.go:1112 cmd/incus/storage_volume.go:1144
+#: cmd/incus/storage_volume.go:1115 cmd/incus/storage_volume.go:1147
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -6059,7 +6070,7 @@ msgstr ""
 msgid "Profile to apply to the new image"
 msgstr ""
 
-#: cmd/incus/copy.go:54 cmd/incus/create.go:52
+#: cmd/incus/copy.go:55 cmd/incus/create.go:52
 msgid "Profile to apply to the new instance"
 msgstr ""
 
@@ -6219,7 +6230,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr "递归传输文件"
 
-#: cmd/incus/storage_volume.go:369
+#: cmd/incus/storage_volume.go:370
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -6227,7 +6238,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr "刷新镜像列表"
 
-#: cmd/incus/copy.go:394
+#: cmd/incus/copy.go:397
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "正在刷新实例: %s"
@@ -6385,7 +6396,7 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1866 cmd/incus/storage_volume.go:1867
+#: cmd/incus/storage_volume.go:1869 cmd/incus/storage_volume.go:1870
 msgid "Rename custom storage volumes"
 msgstr ""
 
@@ -6421,16 +6432,16 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2706 cmd/incus/storage_volume.go:2707
+#: cmd/incus/storage_volume.go:2709 cmd/incus/storage_volume.go:2710
 msgid "Rename storage volume snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1928
+#: cmd/incus/storage_volume.go:1931
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2778
+#: cmd/incus/storage_volume.go:2781
 #, c-format
 msgid "Renamed storage volume snapshot from \"%s\" to \"%s\""
 msgstr ""
@@ -6471,7 +6482,7 @@ msgstr ""
 msgid "Restore instance snapshots"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2793 cmd/incus/storage_volume.go:2794
+#: cmd/incus/storage_volume.go:2796 cmd/incus/storage_volume.go:2797
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -6874,11 +6885,11 @@ msgid ""
 "    incus storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1946
+#: cmd/incus/storage_volume.go:1949
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1947
+#: cmd/incus/storage_volume.go:1950
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6976,7 +6987,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1963
+#: cmd/incus/storage_volume.go:1966
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -7117,11 +7128,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2109
+#: cmd/incus/storage_volume.go:2112
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2110
+#: cmd/incus/storage_volume.go:2113
 msgid ""
 "Show storage volume configurations\n"
 "\n"
@@ -7133,19 +7144,19 @@ msgid ""
 "container or virtual-machine)."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2874
+#: cmd/incus/storage_volume.go:2877
 msgid "Show storage volume snapshhot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2873
+#: cmd/incus/storage_volume.go:2876
 msgid "Show storage volume snapshot configurations"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1313
+#: cmd/incus/storage_volume.go:1316
 msgid "Show storage volume state information"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1314
+#: cmd/incus/storage_volume.go:1317
 msgid ""
 "Show storage volume state information\n"
 "\n"
@@ -7220,15 +7231,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2321 cmd/incus/storage_volume.go:2322
+#: cmd/incus/storage_volume.go:2324 cmd/incus/storage_volume.go:2325
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2050
+#: cmd/incus/storage_volume.go:2053
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1453
+#: cmd/incus/info.go:797 cmd/incus/storage_volume.go:1456
 msgid "Snapshots:"
 msgstr ""
 
@@ -7242,7 +7253,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: cmd/incus/top.go:447
+#: cmd/incus/top.go:448
 msgid "Sorting Method:"
 msgstr ""
 
@@ -7362,7 +7373,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: cmd/incus/copy.go:59 cmd/incus/create.go:57 cmd/incus/import.go:34
+#: cmd/incus/copy.go:60 cmd/incus/create.go:57 cmd/incus/import.go:34
 #: cmd/incus/move.go:63
 msgid "Storage pool name"
 msgstr ""
@@ -7371,25 +7382,25 @@ msgstr ""
 msgid "Storage pool to use or create"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:668
+#: cmd/incus/storage_volume.go:671
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:742
+#: cmd/incus/storage_volume.go:745
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:480
+#: cmd/incus/storage_volume.go:482
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:484
+#: cmd/incus/storage_volume.go:486
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2520
+#: cmd/incus/storage_volume.go:2523
 #, c-format
 msgid "Storage volume snapshot %s deleted from %s"
 msgstr ""
@@ -7436,7 +7447,7 @@ msgstr ""
 msgid "System:"
 msgstr ""
 
-#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2649
+#: cmd/incus/snapshot.go:336 cmd/incus/storage_volume.go:2652
 msgid "TAKEN AT"
 msgstr ""
 
@@ -7452,12 +7463,12 @@ msgstr ""
 #: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
-#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1670
+#: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
 #: cmd/incus/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1525
+#: cmd/incus/info.go:829 cmd/incus/info.go:880 cmd/incus/storage_volume.go:1528
 msgid "Taken at"
 msgstr ""
 
@@ -7581,7 +7592,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: cmd/incus/top.go:170
+#: cmd/incus/top.go:171
 msgid "The minimum refresh rate is 10s"
 msgstr ""
 
@@ -7669,12 +7680,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1289
+#: cmd/incus/storage_volume.go:1292
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1261
+#: cmd/incus/storage_volume.go:1264
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -7726,7 +7737,7 @@ msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
 #: cmd/incus/network.go:576 cmd/incus/network.go:673
-#: cmd/incus/storage_volume.go:833 cmd/incus/storage_volume.go:930
+#: cmd/incus/storage_volume.go:836 cmd/incus/storage_volume.go:933
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -7799,7 +7810,7 @@ msgid ""
 msgstr ""
 
 #: cmd/incus/config.go:301 cmd/incus/config.go:494 cmd/incus/config.go:702
-#: cmd/incus/config.go:802 cmd/incus/copy.go:142 cmd/incus/info.go:386
+#: cmd/incus/config.go:802 cmd/incus/copy.go:144 cmd/incus/info.go:386
 #: cmd/incus/network.go:957 cmd/incus/storage.go:524
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -7808,7 +7819,7 @@ msgstr ""
 msgid "Too many links"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1438
+#: cmd/incus/storage_volume.go:1441
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -7824,7 +7835,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1777
+#: cmd/incus/storage_volume.go:1780
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -7832,11 +7843,11 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:364
+#: cmd/incus/storage_volume.go:365
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: cmd/incus/copy.go:56
+#: cmd/incus/copy.go:57
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
@@ -7849,7 +7860,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: cmd/incus/copy.go:350 cmd/incus/move.go:343
+#: cmd/incus/copy.go:353 cmd/incus/move.go:343
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -7888,7 +7899,7 @@ msgstr ""
 
 #: cmd/incus/image.go:994 cmd/incus/info.go:300 cmd/incus/info.go:433
 #: cmd/incus/info.go:444 cmd/incus/info.go:650 cmd/incus/network.go:973
-#: cmd/incus/storage_volume.go:1423
+#: cmd/incus/storage_volume.go:1426
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -7905,7 +7916,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1675
+#: cmd/incus/project.go:1147 cmd/incus/storage_volume.go:1678
 msgid "USAGE"
 msgstr ""
 
@@ -7921,7 +7932,7 @@ msgstr ""
 #: cmd/incus/network_allocations.go:71 cmd/incus/network_integration.go:452
 #: cmd/incus/network_zone.go:135 cmd/incus/profile.go:748
 #: cmd/incus/project.go:560 cmd/incus/storage.go:712
-#: cmd/incus/storage_volume.go:1674
+#: cmd/incus/storage_volume.go:1677
 msgid "USED BY"
 msgstr ""
 
@@ -7968,8 +7979,8 @@ msgstr ""
 #: cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779
 #: cmd/incus/snapshot.go:352 cmd/incus/storage.go:728
 #: cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931
-#: cmd/incus/storage_volume.go:1708 cmd/incus/storage_volume.go:2664
-#: cmd/incus/top.go:95 cmd/incus/warning.go:244
+#: cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667
+#: cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -8078,11 +8089,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2214
+#: cmd/incus/storage_volume.go:2217
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2215
+#: cmd/incus/storage_volume.go:2218
 msgid ""
 "Unset storage volume configuration keys\n"
 "\n"
@@ -8147,7 +8158,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2227
+#: cmd/incus/storage_volume.go:2230
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -8178,7 +8189,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: cmd/incus/top.go:246
+#: cmd/incus/top.go:247
 #, c-format
 msgid "Updated interval to %v"
 msgstr ""
@@ -8192,12 +8203,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1436
+#: cmd/incus/storage_volume.go:1439
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2966
+#: cmd/incus/export.go:42 cmd/incus/storage_volume.go:2969
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -8283,7 +8294,7 @@ msgstr ""
 msgid "Version: %v"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1527
+#: cmd/incus/storage_volume.go:1530
 msgid "Volume Only"
 msgstr ""
 
@@ -8453,11 +8464,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: cmd/incus/copy.go:113
+#: cmd/incus/copy.go:115
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: cmd/incus/copy.go:96 cmd/incus/move.go:250
+#: cmd/incus/copy.go:98 cmd/incus/move.go:250
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -8465,7 +8476,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:855
+#: cmd/incus/storage_volume.go:858
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -8479,7 +8490,7 @@ msgstr ""
 #: cmd/incus/network.go:1050 cmd/incus/network_acl.go:91
 #: cmd/incus/network_integration.go:413 cmd/incus/network_zone.go:88
 #: cmd/incus/operation.go:110 cmd/incus/profile.go:707 cmd/incus/project.go:509
-#: cmd/incus/storage.go:662 cmd/incus/top.go:40 cmd/incus/version.go:20
+#: cmd/incus/storage.go:662 cmd/incus/top.go:41 cmd/incus/version.go:20
 #: cmd/incus/warning.go:69 cmd/incus/webui.go:17
 msgid "[<remote>:]"
 msgstr ""
@@ -8896,7 +8907,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<bucket>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3125
+#: cmd/incus/storage_volume.go:3128
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -8935,15 +8946,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1865
+#: cmd/incus/storage_volume.go:1868
 msgid "[<remote>:]<pool> <old name> <new name>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:683 cmd/incus/storage_volume.go:2542
+#: cmd/incus/storage_volume.go:686 cmd/incus/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:757
+#: cmd/incus/storage_volume.go:760
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -8951,56 +8962,56 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2705
+#: cmd/incus/storage_volume.go:2708
 msgid "[<remote>:]<pool> <volume> <old snapshot> <new snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2452 cmd/incus/storage_volume.go:2792
+#: cmd/incus/storage_volume.go:2455 cmd/incus/storage_volume.go:2795
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2959
+#: cmd/incus/storage_volume.go:2962
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2320
+#: cmd/incus/storage_volume.go:2323
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:574
+#: cmd/incus/storage_volume.go:577
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2872
+#: cmd/incus/storage_volume.go:2875
 msgid "[<remote>:]<pool> <volume>/<snapshot>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1552
+#: cmd/incus/storage_volume.go:1555
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:952 cmd/incus/storage_volume.go:1312
-#: cmd/incus/storage_volume.go:2108
+#: cmd/incus/storage_volume.go:955 cmd/incus/storage_volume.go:1315
+#: cmd/incus/storage_volume.go:2111
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2213
+#: cmd/incus/storage_volume.go:2216
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1945
+#: cmd/incus/storage_volume.go:1948
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1176
+#: cmd/incus/storage_volume.go:1179
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1771
+#: cmd/incus/storage_volume.go:1774
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:358
+#: cmd/incus/storage_volume.go:359
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -9059,7 +9070,7 @@ msgstr ""
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
-#: cmd/incus/copy.go:37
+#: cmd/incus/copy.go:38
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -9594,7 +9605,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: cmd/incus/storage_volume.go:578
+#: cmd/incus/storage_volume.go:581
 msgid ""
 "incus storage volume create default foo\n"
 "    Create custom storage volume \"foo\" in pool \"default\"\n"
@@ -9604,7 +9615,7 @@ msgid ""
 "configuration from config.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:959
+#: cmd/incus/storage_volume.go:962
 msgid ""
 "incus storage volume edit default container/c1\n"
 "    Edit container storage volume \"c1\" in pool \"default\"\n"
@@ -9614,7 +9625,7 @@ msgid ""
 "of volume.yaml"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1185
+#: cmd/incus/storage_volume.go:1188
 msgid ""
 "incus storage volume get default data size\n"
 "    Returns the size of a custom volume \"data\" in pool \"default\"\n"
@@ -9624,7 +9635,7 @@ msgid ""
 "pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:3129
+#: cmd/incus/storage_volume.go:3132
 msgid ""
 "incus storage volume import default backup0.tar.gz\n"
 "    Create a new custom volume using backup0.tar.gz as the source\n"
@@ -9634,7 +9645,7 @@ msgid ""
 "ROM image"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1319
+#: cmd/incus/storage_volume.go:1322
 msgid ""
 "incus storage volume info default foo\n"
 "    Returns state information for a custom volume \"foo\" in pool "
@@ -9644,7 +9655,7 @@ msgid ""
 "    Returns state information for virtual machine \"v1\" in pool \"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:1955
+#: cmd/incus/storage_volume.go:1958
 msgid ""
 "incus storage volume set default data size=1GiB\n"
 "    Sets the size of a custom volume \"data\" in pool \"default\" to 1 GiB\n"
@@ -9654,7 +9665,7 @@ msgid ""
 "pool \"default\" to seven days"
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2117
+#: cmd/incus/storage_volume.go:2120
 msgid ""
 "incus storage volume show default foo\n"
 "    Will show the properties of custom volume \"foo\" in pool \"default\"\n"
@@ -9668,7 +9679,7 @@ msgid ""
 "\"default\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2324
+#: cmd/incus/storage_volume.go:2327
 msgid ""
 "incus storage volume snapshot create default foo snap0\n"
 "    Create a snapshot of \"foo\" in pool \"default\" called \"snap0\"\n"
@@ -9678,7 +9689,7 @@ msgid ""
 "the configuration from \"config.yaml\""
 msgstr ""
 
-#: cmd/incus/storage_volume.go:2220
+#: cmd/incus/storage_volume.go:2223
 msgid ""
 "incus storage volume unset default foo size\n"
 "    Removes the size/quota of custom volume \"foo\" in pool \"default\"\n"

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -362,6 +362,12 @@ type InstanceSource struct {
 	// Example: false
 	Refresh bool `json:"refresh,omitempty" yaml:"refresh,omitempty"`
 
+	// Whether to exclude source snapshots earlier than latest target snapshot
+	// Example: false
+	//
+	// API extension: custom_volume_refresh_exclude_older_snapshots
+	RefreshExcludeOlder bool `json:"refresh_exclude_older,omitempty" yaml:"refresh_exclude_older,omitempty"`
+
 	// Source project name (for copy and local image)
 	// Example: blah
 	Project string `json:"project,omitempty" yaml:"project,omitempty"`

--- a/shared/api/storage_pool_volume.go
+++ b/shared/api/storage_pool_volume.go
@@ -231,6 +231,12 @@ type StorageVolumeSource struct {
 	// API extension: custom_volume_refresh
 	Refresh bool `json:"refresh" yaml:"refresh"`
 
+	// Whether to exclude source snapshots earlier than latest target snapshot
+	// Example: false
+	//
+	// API extension: custom_volume_refresh_exclude_older_snapshots
+	RefreshExcludeOlder bool `json:"refresh_exclude_older" yaml:"refresh_exclude_older"`
+
 	// Source project name
 	// Example: foo
 	//


### PR DESCRIPTION
This pull request resolves issue https://github.com/lxc/incus/issues/745