### PR TITLE
incus/internal/server/instance/drivers/: Fix incorrect Vars file mapping in edk2 driver

### DIFF
--- a/internal/server/instance/drivers/edk2/driver_edk2.go
+++ b/internal/server/instance/drivers/edk2/driver_edk2.go
@@ -75,7 +75,7 @@ var architectureInstallations = map[int][]Installation{
 				{Code: "edk2-x86_64-code.fd", Vars: "edk2-i386-vars.fd"},
 			},
 			SECUREBOOT: {
-				{Code: "ovmf-x86_64-ms-4m-vars.bin", Vars: "ovmf-x86_64-ms-4m-code.bin"},
+				{Code: "ovmf-x86_64-ms-4m-code.bin", Vars: "ovmf-x86_64-ms-4m-vars.bin"},
 				{Code: "ovmf-x86_64-ms-code.bin", Vars: "ovmf-x86_64-ms-vars.bin"},
 				{Code: "edk2-x86_64-secure-code.fd", Vars: "edk2-i386-vars.fd"},
 			},


### PR DESCRIPTION
The Vars file mappings in the edk2 driver were incorrect for the SECUREBOOT usage. The previous mapping for "ovmf-x86_64-ms-4m-vars.bin" and "ovmf-x86_64-ms-4m-code.bin" was swapped. This commit corrects the mapping by ensuring the proper Vars files are associated with their respective Code files. The change solves an issue in distributions using these file names, such as openSUSE.