### PR TITLE
incus: Display the alias expansion when execution of an alias fails

### DIFF
--- a/cmd/incus/main.go
+++ b/cmd/incus/main.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"slices"
 
+	"github.com/kballard/go-shellquote"
 	"github.com/spf13/cobra"
 
 	incus "github.com/lxc/incus/v6/client"
@@ -337,7 +338,11 @@ If you already added a remote server, make it the default with "incus remote swi
 		}
 
 		// Default error handling
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		if os.Getenv("INCUS_ALIASES") == "1" {
+			fmt.Fprintf(os.Stderr, i18n.G("Error while executing alias expansion: %s\n"), shellquote.Join(os.Args...))
+		}
+
+		fmt.Fprintf(os.Stderr, i18n.G("Error: %v\n"), err)
 
 		// If custom exit status not set, use default error status.
 		if globalCmd.ret == 0 {

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2024-10-06 20:15+0000\n"
 "Last-Translator: Jan Mittelstädter <jan@mittelstaedter.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -627,12 +627,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (backend=%q, quelle=%q)"
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -750,7 +750,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -790,7 +790,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -1004,8 +1004,8 @@ msgstr "Alias %s existiert bereits"
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s existiert nicht"
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr "Aliasbezeichnung fehlt"
 
@@ -1332,7 +1332,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr "Verzeichnis kann ohne --recursive nicht abgerufen werde"
 
@@ -1368,7 +1368,7 @@ msgid "Can't specify column L when not clustered"
 msgstr ""
 "Kann die Spalte L nicht angeben, wenn keine Clusterbildung vorhanden ist"
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Kann uid/gid/mode im rekursiven Modus nicht bereitstellen"
 
@@ -1585,7 +1585,7 @@ msgstr "Clustering aktiviert"
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1598,11 +1598,11 @@ msgstr "Clustering aktiviert"
 msgid "Columns"
 msgstr "Spalten"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Command line client for Incus"
 msgstr "Kommandozeilen-Client für Incus"
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1868,7 +1868,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1990,7 +1990,7 @@ msgstr "Erstellt: %s"
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Erstelle %s"
@@ -2011,7 +2011,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -2082,12 +2082,12 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr ""
 
@@ -2219,16 +2219,16 @@ msgstr ""
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2444,7 +2444,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2549,7 +2549,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2624,7 +2624,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2731,7 +2731,7 @@ msgstr "Alternatives config Verzeichnis."
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2849,6 +2849,16 @@ msgstr "Fehler beim Löschen des Parameters: %v"
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "Fehler beim Aktualisieren der Template Datei: %s"
+
+#: cmd/incus/main.go:342
+#, fuzzy, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, fuzzy, c-format
+msgid "Error: %v\n"
+msgstr "Fehler: %v\n"
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
 #, fuzzy
@@ -3053,7 +3063,7 @@ msgid "FILENAME"
 msgstr "DATEINAME"
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 #, fuzzy
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -3067,12 +3077,12 @@ msgstr "ZUERST BEOBACHTET"
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, fuzzy, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "SSH handshake mit Client %q gescheitert: %v"
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -3087,12 +3097,12 @@ msgstr "Check ob Instanz existiert fehlgeschlagen \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3122,7 +3132,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3162,7 +3172,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3177,12 +3187,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3286,12 +3296,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3389,7 +3399,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to update cluster member state: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3443,7 +3453,7 @@ msgstr ""
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
@@ -3468,7 +3478,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3500,7 +3510,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3795,22 +3805,22 @@ msgstr "Name"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3880,7 +3890,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -4033,12 +4043,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -4052,7 +4062,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -4187,12 +4197,12 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -4224,17 +4234,17 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid sorting type provided"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Ungültiges Ziel %s"
@@ -4670,11 +4680,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -5185,12 +5195,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -5485,8 +5495,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5772,7 +5782,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid "Missing target directory"
 msgstr ""
 
@@ -5812,12 +5822,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6303,7 +6313,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr ""
 
@@ -6383,12 +6393,12 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Administrator Passwort für %s: "
@@ -6467,7 +6477,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6489,7 +6499,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -6497,7 +6507,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -6652,22 +6662,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6729,7 +6739,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6901,8 +6911,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -7096,17 +7106,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -7233,7 +7243,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7465,7 +7475,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
@@ -7474,7 +7484,7 @@ msgstr "Setzt die gid der Datei beim Übertragen"
 msgid "Set the file's perms on create"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
@@ -7483,7 +7493,7 @@ msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 msgid "Set the file's uid on create"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -7561,7 +7571,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7573,11 +7583,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -7632,7 +7642,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance snapshot configuration"
 msgstr "Profil %s erstellt\n"
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -8044,7 +8054,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -8065,7 +8075,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -8077,12 +8087,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8362,7 +8372,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8415,7 +8425,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8427,7 +8437,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -8565,7 +8575,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8580,7 +8590,7 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -8588,7 +8598,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -8607,7 +8617,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -8862,7 +8872,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -9214,7 +9224,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -9314,7 +9324,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -9332,7 +9342,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -9607,7 +9617,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -9625,7 +9635,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -9633,7 +9643,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -9643,7 +9653,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -10588,20 +10598,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -11164,16 +11174,16 @@ msgstr "bitte nutzen Sie ìncus profile`"
 msgid "space used"
 msgstr "Speicherplatz in Benutzung"
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr "sshfs wurde gestoppt"
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs mounted %q auf %q"
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs wurde nicht gefunden. Versuchen Sie stattdessen SSH SFTP Modus mit dem "

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -623,12 +623,12 @@ msgstr "%s (%d más)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -741,7 +741,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -778,7 +778,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -970,8 +970,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1318,7 +1318,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1536,12 +1536,12 @@ msgstr ""
 msgid "Columns"
 msgstr "Columnas"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 #, fuzzy
 msgid "Command line client for Incus"
 msgstr "Cliente de Linea de Comandos para LXD"
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1794,7 +1794,7 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1905,7 +1905,7 @@ msgstr "Creado: %s"
 msgid "Creating %s"
 msgstr "Creando %s"
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Creando %s"
@@ -1926,7 +1926,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -1997,11 +1997,11 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr "Eliminar alias de imagen"
 
@@ -2130,16 +2130,16 @@ msgstr ""
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2345,7 +2345,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2520,7 +2520,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2619,7 +2619,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2732,6 +2732,16 @@ msgstr ""
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
+
+#: cmd/incus/main.go:342
+#, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, fuzzy, c-format
+msgid "Error: %v\n"
+msgstr "Error: %v\n"
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
 #, fuzzy
@@ -2882,7 +2892,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
@@ -2894,12 +2904,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2914,12 +2924,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2949,7 +2959,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2989,7 +2999,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -3004,12 +3014,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -3113,12 +3123,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3216,7 +3226,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to update cluster member state: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3267,7 +3277,7 @@ msgstr ""
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
@@ -3292,7 +3302,7 @@ msgstr "Creando el contenedor"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3324,7 +3334,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3611,22 +3621,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -3696,7 +3706,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3848,11 +3858,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3867,7 +3877,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3969,7 +3979,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -4000,11 +4010,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -4036,17 +4046,17 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid sorting type provided"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Nombre del contenedor es: %s"
@@ -4478,11 +4488,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4989,12 +4999,12 @@ msgstr "Registro:"
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -5264,8 +5274,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5547,7 +5557,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -5587,11 +5597,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -6064,7 +6074,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr ""
 
@@ -6142,12 +6152,12 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Contraseña admin para %s:"
@@ -6224,7 +6234,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6246,7 +6256,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -6254,7 +6264,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -6406,20 +6416,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6481,7 +6491,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6646,8 +6656,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -6837,17 +6847,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6964,7 +6974,7 @@ msgstr "Perfil %s creado"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7188,7 +7198,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -7196,7 +7206,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -7204,7 +7214,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7280,7 +7290,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7292,11 +7302,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -7346,7 +7356,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr "Perfil %s creado"
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -7742,7 +7752,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7763,7 +7773,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -7775,11 +7785,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8055,7 +8065,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8106,7 +8116,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8118,7 +8128,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -8255,7 +8265,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8269,7 +8279,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8277,7 +8287,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -8296,7 +8306,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8541,7 +8551,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8853,7 +8863,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8915,7 +8925,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8925,7 +8935,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9091,7 +9101,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9101,18 +9111,18 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -9754,20 +9764,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -10207,16 +10217,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2024-11-11 22:00+0000\n"
 "Last-Translator: \"Laterria.Severino\" <Laterria.Severino@openmail.pro>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -633,12 +633,12 @@ msgstr "%s (%s) (%d disponible)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (principal=%q, source=%q)"
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge"
@@ -746,7 +746,7 @@ msgstr "<serveur distant> <nouveau nom>"
 msgid "<remote>: <path>"
 msgstr "<serveur_distant>: <chemin>"
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<chemin_source>... [<serveur_distant>:]<instance>/<chemin>"
 
@@ -782,7 +782,7 @@ msgstr "Vous devez fournir le nom d'un membre appartenant à un cluster"
 msgid "ADDRESS"
 msgstr "ADRESSE"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -989,8 +989,8 @@ msgstr "L'alias %s existe déjà"
 msgid "Alias %s doesn't exist"
 msgstr "L'alias %s n'existe pas"
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr "Nom d'alias manquant"
 
@@ -1307,7 +1307,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Impossible de fournir un nom à l'image cible"
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossible de récupérer un répertoire sans --recursive"
 
@@ -1344,7 +1344,7 @@ msgstr ""
 "Impossible de spécifier la colonne L lorsque le serveur ne fait pas partie "
 "d'un cluster"
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Impossible de spécifier uid/gid/mode dans le mode récursif"
 
@@ -1558,7 +1558,7 @@ msgstr "Clustering activé"
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1571,11 +1571,11 @@ msgstr "Clustering activé"
 msgid "Columns"
 msgstr "Colonnes"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Command line client for Incus"
 msgstr "Client en ligne de commande pour Incus"
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1852,7 +1852,7 @@ msgstr "Créer une instance vide"
 msgid "Create and start instances from images"
 msgstr "Créer et démarrer des instances à partir d'images"
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr "Créer tous les répertoires nécessaires"
 
@@ -1994,7 +1994,7 @@ msgstr "Créé : %s"
 msgid "Creating %s"
 msgstr "Création de %s"
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Création de %s"
@@ -2015,7 +2015,7 @@ msgstr "ADRESSE CIBLE PAR DÉFAUT"
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -2088,12 +2088,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 #, fuzzy
 msgid "Delete image aliases"
 msgstr "Supprimer les alias d'image"
@@ -2229,16 +2229,16 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2449,7 +2449,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr "Dossier dans lequel exécuter la commande (/root par défaut)"
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 "Désactivez l'authentification lorsque vous utilisez SSH SFTP en mode écoute"
@@ -2556,7 +2556,7 @@ msgstr "Voulez-vous continuer sans provisionnement virtuel?"
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr "Ne pas afficher les informations sur l'état d'avancement"
 
@@ -2630,7 +2630,7 @@ msgstr "Modifier un groupe de serveurs"
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2737,7 +2737,7 @@ msgstr "Clé de configuration invalide"
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2867,6 +2867,16 @@ msgstr "Erreur dans le déparamétrage de la propriété: %v"
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier: %s"
+
+#: cmd/incus/main.go:342
+#, fuzzy, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr "Erreur lors de l'exécution de l'expansion de l'alias : %s\n"
+
+#: cmd/incus/main.go:344
+#, fuzzy, c-format
+msgid "Error: %v\n"
+msgstr "Erreur : %v\n"
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
 #, fuzzy
@@ -3081,7 +3091,7 @@ msgid "FILENAME"
 msgstr "NOM"
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
@@ -3094,12 +3104,12 @@ msgstr "PREMIÈRE VUE"
 msgid "FQDN"
 msgstr "FQDN (nom de domaine pleinement qualifié)"
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "Échec de l'authentification SSH avec le client %q : %v"
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "Échec de l'acceptation du canal client %q : %v"
@@ -3116,12 +3126,12 @@ msgstr ""
 "Échec de la vérification de l'existence de l'instantané d'instance \"%s:"
 "%s\" : %w"
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "Échec de la connexion au SFTP de l'instance pour le client %q : %v"
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Échec de la connexion au SFTP de l'instance : %w"
@@ -3154,7 +3164,7 @@ msgstr "Échec de la suppression de l'instance %q dans le projet %q : %w"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Échec de la suppression du volume source après la copie : %w"
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec de la génération de la clé hôte SSH : %w"
@@ -3195,7 +3205,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Échec du chargement du pool de stockage %q : %w"
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec de l'analyse de la clé d'hôte SSH : %w"
@@ -3210,12 +3220,12 @@ msgstr "Échec de l'analyse de la réponse de validation : %w"
 msgid "Failed starting command: %w"
 msgstr "Échec de l'exécution de la commande : %w"
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec du démarrage de sshfs : %w"
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec de l'acceptation de la connexion entrante : %w"
@@ -3322,12 +3332,12 @@ msgstr "Échec de la recherche du projet : %w"
 msgid "Failed to join cluster: %w"
 msgstr "Échec de l'adhésion au cluster : %w"
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec de la mise en écoute des demandes de connexion : %w"
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, fuzzy, c-format
 msgid "Failed to load configuration: %s"
 msgstr "Échec du chargement de la configuration : %s"
@@ -3428,7 +3438,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr "Échec de la mise à jour de l'état du membre du cluster : %w"
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "Échec du parcours des fichiers du répertoire %s : %s"
@@ -3482,7 +3492,7 @@ msgstr "Forcer la création de fichiers ou de répertoires"
 msgid "Force delete the project and everything it contains."
 msgstr "Suppression forcée du projet et de toutes les données associées"
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 #, fuzzy
 msgid "Force deleting files, directories, and subdirectories"
 msgstr "Forcer la création de fichiers ou de répertoires"
@@ -3510,7 +3520,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Force the removal of running instances"
 msgstr "Forcer la suppression des conteneurs arrêtés"
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
@@ -3562,7 +3572,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3867,22 +3877,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "La copie d'E/S de SSH vers l'instance a échoué : %v"
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "La copie d'E/S de l'instance vers SSH a échoué : %v"
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "La copie d'E/S de l'instance vers sshfs a échoué : %v"
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "La copie d'E/S de sshfs vers l'instance a échoué : %v"
@@ -3957,7 +3967,7 @@ msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "Si l'instantané de l'image existe déjà, le supprimer d'abord puis le recréer"
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 #, fuzzy
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
@@ -4125,12 +4135,12 @@ msgstr "Données d'entrée"
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "Instance déconnectée pour le client %q"
@@ -4145,7 +4155,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 #, fuzzy
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -4253,7 +4263,7 @@ msgstr "Entrée invalide, veuillez entrer un entier positif"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -4288,12 +4298,12 @@ msgstr ""
 "Nom invalide dans \"%s\", la chaîne vide n'est autorisée que lorsque "
 "maxWidth est défini."
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -4325,17 +4335,17 @@ msgstr "Cible invalide %s"
 msgid "Invalid sorting type provided"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Cible invalide %s"
@@ -4768,11 +4778,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -5343,12 +5353,12 @@ msgstr "Journal :"
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -5637,8 +5647,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5925,7 +5935,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -5968,12 +5978,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -6470,7 +6480,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 #, fuzzy
 msgid "Override the source project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6552,12 +6562,12 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Mot de passe administrateur pour %s : "
@@ -6635,7 +6645,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -6666,7 +6676,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -6820,22 +6830,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6898,7 +6908,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -7074,8 +7084,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -7284,17 +7294,17 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -7418,7 +7428,7 @@ msgstr "Clé de configuration invalide"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7651,7 +7661,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
@@ -7660,7 +7670,7 @@ msgstr "Définir le gid du fichier lors de l'envoi"
 msgid "Set the file's perms on create"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
@@ -7669,7 +7679,7 @@ msgstr "Définir les permissions du fichier lors de l'envoi"
 msgid "Set the file's uid on create"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -7747,7 +7757,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7759,11 +7769,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -7818,7 +7828,7 @@ msgstr "Afficher des informations supplémentaires"
 msgid "Show instance snapshot configuration"
 msgstr "Afficher la configuration étendue"
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -8237,7 +8247,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -8258,7 +8268,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -8271,11 +8281,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8563,7 +8573,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\". Vouliez-vous un alias ?"
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8617,7 +8627,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 #, fuzzy
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
@@ -8631,7 +8641,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -8770,7 +8780,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8785,7 +8795,7 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8793,7 +8803,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -8812,7 +8822,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -9069,7 +9079,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -9399,7 +9409,7 @@ msgstr "[<serveur distant>:] <nom>"
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<serveur distant>:] [<filtre>...]"
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<serveur distant>:] [<filtres>...]"
 
