### PR TITLE
Switch to mount.ceph

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -200,7 +200,6 @@ jobs:
             bind9-dnsutils \
             btrfs-progs \
             busybox-static \
-            ceph-common \
             dnsmasq-base \
             easy-rsa \
             gettext \

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,318 @@
+name: Dev
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-tests:
+    name: Code
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        go:
+          - stable
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        if: github.event_name == 'pull_request'
+
+      - id: ShellCheck
+        name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'pull_request' && matrix.go == 'stable'
+
+      - name: Upload artifact with ShellCheck defects in SARIF format
+        uses: actions/upload-artifact@v4
+        with:
+          name: Differential ShellCheck SARIF
+          path: ${{ steps.ShellCheck.outputs.sarif }}
+        if: github.event_name == 'pull_request' && matrix.go == 'stable'
+
+      - name: Install Go (${{ matrix.go }})
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Check compatible min Go version
+        run: |
+          go mod tidy
+
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository ppa:ubuntu-lxc/daily -y --no-update
+          sudo add-apt-repository ppa:cowsql/stable -y --no-update
+          sudo apt-get update
+
+          sudo apt-get install --no-install-recommends -y \
+            curl \
+            gettext \
+            git \
+            libacl1-dev \
+            libcap-dev \
+            libdbus-1-dev \
+            libcowsql-dev \
+            liblxc-dev \
+            lxc-templates \
+            libseccomp-dev \
+            libselinux-dev \
+            libsqlite3-dev \
+            libtool \
+            libudev-dev \
+            make \
+            pkg-config \
+            shellcheck
+
+          python3 -m pip install flake8
+
+      - name: Download go dependencies
+        run: |
+          go mod download
+
+      - name: Run Incus build
+        run: |
+          make
+
+      - name: Run static analysis
+        env:
+          GITHUB_BEFORE: ${{ github.event.before }}
+        run: |
+          make static-analysis
+
+      - name: Unit tests (all)
+        run: |
+          sudo --preserve-env=CGO_CFLAGS,CGO_LDFLAGS,CGO_LDFLAGS_ALLOW,LD_LIBRARY_PATH LD_LIBRARY_PATH=${LD_LIBRARY_PATH} env "PATH=${PATH}" go test ./...
+  system-tests:
+    env:
+      CGO_LDFLAGS_ALLOW: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
+      INCUS_CEPH_CLUSTER: "ceph"
+      INCUS_CEPH_CEPHFS: "cephfs"
+      INCUS_CEPH_CEPHOBJECT_RADOSGW: "http://127.0.0.1"
+      INCUS_CONCURRENT: "1"
+      INCUS_VERBOSE: "1"
+      INCUS_OFFLINE: "1"
+      INCUS_TMPFS: "1"
+      INCUS_REQUIRED_TESTS: "test_storage_buckets"
+    name: System
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        go:
+          - stable
+        suite:
+          # - cluster
+          - standalone
+        backend:
+          - dir
+          # - btrfs
+          # - lvm
+          # - zfs
+          - ceph
+          # - random
+
+    steps:
+      - name: Performance tuning
+        run: |
+          set -eux
+          # optimize ext4 FSes for performance, not reliability
+          for fs in $(findmnt --noheading --type ext4 --list --uniq | awk '{print $1}'); do
+            # nombcache and data=writeback cannot be changed on remount
+            sudo mount -o remount,noatime,barrier=0,commit=6000 "${fs}" || true
+          done
+
+          # disable dpkg from calling sync()
+          echo "force-unsafe-io" | sudo tee /etc/dpkg/dpkg.cfg.d/force-unsafe-io
+
+      - name: Reclaim some space
+        run: |
+          set -eux
+
+          sudo snap remove lxd --purge
+          # Purge older snap revisions that are disabled/superseded by newer revisions of the same snap
+          snap list --all | while read -r name _ rev _ _ notes _; do
+            [ "${notes}" = "disabled" ] && snap remove "${name}" --revision "${rev}" --purge
+          done || true
+
+          # This was inspired from https://github.com/easimon/maximize-build-space
+          df -h /
+          # dotnet
+          sudo rm -rf /usr/share/dotnet
+          # android
+          sudo rm -rf /usr/local/lib/android
+          # haskell
+          sudo rm -rf /opt/ghc
+          df -h /
+
+      - name: Remove docker
+        run: |
+          set -eux
+          sudo apt-get autopurge -y moby-containerd docker uidmap
+          sudo ip link delete docker0
+          sudo nft flush ruleset
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Go (${{ matrix.go }})
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Install dependencies
+        run: |
+          set -x
+          sudo add-apt-repository ppa:ubuntu-lxc/daily -y --no-update
+          sudo add-apt-repository ppa:cowsql/stable -y --no-update
+          sudo apt-get update
+
+          sudo systemctl mask lxc.service lxc-net.service
+
+          sudo apt-get install --no-install-recommends -y \
+            curl \
+            git \
+            libacl1-dev \
+            libcap-dev \
+            libdbus-1-dev \
+            libcowsql-dev \
+            liblxc-dev \
+            libseccomp-dev \
+            libselinux-dev \
+            libsqlite3-dev \
+            libtool \
+            libudev-dev \
+            make \
+            pkg-config\
+            acl \
+            attr \
+            bind9-dnsutils \
+            btrfs-progs \
+            busybox-static \
+            ceph-common \
+            dnsmasq-base \
+            easy-rsa \
+            gettext \
+            jq \
+            lxc-utils \
+            lvm2 \
+            nftables \
+            quota \
+            rsync \
+            s3cmd \
+            socat \
+            sqlite3 \
+            squashfs-tools \
+            tar \
+            tcl \
+            thin-provisioning-tools \
+            uuid-runtime \
+            xfsprogs \
+            xz-utils \
+            zfsutils-linux
+
+          # reclaim some space
+          sudo apt-get clean
+
+          # Download minio.
+          curl -sSfL https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20240116160738.0.0_amd64.deb --output /tmp/minio.deb
+          sudo apt-get install /tmp/minio.deb --yes
+
+          # Download MinIO client
+          curl -sSfL https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2024-01-16T16-06-34Z --output /tmp/mc
+          sudo mv /tmp/mc /usr/local/bin/
+          sudo chmod +x /usr/local/bin/mc
+
+          # Download latest release of openfga server.
+          mkdir -p "$(go env GOPATH)/bin/"
+          curl -sSfL https://api.github.com/repos/openfga/openfga/releases/latest | jq -r '.assets | .[] | .browser_download_url | select(. | test("_linux_amd64.tar.gz$"))' | xargs -I {} curl -sSfL {} -o openfga.tar.gz
+          tar -xzf openfga.tar.gz -C "$(go env GOPATH)/bin/"
+
+          # Download latest release of openfga cli.
+          curl -sSfL https://api.github.com/repos/openfga/cli/releases/latest | jq -r '.assets | .[] | .browser_download_url | select(. | test("_linux_amd64.tar.gz$"))' | xargs -I {} curl -sSfL {} -o fga.tar.gz
+          tar -xzf fga.tar.gz -C "$(go env GOPATH)/bin/"
+
+      - name: Download go dependencies
+        run: |
+          go mod download
+
+      - name: Run Incus build
+        run: |
+          make
+
+      - name: Setup MicroCeph
+        if: ${{ matrix.backend == 'ceph' }}
+        run: |
+          set -x
+
+          # If the rootfs and the ephemeral part are on the same physical disk, giving the whole
+          # disk to microceph would wipe our rootfs. Since it is pretty rare for GitHub Action
+          # runners to have a single disk, we immediately bail rather than trying to gracefully
+          # handle it. Once snapd releases with https://github.com/snapcore/snapd/pull/13150,
+          # we will be able to stop worrying about that special case.
+          if [ "$(stat -c '%d' /)" = "$(stat -c '%d' /mnt)" ]; then
+            echo "FAIL: rootfs and ephemeral part on the same disk, aborting"
+            exit 1
+          fi
+
+          sudo snap install microceph --channel=quincy/stable
+          sudo apt-get install --no-install-recommends -y ceph-common
+          sudo microceph cluster bootstrap
+          sudo microceph.ceph config set global osd_pool_default_size 1
+          sudo microceph.ceph config set global mon_allow_pool_delete true
+          sudo microceph.ceph config set global osd_memory_target 939524096
+          sudo microceph.ceph osd crush rule rm replicated_rule
+          sudo microceph.ceph osd crush rule create-replicated replicated default osd
+          for flag in nosnaptrim noscrub nobackfill norebalance norecover noscrub nodeep-scrub; do
+              sudo microceph.ceph osd set $flag
+          done
+          # Repurpose the ephemeral disk for ceph OSD.
+          sudo swapoff /mnt/swapfile
+          ephemeral_disk="$(findmnt --noheadings --output SOURCE --target /mnt | sed 's/[0-9]\+$//')"
+          sudo umount /mnt
+          sudo microceph disk add --wipe "${ephemeral_disk}"
+          sudo rm -rf /etc/ceph
+          sudo ln -s /var/snap/microceph/current/conf/ /etc/ceph
+          sudo find /etc/ceph -exec echo \{\} \; -exec cat \{\} \;
+          sudo microceph enable rgw
+          sudo microceph.ceph osd pool create cephfs_meta 32
+          sudo microceph.ceph osd pool create cephfs_data 32
+          sudo microceph.ceph fs new cephfs cephfs_meta cephfs_data
+          sudo microceph.ceph fs ls
+          sleep 30
+          sudo microceph.ceph status
+          # Wait until there are no more "unkowns" pgs
+          for _ in $(seq 60); do
+            if sudo microceph.ceph pg stat | grep -wF unknown; then
+              sleep 1
+            else
+              break
+            fi
+          done
+          sudo microceph.ceph status
+          sudo rm -f /snap/bin/rbd
+
+      - name: "Ensure offline mode (block image server)"
+        run: |
+          sudo nft add table inet filter
+          sudo nft add chain 'inet filter output { type filter hook output priority 10 ; }'
+          sudo nft add rule inet filter output ip daddr 45.45.148.8 reject
+          sudo nft add rule inet filter output ip6 daddr 2602:fc62:a:1::8 reject
+
+      - name: "Run system tests (${{ matrix.go }}, ${{ matrix.suite }}, ${{ matrix.backend }})"
+        run: |
+          chmod +x ~
+          echo "root:1000000:1000000000" | sudo tee /etc/subuid /etc/subgid
+          cd test
+          sudo --preserve-env=PATH,GOPATH,GITHUB_ACTIONS,INCUS_VERBOSE,INCUS_BACKEND,INCUS_CEPH_CLUSTER,INCUS_CEPH_CEPHFS,INCUS_CEPH_CEPHOBJECT_RADOSGW,INCUS_OFFLINE,INCUS_SKIP_TESTS,INCUS_REQUIRED_TESTS, INCUS_BACKEND=${{ matrix.backend }} ./main.sh ${{ matrix.suite }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -284,7 +284,6 @@ jobs:
           sudo microceph disk add --wipe "${ephemeral_disk}"
           sudo rm -rf /etc/ceph
           sudo ln -s /var/snap/microceph/current/conf/ /etc/ceph
-          sudo find /etc/ceph -exec echo \{\} \; -exec cat \{\} \;
           sudo microceph enable rgw
           sudo microceph.ceph osd pool create cephfs_meta 32
           sudo microceph.ceph osd pool create cephfs_data 32
@@ -301,6 +300,8 @@ jobs:
             fi
           done
           sudo microceph.ceph status
+          echo "### MicroCeph Config ###"
+          sudo find /etc/ceph -type f -exec echo \{\} \; -exec cat \{\} \;
           sudo rm -f /snap/bin/rbd
 
       - name: "Ensure offline mode (block image server)"
@@ -316,3 +317,50 @@ jobs:
           echo "root:1000000:1000000000" | sudo tee /etc/subuid /etc/subgid
           cd test
           sudo --preserve-env=PATH,GOPATH,GITHUB_ACTIONS,INCUS_VERBOSE,INCUS_BACKEND,INCUS_CEPH_CLUSTER,INCUS_CEPH_CEPHFS,INCUS_CEPH_CEPHOBJECT_RADOSGW,INCUS_OFFLINE,INCUS_SKIP_TESTS,INCUS_REQUIRED_TESTS, INCUS_BACKEND=${{ matrix.backend }} ./main.sh ${{ matrix.suite }}
+  documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install aspell aspell-en
+          sudo snap install mdl
+
+      - name: Run markdown linter
+        run: |
+          make doc-lint
+
+      - name: Run spell checker
+        run: |
+          make doc-spellcheck
+
+      - name: Run inclusive naming checker
+        uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: true
+          woke-args: "*.md **/*.md -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml"
+
+      - name: Run link checker
+        run: |
+          make doc-linkcheck
+
+      - name: Build docs (Sphinx)
+        run: make doc
+
+      - name: Print warnings (Sphinx)
+        run: if [ -s doc/.sphinx/warnings.txt ]; then cat doc/.sphinx/warnings.txt; exit 1; fi
+
+      - name: Upload documentation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: doc/html

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -23,32 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Dependency Review
-        uses: actions/dependency-review-action@v4
-        if: github.event_name == 'pull_request'
-
-      - id: ShellCheck
-        name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'pull_request' && matrix.go == 'stable'
-
-      - name: Upload artifact with ShellCheck defects in SARIF format
-        uses: actions/upload-artifact@v4
-        with:
-          name: Differential ShellCheck SARIF
-          path: ${{ steps.ShellCheck.outputs.sarif }}
-        if: github.event_name == 'pull_request' && matrix.go == 'stable'
-
       - name: Install Go (${{ matrix.go }})
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-
-      - name: Check compatible min Go version
-        run: |
-          go mod tidy
 
       - name: Install dependencies
         run: |
@@ -77,6 +55,28 @@ jobs:
 
           python3 -m pip install flake8
 
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        if: github.event_name == 'pull_request'
+
+      - name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        id: ShellCheck
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'pull_request' && matrix.go == 'stable'
+
+      - name: Upload artifact with ShellCheck defects in SARIF format
+        uses: actions/upload-artifact@v4
+        with:
+          name: Differential ShellCheck SARIF
+          path: ${{ steps.ShellCheck.outputs.sarif }}
+        if: github.event_name == 'pull_request' && matrix.go == 'stable'
+
+      - name: Check compatible min Go version
+        run: |
+          go mod tidy
+
       - name: Download go dependencies
         run: |
           go mod download
@@ -94,6 +94,7 @@ jobs:
       - name: Unit tests (all)
         run: |
           sudo --preserve-env=CGO_CFLAGS,CGO_LDFLAGS,CGO_LDFLAGS_ALLOW,LD_LIBRARY_PATH LD_LIBRARY_PATH=${LD_LIBRARY_PATH} env "PATH=${PATH}" go test ./...
+
   system-tests:
     env:
       CGO_LDFLAGS_ALLOW: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
@@ -163,9 +164,6 @@ jobs:
           sudo ip link delete docker0
           sudo nft flush ruleset
 
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Install Go (${{ matrix.go }})
         uses: actions/setup-go@v5
         with:
@@ -221,9 +219,6 @@ jobs:
             xz-utils \
             zfsutils-linux
 
-          # reclaim some space
-          sudo apt-get clean
-
           # Download minio.
           curl -sSfL https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20240116160738.0.0_amd64.deb --output /tmp/minio.deb
           sudo apt-get install /tmp/minio.deb --yes
@@ -242,13 +237,11 @@ jobs:
           curl -sSfL https://api.github.com/repos/openfga/cli/releases/latest | jq -r '.assets | .[] | .browser_download_url | select(. | test("_linux_amd64.tar.gz$"))' | xargs -I {} curl -sSfL {} -o fga.tar.gz
           tar -xzf fga.tar.gz -C "$(go env GOPATH)/bin/"
 
-      - name: Download go dependencies
+      - name: Install dependencies (ceph-common)
+        if: ${{ matrix.backend == 'ceph' }}
         run: |
-          go mod download
-
-      - name: Run Incus build
-        run: |
-          make
+          sudo apt-get install --no-install-recommends -y \
+            ceph-common
 
       - name: Setup MicroCeph
         if: ${{ matrix.backend == 'ceph' }}
@@ -303,6 +296,21 @@ jobs:
           sudo find /etc/ceph -type f -exec echo \{\} \; -exec cat \{\} \;
           sudo rm -f /snap/bin/rbd
 
+      - name: Cleanup apt cache
+        run: |
+          sudo apt-get clean
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download go dependencies
+        run: |
+          go mod download
+
+      - name: Run Incus build
+        run: |
+          make
+
       - name: "Ensure offline mode (block image server)"
         run: |
           sudo nft add table inet filter
@@ -316,6 +324,7 @@ jobs:
           echo "root:1000000:1000000000" | sudo tee /etc/subuid /etc/subgid
           cd test
           sudo --preserve-env=PATH,GOPATH,GITHUB_ACTIONS,INCUS_VERBOSE,INCUS_BACKEND,INCUS_CEPH_CLUSTER,INCUS_CEPH_CEPHFS,INCUS_CEPH_CEPHOBJECT_RADOSGW,INCUS_OFFLINE,INCUS_SKIP_TESTS,INCUS_REQUIRED_TESTS, INCUS_BACKEND=${{ matrix.backend }} ./main.sh ${{ matrix.suite }}
+
   documentation:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -249,6 +249,7 @@ jobs:
             bind9-dnsutils \
             btrfs-progs \
             busybox-static \
+            ceph-common \
             dnsmasq-base \
             easy-rsa \
             gettext \
@@ -389,7 +390,7 @@ jobs:
 
       - name: Create build directory
         run: |
-            mkdir bin
+          mkdir bin
 
       - name: Build static x86_64 incus
         env:

--- a/cmd/incus/project.go
+++ b/cmd/incus/project.go
@@ -1185,6 +1185,11 @@ func (c *cmdProjectGetCurrent) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(i18n.G("Remote %s doesn't exist"), conf.DefaultRemote)
 	}
 
