### PR TITLE
Automatic live-migration to balance load on cluster

### DIFF
--- a/cmd/incus/monitor.go
+++ b/cmd/incus/monitor.go
@@ -151,7 +151,13 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 
 			entry := &logrus.Entry{Logger: logger}
 			entry.Data = c.unpackCtx(record.Ctx)
-			entry.Message = record.Msg
+
+			if event.Type == "logging" && d.IsClustered() {
+				entry.Message = fmt.Sprintf("[%s] %s", event.Location, record.Msg)
+			} else {
+				entry.Message = record.Msg
+			}
+
 			entry.Time = record.Time
 			entry.Level = msgLevel
 			format := logrus.TextFormatter{FullTimestamp: true, PadLevelText: true}

--- a/cmd/incusd/api_cluster_rebalance.go
+++ b/cmd/incusd/api_cluster_rebalance.go
@@ -1,0 +1,391 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"time"
+
+	internalInstance "github.com/lxc/incus/v6/internal/instance"
+	"github.com/lxc/incus/v6/internal/server/cluster"
+	"github.com/lxc/incus/v6/internal/server/db"
+	dbCluster "github.com/lxc/incus/v6/internal/server/db/cluster"
+	"github.com/lxc/incus/v6/internal/server/instance"
+	"github.com/lxc/incus/v6/internal/server/instance/instancetype"
+	"github.com/lxc/incus/v6/internal/server/project"
+	"github.com/lxc/incus/v6/internal/server/state"
+	"github.com/lxc/incus/v6/internal/server/task"
+	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/logger"
+)
+
+// ServerScore represents server score taken into account during load balancing.
+type ServerScore struct {
+	NodeInfo  db.NodeInfo
+	Resources *api.Resources
+	Score     uint8
+}
+
+// ServerUsage represents current server load.
+type ServerUsage struct {
+	MemoryUsage uint64
+	MemoryTotal uint64
+	CPUUsage    float64
+	CPUTotal    uint64
+}
+
+// sortAndGroupByArch sorts servers by its score and groups them by cpu architecture.
+func sortAndGroupByArch(servers []*ServerScore) map[string][]*ServerScore {
+	sort.Slice(servers, func(i, j int) bool {
+		return servers[i].Score > servers[j].Score
+	})
+
+	result := make(map[string][]*ServerScore)
+	for _, s := range servers {
+		arch := s.Resources.CPU.Architecture
+		_, ok := result[arch]
+		if !ok {
+			result[arch] = []*ServerScore{}
+		}
+
+		result[arch] = append(result[arch], s)
+	}
+
+	return result
+}
+
+// calculateScore calculates score for single server.
+func calculateScore(su *ServerUsage, au *ServerUsage) uint8 {
+	memoryUsage := su.MemoryUsage
+	memoryTotal := su.MemoryTotal
+	cpuUsage := su.CPUUsage
+	cpuTotal := su.CPUTotal
+
+	if au != nil {
+		memoryUsage += au.MemoryUsage
+		memoryTotal += au.MemoryTotal
+		cpuUsage += au.CPUUsage
+		cpuTotal += au.CPUTotal
+	}
+
+	memoryScore := uint8(float64(memoryUsage) * 100 / float64(memoryTotal))
+	cpuScore := uint8((cpuUsage * 100) / float64(cpuTotal))
+
+	return (memoryScore + cpuScore) / 2
+}
+
+// calculateServersScore calculates score based on memory and CPU usage for servers in cluster.
+func calculateServersScore(s *state.State, members []db.NodeInfo) (map[string][]*ServerScore, error) {
+	scores := []*ServerScore{}
+	for _, member := range members {
+		clusterMember, err := cluster.Connect(member.Address, s.Endpoints.NetworkCert(), s.ServerCert(), nil, true)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to connect to cluster member: %w", err)
+		}
+
+		res, err := clusterMember.GetServerResources()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get resources for cluster member: %w", err)
+		}
+
+		su := &ServerUsage{
+			MemoryUsage: res.Memory.Used,
+			MemoryTotal: res.Memory.Total,
+			CPUUsage:    res.Load.Average1Min,
+			CPUTotal:    res.CPU.Total,
+		}
+
+		serverScore := calculateScore(su, nil)
+		scores = append(scores, &ServerScore{NodeInfo: member, Resources: res, Score: serverScore})
+	}
+
+	return sortAndGroupByArch(scores), nil
+}
+
+// clusterRebalanceServers is responsible for instances migration from most to less busy server.
+func clusterRebalanceServers(ctx context.Context, s *state.State, srcServer *ServerScore, dstServer *ServerScore, maxToMigrate int64) (int64, error) {
+	numOfMigrated := int64(0)
+
+	// Keep track of project restrictions.
+	projectStatuses := map[string]bool{}
+
+	// Get a list of migratable instances.
+	var dbInstances []dbCluster.Instance
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+
+		// Get the instance list.
+		instType := instancetype.VM
+		dbInstances, err = dbCluster.GetInstances(ctx, tx.Tx(), dbCluster.InstanceFilter{Node: &srcServer.NodeInfo.Name, Type: &instType})
+		if err != nil {
+			return fmt.Errorf("Failed to get instances: %w", err)
+		}
+
+		// Check project restrictions.
+		for _, dbInst := range dbInstances {
+			_, ok := projectStatuses[dbInst.Project]
+			if ok {
+				continue
+			}
+
+			dbProject, err := dbCluster.GetProject(ctx, tx.Tx(), dbInst.Project)
+			if err != nil {
+				return fmt.Errorf("Failed to get project: %w", err)
+			}
+
+			apiProject, err := dbProject.ToAPI(ctx, tx.Tx())
+			if err != nil {
+				return fmt.Errorf("Failed to load project: %w", err)
+			}
+
+			_, _, err = project.CheckTarget(ctx, s.Authorizer, nil, tx, apiProject, dstServer.NodeInfo.Name, []db.NodeInfo{dstServer.NodeInfo})
+			projectStatuses[dbInst.Project] = err == nil
+		}
+
+		return nil
+	})
+	if err != nil {
+		return -1, fmt.Errorf("Failed to get instances: %w", err)
+	}
+
+	// Filter for instances that can be live migrated to the new target.
+	var instances []instance.Instance
+	for _, dbInst := range dbInstances {
+		if !projectStatuses[dbInst.Project] {
+			// Project restrictions prevent moving to that target.
+			continue
+		}
+
+		inst, err := instance.LoadByProjectAndName(s, dbInst.Project, dbInst.Name)
+		if err != nil {
+			return -1, fmt.Errorf("Failed to load instance: %w", err)
+		}
+
+		// Do not allow to migrate instance which doesn't support live migration.
+		if inst.CanMigrate() != "live-migrate" {
+			continue
+		}
+
+		// Check if instance is ready for next migration.
+		lastMove := inst.LocalConfig()["volatile.rebalance.last_move"]
+		cooldown := s.GlobalConfig.ClusterRebalanceCooldown()
+		if lastMove != "" {
+			v, err := strconv.ParseInt(lastMove, 10, 64)
+			if err != nil {
+				return -1, fmt.Errorf("Failed to parse last_move value: %w", err)
+			}
+
+			expiry, err := internalInstance.GetExpiry(time.Unix(v, 0), cooldown)
+			if err != nil {
+				return -1, fmt.Errorf("Failed to calculate expiration for cooldown time: %w", err)
+			}
+
+			if time.Now().Before(expiry) {
+				continue
+			}
+		}
+
+		instances = append(instances, inst)
+	}
+
+	// Calculate current and target scores.
+	targetScore := (srcServer.Score + dstServer.Score) / 2
+	currentScore := dstServer.Score
+	targetServerUsage := &ServerUsage{
+		MemoryUsage: dstServer.Resources.Memory.Used,
+		MemoryTotal: dstServer.Resources.Memory.Total,
+		CPUUsage:    dstServer.Resources.Load.Average1Min,
+		CPUTotal:    dstServer.Resources.CPU.Total,
+	}
+
+	// Prepare the API client.
+	srcNode, err := cluster.Connect(srcServer.NodeInfo.Address, s.Endpoints.NetworkCert(), s.ServerCert(), nil, true)
+	if err != nil {
+		return -1, fmt.Errorf("Failed to connect to cluster member: %w", err)
+	}
+
+	srcNode = srcNode.UseTarget(dstServer.NodeInfo.Name)
+
+	for _, inst := range instances {
+		if numOfMigrated >= maxToMigrate {
+			// We're done moving instances for now.
+			return numOfMigrated, nil
+		}
+
+		if currentScore >= targetScore {
+			// We've balanced the load.
+			return numOfMigrated, nil
+		}
+
+		// Calculate resource consumption.
+		cpuUsage, memUsage, _, err := instance.ResourceUsage(inst.ExpandedConfig(), inst.ExpandedDevices().CloneNative(), api.InstanceType(inst.Type().String()))
+		if err != nil {
+			return -1, fmt.Errorf("Failed to establish instance resource usage: %w", err)
+		}
+
+		// Calculate impact of migration.
+		additionalUsage := &ServerUsage{
+			MemoryUsage: uint64(cpuUsage),
+			CPUUsage:    float64(memUsage),
+		}
+
+		expectedScore := calculateScore(targetServerUsage, additionalUsage)
+		if expectedScore >= targetScore {
+			// Skip the instance as it would have too big an impact.
+			continue
+		}
+
+		// Prepare for live migration.
+		req := api.InstancePost{
+			Migration: true,
+			Live:      true,
+		}
+
+		migrationOp, err := srcNode.MigrateInstance(inst.Name(), req)
+		if err != nil {
+			return -1, fmt.Errorf("Migration API failure: %w", err)
+		}
+
+		err = migrationOp.Wait()
+		if err != nil {
+			return -1, fmt.Errorf("Failed to wait for migration to finish: %w", err)
+		}
+
+		// Record the migration in the instance volatile storage.
+		err = inst.VolatileSet(map[string]string{"volatile.rebalance.last_move": strconv.FormatInt(time.Now().Unix(), 10)})
+		if err != nil {
+			return -1, err
+		}
+
+		// Update counters and scores.
+		numOfMigrated += 1
+		currentScore = expectedScore
+		targetServerUsage.MemoryUsage += additionalUsage.MemoryUsage
+		targetServerUsage.CPUUsage += additionalUsage.CPUUsage
+	}
+
+	return numOfMigrated, nil
+}
+
+// clusterRebalance performs cluster re-balancing.
+func clusterRebalance(ctx context.Context, s *state.State, servers map[string][]*ServerScore) error {
+	rebalanceThreshold := s.GlobalConfig.ClusterRebalanceThreshold()
+	rebalanceBatch := s.GlobalConfig.ClusterRebalanceBatch()
+	numOfMigrated := int64(0)
+
+	for archName, v := range servers {
+		if numOfMigrated >= rebalanceBatch {
+			// Maximum number of instances already migrated in this run.
+			continue
+		}
+
+		if len(v) < 2 {
+			// Skip if there isn't at least 2 servers with specific arch.
+			continue
+		}
+
+		if v[0].Score == 0 {
+			// Don't migrate anything if most loaded isn't loaded.
+			continue
+		}
+
+		leastBusyIndex := len(v) - 1
+		percentageChange := int64(float64(v[0].Score-v[leastBusyIndex].Score) / float64(v[0].Score) * 100)
+		logger.Debug("Automatic re-balancing", logger.Ctx{"Architecture": archName, "LeastBusy": v[leastBusyIndex].NodeInfo.Name, "LeastBusyScore": v[leastBusyIndex].Score, "MostBusy": v[0].NodeInfo.Name, "MostBusyScore": v[0].Score, "Difference": fmt.Sprintf("%d%%", percentageChange), "Threshold": fmt.Sprintf("%d%%", rebalanceThreshold)})
+
+		if percentageChange < rebalanceThreshold {
+			continue // Skip as threshold condition is not met.
+		}
+
+		n, err := clusterRebalanceServers(ctx, s, v[0], v[leastBusyIndex], rebalanceBatch-numOfMigrated)
+		if err != nil {
+			return fmt.Errorf("Failed to rebalance cluster: %w", err)
+		}
+
+		numOfMigrated += n
+	}
+
+	return nil
+}
+
+func autoRebalanceCluster(ctx context.Context, d *Daemon) error {
+	s := d.State()
+
+	// Confirm we should run the rebalance.
+	leader, err := s.Cluster.LeaderAddress()
+	if err != nil {
+		if errors.Is(err, cluster.ErrNodeIsNotClustered) {
+			// Not clustered.
+			return nil
+		}
+
+		return fmt.Errorf("Failed to get leader cluster member address: %w", err)
+	}
+
+	if s.LocalConfig.ClusterAddress() != leader {
+		// Not the leader.
+		return nil
+	}
+
+	// Get all online members
+	var onlineMembers []db.NodeInfo
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		members, err := tx.GetNodes(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed getting cluster members: %w", err)
+		}
+
+		onlineMembers, err = tx.GetCandidateMembers(ctx, members, nil, "", nil, s.GlobalConfig.OfflineThreshold())
+		if err != nil {
+			return fmt.Errorf("Failed getting online cluster members: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Failed getting cluster members: %w", err)
+	}
+
+	servers, err := calculateServersScore(s, onlineMembers)
+	if err != nil {
+		return fmt.Errorf("Failed calculating servers score: %w", err)
+	}
+
+	err = clusterRebalance(ctx, s, servers)
+	if err != nil {
+		return fmt.Errorf("Failed rebalancing cluster: %w", err)
+	}
+
+	return nil
+}
+
+func autoRebalanceClusterTask(d *Daemon) (task.Func, task.Schedule) {
+	f := func(ctx context.Context) {
+		s := d.State()
+
+		// Check that we should run now.
+		interval := s.GlobalConfig.ClusterRebalanceInterval()
+		if interval <= 0 {
+			// Re-balance is disabled.
+			return
+		}
+
+		now := time.Now()
+		elapsed := int64(math.Round(now.Sub(s.StartTime).Minutes()))
+		if elapsed%interval != 0 {
+			// It's not time for a re-balance.
+			return
+		}
+
+		// Run the rebalance.
+		err := autoRebalanceCluster(ctx, d)
+		if err != nil {
+			logger.Error("Failed during cluster auto rebalancing", logger.Ctx{"err": err})
+		}
+	}
+
+	return f, task.Every(time.Minute)
+}