@@ -9481,7 +9491,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -9505,7 +9515,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -9816,7 +9826,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -9840,7 +9850,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -9848,7 +9858,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -9861,7 +9871,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -10855,20 +10865,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -11331,16 +11341,16 @@ msgstr "veuillez utiliser `incus profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr "sshfs s'est arrêté"
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs monté %q sur %q"
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs non trouvé. Essayez le mode SSH SFTP en utilisant l'option --listen"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2024-11-09 07:00+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -386,12 +386,12 @@ msgstr "%s (%s) (%d tersedia)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (backend=%q, sumber=%q)"
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s bukan direktori"
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' bukan tipe berkas yang didukung"
@@ -496,7 +496,7 @@ msgstr "<remote> <nama-baru>"
 msgid "<remote>: <path>"
 msgstr "<remote>: <path>"
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<path sumber>... [<remote>:]<instansi>/<path>"
 
@@ -531,7 +531,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr "ALAMAT"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -718,8 +718,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1056,7 +1056,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1260,7 +1260,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1273,11 +1273,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Kolom"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr "Dibuat: %s"
 msgid "Creating %s"
 msgstr "Membuat %s"
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, c-format
 msgid "Creating %s: %%s"
 msgstr "Membuat %s: %%s"
@@ -1647,7 +1647,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -1717,11 +1717,11 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 msgid "Delete files in instances"
 msgstr "Hapus berkas dalam instansi"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr "Hapus alias image"
 
@@ -1842,16 +1842,16 @@ msgstr "Hapus peringatan"
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2052,7 +2052,7 @@ msgstr "Impor direktori tidak tersedia di platform ini"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "Nonaktifkan autentikasi saat menggunakan pendengar SSH SFTP"
 
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2220,7 +2220,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2425,6 +2425,16 @@ msgstr ""
 #: cmd/incus/config_template.go:253
 #, c-format
 msgid "Error updating template file: %s"
+msgstr ""
+
+#: cmd/incus/main.go:342
+#, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, fuzzy, c-format
+msgid "Error: %v\n"
 msgstr ""
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
@@ -2570,7 +2580,7 @@ msgid "FILENAME"
 msgstr "NAMA_BERKAS"
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr "SIDIKJARI"
 
@@ -2582,12 +2592,12 @@ msgstr "PERTAMA TERLIHAT"
 msgid "FQDN"
 msgstr "FQDN"
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2602,12 +2612,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2637,7 +2647,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2677,7 +2687,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2692,12 +2702,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2801,12 +2811,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -2904,7 +2914,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2955,7 +2965,7 @@ msgstr ""
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
@@ -2979,7 +2989,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3011,7 +3021,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3276,22 +3286,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3359,7 +3369,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3505,11 +3515,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3523,7 +3533,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3623,7 +3633,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3654,11 +3664,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3686,17 +3696,17 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -4120,11 +4130,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4622,12 +4632,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -4882,8 +4892,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5149,7 +5159,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid "Missing target directory"
 msgstr ""
 
@@ -5187,11 +5197,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5660,7 +5670,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr ""
 
