### PR TITLE
Fix gap in validation of pre-existing certificates when switching to PKI mode

### DIFF
--- a/cmd/incusd/certificates.go
+++ b/cmd/incusd/certificates.go
@@ -177,7 +177,11 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 
 	body := []string{}
 
-	trustedCertificates := d.getTrustedCertificates()
+	trustedCertificates, err := d.getTrustedCertificates()
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	for _, certs := range trustedCertificates {
 		for _, cert := range certs {
 			fingerprint := localtls.CertFingerprint(&cert)

--- a/internal/server/cluster/gateway_test.go
+++ b/internal/server/cluster/gateway_test.go
@@ -22,6 +22,10 @@ import (
 	localtls "github.com/lxc/incus/v6/shared/tls"
 )
 
+func trustedCerts() (map[certificate.Type]map[string]x509.Certificate, error) {
+	return nil, nil
+}
+
 // Basic creation and shutdown. By default, the gateway runs an in-memory gRPC
 // server.
 func TestGateway_Single(t *testing.T) {
@@ -36,10 +40,6 @@ func TestGateway_Single(t *testing.T) {
 
 	gateway := newGateway(t, node, cert, s)
 	defer func() { _ = gateway.Shutdown() }()
-
-	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
-		return nil
-	}
 
 	handlerFuncs := gateway.HandlerFuncs(nil, trustedCerts)
 	assert.Len(t, handlerFuncs, 1)
@@ -101,10 +101,6 @@ func TestGateway_SingleWithNetworkAddress(t *testing.T) {
 	gateway := newGateway(t, node, cert, s)
 	defer func() { _ = gateway.Shutdown() }()
 
-	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
-		return nil
-	}
-
 	for path, handler := range gateway.HandlerFuncs(nil, trustedCerts) {
 		mux.HandleFunc(path, handler)
 	}
@@ -145,10 +141,6 @@ func TestGateway_NetworkAuth(t *testing.T) {
 
 	gateway := newGateway(t, node, cert, s)
 	defer func() { _ = gateway.Shutdown() }()
-
-	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
-		return nil
-	}
 
 	for path, handler := range gateway.HandlerFuncs(nil, trustedCerts) {
 		mux.HandleFunc(path, handler)

--- a/internal/server/cluster/heartbeat_test.go
+++ b/internal/server/cluster/heartbeat_test.go
@@ -2,7 +2,6 @@ package cluster_test
 
 import (
 	"context"
-	"crypto/x509"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/incus/v6/internal/server/certificate"
 	"github.com/lxc/incus/v6/internal/server/cluster"
 	clusterConfig "github.com/lxc/incus/v6/internal/server/cluster/config"
 	"github.com/lxc/incus/v6/internal/server/db"
@@ -213,10 +211,6 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 
 	mux := http.NewServeMux()
 	server := newServer(serverCert, mux)
-
-	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
-		return nil
-	}
 
 	for path, handler := range gateway.HandlerFuncs(nil, trustedCerts) {
 		mux.HandleFunc(path, handler)

--- a/internal/server/cluster/membership_test.go
+++ b/internal/server/cluster/membership_test.go
@@ -139,10 +139,6 @@ func TestBootstrap(t *testing.T) {
 	// The cluster certificate is in place.
 	assert.True(t, util.PathExists(filepath.Join(state.OS.VarDir, "cluster.crt")))
 
-	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
-		return nil
-	}
-
 	// The dqlite driver is now exposed over the network.
 	for path, handler := range gateway.HandlerFuncs(nil, trustedCerts) {
 		mux.HandleFunc(path, handler)
@@ -297,12 +293,12 @@ func TestJoin(t *testing.T) {
 	altServerCert := localtls.TestingAltKeyPair()
 	trustedAltServerCert, _ := x509.ParseCertificate(altServerCert.KeyPair().Certificate[0])
 
-	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
+	trustedCerts := func() (map[certificate.Type]map[string]x509.Certificate, error) {
 		return map[certificate.Type]map[string]x509.Certificate{
 			certificate.TypeServer: {
 				altServerCert.Fingerprint(): *trustedAltServerCert,
 			},
-		}
+		}, nil
 	}
 
 	for path, handler := range targetGateway.HandlerFuncs(nil, trustedCerts) {

--- a/internal/server/cluster/upgrade_test.go
+++ b/internal/server/cluster/upgrade_test.go
@@ -2,7 +2,6 @@ package cluster_test
 
 import (
 	"context"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -18,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/lxc/incus/v6/internal/server/certificate"
 	"github.com/lxc/incus/v6/internal/server/cluster"
 	"github.com/lxc/incus/v6/internal/server/db"
 	"github.com/lxc/incus/v6/internal/server/node"
@@ -159,10 +157,6 @@ func TestUpgradeMembersWithoutRole(t *testing.T) {
 
 	gateway := newGateway(t, state.DB.Node, serverCert, state)
 	defer func() { _ = gateway.Shutdown() }()
-
-	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
-		return nil
-	}
 
 	for path, handler := range gateway.HandlerFuncs(nil, trustedCerts) {
 		mux.HandleFunc(path, handler)


### PR DESCRIPTION
This resolves the issue reported as LXD CVE-2024-6156