--- a/cmd/incusd/api_internal.go
+++ b/cmd/incusd/api_internal.go
@@ -62,6 +62,7 @@ var apiInternal = []APIEndpoint{
 	internalImageOptimizeCmd,
 	internalImageRefreshCmd,
 	internalRAFTSnapshotCmd,
+	internalRebalanceLoadCmd,
 	internalReadyCmd,
 	internalShutdownCmd,
 	internalSQLCmd,
@@ -145,6 +146,12 @@ var internalBGPStateCmd = APIEndpoint{
 	Path: "testing/bgp",
 
 	Get: APIEndpointAction{Handler: internalBGPState, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanEdit)},
+}
+
+var internalRebalanceLoadCmd = APIEndpoint{
+	Path: "rebalance",
+
+	Get: APIEndpointAction{Handler: internalRebalanceLoad, AccessHandler: allowPermission(auth.ObjectTypeServer, auth.EntitlementCanEdit)},
 }
 
 type internalImageOptimizePost struct {
@@ -1073,4 +1080,13 @@ func internalBGPState(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	return response.SyncResponse(true, s.BGP.Debug())
+}
+
+func internalRebalanceLoad(d *Daemon, r *http.Request) response.Response {
+	err := autoRebalanceCluster(context.TODO(), d)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.EmptySyncResponse
 }

--- a/cmd/incusd/daemon.go
+++ b/cmd/incusd/daemon.go
@@ -1719,6 +1719,9 @@ func (d *Daemon) startClusterTasks() {
 	// Perform automatic evacuation for offline cluster members
 	d.clusterTasks.Add(autoHealClusterTask(d))
 
+	// Perform automatic live-migration to alance load on cluster
+	d.clusterTasks.Add(autoRebalanceClusterTask(d))
+
 	// Start all background tasks
 	d.clusterTasks.Start(d.shutdownCtx)
 }

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2631,3 +2631,14 @@ This adds support for `bridge.external_interfaces` on OVN networks.
 ## `instances_scriptlet_get_instances_count`
 
 This allows the instance scriptlet to fetch the count instances given an optional Project or Location filter as well as including pending instances.
+
+## `cluster_rebalance`
+
+This adds automatic live-migration to balance load on cluster again.
+
+As part of this, the following configuration options have been added:
+
+* `cluster.rebalance.batch`
+* `cluster.rebalance.cooldown`
+* `cluster.rebalance.interval`
+* `cluster.rebalance.threshold`

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1416,6 +1416,12 @@ The cluster member that the instance lived on before evacuation.
 
 ```
 
+```{config:option} volatile.rebalance.last_move instance-volatile
+:shortdesc: "Timestamp of last move by automatic live-migration"
+:type: "integer"
+
+```
+
 ```{config:option} volatile.uuid instance-volatile
 :shortdesc: "Instance UUID"
 :type: "string"
@@ -2119,6 +2125,38 @@ This must be an odd number >= `3`.
 :shortdesc: "Threshold when an unresponsive member is considered offline"
 :type: "integer"
 Specify the number of seconds after which an unresponsive member is considered offline.
+```
+
+```{config:option} cluster.rebalance.batch server-cluster
+:defaultdesc: "`1`"
+:scope: "global"
+:shortdesc: "Maximum number of instances to move during one re-balancing run"
+:type: "integer"
+
+```
+
+```{config:option} cluster.rebalance.cooldown server-cluster
+:defaultdesc: "`6H`"
+:scope: "global"
+:shortdesc: "Amount of time during which an instance will not be moved again"
+:type: "string"
+
+```
+
+```{config:option} cluster.rebalance.interval server-cluster
+:defaultdesc: "`0`"
+:scope: "global"
+:shortdesc: "How often (in minutes) to consider re-balancing things. 0 to disable (default)"
+:type: "integer"
+
+```
+
+```{config:option} cluster.rebalance.threshold server-cluster
+:defaultdesc: "`20`"
+:scope: "global"
+:shortdesc: "Percentage load difference between most and least busy server needed to trigger a migration"
+:type: "integer"
+
 ```
 
 <!-- config group server-cluster end -->

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -97,6 +97,23 @@ One way to automatically achieve this is to have a piece of software monitor Inc
 power to the server in question by interacting with its BMC or PDU.
 ```
 
+(cluster-automatic-balancing)=
+### Cluster re-balancing
+
+Incus can automatically balance the load across cluster members.
+
+This is done through a few configuration options:
+
+- {config:option}`server-cluster:cluster.rebalance.batch`
+- {config:option}`server-cluster:cluster.rebalance.cooldown`
+- {config:option}`server-cluster:cluster.rebalance.interval`
+- {config:option}`server-cluster:cluster.rebalance.threshold`
+
+Incus will compare the load across all servers and if the difference in
+percent exceeds the threshold, it will start identifying
+virtual-machines that can be safely live-migrated to the least loaded
+server.
+
 (cluster-manage-delete-members)=
 ## Delete cluster members
 

--- a/internal/instance/config.go
+++ b/internal/instance/config.go
@@ -400,6 +400,13 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	//  shortdesc: Instance marked itself as ready
 	"volatile.last_state.ready": validate.IsBool,
 
+	// gendoc:generate(entity=instance, group=volatile, key=volatile.rebalance.last_move)
+	//
+	// ---
+	//  type: integer
+	//  shortdesc: Timestamp of last move by automatic live-migration
+	"volatile.rebalance.last_move": validate.Optional(validate.IsInt64),
+
 	// gendoc:generate(entity=instance, group=volatile, key=volatile.uuid)
 	// The instance UUID is globally unique across all servers and projects.
 	// ---

--- a/internal/server/cluster/config/config.go
+++ b/internal/server/cluster/config/config.go
@@ -135,9 +135,9 @@ func (c *Config) ClusterRebalanceCooldown() string {
 	return c.m.GetString("cluster.rebalance.cooldown")
 }
 
-// ClusterRebalanceFrequency returns the frequency of considering re-balanicng.
-func (c *Config) ClusterRebalanceFrequency() int64 {
-	return c.m.GetInt64("cluster.rebalance.frequency")
+// ClusterRebalanceInterval returns the interval at which to evaluate re-balanicng.
+func (c *Config) ClusterRebalanceInterval() int64 {
+	return c.m.GetInt64("cluster.rebalance.interval")
 }
 
 // ClusterRebalanceThreshold returns load difference between most and least busy server
@@ -429,21 +429,21 @@ var ConfigSchema = config.Schema{
 	//  shortdesc: Amount of time during which an instance will not be moved again
 	"cluster.rebalance.cooldown": {Type: config.String, Default: "6H", Validator: validate.Optional(expiryValidator)},
 
-	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.frequency)
+	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.interval)
 	//
 	// ---
 	//  type: integer
 	//  scope: global
 	//  defaultdesc: `0`
 	//  shortdesc: How often (in minutes) to consider re-balancing things. 0 to disable (default)
-	"cluster.rebalance.frequency": {Type: config.Int64, Default: "0"},
+	"cluster.rebalance.interval": {Type: config.Int64, Default: "0"},
 
 	// gendoc:generate(entity=server, group=cluster, key=cluster.rebalance.threshold)
 	//
 	// ---
 	//  type: integer
 	//  scope: global
-	//  defaultdesc: `0`
+	//  defaultdesc: `20`
 	//  shortdesc: Percentage load difference between most and least busy server needed to trigger a migration
 	"cluster.rebalance.threshold": {Type: config.Int64, Default: "20", Validator: validate.Optional(rebalanceThresholdValidator)},
 

--- a/internal/server/instance/instance_utils.go
+++ b/internal/server/instance/instance_utils.go
@@ -26,11 +26,14 @@ import (
 	"github.com/lxc/incus/v6/internal/server/db"
 	"github.com/lxc/incus/v6/internal/server/db/cluster"
 	deviceConfig "github.com/lxc/incus/v6/internal/server/device/config"
+	"github.com/lxc/incus/v6/internal/server/instance/drivers/qemudefault"
 	"github.com/lxc/incus/v6/internal/server/instance/instancetype"
 	"github.com/lxc/incus/v6/internal/server/instance/operationlock"
 	"github.com/lxc/incus/v6/internal/server/operations"
+	"github.com/lxc/incus/v6/internal/server/resources"
 	"github.com/lxc/incus/v6/internal/server/seccomp"
 	"github.com/lxc/incus/v6/internal/server/state"
+	storageDrivers "github.com/lxc/incus/v6/internal/server/storage/drivers"
 	"github.com/lxc/incus/v6/internal/server/sys"
 	localUtil "github.com/lxc/incus/v6/internal/server/util"
 	internalUtil "github.com/lxc/incus/v6/internal/util"
@@ -40,6 +43,7 @@ import (
 	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/osarch"
 	"github.com/lxc/incus/v6/shared/revert"
+	"github.com/lxc/incus/v6/shared/units"
 	"github.com/lxc/incus/v6/shared/util"
 	"github.com/lxc/incus/v6/shared/validate"
 )
@@ -1273,4 +1277,72 @@ func SnapshotProtobufToInstanceArgs(s *state.State, inst Instance, snap *migrati
 	}
 
 	return &args, nil
+}
+
+// ResourceUsage returns an instance's expected CPU, memory and disk usage.
+func ResourceUsage(instConfig map[string]string, instDevices map[string]map[string]string, instType api.InstanceType) (int64, int64, int64, error) {
+	var err error
+
+	limitsCPU := instConfig["limits.cpu"]
+	limitsMemory := instConfig["limits.memory"]
+	cpuUsage := int64(0)
+	memoryUsage := int64(0)
+	diskUsage := int64(0)
+
+	// Parse limits.cpu.
+	if limitsCPU != "" {
+		// Check if using shared CPU limits.
+		cpuUsage, err = strconv.ParseInt(limitsCPU, 10, 64)
+		if err != nil {
+			// Or get count of pinned CPUs.
+			pinnedCPUs, err := resources.ParseCpuset(limitsCPU)
+			if err != nil {
+				return -1, -1, -1, fmt.Errorf("Failed parsing instance resources limits.cpu: %w", err)
+			}
+
+			cpuUsage = int64(len(pinnedCPUs))
+		}
+	} else if instType == api.InstanceTypeVM {
+		// Apply VM CPU cores defaults if not specified.
+		cpuUsage = qemudefault.CPUCores
+	}
+
+	// Parse limits.memory.
+	memoryLimitStr := limitsMemory
+
+	// Apply VM memory limit defaults if not specified.
+	if instType == api.InstanceTypeVM && memoryLimitStr == "" {
+		memoryLimitStr = qemudefault.MemSize
+	}
+
+	if memoryLimitStr != "" {
+		memoryLimit, err := units.ParseByteSizeString(memoryLimitStr)
+		if err != nil {
+			return -1, -1, -1, fmt.Errorf("Failed parsing instance resources limits.memory: %w", err)
+		}
+
+		memoryUsage = int64(memoryLimit)
+	}
+
+	// Parse root disk size.
+	_, rootDiskConfig, err := instance.GetRootDiskDevice(instDevices)
+	if err == nil {
+		rootDiskSizeStr := rootDiskConfig["size"]
+
+		// Apply VM root disk size defaults if not specified.
+		if instType == api.InstanceTypeVM && rootDiskSizeStr == "" {
+			rootDiskSizeStr = storageDrivers.DefaultBlockSize
+		}
+
+		if rootDiskSizeStr != "" {
+			rootDiskSize, err := units.ParseByteSizeString(rootDiskSizeStr)
+			if err != nil {
+				return -1, -1, -1, fmt.Errorf("Failed parsing instance resources root disk size: %w", err)
+			}
+
+			diskUsage = int64(rootDiskSize)
+		}
+	}
+
+	return cpuUsage, memoryUsage, diskUsage, nil
 }

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -1543,6 +1543,13 @@
 						}
 					},
 					{
+						"volatile.rebalance.last_move": {
+							"longdesc": "",
+							"shortdesc": "Timestamp of last move by automatic live-migration",
+							"type": "integer"
+						}
+					},
+					{
 						"volatile.uuid": {
 							"longdesc": "The instance UUID is globally unique across all servers and projects.",
 							"shortdesc": "Instance UUID",
@@ -2334,6 +2341,42 @@
 							"longdesc": "Specify the number of seconds after which an unresponsive member is considered offline.",
 							"scope": "global",
 							"shortdesc": "Threshold when an unresponsive member is considered offline",
+							"type": "integer"
+						}
+					},
+					{
+						"cluster.rebalance.batch": {
+							"defaultdesc": "`1`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Maximum number of instances to move during one re-balancing run",
+							"type": "integer"
+						}
+					},
+					{
+						"cluster.rebalance.cooldown": {
+							"defaultdesc": "`6H`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Amount of time during which an instance will not be moved again",
+							"type": "string"
+						}
+					},
+					{
+						"cluster.rebalance.interval": {
+							"defaultdesc": "`0`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "How often (in minutes) to consider re-balancing things. 0 to disable (default)",
+							"type": "integer"
+						}
+					},
+					{
+						"cluster.rebalance.threshold": {
+							"defaultdesc": "`20`",
+							"longdesc": "",
+							"scope": "global",
+							"shortdesc": "Percentage load difference between most and least busy server needed to trigger a migration",
 							"type": "integer"
 						}
 					}

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -448,6 +448,7 @@ var APIExtensions = []string{
 	"storage_lvm_cluster_create",
 	"network_ovn_external_interfaces",
 	"instances_scriptlet_get_instances_count",
+	"cluster_rebalance",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds feature to automatically move some workloads to re-balance load across cluster.
The logic works in following way:
- Spawns a background task which is performed on the current leader
- Calculates a per-server score (based on CPU and memory)
- Splits the servers by CPU architecture, then sort the servers by their score and check difference between most and least busy for each architecture, exit the re-balance if the difference is less than the threshold
- Pulls the list of instances from the most busy server and filter out those that cannot be live migrated
- Determines what instances should be migrated to equalize the score between the two servers looking at their current memory usage and CPU allocation and migrate them

Fixes: #485
Closes: #835