@@ -5738,12 +5748,12 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5819,7 +5829,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5841,7 +5851,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -5849,7 +5859,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -5997,20 +6007,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6070,7 +6080,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6229,8 +6239,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -6408,17 +6418,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6532,7 +6542,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6749,7 +6759,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -6757,7 +6767,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -6765,7 +6775,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6833,7 +6843,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6845,11 +6855,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -6897,7 +6907,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -7277,7 +7287,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7298,7 +7308,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -7310,11 +7320,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7590,7 +7600,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7640,7 +7650,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -7652,7 +7662,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -7786,7 +7796,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7800,7 +7810,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7808,7 +7818,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -7827,7 +7837,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8050,7 +8060,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8352,7 +8362,7 @@ msgstr "[<remote>:] <nama>"
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -8402,7 +8412,7 @@ msgstr "[<remote>:]<Zone> <kunci>=<nilai>..."
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zona> [kunci=nilai...]"
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 msgid "[<remote>:]<alias>"
 msgstr "[<remote>:]<alias>"
 
@@ -8410,7 +8420,7 @@ msgstr "[<remote>:]<alias>"
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "[<remote>:]<alias> <sidikjari>"
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <nama-baru>"
 
@@ -8545,7 +8555,7 @@ msgstr "[<remote>:]<instansi> [flags] [--] <baris perintah>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -8553,16 +8563,16 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -9112,20 +9122,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9565,16 +9575,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-11-27 22:32+0000\n"
+        "POT-Creation-Date: 2024-12-05 00:32+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -360,12 +360,12 @@ msgstr  ""
 msgid   "%s (backend=%q, source=%q)"
 msgstr  ""
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -469,7 +469,7 @@ msgstr  ""
 msgid   "<remote>: <path>"
 msgstr  ""
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -502,7 +502,7 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid   "ALIAS"
 msgstr  ""
 
@@ -681,7 +681,7 @@ msgstr  ""
 msgid   "Alias %s doesn't exist"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136 cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161 cmd/incus/image_alias.go:399
 msgid   "Alias name missing"
 msgstr  ""
 
@@ -974,7 +974,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -1008,7 +1008,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -1170,15 +1170,15 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092 cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421 cmd/incus/config_trust.go:610 cmd/incus/image.go:1093 cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072 cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:138 cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:687 cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904 cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551 cmd/incus/top.go:64 cmd/incus/warning.go:93
+#: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092 cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421 cmd/incus/config_trust.go:610 cmd/incus/image.go:1093 cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072 cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62 cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438 cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111 cmd/incus/network_zone.go:115 cmd/incus/operation.go:138 cmd/incus/profile.go:725 cmd/incus/project.go:531 cmd/incus/remote.go:750 cmd/incus/snapshot.go:316 cmd/incus/storage.go:687 cmd/incus/storage_bucket.go:502 cmd/incus/storage_bucket.go:904 cmd/incus/storage_volume.go:1560 cmd/incus/storage_volume.go:2551 cmd/incus/top.go:64 cmd/incus/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid   "Command line client for Incus"
 msgstr  ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid   "Command line client for Incus\n"
         "\n"
         "All of Incus's features can be driven through the various commands below.\n"
@@ -1405,7 +1405,7 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1507,7 +1507,7 @@ msgstr  ""
 msgid   "Creating %s"
 msgstr  ""
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, c-format
 msgid   "Creating %s: %%s"
 msgstr  ""
@@ -1525,7 +1525,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499 cmd/incus/config_trust.go:435 cmd/incus/image.go:1115 cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133 cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141 cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134 cmd/incus/network_zone.go:917 cmd/incus/operation.go:151 cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916 cmd/incus/storage_volume.go:1675
+#: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499 cmd/incus/config_trust.go:435 cmd/incus/image.go:1115 cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098 cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133 cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141 cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134 cmd/incus/network_zone.go:917 cmd/incus/operation.go:151 cmd/incus/profile.go:747 cmd/incus/project.go:559 cmd/incus/storage.go:710 cmd/incus/storage_bucket.go:515 cmd/incus/storage_bucket.go:916 cmd/incus/storage_volume.go:1675
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1588,11 +1588,11 @@ msgstr  ""
 msgid   "Delete custom storage volumes"
 msgstr  ""
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 msgid   "Delete files in instances"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid   "Delete image aliases"
 msgstr  ""
 
@@ -1672,7 +1672,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470 cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158 cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104 cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437 cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792 cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985 cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762 cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957 cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317 cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562 cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113 cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797 cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964 cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491 cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183 cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104 cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437 cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792 cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985 cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762 cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957 cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317 cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562 cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113 cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797 cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964 cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
@@ -1764,7 +1764,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1862,7 +1862,7 @@ msgstr  ""
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid   "Don't show progress information"
 msgstr  ""
 
@@ -1925,7 +1925,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -2012,7 +2012,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:631 cmd/incus/image.go:1133 cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113 cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:166 cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:722 cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925 cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661 cmd/incus/top.go:90 cmd/incus/warning.go:236
+#: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121 cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447 cmd/incus/config_trust.go:631 cmd/incus/image.go:1133 cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113 cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83 cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460 cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140 cmd/incus/network_zone.go:147 cmd/incus/operation.go:166 cmd/incus/profile.go:763 cmd/incus/project.go:569 cmd/incus/remote.go:773 cmd/incus/snapshot.go:346 cmd/incus/storage.go:722 cmd/incus/storage_bucket.go:532 cmd/incus/storage_bucket.go:925 cmd/incus/storage_volume.go:1703 cmd/incus/storage_volume.go:2661 cmd/incus/top.go:90 cmd/incus/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -2095,6 +2095,16 @@ msgstr  ""
 #: cmd/incus/config_template.go:253
 #, c-format
 msgid   "Error updating template file: %s"
+msgstr  ""
+
+#: cmd/incus/main.go:342
+#, c-format
+msgid   "Error while executing alias expansion: %s\n"
+msgstr  ""
+
+#: cmd/incus/main.go:344
+#, c-format
+msgid   "Error: %v\n"
 msgstr  ""
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
@@ -2233,7 +2243,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117 cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117 cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -2245,12 +2255,12 @@ msgstr  ""
 msgid   "FQDN"
 msgstr  ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -2265,12 +2275,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2300,7 +2310,7 @@ msgstr  ""
 msgid   "Failed deleting source volume after copy: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2340,7 +2350,7 @@ msgstr  ""
 msgid   "Failed loading storage pool %q: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2355,12 +2365,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2464,12 +2474,12 @@ msgstr  ""
 msgid   "Failed to join cluster: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid   "Failed to load configuration: %s"
 msgstr  ""
@@ -2564,7 +2574,7 @@ msgstr  ""
 msgid   "Failed to update cluster member state: %w"
 msgstr  ""
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2614,7 +2624,7 @@ msgstr  ""
 msgid   "Force delete the project and everything it contains."
 msgstr  ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid   "Force deleting files, directories, and subdirectories"
 msgstr  ""
 
@@ -2638,7 +2648,7 @@ msgstr  ""
 msgid   "Force the removal of running instances"
 msgstr  ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid   "Force using the local unix socket"
 msgstr  ""
 
@@ -2661,7 +2671,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:609 cmd/incus/image.go:1094 cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073 cmd/incus/network.go:1272 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:859 cmd/incus/operation.go:136 cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902 cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
+#: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:609 cmd/incus/image.go:1094 cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073 cmd/incus/network.go:1272 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:859 cmd/incus/operation.go:136 cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902 cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2911,22 +2921,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2994,7 +3004,7 @@ msgstr  ""
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid   "If this is your first time running Incus on this machine, you should also run: incus admin init"
 msgstr  ""
 
@@ -3137,11 +3147,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -3155,7 +3165,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -3253,7 +3263,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -3283,11 +3293,11 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -3313,17 +3323,17 @@ msgstr  ""
 msgid   "Invalid sorting type provided"
 msgstr  ""
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, c-format
 msgid   "Invalid type %q"
 msgstr  ""
@@ -3732,11 +3742,11 @@ msgid   "List background operations\n"
         "  L - Location of the operation (e.g. its cluster member)"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid   "List image aliases"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid   "List image aliases\n"
         "\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
@@ -4211,12 +4221,12 @@ msgstr  ""
 msgid   "Logical router"
 msgstr  ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid   "Login with username %q and password %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid   "Login without username and password"
 msgstr  ""
 
@@ -4640,7 +4650,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -4676,11 +4686,11 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -5124,7 +5134,7 @@ msgstr  ""
 msgid   "Optimized Storage"
 msgstr  ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid   "Override the source project"
 msgstr  ""
 
@@ -5198,12 +5208,12 @@ msgstr  ""
 msgid   "Partitions:"
 msgstr  ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, c-format
 msgid   "Password rejected for %q"
 msgstr  ""
@@ -5279,7 +5289,7 @@ msgstr  ""
 msgid   "Press CTRL-C to exit"
 msgstr  ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
@@ -5291,7 +5301,7 @@ msgstr  ""
 msgid   "Pretty rendering (short for --format=pretty)"
 msgstr  ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid   "Print help"
 msgstr  ""
 
@@ -5299,7 +5309,7 @@ msgstr  ""
 msgid   "Print the raw response"
 msgstr  ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid   "Print version number"
 msgstr  ""
 
@@ -5447,20 +5457,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 msgid   "Push files into instances"
 msgstr  ""
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -5514,7 +5524,7 @@ msgid   "Recover missing instances and volumes from existing and unknown storage
         "  pools but are not in the database. It will then offer to recreate these database records."
 msgstr  ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -5669,7 +5679,7 @@ msgstr  ""
 msgid   "Rename a cluster member"
 msgstr  ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333 cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366 cmd/incus/image_alias.go:367
 msgid   "Rename aliases"
 msgstr  ""
 
@@ -5846,17 +5856,17 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid   "SSH SFTP listening on %v"
 msgstr  ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -5967,7 +5977,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -6151,7 +6161,7 @@ msgstr  ""
 msgid   "Set the file's gid on create"
 msgstr  ""
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid   "Set the file's gid on push"
 msgstr  ""
 
@@ -6159,7 +6169,7 @@ msgstr  ""
 msgid   "Set the file's perms on create"
 msgstr  ""
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid   "Set the file's perms on push"
 msgstr  ""
 
@@ -6167,7 +6177,7 @@ msgstr  ""
 msgid   "Set the file's uid on create"
 msgstr  ""
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -6235,7 +6245,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -6247,11 +6257,11 @@ msgstr  ""
 msgid   "Setup loop based storage with SIZE in GiB"
 msgstr  ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid   "Show all debug messages"
 msgstr  ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid   "Show all information messages"
 msgstr  ""
 