-	fmt.Println(remote.Project)
+	if remote.Project == "" {
+		fmt.Println(api.ProjectDefaultName)
+	} else {
+		fmt.Println(remote.Project)
+	}
+
 	return nil
 }

--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -84,6 +84,7 @@ ESA
 ETag
 failover
 FQDNs
+FSID
 Furo
 gapped
 GARM
@@ -159,6 +160,7 @@ MicroCeph
 MicroCloud
 MII
 MITM
+mon
 MTU
 Mullvad
 multicast

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -61,10 +61,10 @@ User keys can be used in search.
 :required: "no"
 :shortdesc: "Ceph File System ID"
 :type: "string"
-Uniquely identifies the ceph cluster
+Uniquely identifies the Ceph cluster
 
-Overrides ceph.cluster_name
-This will usually be retrieved from ceph.conf or the cluster directly
+Overrides `ceph.cluster_name`
+This will usually be retrieved from `ceph.conf` or the cluster directly
 using `ceph-conf` or `ceph` respectively. If these tools are not available
 then this will need to be provided.
 
@@ -74,12 +74,12 @@ then this will need to be provided.
 :required: "no"
 :shortdesc: "Ceph monitor address(es)"
 :type: "string"
-Used to establish connection to the ceph cluster.
+Used to establish connection to the Ceph cluster.
 
