### PR TITLE
incusd: Fill ExpiryDate and remove LastUsedDate in volumeSnapshotToProtobuf

### DIFF
--- a/cmd/incusd/migrate_storage_volumes.go
+++ b/cmd/incusd/migrate_storage_volumes.go
@@ -502,7 +502,6 @@ func volumeSnapshotToProtobuf(vol *api.StorageVolumeSnapshot) *migration.Snapsho
 		Architecture: proto.Int32(0),
 		Stateful:     proto.Bool(false),
 		CreationDate: proto.Int64(vol.CreatedAt.UnixNano()),
-		LastUsedDate: proto.Int64(0),
-		ExpiryDate:   proto.Int64(0),
+		ExpiryDate:   proto.Int64(vol.CreatedAt.UnixNano()),
 	}
 }


### PR DESCRIPTION
The `LastUsedDate` field is not utilized by volume snapshots and can be removed to avoid confusion.
The `ExpiryDate` field is currently unused but can be populated to provide clarity.