@@ -6299,7 +6309,7 @@ msgstr  ""
 msgid   "Show instance snapshot configuration"
 msgstr  ""
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -6670,7 +6680,7 @@ msgstr  ""
 msgid   "Switch the default remote"
 msgstr  ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid   "Symlink target path can only be used for type \"symlink\""
 msgstr  ""
 
@@ -6690,7 +6700,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123 cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094 cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73 cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131 cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673 cmd/incus/warning.go:216
+#: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123 cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094 cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73 cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131 cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673 cmd/incus/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -6698,11 +6708,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -6960,7 +6970,7 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid   "This client hasn't been configured to use a remote server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote server.\n"
         "\n"
@@ -7007,7 +7017,7 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid   "To start your first container, try: incus launch images:ubuntu/22.04\n"
         "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
 msgstr  ""
@@ -7016,7 +7026,7 @@ msgstr  ""
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid   "Too many links"
 msgstr  ""
 
@@ -7141,7 +7151,7 @@ msgstr  ""
 msgid   "Unable to connect to any of the cluster members specified in join token"
 msgstr  ""
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -7155,12 +7165,12 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455 cmd/incus/config_trust.go:637 cmd/incus/image.go:1141 cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119 cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:172 cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:728 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667 cmd/incus/top.go:96 cmd/incus/warning.go:244
+#: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127 cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455 cmd/incus/config_trust.go:637 cmd/incus/image.go:1141 cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119 cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89 cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466 cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146 cmd/incus/network_zone.go:153 cmd/incus/operation.go:172 cmd/incus/profile.go:769 cmd/incus/project.go:575 cmd/incus/remote.go:779 cmd/incus/snapshot.go:352 cmd/incus/storage.go:728 cmd/incus/storage_bucket.go:538 cmd/incus/storage_bucket.go:931 cmd/incus/storage_volume.go:1711 cmd/incus/storage_volume.go:2667 cmd/incus/top.go:96 cmd/incus/warning.go:244
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -7170,7 +7180,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -7388,7 +7398,7 @@ msgstr  ""
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
@@ -7667,7 +7677,7 @@ msgstr  ""
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
@@ -7715,7 +7725,7 @@ msgstr  ""
 msgid   "[<remote>:]<Zone> [key=value...]"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 msgid   "[<remote>:]<alias>"
 msgstr  ""
 
@@ -7723,7 +7733,7 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <fingerprint>"
 msgstr  ""
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
@@ -7851,7 +7861,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -7859,15 +7869,15 @@ msgstr  ""
 msgid   "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr  ""
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -8370,17 +8380,17 @@ msgid   "incus file create foo/bar\n"
         "	   To create a symlink /bar in instance foo whose target is baz."
 msgstr  ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid   "incus file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid   "incus file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid   "incus file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -8743,16 +8753,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -627,12 +627,12 @@ msgstr "%s (altri %d)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -740,7 +740,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -777,7 +777,7 @@ msgstr "Il nome del container è: %s"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -969,8 +969,8 @@ msgstr "il remote %s esiste già"
 msgid "Alias %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr "Nome dell'alias mancante"
 
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1531,11 +1531,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Colonne"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1785,7 +1785,7 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1898,7 +1898,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Creazione di %s in corso"
@@ -1919,7 +1919,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -1990,12 +1990,12 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr ""
 
@@ -2123,16 +2123,16 @@ msgstr ""
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2337,7 +2337,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2444,7 +2444,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -2613,7 +2613,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2725,6 +2725,16 @@ msgstr ""
 #: cmd/incus/config_template.go:253
 #, c-format
 msgid "Error updating template file: %s"
+msgstr ""
+
+#: cmd/incus/main.go:342
+#, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, fuzzy, c-format
+msgid "Error: %v\n"
 msgstr ""
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
@@ -2875,7 +2885,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2887,12 +2897,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2907,12 +2917,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2942,7 +2952,7 @@ msgstr "Accetta certificato"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2982,7 +2992,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2997,12 +3007,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -3106,12 +3116,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3209,7 +3219,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to update cluster member state: %w"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3261,7 +3271,7 @@ msgstr ""
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
@@ -3286,7 +3296,7 @@ msgstr "Creazione del container in corso"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3318,7 +3328,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3602,22 +3612,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -3685,7 +3695,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3837,11 +3847,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3855,7 +3865,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3957,7 +3967,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3988,12 +3998,12 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -4025,17 +4035,17 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid sorting type provided"
 msgstr "Proprietà errata: %s"
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Proprietà errata: %s"
@@ -4467,11 +4477,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4979,12 +4989,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -5259,8 +5269,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid "Missing target directory"
 msgstr ""
 
@@ -5581,11 +5591,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -6057,7 +6067,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr ""
 
@@ -6137,12 +6147,12 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Password amministratore per %s: "
@@ -6220,7 +6230,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6242,7 +6252,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -6250,7 +6260,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -6400,21 +6410,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6476,7 +6486,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6642,8 +6652,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -6833,17 +6843,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6960,7 +6970,7 @@ msgstr "Il nome del container è: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7182,7 +7192,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -7190,7 +7200,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -7198,7 +7208,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7272,7 +7282,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7284,11 +7294,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -7338,7 +7348,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -7736,7 +7746,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7757,7 +7767,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -7770,11 +7780,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8051,7 +8061,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8102,7 +8112,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8114,7 +8124,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -8252,7 +8262,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Il nome del container è: %s"
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8267,7 +8277,7 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8275,7 +8285,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -8294,7 +8304,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8535,7 +8545,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8851,7 +8861,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
@@ -8913,7 +8923,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr "Creazione del container in corso"
@@ -8923,7 +8933,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
@@ -9089,7 +9099,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -9099,18 +9109,18 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -9752,20 +9762,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -10206,16 +10216,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2024-06-02 16:41+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -620,12 +620,12 @@ msgstr "%s (%s) (%d個使用可能)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s（バックエンド=%q, ソース=%q）"
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -731,7 +731,7 @@ msgstr "<remote> <new-name>"
 msgid "<remote>: <path>"
 msgstr "<remote>: <path>"
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -767,7 +767,7 @@ msgstr "クラスターメンバー名が必要です"
 msgid "ADDRESS"
 msgstr "ADDRESS"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -970,8 +970,8 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Alias %s doesn't exist"
 msgstr "エイリアス %s は存在しません"
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr "エイリアスを指定してください"
 
@@ -1284,7 +1284,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1320,7 +1320,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスターでない場合はカラムとして L は指定できません"
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1532,7 +1532,7 @@ msgstr "クラスタリングが有効になりました"
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1545,11 +1545,11 @@ msgstr "クラスタリングが有効になりました"
 msgid "Columns"
 msgstr "カラムレイアウト"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Command line client for Incus"
 msgstr "incus のコマンドラインクライアント"
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1820,7 +1820,7 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -1930,7 +1930,7 @@ msgstr "作成日時: %s"
 msgid "Creating %s"
 msgstr "%s を作成中"
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, c-format
 msgid "Creating %s: %%s"
 msgstr "%s: %%s を作成中"
@@ -1950,7 +1950,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -2023,11 +2023,11 @@ msgstr "警告をすべて削除します"
 msgid "Delete custom storage volumes"
 msgstr "ストレージボリュームを削除します"
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
@@ -2149,16 +2149,16 @@ msgstr "警告を削除します"
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2368,7 +2368,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2496,7 +2496,7 @@ msgstr "Thin provisioning なしで続けますか?"
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
@@ -2567,7 +2567,7 @@ msgstr "クラスターグループを編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -2661,7 +2661,7 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2784,6 +2784,16 @@ msgstr "プロパティの設定解除エラー: %v"
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
+
+#: cmd/incus/main.go:342
+#, fuzzy, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, fuzzy, c-format
+msgid "Error: %v\n"
+msgstr ""
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
 msgid "Evacuate cluster member"
@@ -2972,7 +2982,7 @@ msgid "FILENAME"
 msgstr "FILENAME"
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
@@ -2984,12 +2994,12 @@ msgstr "FIRST SEEN"
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -3004,12 +3014,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -3039,7 +3049,7 @@ msgstr "インスタンス %q （プロジェクト %q 内）の削除に失敗�
 msgid "Failed deleting source volume after copy: %w"
 msgstr "コピー後のソースボリュームの削除に失敗しました: %w"
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -3079,7 +3089,7 @@ msgstr "デバイス上書きのためのプロファイル %q のロードに�
 msgid "Failed loading storage pool %q: %w"
 msgstr "ストレージプール %q の取得に失敗しました: %w"
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -3094,12 +3104,12 @@ msgstr "バリデーションレスポンスの読み取りに失敗しました
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -3203,12 +3213,12 @@ msgstr "プロジェクトが見つけられませんでした: %w"
 msgid "Failed to join cluster: %w"
 msgstr "クラスターへの join に失敗しました: %w"
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3306,7 +3316,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to update cluster member state: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -3357,7 +3367,7 @@ msgstr "強制的にファイルまたはディレクトリーを作成します
 msgid "Force delete the project and everything it contains."
 msgstr "プロジェクトとプロジェクトに含まれるすべてを強制的に削除します。"
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 #, fuzzy
 msgid "Force deleting files, directories, and subdirectories"
 msgstr "強制的にファイルまたはディレクトリーを作成します"
@@ -3382,7 +3392,7 @@ msgstr "インスタンスを強制停止します"
 msgid "Force the removal of running instances"
 msgstr "稼働中のインスタンスを強制的に削除します"
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
@@ -3429,7 +3439,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3715,22 +3725,22 @@ msgstr "名前"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -3803,7 +3813,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 #, fuzzy
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
@@ -3961,11 +3971,11 @@ msgstr "入力するデータ"
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3979,7 +3989,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -4083,7 +4093,7 @@ msgstr "入力が無効です。正の値を入力してください"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -4117,11 +4127,11 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -4152,17 +4162,17 @@ msgstr "不正な送り先 %s"
 msgid "Invalid sorting type provided"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "不正な送り先 %s"
