### PR TITLE
incus: Fix completion for `image alias create`

### DIFF
--- a/cmd/incus/completion.go
+++ b/cmd/incus/completion.go
@@ -253,6 +253,28 @@ func (g *cmdGlobal) cmpImages(toComplete string) ([]string, cobra.ShellCompDirec
 	return results, cmpDirectives
 }
 
+func (g *cmdGlobal) cmpImageFingerprintsFromRemote(toComplete string, remote string) ([]string, cobra.ShellCompDirective) {
+	results := []string{}
+
+	if remote == "" {
+		remote = g.conf.DefaultRemote
+	}
+
+	remoteServer, _ := g.conf.GetImageServer(remote)
+
+	images, _ := remoteServer.GetImages()
+
+	for _, image := range images {
+		if !strings.HasPrefix(image.Fingerprint, toComplete) {
+			continue
+		}
+
+		results = append(results, image.Fingerprint)
+	}
+
+	return results, cobra.ShellCompDirectiveNoFileComp
+}
+
 func (g *cmdGlobal) cmpImageFingerprints(toComplete string) ([]string, cobra.ShellCompDirective) {
 	results := []string{}
 	var remote string

--- a/cmd/incus/image_alias.go
+++ b/cmd/incus/image_alias.go
@@ -77,16 +77,11 @@ func (c *cmdImageAliasCreate) Command() *cobra.Command {
 		}
 
 		remote, _, found := strings.Cut(args[0], ":")
-		if found {
-			toComplete = remote + ":" + toComplete
+		if !found {
+			remote = ""
 		}
 
-		fingerprints, directives := c.global.cmpImageFingerprints(toComplete)
-		for i, f := range fingerprints {
-			fingerprints[i], _ = strings.CutPrefix(f, remote+":")
-		}
-
-		return fingerprints, directives
+		return c.global.cmpImageFingerprintsFromRemote(toComplete, remote)
 	}
 
 	return cmd


### PR DESCRIPTION
When there was no remote part in the alias, remote names was included in the fingerprint completions which was wrong.