-This will usually be retrieved from ceph.conf or the cluster directly
+This will usually be retrieved from `ceph.conf` or the cluster directly
 using `ceph-conf` or `ceph` respectively. If these tools are not available
-then this will need to be provided. Can be provided as ip addresses or
-hostnames, port is optional
+then this will need to be provided. Can be provided as IP addresses or
+host names, port is optional
 
 Has the form:
 mon1:3300,1.2.3.4:5678,mon2.example.net:6789
@@ -89,7 +89,7 @@ mon1:3300,1.2.3.4:5678,mon2.example.net:6789
 :required: "no"
 :shortdesc: "Ceph user key"
 :type: "string"
-Used if authentication with cephx is required.
+Used if authentication with Ceph is required.
 
 If needed at all will usually be retrieved using the `ceph-conf` tool.
 However if this is not available on the host or the key is not accessible

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -57,6 +57,45 @@ User keys can be used in search.
 
 ```
 
+```{config:option} ceph.fsid devices-disk
+:required: "no"
+:shortdesc: "Ceph File System ID"
+:type: "string"
+Uniquely identifies the ceph cluster
+
+Overrides ceph.cluster_name
+This will usually be retrieved from ceph.conf or the cluster directly
+using `ceph-conf` or `ceph` respectively. If these tools are not available
+then this will need to be provided.
+
+```
+
+```{config:option} ceph.mon_addr devices-disk
+:required: "no"
+:shortdesc: "Ceph monitor address(es)"
+:type: "string"
+Used to establish connection to the ceph cluster.
+
+This will usually be retrieved from ceph.conf or the cluster directly
+using `ceph-conf` or `ceph` respectively. If these tools are not available
+then this will need to be provided. Can be provided as ip addresses or
+hostnames, port is optional
+
+Has the form:
+mon1:3300,1.2.3.4:5678,mon2.example.net:6789
+```
+
+```{config:option} ceph.user_key devices-disk
+:required: "no"
+:shortdesc: "Ceph user key"
+:type: "string"
+Used if authentication with cephx is required.
+
+If needed at all will usually be retrieved using the `ceph-conf` tool.
+However if this is not available on the host or the key is not accessible
+to those tools then this will need to be provided.
+```
+
 ```{config:option} ceph.user_name devices-disk
 :default: "`admin`"
 :required: "no"

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -54,7 +54,7 @@ The `cephfs` driver in Incus supports snapshots if snapshots are enabled on the 
 ## Configuration options
 
 The following configuration options are available for storage pools that use the `cephfs` driver and for storage volumes in these pools.