@@ -4863,11 +4873,11 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr "イメージのエイリアスを一覧表示します"
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -5725,12 +5735,12 @@ msgstr "ログ:"
 msgid "Logical router"
 msgstr "論理ルーター"
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr "ユーザー名 %q とパスワード %q でログイン"
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr "ユーザー名、パスワードを使用せずにログイン"
 
@@ -6004,8 +6014,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -6277,7 +6287,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -6321,13 +6331,13 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -6829,7 +6839,7 @@ msgstr "バックグラウンド操作 %s を削除しました"
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr "プロジェクトを指定します"
 
@@ -6910,12 +6920,12 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "%s のパスワード: "
@@ -6992,7 +7002,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
@@ -7016,7 +7026,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr "Pretty レンダリング（--format=pretty の短縮系）"
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr "ヘルプを表示します"
 
@@ -7024,7 +7034,7 @@ msgstr "ヘルプを表示します"
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
@@ -7172,20 +7182,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -7255,7 +7265,7 @@ msgstr ""
 "リュームを特定します。\n"
 "  そして、データベースレコードの再作成を提案します。"
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -7415,8 +7425,8 @@ msgstr "クラスターグループの名前を変更します"
 msgid "Rename a cluster member"
 msgstr "クラスターメンバの名前を変更します"
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
@@ -7606,17 +7616,17 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr "SSH SFTP は %v でリッスンしています"
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -7737,7 +7747,7 @@ msgstr "クラスターメンバーの設定を行います"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -8031,7 +8041,7 @@ msgstr "リモートの URL を設定します"
 msgid "Set the file's gid on create"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
@@ -8040,7 +8050,7 @@ msgstr "プッシュ時にファイルのgidを設定します"
 msgid "Set the file's perms on create"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
@@ -8049,7 +8059,7 @@ msgstr "プッシュ時にファイルのパーミションを設定します"
 msgid "Set the file's uid on create"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -8128,7 +8138,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr "インスタンスプロパティとして設定します"
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -8141,11 +8151,11 @@ msgstr "DEVICE を使ってストレージベースのデバイスをセット�
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr "サイズ GiB で loop ベースのストレージをセットアップします"
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr "デバッグメッセージをすべて表示します"
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
@@ -8194,7 +8204,7 @@ msgstr "インスタンスもしくはサーバの情報を表示します"
 msgid "Show instance snapshot configuration"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -8587,7 +8597,7 @@ msgstr "現在のプロジェクトを切り替えます"
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr "シンボリックリンクのターゲットパスは \"symlink\" タイプにのみ使えます"
 
@@ -8608,7 +8618,7 @@ msgid "TOKEN"
 msgstr "TOKEN"
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -8620,11 +8630,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -8945,7 +8955,7 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 #, fuzzy
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
@@ -9013,7 +9023,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 #, fuzzy
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
@@ -9031,7 +9041,7 @@ msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスターに属していなければ"
 "なりません"
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr "リンクが多すぎます"
 
@@ -9170,7 +9180,7 @@ msgstr "UUID: %v"
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "クラスタメンバへの接続に失敗しました"
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -9184,7 +9194,7 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
@@ -9192,7 +9202,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -9211,7 +9221,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -9451,7 +9461,7 @@ msgstr ""
 "最適化された形でストレージドライバを使います (同様のプール上にのみリストアで"
 "きます)"
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
@@ -9782,7 +9792,7 @@ msgstr "[<remote>:] <name>"
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
@@ -9832,7 +9842,7 @@ msgstr "[<remote>:]<Zone> <key>=<value>..."
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zone> [key=value...]"
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 msgid "[<remote>:]<alias>"
 msgstr "[<remote>:]<alias>"
 
@@ -9840,7 +9850,7 @@ msgstr "[<remote>:]<alias>"
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "[<remote>:]<alias> <fingerprint>"
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
@@ -9984,7 +9994,7 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
@@ -9993,17 +10003,17 @@ msgstr "[<remote>:]<instance>/<path>"
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -10645,7 +10655,7 @@ msgstr ""
 "\t   インスタンス foo 内に、ターゲットが baz であるシンボリックリンク /bar を"
 "作成します。"
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 #, fuzzy
 msgid ""
 "incus file mount foo/root fooroot\n"
@@ -10655,7 +10665,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 #, fuzzy
 msgid ""
 "incus file pull foo/etc/hosts .\n"
@@ -10666,7 +10676,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 #, fuzzy
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
@@ -11316,16 +11326,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -390,12 +390,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -500,7 +500,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr ""
 
@@ -721,8 +721,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1059,7 +1059,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1263,7 +1263,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1276,11 +1276,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1525,7 +1525,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1630,7 +1630,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1650,7 +1650,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -1720,11 +1720,11 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1845,16 +1845,16 @@ msgstr ""
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2223,7 +2223,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2316,7 +2316,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2428,6 +2428,16 @@ msgstr ""
 #: cmd/incus/config_template.go:253
 #, c-format
 msgid "Error updating template file: %s"
+msgstr ""
+
+#: cmd/incus/main.go:342
+#, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, c-format
+msgid "Error: %v\n"
 msgstr ""
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
@@ -2573,7 +2583,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2585,12 +2595,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2605,12 +2615,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2640,7 +2650,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2680,7 +2690,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2695,12 +2705,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2804,12 +2814,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -2907,7 +2917,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2958,7 +2968,7 @@ msgstr ""
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
@@ -2982,7 +2992,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3014,7 +3024,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3280,22 +3290,22 @@ msgstr "navn"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3363,7 +3373,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3509,11 +3519,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3527,7 +3537,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3627,7 +3637,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3658,11 +3668,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3690,17 +3700,17 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -4124,11 +4134,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4626,12 +4636,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -4886,8 +4896,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5153,7 +5163,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid "Missing target directory"
 msgstr ""
 
@@ -5191,11 +5201,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr ""
 
@@ -5742,12 +5752,12 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5823,7 +5833,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5845,7 +5855,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -5853,7 +5863,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -6001,20 +6011,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6074,7 +6084,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6233,8 +6243,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -6412,17 +6422,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6536,7 +6546,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6753,7 +6763,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -6761,7 +6771,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -6769,7 +6779,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6837,7 +6847,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6849,11 +6859,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -6901,7 +6911,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -7281,7 +7291,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7302,7 +7312,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -7314,11 +7324,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7594,7 +7604,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7644,7 +7654,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -7656,7 +7666,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -7790,7 +7800,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7804,7 +7814,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7812,7 +7822,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -7831,7 +7841,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8054,7 +8064,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8356,7 +8366,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -8406,7 +8416,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -8414,7 +8424,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -8549,7 +8559,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -8557,16 +8567,16 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -9116,20 +9126,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9569,16 +9579,16 @@ msgstr "vennligst bruk `incus profile`"
 msgid "space used"
 msgstr "brukt plass"
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr "sshfs har stoppet"
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -643,12 +643,12 @@ msgstr "%s (%s) (%d beschikbaar)"
 msgid "%s (backend=%q, source=%q)"
 msgstr "%s (backend=%q, source=%q)"
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s is geen directory"
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' is geen ondersteund bestandstype"
@@ -759,7 +759,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -793,7 +793,7 @@ msgstr "Een clusterlid (cluster member) naam (name) moet worden meegegeven"
 msgid "ADDRESS"
 msgstr "ADRES"
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -993,8 +993,8 @@ msgstr "Alias %s bestaat al"
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s bestaat niet"
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr "Alias naam (name) mist"
 
@@ -1307,7 +1307,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1342,7 +1342,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1546,7 +1546,7 @@ msgstr "Clustering aan"
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1559,11 +1559,11 @@ msgstr "Clustering aan"
 msgid "Columns"
 msgstr "Kolommen"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Command line client for Incus"
 msgstr "Lijncommando client voor Incus"
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1816,7 +1816,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1921,7 +1921,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1941,7 +1941,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -2011,11 +2011,11 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr "Verwijder aangepaste opslag volumes (storage volume)"
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr ""
 
@@ -2136,16 +2136,16 @@ msgstr ""
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2445,7 +2445,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr "Toon geen voortgang indicator/informatie"
 
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2607,7 +2607,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2719,6 +2719,16 @@ msgstr ""
 #: cmd/incus/config_template.go:253
 #, c-format
 msgid "Error updating template file: %s"
+msgstr ""
+
+#: cmd/incus/main.go:342
+#, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, fuzzy, c-format
+msgid "Error: %v\n"
 msgstr ""
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
@@ -2864,7 +2874,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2876,12 +2886,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2896,12 +2906,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2931,7 +2941,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2971,7 +2981,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2986,12 +2996,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -3095,12 +3105,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3198,7 +3208,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3249,7 +3259,7 @@ msgstr ""
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
@@ -3273,7 +3283,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3305,7 +3315,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3570,22 +3580,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3653,7 +3663,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3799,11 +3809,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3817,7 +3827,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3917,7 +3927,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3948,11 +3958,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3980,17 +3990,17 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -4414,11 +4424,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4916,12 +4926,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -5176,8 +5186,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5443,7 +5453,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid "Missing target directory"
 msgstr ""
 
@@ -5481,11 +5491,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5954,7 +5964,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr ""
 
@@ -6032,12 +6042,12 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -6113,7 +6123,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6135,7 +6145,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -6143,7 +6153,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -6291,20 +6301,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6364,7 +6374,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6523,8 +6533,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -6702,17 +6712,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6826,7 +6836,7 @@ msgstr "Definieer een cluster groep configuratie sleutels (keys)"
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7043,7 +7053,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -7051,7 +7061,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -7059,7 +7069,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7129,7 +7139,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7141,11 +7151,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -7193,7 +7203,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -7573,7 +7583,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7594,7 +7604,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -7606,11 +7616,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7886,7 +7896,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7936,7 +7946,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -7948,7 +7958,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -8082,7 +8092,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8096,7 +8106,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8104,7 +8114,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -8123,7 +8133,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8347,7 +8357,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8649,7 +8659,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -8699,7 +8709,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -8707,7 +8717,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -8842,7 +8852,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -8850,16 +8860,16 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -9409,20 +9419,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9869,16 +9879,16 @@ msgstr "gebruik `incus profile`"
 msgid "space used"
 msgstr "ruimte gebruikt"
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr "sshfs is gestopt"
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs koppelen van %q op %q"
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr "sshfs niet gevonden. Probeer SSH SFTP methode via de --listen optie"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -383,12 +383,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -493,7 +493,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr ""
 
