### PR TITLE
OCI image debugging improvements

### DIFF
--- a/cmd/incusd/daemon_images.go
+++ b/cmd/incusd/daemon_images.go
@@ -102,7 +102,7 @@ func ImageDownload(ctx context.Context, r *http.Request, s *state.State, op *ope
 			// Setup OCI client
 			remote, err = incus.ConnectOCI(args.Server, clientArgs)
 			if err != nil {
-				return nil, false, fmt.Errorf("Failed to connect to simple streams server %q: %w", args.Server, err)
+				return nil, false, fmt.Errorf("Failed to connect to oci server %q: %w", args.Server, err)
 			}
 		} else if protocol == "simplestreams" {
 			// Setup simplestreams client
@@ -114,7 +114,7 @@ func ImageDownload(ctx context.Context, r *http.Request, s *state.State, op *ope
 
 		// For public images, handle aliases and initial metadata
 		if args.Secret == "" {
-			// Look for a matching alias
+			// Look for a matching alias.  Note, this err message is lost!
 			entry, _, err := remote.GetImageAliasType(args.Type, fp)
 			if err == nil {
 				fp = entry.Target


### PR DESCRIPTION
### Problem

I ran into some challenges while trying to get the new incus OCI image support working with a Google Cloud registry (Artifact Registry).  The good news it was all self inflicted and the feature worked as designed, but it wasn't easy to debug given the reliance on skopeo/umoci and lack of logging and error pass throughs.  

### Solution
Added debug logging of the skopeo and umoci std err.  This is especially useful with authenticated connections that need to use the auth.json configuration file to work.

### Potential Improvements
I considered changing the error handling / pass through logic in `ImageDownload`, however I'm not familiar enough with the code and the tests aren't working in my development environment.  There might be cases where `GetImageAliasType` can fail however `GetImage` will not.

```		if args.Secret == "" {
			// Look for a matching alias.  Note, this err message is lost!
			entry, _, err := remote.GetImageAliasType(args.Type, fp)
			if err != nil {
				return nil, false, fmt.Errorf("Failed getting remote image alias: %w", err)
			}
                         fp = entry.Target

			// Expand partial fingerprints
			info, _, err = remote.GetImage(fp)
			if err != nil {
				return nil, false, fmt.Errorf("Failed getting remote image info: %w", err)
			}
```
