### PR TITLE
incusd/instance/qemu: Don't take over operations on console retrieval

### DIFF
--- a/internal/server/instance/drivers/driver_qemu.go
+++ b/internal/server/instance/drivers/driver_qemu.go
@@ -9322,7 +9322,10 @@ func (d *qemu) ConsoleLog() (string, error) {
 		return "", err
 	}
 
-	defer op.Done(nil)
+	// Only mark the operation as done if only processing the console retrieval.
+	if op.Action() == operationlock.ActionConsoleRetrieve {
+		defer op.Done(nil)
+	}
 
 	// Check if the agent is running.
 	monitor, err := qmp.Connect(d.monitorPath(), qemuSerialChardevName, d.getMonitorEventHandler(), d.QMPLogFilePath())


### PR DESCRIPTION
This fixes an issue where we'd get both stopped and migrated events during live-migration as the console retrieval happening during the migration would mark the migration operation as completed, turning the final stop operation into its own entity rather than completing the migration operation.