@@ -714,8 +714,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1052,7 +1052,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1269,11 +1269,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1623,7 +1623,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1643,7 +1643,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -1713,11 +1713,11 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1838,16 +1838,16 @@ msgstr ""
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2048,7 +2048,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2147,7 +2147,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2309,7 +2309,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2421,6 +2421,16 @@ msgstr ""
 #: cmd/incus/config_template.go:253
 #, c-format
 msgid "Error updating template file: %s"
+msgstr ""
+
+#: cmd/incus/main.go:342
+#, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, c-format
+msgid "Error: %v\n"
 msgstr ""
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
@@ -2566,7 +2576,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2578,12 +2588,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2598,12 +2608,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2633,7 +2643,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2673,7 +2683,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2688,12 +2698,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2797,12 +2807,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -2900,7 +2910,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2951,7 +2961,7 @@ msgstr ""
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
@@ -2975,7 +2985,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3007,7 +3017,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3272,22 +3282,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3355,7 +3365,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3501,11 +3511,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3519,7 +3529,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3619,7 +3629,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3650,11 +3660,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3682,17 +3692,17 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -4116,11 +4126,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4618,12 +4628,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -4878,8 +4888,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5145,7 +5155,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid "Missing target directory"
 msgstr ""
 
@@ -5183,11 +5193,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5656,7 +5666,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr ""
 
@@ -5734,12 +5744,12 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5815,7 +5825,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5837,7 +5847,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -5845,7 +5855,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -5993,20 +6003,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6066,7 +6076,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6225,8 +6235,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -6404,17 +6414,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6528,7 +6538,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6745,7 +6755,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -6753,7 +6763,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -6761,7 +6771,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -6829,7 +6839,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6841,11 +6851,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -6893,7 +6903,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -7273,7 +7283,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7294,7 +7304,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -7306,11 +7316,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7586,7 +7596,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7636,7 +7646,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -7648,7 +7658,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -7782,7 +7792,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7796,7 +7806,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7804,7 +7814,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -7823,7 +7833,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8046,7 +8056,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8348,7 +8358,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -8398,7 +8408,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -8406,7 +8416,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -8541,7 +8551,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -8549,16 +8559,16 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -9108,20 +9118,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9561,16 +9571,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -618,12 +618,12 @@ msgstr "%s (%d mais)"
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -741,7 +741,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr "Criar perfis"
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -778,7 +778,7 @@ msgstr "Nome de membro do cluster"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -974,8 +974,8 @@ msgstr "Alias %s já existe"
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s não existe"
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr "Nome do alias ausente"
 
@@ -1290,7 +1290,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1531,7 +1531,7 @@ msgstr "Clustering ativado"
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1544,12 +1544,12 @@ msgstr "Clustering ativado"
 msgid "Columns"
 msgstr "Colunas"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 #, fuzzy
 msgid "Command line client for Incus"
 msgstr "Cliente de linha de comando para LXD"
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 #, fuzzy
 msgid ""
 "Command line client for Incus\n"
@@ -1809,7 +1809,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1930,7 +1930,7 @@ msgstr "Criado: %s"
 msgid "Creating %s"
 msgstr "Criando %s"
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, fuzzy, c-format
 msgid "Creating %s: %%s"
 msgstr "Criando %s"
@@ -1951,7 +1951,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -2024,12 +2024,12 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "Delete custom storage volumes"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
@@ -2162,16 +2162,16 @@ msgstr ""
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2377,7 +2377,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -2661,7 +2661,7 @@ msgstr "Editar configurações de perfil como YAML"
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2773,6 +2773,16 @@ msgstr ""
 #: cmd/incus/config_template.go:253
 #, c-format
 msgid "Error updating template file: %s"
+msgstr ""
+
+#: cmd/incus/main.go:342
+#, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, fuzzy, c-format
+msgid "Error: %v\n"
 msgstr ""
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
@@ -2921,7 +2931,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2933,12 +2943,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2953,12 +2963,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2988,7 +2998,7 @@ msgstr "Aceitar certificado"
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -3028,7 +3038,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -3043,12 +3053,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -3152,12 +3162,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3255,7 +3265,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to update cluster member state: %w"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3306,7 +3316,7 @@ msgstr ""
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
@@ -3331,7 +3341,7 @@ msgstr "Ignorar o estado do container"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3363,7 +3373,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3654,22 +3664,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -3737,7 +3747,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3889,11 +3899,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3907,7 +3917,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -4009,7 +4019,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -4040,11 +4050,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -4076,17 +4086,17 @@ msgstr "Editar arquivos no container"
 msgid "Invalid sorting type provided"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Editar arquivos no container"
@@ -4516,11 +4526,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -5026,12 +5036,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -5311,8 +5321,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5593,7 +5603,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid "Missing target directory"
 msgstr ""
 
@@ -5633,11 +5643,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -6111,7 +6121,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr ""
 
@@ -6191,12 +6201,12 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -6273,7 +6283,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6295,7 +6305,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -6303,7 +6313,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -6456,21 +6466,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6532,7 +6542,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6703,8 +6713,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -6900,17 +6910,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -7027,7 +7037,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7256,7 +7266,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -7264,7 +7274,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -7272,7 +7282,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7349,7 +7359,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7361,11 +7371,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -7420,7 +7430,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance snapshot configuration"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -7821,7 +7831,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7842,7 +7852,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -7854,12 +7864,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8135,7 +8145,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8186,7 +8196,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8198,7 +8208,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -8336,7 +8346,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Nome de membro do cluster"
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8351,7 +8361,7 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8359,7 +8369,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -8378,7 +8388,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8630,7 +8640,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8939,7 +8949,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -8999,7 +9009,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -9007,7 +9017,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -9156,7 +9166,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -9165,16 +9175,16 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr "Editar templates de arquivo do container"
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -9778,20 +9788,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -10231,16 +10241,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -643,12 +643,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -758,7 +758,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -798,7 +798,7 @@ msgstr "Копирование образа: %s"
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
@@ -992,8 +992,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr ""
 
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1339,7 +1339,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1557,11 +1557,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Столбцы"
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1810,7 +1810,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1951,7 +1951,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -2022,12 +2022,12 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr ""
 
@@ -2158,16 +2158,16 @@ msgstr ""
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2371,7 +2371,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2479,7 +2479,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2548,7 +2548,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2649,7 +2649,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2762,6 +2762,16 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
+
+#: cmd/incus/main.go:342
+#, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, fuzzy, c-format
+msgid "Error: %v\n"
+msgstr ""
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
 #, fuzzy
@@ -2917,7 +2927,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2929,12 +2939,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2949,12 +2959,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2984,7 +2994,7 @@ msgstr "Принять сертификат"
 msgid "Failed deleting source volume after copy: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -3024,7 +3034,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -3039,12 +3049,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -3148,12 +3158,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3251,7 +3261,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to update cluster member state: %w"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3302,7 +3312,7 @@ msgstr ""
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
@@ -3327,7 +3337,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3359,7 +3369,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3648,22 +3658,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3731,7 +3741,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3885,11 +3895,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3904,7 +3914,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -4006,7 +4016,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -4037,11 +4047,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -4073,17 +4083,17 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid sorting type provided"
 msgstr "Имя контейнера: %s"
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, fuzzy, c-format
 msgid "Invalid type %q"
 msgstr "Имя контейнера: %s"
@@ -4515,11 +4525,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -5030,12 +5040,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -5317,8 +5327,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5602,7 +5612,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid "Missing target directory"
 msgstr ""
 
@@ -5641,11 +5651,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6124,7 +6134,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr ""
 
@@ -6204,12 +6214,12 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, fuzzy, c-format
 msgid "Password rejected for %q"
 msgstr "Пароль администратора для %s: "
@@ -6286,7 +6296,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -6308,7 +6318,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -6316,7 +6326,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -6464,20 +6474,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid "Pull files from instances"
 msgstr ""
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 msgid "Push files into instances"
 msgstr ""
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -6539,7 +6549,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -6707,8 +6717,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -6899,17 +6909,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -7026,7 +7036,7 @@ msgstr "Копирование образа: %s"
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -7250,7 +7260,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -7258,7 +7268,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -7266,7 +7276,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7344,7 +7354,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7356,11 +7366,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -7412,7 +7422,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -7816,7 +7826,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7837,7 +7847,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -7849,11 +7859,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -8129,7 +8139,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -8180,7 +8190,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -8192,7 +8202,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -8330,7 +8340,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -8344,7 +8354,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -8352,7 +8362,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -8371,7 +8381,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8619,7 +8629,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8956,7 +8966,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -9054,7 +9064,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -9070,7 +9080,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -9333,7 +9343,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -9349,7 +9359,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -9357,7 +9367,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -9366,7 +9376,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -10284,20 +10294,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -10737,16 +10747,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-11-27 22:32+0000\n"
+"POT-Creation-Date: 2024-12-05 00:32+0100\n"
 "PO-Revision-Date: 2024-08-14 07:23+0000\n"
 "Last-Translator: Kwok Guy <kwokjuy@163.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -544,12 +544,12 @@ msgstr ""
 msgid "%s (backend=%q, source=%q)"
 msgstr ""
 
-#: cmd/incus/file.go:1198
+#: cmd/incus/file.go:1237
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是目录"
 
-#: cmd/incus/file.go:1088
+#: cmd/incus/file.go:1127
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -654,7 +654,7 @@ msgstr ""
 msgid "<remote>: <path>"
 msgstr ""
 
-#: cmd/incus/file.go:687
+#: cmd/incus/file.go:717
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -688,7 +688,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:205
+#: cmd/incus/alias.go:148 cmd/incus/image.go:1119 cmd/incus/image_alias.go:238
 msgid "ALIAS"
 msgstr ""
 
