### PR TITLE
incusd/instance: Lock image access

### DIFF
--- a/cmd/incusd/instance.go
+++ b/cmd/incusd/instance.go
@@ -183,6 +183,15 @@ func instanceCreateFromImage(ctx context.Context, s *state.State, r *http.Reques
 		return fmt.Errorf("Failed loading instance storage pool: %w", err)
 	}
 
+	// Lock this operation to ensure that concurrent image operations don't conflict.
+	// Other operations will wait for this one to finish.
+	unlock, err := imageOperationLock(ctx, img.Fingerprint)
+	if err != nil {
+		return err
+	}
+
+	defer unlock()
+
 	err = pool.CreateInstanceFromImage(inst, img.Fingerprint, op)
 	if err != nil {
 		return fmt.Errorf("Failed creating instance from image: %w", err)


### PR DESCRIPTION
With the Terraform provider we've managed to delete an image as it was being unpacked, leading to obvious problems, so let's make sure that we hold the image lock when triggering an unpack.