-Usually [`cephfs.fsid`](storage-cephfs-pool-config), [`cephfs.monitor_addrs`](storage-cephfs-pool-config), and [`cephfs.user.key`](storage-cephfs-pool-config) will be automatically discovered using the Ceph admin tool & mount helper. However if those tools are not availble on the host then they will need to be provided.
+Usually [`cephfs.fsid`](storage-cephfs-pool-config), [`cephfs.monitor_addrs`](storage-cephfs-pool-config), and [`cephfs.user.key`](storage-cephfs-pool-config) will be automatically discovered using the Ceph admin tool & mount helper. However if those tools are not available on the host then they will need to be provided.
 
 (storage-cephfs-pool-config)=
 ### Storage pool configuration

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -54,6 +54,7 @@ The `cephfs` driver in Incus supports snapshots if snapshots are enabled on the 
 ## Configuration options
 
 The following configuration options are available for storage pools that use the `cephfs` driver and for storage volumes in these pools.
+Usually [`cephfs.fsid`](storage-cephfs-pool-config), [`cephfs.monitor_addrs`](storage-cephfs-pool-config), and [`cephfs.user.key`](storage-cephfs-pool-config) will be automatically discovered using the Ceph admin tool & mount helper. However if those tools are not availble on the host then they will need to be provided.
 
 (storage-cephfs-pool-config)=
 ### Storage pool configuration
@@ -64,10 +65,13 @@ Key                           | Type                          | Default         
 `cephfs.create_missing`       | bool                          | `false`                                 | Create the file system and the missing data and metadata OSD pools
 `cephfs.data_pool`            | string                        | -                                       | Data OSD pool name to create for the file system
 `cephfs.fscache`              | bool                          | `false`                                 | Enable use of kernel `fscache` and `cachefilesd`
+`cephfs.fsid`                 | string                        | -                                       | Ceph cluster FSID, overrides `cluster_name`. Can usually be inferred.
 `cephfs.meta_pool`            | string                        | -                                       | Metadata OSD pool name to create for the file system
+`cephfs.mon_addr`             | string                        | -                                       | Ceph mon addresses, usually not required.
 `cephfs.osd_pg_num`           | string                        | -                                       | OSD pool `pg_num` to use when creating missing OSD pools
 `cephfs.path`                 | string                        | `/`                                     | The base path for the CephFS mount
 `cephfs.user.name`            | string                        | `admin`                                 | The Ceph user to use
+`cephfs.user.key`             | string                        | -                                       | Ceph user key, usually not required.
 `source`                      | string                        | -                                       | Existing CephFS file system or file system path to use
 `volatile.pool.pristine`      | string                        | `true`                                  | Whether the CephFS file system was empty on creation time
 