@@ -875,8 +875,8 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: cmd/incus/image_alias.go:89 cmd/incus/image_alias.go:136
-#: cmd/incus/image_alias.go:358
+#: cmd/incus/image_alias.go:106 cmd/incus/image_alias.go:161
+#: cmd/incus/image_alias.go:399
 msgid "Alias name missing"
 msgstr ""
 
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: cmd/incus/file.go:562
+#: cmd/incus/file.go:592
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: cmd/incus/file.go:764
+#: cmd/incus/file.go:803
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1417,7 +1417,7 @@ msgstr ""
 #: cmd/incus/cluster.go:150 cmd/incus/cluster.go:1092
 #: cmd/incus/cluster_group.go:477 cmd/incus/config_trust.go:421
 #: cmd/incus/config_trust.go:610 cmd/incus/image.go:1093
-#: cmd/incus/image_alias.go:180 cmd/incus/list.go:134 cmd/incus/network.go:1072
+#: cmd/incus/image_alias.go:205 cmd/incus/list.go:134 cmd/incus/network.go:1072
 #: cmd/incus/network.go:1273 cmd/incus/network_allocations.go:62
 #: cmd/incus/network_forward.go:115 cmd/incus/network_integration.go:438
 #: cmd/incus/network_load_balancer.go:123 cmd/incus/network_peer.go:111
@@ -1430,11 +1430,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: cmd/incus/main.go:105
+#: cmd/incus/main.go:106
 msgid "Command line client for Incus"
 msgstr ""
 
-#: cmd/incus/main.go:106
+#: cmd/incus/main.go:107
 msgid ""
 "Command line client for Incus\n"
 "\n"
@@ -1679,7 +1679,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: cmd/incus/file.go:143 cmd/incus/file.go:476 cmd/incus/file.go:696
+#: cmd/incus/file.go:143 cmd/incus/file.go:497 cmd/incus/file.go:726
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1784,7 +1784,7 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
-#: cmd/incus/file.go:273
+#: cmd/incus/file.go:282
 #, c-format
 msgid "Creating %s: %%s"
 msgstr ""
@@ -1804,7 +1804,7 @@ msgstr ""
 
 #: cmd/incus/cluster.go:176 cmd/incus/cluster_group.go:499
 #: cmd/incus/config_trust.go:435 cmd/incus/image.go:1115
-#: cmd/incus/image_alias.go:208 cmd/incus/list.go:575 cmd/incus/network.go:1098
+#: cmd/incus/image_alias.go:241 cmd/incus/list.go:575 cmd/incus/network.go:1098
 #: cmd/incus/network_acl.go:169 cmd/incus/network_forward.go:133
 #: cmd/incus/network_integration.go:450 cmd/incus/network_load_balancer.go:141
 #: cmd/incus/network_peer.go:129 cmd/incus/network_zone.go:134
@@ -1874,11 +1874,11 @@ msgstr ""
 msgid "Delete custom storage volumes"
 msgstr ""
 
-#: cmd/incus/file.go:321 cmd/incus/file.go:322
+#: cmd/incus/file.go:330 cmd/incus/file.go:331
 msgid "Delete files in instances"
 msgstr ""
 
-#: cmd/incus/image_alias.go:111 cmd/incus/image_alias.go:112
+#: cmd/incus/image_alias.go:128 cmd/incus/image_alias.go:129
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1999,16 +1999,16 @@ msgstr ""
 #: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
-#: cmd/incus/file.go:322 cmd/incus/file.go:400 cmd/incus/file.go:470
-#: cmd/incus/file.go:689 cmd/incus/file.go:1249 cmd/incus/image.go:40
+#: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
+#: cmd/incus/file.go:719 cmd/incus/file.go:1288 cmd/incus/image.go:40
 #: cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363
 #: cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924
 #: cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501
 #: cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697
 #: cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65
-#: cmd/incus/image_alias.go:112 cmd/incus/image_alias.go:158
-#: cmd/incus/image_alias.go:334 cmd/incus/import.go:27 cmd/incus/info.go:35
-#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:106
+#: cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183
+#: cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35
+#: cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:107
 #: cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35
 #: cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240
 #: cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506
@@ -2209,7 +2209,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: cmd/incus/file.go:1257
+#: cmd/incus/file.go:1295
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: cmd/incus/main.go:127
+#: cmd/incus/main.go:128
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2377,7 +2377,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: cmd/incus/file.go:399 cmd/incus/file.go:400
+#: cmd/incus/file.go:412 cmd/incus/file.go:413
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2470,7 +2470,7 @@ msgstr ""
 #: cmd/incus/cluster.go:187 cmd/incus/cluster.go:1121
 #: cmd/incus/cluster_group.go:507 cmd/incus/config_trust.go:447
 #: cmd/incus/config_trust.go:631 cmd/incus/image.go:1133
-#: cmd/incus/image_alias.go:217 cmd/incus/list.go:633 cmd/incus/network.go:1113
+#: cmd/incus/image_alias.go:250 cmd/incus/list.go:633 cmd/incus/network.go:1113
 #: cmd/incus/network.go:1307 cmd/incus/network_allocations.go:83
 #: cmd/incus/network_forward.go:147 cmd/incus/network_integration.go:460
 #: cmd/incus/network_load_balancer.go:154 cmd/incus/network_peer.go:140
@@ -2582,6 +2582,16 @@ msgstr ""
 #: cmd/incus/config_template.go:253
 #, c-format
 msgid "Error updating template file: %s"
+msgstr ""
+
+#: cmd/incus/main.go:342
+#, c-format
+msgid "Error while executing alias expansion: %s\n"
+msgstr ""
+
+#: cmd/incus/main.go:344
+#, c-format
+msgid "Error: %v\n"
 msgstr ""
 
 #: cmd/incus/cluster.go:1448 cmd/incus/cluster.go:1449
@@ -2727,7 +2737,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: cmd/incus/config_trust.go:434 cmd/incus/image.go:1117
-#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:206
+#: cmd/incus/image.go:1118 cmd/incus/image_alias.go:239
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2739,12 +2749,12 @@ msgstr ""
 msgid "FQDN"
 msgstr ""
 
-#: cmd/incus/file.go:1500
+#: cmd/incus/file.go:1552
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1523
+#: cmd/incus/file.go:1575
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2759,12 +2769,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: cmd/incus/file.go:1550
+#: cmd/incus/file.go:1602
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1335
+#: cmd/incus/file.go:1387
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2794,7 +2804,7 @@ msgstr ""
 msgid "Failed deleting source volume after copy: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1456
+#: cmd/incus/file.go:1508
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2834,7 +2844,7 @@ msgstr ""
 msgid "Failed loading storage pool %q: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1461
+#: cmd/incus/file.go:1513
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2849,12 +2859,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1361
+#: cmd/incus/file.go:1413
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1488
+#: cmd/incus/file.go:1540
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2958,12 +2968,12 @@ msgstr ""
 msgid "Failed to join cluster: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1473
+#: cmd/incus/file.go:1525
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: cmd/incus/main.go:387 cmd/incus/main_aliases.go:213
+#: cmd/incus/main.go:391 cmd/incus/main_aliases.go:213
 #, c-format
 msgid "Failed to load configuration: %s"
 msgstr ""
@@ -3061,7 +3071,7 @@ msgstr ""
 msgid "Failed to update cluster member state: %w"
 msgstr ""
 
-#: cmd/incus/file.go:1083
+#: cmd/incus/file.go:1122
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -3112,7 +3122,7 @@ msgstr ""
 msgid "Force delete the project and everything it contains."
 msgstr ""
 
-#: cmd/incus/file.go:325
+#: cmd/incus/file.go:334
 msgid "Force deleting files, directories, and subdirectories"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: cmd/incus/main.go:123
+#: cmd/incus/main.go:124
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -3168,7 +3178,7 @@ msgstr ""
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
 #: cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422
 #: cmd/incus/config_trust.go:609 cmd/incus/image.go:1094
-#: cmd/incus/image_alias.go:179 cmd/incus/list.go:135 cmd/incus/network.go:1073
+#: cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073
 #: cmd/incus/network.go:1272 cmd/incus/network_acl.go:97
 #: cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114
 #: cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122
@@ -3433,22 +3443,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: cmd/incus/file.go:1573
+#: cmd/incus/file.go:1625
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1562
+#: cmd/incus/file.go:1614
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1385
+#: cmd/incus/file.go:1437
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: cmd/incus/file.go:1395
+#: cmd/incus/file.go:1447
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3516,7 +3526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: cmd/incus/main.go:448
+#: cmd/incus/main.go:452
 msgid ""
 "If this is your first time running Incus on this machine, you should also "
 "run: incus admin init"
@@ -3662,11 +3672,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: cmd/incus/file.go:1387
+#: cmd/incus/file.go:1439
 msgid "Instance disconnected"
 msgstr ""
 
-#: cmd/incus/file.go:1564
+#: cmd/incus/file.go:1616
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3680,7 +3690,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1307
+#: cmd/incus/file.go:1359
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3780,7 +3790,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: cmd/incus/file.go:1302
+#: cmd/incus/file.go:1354
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3811,11 +3821,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: cmd/incus/main.go:544 cmd/incus/storage.go:134
+#: cmd/incus/main.go:548 cmd/incus/storage.go:134
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: cmd/incus/file.go:357
+#: cmd/incus/file.go:370
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3843,17 +3853,17 @@ msgstr ""
 msgid "Invalid sorting type provided"
 msgstr ""
 
-#: cmd/incus/file.go:535
+#: cmd/incus/file.go:565
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: cmd/incus/file.go:177 cmd/incus/file.go:717
+#: cmd/incus/file.go:186 cmd/incus/file.go:756
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
 
-#: cmd/incus/file.go:163
+#: cmd/incus/file.go:172
 #, c-format
 msgid "Invalid type %q"
 msgstr ""
@@ -4277,11 +4287,11 @@ msgid ""
 "  L - Location of the operation (e.g. its cluster member)"
 msgstr ""
 
-#: cmd/incus/image_alias.go:157
+#: cmd/incus/image_alias.go:182
 msgid "List image aliases"
 msgstr ""
 
-#: cmd/incus/image_alias.go:158
+#: cmd/incus/image_alias.go:183
 msgid ""
 "List image aliases\n"
 "\n"
