### PR TITLE
Fixes an issue when copying a custom volume using the `--refresh` flag

### DIFF
--- a/cmd/incusd/migrate_storage_volumes.go
+++ b/cmd/incusd/migrate_storage_volumes.go
@@ -353,7 +353,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 		for _, sourceSnap := range sourceSnapshots {
 			sourceSnapshotComparable = append(sourceSnapshotComparable, storagePools.ComparableSnapshot{
 				Name:         sourceSnap.GetName(),
-				CreationDate: time.Unix(sourceSnap.GetCreationDate(), 0),
+				CreationDate: time.Unix(0, sourceSnap.GetCreationDate()),
 			})
 		}
 
@@ -501,7 +501,7 @@ func volumeSnapshotToProtobuf(vol *api.StorageVolumeSnapshot) *migration.Snapsho
 		LocalDevices: []*migration.Device{},
 		Architecture: proto.Int32(0),
 		Stateful:     proto.Bool(false),
-		CreationDate: proto.Int64(0),
+		CreationDate: proto.Int64(vol.CreatedAt.UnixNano()),
 		LastUsedDate: proto.Int64(0),
 		ExpiryDate:   proto.Int64(0),
 	}

--- a/internal/server/storage/backend.go
+++ b/internal/server/storage/backend.go
@@ -6211,6 +6211,7 @@ func (b *backend) GenerateCustomVolumeBackupConfig(projectName string, volName s
 				Name:        snapName, // Snapshot only name, not full name.
 				Config:      dbVolSnaps[i].Config,
 				ContentType: dbVolSnaps[i].ContentType,
+				CreatedAt:   dbVolSnaps[i].CreationDate,
 			}
 
 			config.VolumeSnapshots = append(config.VolumeSnapshots, &snapshot)


### PR DESCRIPTION
This PR fixes an issue when copying a custom volume between two different hosts using the `--refresh` flag.

A creation date was added to the necessary struct, and this information is now properly populated.
The `UnixNano` function is used because the database stores time information with nanosecond precision.

After this fix, some tests were failing because the snapshots on vol6 had different creation dates, so all snapshots were replaced. Currently, in the first stage, we copy snapshots (with the `--refresh` flag) between two different pools. In the second stage, we create two new snapshots: one in the source pool and one in the target pool. After that, the copy operation with the `--refresh` flag is performed again. The result is as follows:
- Existing snapshots remain unchanged.
- The new snapshot from the source pool is added to the target pool.
- The new snapshot from the target pool is removed, as it does not exist in the source pool.

Fixes: #1418