--- a/internal/server/device/device_utils_disk.go
+++ b/internal/server/device/device_utils_disk.go
@@ -138,12 +138,7 @@ func DiskMount(srcPath string, dstPath string, recursive bool, propagation strin
 
 	// Mount the filesystem
 	if fsName == "ceph" {
-		// shell out to `mount.ceph` to do the work of
-		// determining monitor addresses and keyring
-		_, err = subprocess.RunCommand(
-			"mount.ceph", srcPath, dstPath,
-			"-o", mountOptionsStr,
-		)
+		err = storageDrivers.CephMount(srcPath, dstPath, mountOptionsStr)
 	} else {
 		err = unix.Mount(srcPath, dstPath, fsName, uintptr(flags), mountOptionsStr)
 	}

--- a/internal/server/device/device_utils_disk.go
+++ b/internal/server/device/device_utils_disk.go
@@ -147,6 +147,7 @@ func DiskMount(srcPath string, dstPath string, recursive bool, propagation strin
 	} else {
 		err = unix.Mount(srcPath, dstPath, fsName, uintptr(flags), mountOptionsStr)
 	}
+
 	if err != nil {
 		return fmt.Errorf("Unable to mount %q at %q with filesystem %q: %w", srcPath, dstPath, fsName, err)
 	}

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -1790,17 +1790,13 @@ func (d *disk) createDevice(srcPath string) (func(), string, bool, error) {
 			mdsPath := fields[1]
 			clusterName, userName := d.cephCreds()
 
-			// Get the mount options.
-			mntSrcPath, fsOptions, fsErr := diskCephfsOptions(clusterName, userName, mdsName, mdsPath)
-			if fsErr != nil {
-				return nil, "", false, fsErr
+			fsid, err := storageDrivers.CephFSID(clusterName)
+			if err != nil {
+				return nil, "", false, fmt.Errorf("Failed to get fsid for cluster %q: %w", clusterName, err)
 			}
 
-			// Join the options with any provided by the user.
-			mntOptions = append(mntOptions, fsOptions...)
-
 			fsName = "ceph"
-			srcPath = mntSrcPath
+			srcPath = fmt.Sprintf("%s@%s.%s=/%s", userName, fsid, mdsName, mdsPath)
 			isFile = false
 		} else if d.sourceIsCeph() {
 			// Get the pool and volume names.

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -301,10 +301,10 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		"ceph.cluster_name": validate.IsAny,
 
 		// gendoc:generate(entity=devices, group=disk, key=ceph.fsid)
-		// Uniquely identifies the ceph cluster
+		// Uniquely identifies the Ceph cluster
 		//
-		// Overrides ceph.cluster_name
-		// This will usually be retrieved from ceph.conf or the cluster directly
+		// Overrides `ceph.cluster_name`
+		// This will usually be retrieved from `ceph.conf` or the cluster directly
 		// using `ceph-conf` or `ceph` respectively. If these tools are not available
 		// then this will need to be provided.
 		//
@@ -315,12 +315,12 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		"ceph.fsid": validate.Optional(validate.IsUUID),
 
 		// gendoc:generate(entity=devices, group=disk, key=ceph.mon_addr)
-		// Used to establish connection to the ceph cluster.
+		// Used to establish connection to the Ceph cluster.
 		//
-		// This will usually be retrieved from ceph.conf or the cluster directly
+		// This will usually be retrieved from `ceph.conf` or the cluster directly
 		// using `ceph-conf` or `ceph` respectively. If these tools are not available
-		// then this will need to be provided. Can be provided as ip addresses or
-		// hostnames, port is optional
+		// then this will need to be provided. Can be provided as IP addresses or
+		// host names, port is optional
 		//
 		// Has the form:
 		// mon1:3300,1.2.3.4:5678,mon2.example.net:6789
@@ -342,7 +342,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		"ceph.user_name": validate.IsAny,
 
 		// gendoc:generate(entity=devices, group=disk, key=ceph.user_key)
-		// Used if authentication with cephx is required.
+		// Used if authentication with Ceph is required.
 		//
 		// If needed at all will usually be retrieved using the `ceph-conf` tool.
 		// However if this is not available on the host or the key is not accessible

--- a/internal/server/device/disk.go
+++ b/internal/server/device/disk.go
@@ -300,6 +300,38 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		//  shortdesc: The cluster name of the Ceph cluster (required for Ceph or CephFS sources)
 		"ceph.cluster_name": validate.IsAny,
 
+		// gendoc:generate(entity=devices, group=disk, key=ceph.fsid)
+		// Uniquely identifies the ceph cluster
+		//
+		// Overrides ceph.cluster_name
+		// This will usually be retrieved from ceph.conf or the cluster directly
+		// using `ceph-conf` or `ceph` respectively. If these tools are not available
+		// then this will need to be provided.
+		//
+		// ---
+		// type: string
+		// required: no
+		// shortdesc: Ceph File System ID
+		"ceph.fsid": validate.Optional(validate.IsUUID),
+
+		// gendoc:generate(entity=devices, group=disk, key=ceph.mon_addr)
+		// Used to establish connection to the ceph cluster.
+		//
+		// This will usually be retrieved from ceph.conf or the cluster directly
+		// using `ceph-conf` or `ceph` respectively. If these tools are not available
+		// then this will need to be provided. Can be provided as ip addresses or
+		// hostnames, port is optional
+		//
+		// Has the form:
+		// mon1:3300,1.2.3.4:5678,mon2.example.net:6789
+		// ---
+		// type: string
+		// required: no
+		// shortdesc: Ceph monitor address(es)
+		"ceph.mon_addr": validate.Optional(
+			validate.IsListOf(validate.IsListenAddress(true, false, false)),
+		),
+
 		// gendoc:generate(entity=devices, group=disk, key=ceph.user_name)
 		//
 		// ---
@@ -308,6 +340,18 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		//  required: no
 		//  shortdesc: The user name of the Ceph cluster (required for Ceph or CephFS sources)
 		"ceph.user_name": validate.IsAny,
+
+		// gendoc:generate(entity=devices, group=disk, key=ceph.user_key)
+		// Used if authentication with cephx is required.
+		//
+		// If needed at all will usually be retrieved using the `ceph-conf` tool.
+		// However if this is not available on the host or the key is not accessible
+		// to those tools then this will need to be provided.
+		// ---
+		// type: string
+		// required: no
+		// shortdesc: Ceph user key
+		"ceph.user_key": validate.IsAny,
 
 		// gendoc:generate(entity=devices, group=disk, key=boot.priority)
 		//

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -69,12 +69,44 @@
 						}
 					},
 					{
+						"ceph.fsid": {
+							"longdesc": "Uniquely identifies the ceph cluster\n\nOverrides ceph.cluster_name\nThis will usually be retrieved from ceph.conf or the cluster directly\nusing `ceph-conf` or `ceph` respectively. If these tools are not available\nthen this will need to be provided.\n",
+							"required": "no",
+							"shortdesc": "Ceph File System ID",
+							"type": "string"
+						}
+					},
+					{
+						"ceph.mon_addr": {
+							"longdesc": "Used to establish connection to the ceph cluster.\n\nThis will usually be retrieved from ceph.conf or the cluster directly\nusing `ceph-conf` or `ceph` respectively. If these tools are not available\nthen this will need to be provided. Can be provided as ip addresses or\nhostnames, port is optional\n\nHas the form:\nmon1:3300,1.2.3.4:5678,mon2.example.net:6789",
+							"required": "no",
+							"shortdesc": "Ceph monitor address(es)",
+							"type": "string"
+						}
+					},
+					{
+						"ceph.user_key": {
+							"longdesc": "Used if authentication with cephx is required.\n\nIf needed at all will usually be retrieved using the `ceph-conf` tool.\nHowever if this is not available on the host or the key is not accessible\nto those tools then this will need to be provided.",
+							"required": "no",
+							"shortdesc": "Ceph user key",
+							"type": "string"
+						}
+					},
+					{
 						"ceph.user_name": {
 							"default": "`admin`",
 							"longdesc": "",
 							"required": "no",
 							"shortdesc": "The user name of the Ceph cluster (required for Ceph or CephFS sources)",
 							"type": "string"
+						}
+					},
+					{
+						"ceph.user_key": {
+							"required": "no",
+							"type": "string",
+							"shortdesc": "Ceph user key",
+							"longdesc": "Usually inferred using Ceph client tools on the host."
 						}
 					},
 					{

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -70,7 +70,7 @@
 					},
 					{
 						"ceph.fsid": {
-							"longdesc": "Uniquely identifies the ceph cluster\n\nOverrides ceph.cluster_name\nThis will usually be retrieved from ceph.conf or the cluster directly\nusing `ceph-conf` or `ceph` respectively. If these tools are not available\nthen this will need to be provided.\n",
+							"longdesc": "Uniquely identifies the Ceph cluster\n\nOverrides `ceph.cluster_name`\nThis will usually be retrieved from `ceph.conf` or the cluster directly\nusing `ceph-conf` or `ceph` respectively. If these tools are not available\nthen this will need to be provided.\n",
 							"required": "no",
 							"shortdesc": "Ceph File System ID",
 							"type": "string"
@@ -78,7 +78,7 @@
 					},
 					{
 						"ceph.mon_addr": {
-							"longdesc": "Used to establish connection to the ceph cluster.\n\nThis will usually be retrieved from ceph.conf or the cluster directly\nusing `ceph-conf` or `ceph` respectively. If these tools are not available\nthen this will need to be provided. Can be provided as ip addresses or\nhostnames, port is optional\n\nHas the form:\nmon1:3300,1.2.3.4:5678,mon2.example.net:6789",
+							"longdesc": "Used to establish connection to the Ceph cluster.\n\nThis will usually be retrieved from `ceph.conf` or the cluster directly\nusing `ceph-conf` or `ceph` respectively. If these tools are not available\nthen this will need to be provided. Can be provided as IP addresses or\nhost names, port is optional\n\nHas the form:\nmon1:3300,1.2.3.4:5678,mon2.example.net:6789",
 							"required": "no",
 							"shortdesc": "Ceph monitor address(es)",
 							"type": "string"
@@ -86,7 +86,7 @@
 					},
 					{
 						"ceph.user_key": {
-							"longdesc": "Used if authentication with cephx is required.\n\nIf needed at all will usually be retrieved using the `ceph-conf` tool.\nHowever if this is not available on the host or the key is not accessible\nto those tools then this will need to be provided.",
+							"longdesc": "Used if authentication with Ceph is required.\n\nIf needed at all will usually be retrieved using the `ceph-conf` tool.\nHowever if this is not available on the host or the key is not accessible\nto those tools then this will need to be provided.",
 							"required": "no",
 							"shortdesc": "Ceph user key",
 							"type": "string"

--- a/internal/server/metadata/configuration.json
+++ b/internal/server/metadata/configuration.json
@@ -102,14 +102,6 @@
 						}
 					},
 					{
-						"ceph.user_key": {
-							"required": "no",
-							"type": "string",
-							"shortdesc": "Ceph user key",
-							"longdesc": "Usually inferred using Ceph client tools on the host."
-						}
-					},
-					{
 						"initial.*": {
 							"longdesc": "",
 							"required": "no",

--- a/internal/server/storage/drivers/driver_cephfs.go
+++ b/internal/server/storage/drivers/driver_cephfs.go
@@ -387,9 +387,12 @@ func (d *cephfs) Delete(op *operations.Operation) error {
 func (d *cephfs) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
 		"cephfs.cluster_name":    validate.IsAny,
+		"cephfs.fsid":            validate.Optional(validate.IsUUID),
+		"cephfs.mon_addr":        validate.Optional(validate.IsListOf(validate.IsListenAddress(true, false, false))),
 		"cephfs.fscache":         validate.Optional(validate.IsBool),
 		"cephfs.path":            validate.IsAny,
 		"cephfs.user.name":       validate.IsAny,
+		"cephfs.user.secret":     validate.Optional(validate.IsAny),
 		"cephfs.create_missing":  validate.Optional(validate.IsBool),
 		"cephfs.osd_pg_num":      validate.Optional(validate.IsInt64),
 		"cephfs.meta_pool":       validate.IsAny,

--- a/internal/server/storage/drivers/driver_cephfs_utils.go
+++ b/internal/server/storage/drivers/driver_cephfs_utils.go
@@ -44,20 +44,3 @@ func (d *cephfs) osdPoolExists(clusterName string, userName string, osdPoolName 
 
 	return true, nil
 }
-
-// getConfig parses the Ceph configuration file and returns the list of monitors and secret key.
-func (d *cephfs) getConfig(clusterName string, userName string) ([]string, string, error) {
-	// Get the monitor list.
-	monitors, err := CephMonitors(clusterName)
-	if err != nil {
-		return nil, "", err
-	}
-
-	// Get the keyring entry.
-	secret, err := CephKeyring(clusterName, userName)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return monitors, secret, nil
-}

--- a/internal/server/storage/drivers/utils.go
+++ b/internal/server/storage/drivers/utils.go
@@ -165,12 +165,7 @@ func TryMount(src string, dst string, fs string, flags uintptr, options string) 
 	var err error
 
 	if fs == "ceph" {
-		// shell out to `mount.ceph` to do the work of
-		// determining monitor addresses and keyring
-		_, err = subprocess.RunCommand(
-			"mount.ceph", src, dst,
-			"-o", options,
-		)
+		err = CephMount(src, dst, options)
 	} else {
 		// Attempt 20 mounts over 10s
 		for i := 0; i < 20; i++ {

--- a/internal/server/storage/drivers/utils_ceph.go
+++ b/internal/server/storage/drivers/utils_ceph.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/subprocess"
 	"github.com/lxc/incus/v6/shared/util"
 )
 
@@ -248,4 +249,13 @@ func CephKeyring(cluster string, client string) (string, error) {
 	}
 
 	return cephSecret, nil
+}
+
+func CephFSID(cluster string) (string, error) {
+	fsid, err := subprocess.RunCommand("ceph", "--cluster", cluster)
+	if err != nil {
+		return "", fmt.Errorf("Failed to get fsid for cluster %q: %w", cluster, err)
+	}
+	fsid = strings.TrimSpace(fsid)
+	return fsid, nil
 }

--- a/internal/server/storage/drivers/utils_ceph.go
+++ b/internal/server/storage/drivers/utils_ceph.go
@@ -1,15 +1,33 @@
 package drivers
 
 import (
-	"bufio"
+	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/subprocess"
-	"github.com/lxc/incus/v6/shared/util"
 )
+
+// CephMonmap represents the json (partial) output of `ceph mon dump`.
+type CephMonmap struct {
+	Fsid string `json:"fsid"`
+	Mons []struct {
+		Name        string `json:"name"`
+		PublicAddrs struct {
+			Addrvec []struct {
+				Type  string `json:"type"`
+				Addr  string `json:"addr"`
+				Nonce int    `json:"nonce"`
+			} `json:"addrvec"`
+		} `json:"public_addrs"`
+		Addr       string `json:"addr"`
+		PublicAddr string `json:"public_addr"`
+		Priority   int    `json:"priority"`
+		Weight     int    `json:"weight"`
+	} `json:"mons"`
+}
 
 // CephGetRBDImageName returns the RBD image name as it is used in ceph.
 // Example:
@@ -61,191 +79,71 @@ func CephGetRBDImageName(vol Volume, snapName string, zombie bool) string {
 
 // CephMonitors gets the mon-host field for the relevant cluster and extracts the list of addresses and ports.
 func CephMonitors(cluster string) ([]string, error) {
-	// Open the CEPH configuration.
-	cephConf, err := os.Open(fmt.Sprintf("/etc/ceph/%s.conf", cluster))
+	ctx := logger.Ctx{"cluster": cluster}
+	cephMon := []string{}
+
+	// First try the ceph client admin tool
+	jsonBlob, err := subprocess.RunCommand(
+		"ceph", "mon", "dump",
+		"--cluster", cluster,
+		"--format", "json",
+	)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to open %q: %w", fmt.Sprintf("/etc/ceph/%s.conf", cluster), err)
+		ctx["err"] = err
+		logger.Warn("Failed to get monitors from ceph client", ctx)
+	} else {
+		// Extract monitor public addresses from json
+		var monmap CephMonmap
+		err = json.Unmarshal([]byte(jsonBlob), &monmap)
+		if err != nil {
+			ctx["err"] = err
+			logger.Warn("Failed to decode json from 'ceph mon dump'", ctx)
+		} else {
+			for _, mon := range monmap.Mons {
+				cephMon = append(cephMon, mon.PublicAddr)
+			}
+		}
 	}
 
-	// Locate the mon-host key and its values.
-	cephMon := []string{}
-	scan := bufio.NewScanner(cephConf)
-	for scan.Scan() {
-		line := scan.Text()
-		line = strings.TrimSpace(line)
-
-		if line == "" {
-			continue
-		}
-
-		if strings.HasPrefix(line, "mon_host") || strings.HasPrefix(line, "mon-host") || strings.HasPrefix(line, "mon host") {
-			fields := strings.SplitN(line, "=", 2)
-			if len(fields) < 2 {
-				continue
-			}
-
-			// Parsing mon_host is quite tricky.
-			// It supports a space separate list of comma separated lists of:
-			//  - DNS names
-			//  - IPv4 addresses
-			//  - IPv6 addresses (square brackets)
-			//  - Optional version indicator
-			//  - Optional port numbers
-			//  - Optional data (after / separator)
-			//  - Tuples of addresses with all the above still applying inside the tuple
-			//
-			// As this function is primarily used for cephfs which
-			// doesn't take the version indication, trailing bits or supports those
-			// tuples, all of those effectively get stripped away to get a clean
-			// address list (with ports).
-			entries := strings.Split(fields[1], " ")
-			for _, entry := range entries {
-				servers := strings.Split(entry, ",")
-				for _, server := range servers {
-					// Trim leading/trailing spaces.
-					server = strings.TrimSpace(server)
-
-					// Trim leading protocol version.
-					server = strings.TrimPrefix(server, "v1:")
-					server = strings.TrimPrefix(server, "v2:")
-					server = strings.TrimPrefix(server, "[v1:")
-					server = strings.TrimPrefix(server, "[v2:")
-
-					// Trim trailing divider.
-					server = strings.Split(server, "/")[0]
-
-					// Handle end of nested blocks.
-					server = strings.ReplaceAll(server, "]]", "]")
-					if !strings.HasPrefix(server, "[") {
-						server = strings.TrimSuffix(server, "]")
-					}
-
-					// Trim any spaces.
-					server = strings.TrimSpace(server)
-
-					// If nothing left, skip.
-					if server == "" {
-						continue
-					}
-
-					// Append the default v1 port if none are present.
-					if !strings.HasSuffix(server, ":6789") && !strings.HasSuffix(server, ":3300") {
-						server += ":6789"
-					}
-
-					cephMon = append(cephMon, strings.TrimSpace(server))
+	// If that fails try ceph-conf
+	if len(cephMon) == 0 {
+		monBlob, err := subprocess.RunCommand(
+			"ceph-conf", "mon_host",
+			"--cluster", cluster,
+		)
+		if err != nil {
+			logger.Warn("Failed to get monitors from ceph-conf", logger.Ctx{"cluster": cluster, "err": err})
+		} else {
+			// sadly ceph-conf doesn't give us a nice json blob like 'ceph mon dump'
+			for _, mon := range strings.Split(monBlob, " ") {
+				mon = strings.Trim(mon, "[]")
+				for _, addr := range strings.Split(mon, ",") {
+					addr = strings.Split(addr, ":")[1]
+					addr = strings.Split(addr, "/")[0]
+					cephMon = append(cephMon, addr)
 				}
 			}
 		}
 	}
 
 	if len(cephMon) == 0 {
-		return nil, fmt.Errorf("Couldn't find a CEPH mon")
+		return nil, fmt.Errorf("Failed to retrieve monitors for %q", cluster)
 	}
 
 	return cephMon, nil
 }
 
-func getCephKeyFromFile(path string) (string, error) {
-	cephKeyring, err := os.Open(path)
-	if err != nil {
-		return "", fmt.Errorf("Failed to open %q: %w", path, err)
-	}
-
-	// Locate the keyring entry and its value.
-	var cephSecret string
-	scan := bufio.NewScanner(cephKeyring)
-	for scan.Scan() {
-		line := scan.Text()
-		line = strings.TrimSpace(line)
-
-		if line == "" {
-			continue
-		}
-
-		if strings.HasPrefix(line, "key") {
-			fields := strings.SplitN(line, "=", 2)
-			if len(fields) < 2 {
-				continue
-			}
-
-			cephSecret = strings.TrimSpace(fields[1])
-			break
-		}
-	}
-
-	if cephSecret == "" {
-		return "", fmt.Errorf("Couldn't find a keyring entry")
-	}
-
-	return cephSecret, nil
-}
-
 // CephKeyring gets the key for a particular Ceph cluster and client name.
 func CephKeyring(cluster string, client string) (string, error) {
 	var cephSecret string
-	cephConfigPath := fmt.Sprintf("/etc/ceph/%v.conf", cluster)
 
-	keyringPathFull := fmt.Sprintf("/etc/ceph/%v.client.%v.keyring", cluster, client)
-	keyringPathCluster := fmt.Sprintf("/etc/ceph/%v.keyring", cluster)
-	keyringPathGlobal := "/etc/ceph/keyring"
-	keyringPathGlobalBin := "/etc/ceph/keyring.bin"
-
-	if util.PathExists(keyringPathFull) {
-		return getCephKeyFromFile(keyringPathFull)
-	} else if util.PathExists(keyringPathCluster) {
-		return getCephKeyFromFile(keyringPathCluster)
-	} else if util.PathExists(keyringPathGlobal) {
-		return getCephKeyFromFile(keyringPathGlobal)
-	} else if util.PathExists(keyringPathGlobalBin) {
-		return getCephKeyFromFile(keyringPathGlobalBin)
-	} else if util.PathExists(cephConfigPath) {
-		// Open the CEPH config file.
-		cephConfig, err := os.Open(cephConfigPath)
-		if err != nil {
-			return "", fmt.Errorf("Failed to open %q: %w", cephConfigPath, err)
-		}
-
-		// Locate the keyring entry and its value.
-		scan := bufio.NewScanner(cephConfig)
-		for scan.Scan() {
-			line := scan.Text()
-			line = strings.TrimSpace(line)
-
-			if line == "" {
-				continue
-			}
-
-			if strings.HasPrefix(line, "key") {
-				fields := strings.SplitN(line, "=", 2)
-				if len(fields) < 2 {
-					continue
-				}
-
-				// Check all key related config keys.
-				switch strings.TrimSpace(fields[0]) {
-				case "key":
-					cephSecret = strings.TrimSpace(fields[1])
-				case "keyfile":
-					key, err := os.ReadFile(fields[1])
-					if err != nil {
-						return "", err
-					}
-
-					cephSecret = strings.TrimSpace(string(key))
-				case "keyring":
-					return getCephKeyFromFile(strings.TrimSpace(fields[1]))
-				}
-			}
-
-			if cephSecret != "" {
-				break
-			}
-		}
-	}
-
-	if cephSecret == "" {
-		return "", fmt.Errorf("Couldn't find a keyring entry")
+	cephSecret, err := subprocess.RunCommand(
+		"ceph-conf", "key",
+		"--cluster", cluster,
+		"--name", "client."+client,
+	)
+	if err != nil {
+		return "", fmt.Errorf("Failed to get key for 'client.%s' on %q", client, cluster)
 	}
 
 	return cephSecret, nil

--- a/internal/server/storage/drivers/utils_ceph.go
+++ b/internal/server/storage/drivers/utils_ceph.go
@@ -251,11 +251,14 @@ func CephKeyring(cluster string, client string) (string, error) {
 	return cephSecret, nil
 }
 
+// CephFSID returns the ceph fsid for a given cluster name
+// requires that the ceph client is avaible on the host.
 func CephFSID(cluster string) (string, error) {
 	fsid, err := subprocess.RunCommand("ceph", "--cluster", cluster)
 	if err != nil {
 		return "", fmt.Errorf("Failed to get fsid for cluster %q: %w", cluster, err)
 	}
+
 	fsid = strings.TrimSpace(fsid)
 	return fsid, nil
 }

--- a/internal/server/storage/drivers/utils_ceph.go
+++ b/internal/server/storage/drivers/utils_ceph.go
@@ -160,3 +160,18 @@ func CephFSID(cluster string) (string, error) {
 	fsid = strings.TrimSpace(fsid)
 	return fsid, nil
 }
+
+// CephMount attempts to mount a CephFS volume via the `ceph.mount` helper.
+func CephMount(src string, dst string, options string) error {
+	args := []string{
+		src,
+		dst,
+	}
+
+	if options != "" {
+		args = append(args, "-o", options)
+	}
+
+	_, err := subprocess.RunCommand("mount.ceph", args...)
+	return err
+}


### PR DESCRIPTION
Currently when mounting CephFS Incus will construct the mount syscall by attempting to parse `/etc/ceph/ceph.conf `. Unfortunately this is fragile given the varieties of locations, layouts, and forms the necessary options can take.

This PR fixes that by instead diverting ceph mounts through the mount.ceph helper which will do all the necessary lifting. This obviously implies a dependency on the ceph client tools, however that dependency already existed for other ceph operations and isn't particularly unreasonable for a host interacting with ceph.

* Currently this is untested *