@@ -4779,12 +4789,12 @@ msgstr ""
 msgid "Logical router"
 msgstr ""
 
-#: cmd/incus/file.go:1479
+#: cmd/incus/file.go:1531
 #, c-format
 msgid "Login with username %q and password %q"
 msgstr ""
 
-#: cmd/incus/file.go:1481
+#: cmd/incus/file.go:1533
 msgid "Login without username and password"
 msgstr ""
 
@@ -5039,8 +5049,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom\" "
+"(user created) volumes."
 msgstr ""
 
 #: cmd/incus/remote.go:43 cmd/incus/remote.go:44
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: cmd/incus/file.go:812
+#: cmd/incus/file.go:851
 msgid "Missing target directory"
 msgstr ""
 
@@ -5344,12 +5354,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: cmd/incus/file.go:510
+#: cmd/incus/file.go:540
 #, fuzzy
 msgid "More than one file to download, but target is not a directory"
 msgstr "将下载多个文件, 但目标不是目录"
 
-#: cmd/incus/file.go:1248 cmd/incus/file.go:1249
+#: cmd/incus/file.go:1287 cmd/incus/file.go:1288
 msgid "Mount files from instances"
 msgstr ""
 
@@ -5818,7 +5828,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: cmd/incus/main.go:124
+#: cmd/incus/main.go:125
 msgid "Override the source project"
 msgstr ""
 
@@ -5896,12 +5906,12 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: cmd/incus/main.go:409
+#: cmd/incus/main.go:413
 #, c-format
 msgid "Password for %s: "
 msgstr ""
 
-#: cmd/incus/file.go:1449
+#: cmd/incus/file.go:1501
 #, c-format
 msgid "Password rejected for %q"
 msgstr ""
@@ -5977,7 +5987,7 @@ msgstr ""
 msgid "Press CTRL-C to exit"
 msgstr ""
 
-#: cmd/incus/file.go:1365
+#: cmd/incus/file.go:1417
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5999,7 +6009,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: cmd/incus/main.go:122
+#: cmd/incus/main.go:123
 msgid "Print help"
 msgstr ""
 
@@ -6007,7 +6017,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: cmd/incus/main.go:121
+#: cmd/incus/main.go:122
 msgid "Print version number"
 msgstr ""
 
@@ -6155,20 +6165,20 @@ msgstr "发布实例为镜像"
 msgid "Publishing instance: %s"
 msgstr "正在发布实例: %s"
 
-#: cmd/incus/file.go:469 cmd/incus/file.go:470
+#: cmd/incus/file.go:490 cmd/incus/file.go:491
 msgid "Pull files from instances"
 msgstr "从实例拉取文件"
 
-#: cmd/incus/file.go:638 cmd/incus/file.go:1030
+#: cmd/incus/file.go:668 cmd/incus/file.go:1069
 #, fuzzy, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "正在从 %[2]s 拉取 %[1]s: %%s"
 
-#: cmd/incus/file.go:688 cmd/incus/file.go:689
+#: cmd/incus/file.go:718 cmd/incus/file.go:719
 msgid "Push files into instances"
 msgstr "向实例推送文件"
 
-#: cmd/incus/file.go:909 cmd/incus/file.go:1130
+#: cmd/incus/file.go:948 cmd/incus/file.go:1169
 #, fuzzy, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "正在向 %[2]s 推送 %[1]s: %%s"
@@ -6230,7 +6240,7 @@ msgid ""
 "database records."
 msgstr ""
 
-#: cmd/incus/file.go:477 cmd/incus/file.go:695
+#: cmd/incus/file.go:498 cmd/incus/file.go:725
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "递归传输文件"
@@ -6396,8 +6406,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:333
-#: cmd/incus/image_alias.go:334
+#: cmd/incus/alias.go:167 cmd/incus/alias.go:168 cmd/incus/image_alias.go:366
+#: cmd/incus/image_alias.go:367
 msgid "Rename aliases"
 msgstr ""
 
@@ -6575,17 +6585,17 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: cmd/incus/file.go:1476
+#: cmd/incus/file.go:1528
 #, c-format
 msgid "SSH SFTP listening on %v"
 msgstr ""
 
-#: cmd/incus/file.go:1493
+#: cmd/incus/file.go:1545
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: cmd/incus/file.go:1494
+#: cmd/incus/file.go:1546
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -6699,7 +6709,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: cmd/incus/file.go:1258
+#: cmd/incus/file.go:1296
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -6916,7 +6926,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: cmd/incus/file.go:698
+#: cmd/incus/file.go:728
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -6924,7 +6934,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: cmd/incus/file.go:699
+#: cmd/incus/file.go:729
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -6932,7 +6942,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: cmd/incus/file.go:697
+#: cmd/incus/file.go:727
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -7000,7 +7010,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: cmd/incus/file.go:1256
+#: cmd/incus/file.go:1294
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -7012,11 +7022,11 @@ msgstr ""
 msgid "Setup loop based storage with SIZE in GiB"
 msgstr ""
 
-#: cmd/incus/main.go:125
+#: cmd/incus/main.go:126
 msgid "Show all debug messages"
 msgstr ""
 
-#: cmd/incus/main.go:126
+#: cmd/incus/main.go:127
 msgid "Show all information messages"
 msgstr ""
 
@@ -7064,7 +7074,7 @@ msgstr ""
 msgid "Show instance snapshot configuration"
 msgstr ""
 
-#: cmd/incus/main.go:305 cmd/incus/main.go:306
+#: cmd/incus/main.go:306 cmd/incus/main.go:307
 msgid "Show less common commands"
 msgstr ""
 
@@ -7444,7 +7454,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: cmd/incus/file.go:167
+#: cmd/incus/file.go:176
 msgid "Symlink target path can only be used for type \"symlink\""
 msgstr ""
 
@@ -7465,7 +7475,7 @@ msgid "TOKEN"
 msgstr ""
 
 #: cmd/incus/config_trust.go:432 cmd/incus/image.go:1123
-#: cmd/incus/image_alias.go:207 cmd/incus/list.go:589 cmd/incus/network.go:1094
+#: cmd/incus/image_alias.go:240 cmd/incus/list.go:589 cmd/incus/network.go:1094
 #: cmd/incus/network.go:1295 cmd/incus/network_allocations.go:73
 #: cmd/incus/network_integration.go:451 cmd/incus/network_peer.go:131
 #: cmd/incus/operation.go:150 cmd/incus/storage_volume.go:1673
@@ -7477,12 +7487,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: cmd/incus/file.go:1295
+#: cmd/incus/file.go:1347
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "目标路径和 --listen 标记不能一起使用"
 
-#: cmd/incus/file.go:1289
+#: cmd/incus/file.go:1341
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7758,7 +7768,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: cmd/incus/main.go:332
+#: cmd/incus/main.go:333
 msgid ""
 "This client hasn't been configured to use a remote server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -7808,7 +7818,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: cmd/incus/main.go:453
+#: cmd/incus/main.go:457
 msgid ""
 "To start your first container, try: incus launch images:ubuntu/22.04\n"
 "Or for a virtual machine: incus launch images:ubuntu/22.04 --vm"
@@ -7820,7 +7830,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: cmd/incus/file.go:601
+#: cmd/incus/file.go:631
 msgid "Too many links"
 msgstr ""
 
@@ -7954,7 +7964,7 @@ msgstr ""
 msgid "Unable to connect to any of the cluster members specified in join token"
 msgstr ""
 
-#: cmd/incus/file.go:425
+#: cmd/incus/file.go:446
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7968,7 +7978,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1516
+#: cmd/incus/file.go:1568
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7976,7 +7986,7 @@ msgstr ""
 #: cmd/incus/cluster.go:193 cmd/incus/cluster.go:1127
 #: cmd/incus/cluster_group.go:513 cmd/incus/config_trust.go:455
 #: cmd/incus/config_trust.go:637 cmd/incus/image.go:1141
-#: cmd/incus/image_alias.go:223 cmd/incus/list.go:648 cmd/incus/network.go:1119
+#: cmd/incus/image_alias.go:256 cmd/incus/list.go:648 cmd/incus/network.go:1119
 #: cmd/incus/network.go:1313 cmd/incus/network_allocations.go:89
 #: cmd/incus/network_forward.go:153 cmd/incus/network_integration.go:466
 #: cmd/incus/network_load_balancer.go:160 cmd/incus/network_peer.go:146
@@ -7995,7 +8005,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: cmd/incus/file.go:1070
+#: cmd/incus/file.go:1109
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -8218,7 +8228,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: cmd/incus/main.go:128
+#: cmd/incus/main.go:129
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -8520,7 +8530,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:155
+#: cmd/incus/image_alias.go:180
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -8570,7 +8580,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: cmd/incus/image_alias.go:109
+#: cmd/incus/image_alias.go:126
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -8578,7 +8588,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: cmd/incus/image_alias.go:331
+#: cmd/incus/image_alias.go:364
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -8713,7 +8723,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: cmd/incus/file.go:398
+#: cmd/incus/file.go:411
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -8721,16 +8731,16 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
 msgstr ""
 
-#: cmd/incus/file.go:319
+#: cmd/incus/file.go:328
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: cmd/incus/file.go:468
+#: cmd/incus/file.go:489
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: cmd/incus/file.go:1247
+#: cmd/incus/file.go:1286
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -9280,20 +9290,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: cmd/incus/file.go:1251
+#: cmd/incus/file.go:1290
 msgid ""
 "incus file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: cmd/incus/file.go:472
+#: cmd/incus/file.go:493
 msgid ""
 "incus file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: cmd/incus/file.go:691
+#: cmd/incus/file.go:721
 msgid ""
 "incus file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9733,16 +9743,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: cmd/incus/file.go:1405
+#: cmd/incus/file.go:1457
 msgid "sshfs has stopped"
 msgstr ""
 
-#: cmd/incus/file.go:1364
+#: cmd/incus/file.go:1416
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: cmd/incus/file.go:1317
+#: cmd/incus/file.go:1369
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 


### PR DESCRIPTION
Sometimes the error message displayed when the execution of an alias
fails can be a little bit hard to decipher. So to better understand
the error, when an error occurs due to the execution of an alias, its
expansion is displayed along with the error message.