### PR TITLE
Accept io.Writer in RenderTable

### DIFF
--- a/cmd/incus-simplestreams/main_list.go
+++ b/cmd/incus-simplestreams/main_list.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -67,5 +68,5 @@ func (c *cmdList) Run(cmd *cobra.Command, args []string) error {
 		"CREATED",
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, images)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, images)
 }

--- a/cmd/incus/admin_sql.go
+++ b/cmd/incus/admin_sql.go
@@ -166,5 +166,5 @@ func (c *cmdAdminSQL) sqlPrintSelectResult(result internalSQL.SQLResult) error {
 		data = append(data, rowData)
 	}
 
-	return cli.RenderTable(c.flagFormat, result.Columns, data, result)
+	return cli.RenderTable(os.Stdout, c.flagFormat, result.Columns, data, result)
 }

--- a/cmd/incus/alias.go
+++ b/cmd/incus/alias.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -149,7 +150,7 @@ func (c *cmdAliasList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("TARGET"),
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, conf.Aliases)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, conf.Aliases)
 }
 
 // Rename.

--- a/cmd/incus/cluster.go
+++ b/cmd/incus/cluster.go
@@ -302,7 +302,7 @@ func (c *cmdClusterList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, members)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, members)
 }
 
 // Show.
@@ -1221,7 +1221,7 @@ func (c *cmdClusterListTokens) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, joinTokens)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, joinTokens)
 }
 
 // Revoke Tokens.

--- a/cmd/incus/cluster_group.go
+++ b/cmd/incus/cluster_group.go
@@ -592,7 +592,7 @@ func (c *cmdClusterGroupList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, groups)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, groups)
 }
 
 // Remove.

--- a/cmd/incus/config_template.go
+++ b/cmd/incus/config_template.go
@@ -339,7 +339,7 @@ func (c *cmdConfigTemplateList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("FILENAME"),
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, templates)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, templates)
 }
 
 // Show.

--- a/cmd/incus/config_trust.go
+++ b/cmd/incus/config_trust.go
@@ -565,7 +565,7 @@ func (c *cmdConfigTrustList) Run(cmd *cobra.Command, args []string) error {
 		headers = append(headers, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, headers, data, trust)
+	return cli.RenderTable(os.Stdout, c.flagFormat, headers, data, trust)
 }
 
 // List tokens.
@@ -725,7 +725,7 @@ func (c *cmdConfigTrustListTokens) Run(cmd *cobra.Command, args []string) error 
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, joinTokens)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, joinTokens)
 }
 
 // Remove.

--- a/cmd/incus/image.go
+++ b/cmd/incus/image.go
@@ -1401,7 +1401,7 @@ func (c *cmdImageList) Run(cmd *cobra.Command, args []string) error {
 		headers = append(headers, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, headers, data, rawData)
+	return cli.RenderTable(os.Stdout, c.flagFormat, headers, data, rawData)
 }
 
 // Refresh.

--- a/cmd/incus/image_alias.go
+++ b/cmd/incus/image_alias.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -349,7 +350,7 @@ func (c *cmdImageAliasList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, aliases)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, aliases)
 }
 
 // Rename.

--- a/cmd/incus/info.go
+++ b/cmd/incus/info.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -831,7 +832,7 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 			i18n.G("Stateful"),
 		}
 
-		_ = cli.RenderTable(cli.TableFormatTable, snapHeader, snapData, inst.Snapshots)
+		_ = cli.RenderTable(os.Stdout, cli.TableFormatTable, snapHeader, snapData, inst.Snapshots)
 	}
 
 	// List backups
@@ -883,7 +884,7 @@ func (c *cmdInfo) instanceInfo(d incus.InstanceServer, remote config.Remote, nam
 			i18n.G("Optimized Storage"),
 		}
 
-		_ = cli.RenderTable(cli.TableFormatTable, backupHeader, backupData, inst.Backups)
+		_ = cli.RenderTable(os.Stdout, cli.TableFormatTable, backupHeader, backupData, inst.Backups)
 	}
 
 	if showLog {

--- a/cmd/incus/list.go
+++ b/cmd/incus/list.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"os"
 	"regexp"
 	"slices"
 	"sort"
@@ -453,7 +454,7 @@ func (c *cmdList) showInstances(instances []api.InstanceFull, filters []string, 
 		headers = append(headers, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, headers, data, instancesFiltered)
+	return cli.RenderTable(os.Stdout, c.flagFormat, headers, data, instancesFiltered)
 }
 
 func (c *cmdList) Run(cmd *cobra.Command, args []string) error {

--- a/cmd/incus/network.go
+++ b/cmd/incus/network.go
@@ -1227,7 +1227,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, networks)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, networks)
 }
 
 // List leases.
@@ -1388,7 +1388,7 @@ func (c *cmdNetworkListLeases) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, leases)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, leases)
 }
 
 // Rename.

--- a/cmd/incus/network_acl.go
+++ b/cmd/incus/network_acl.go
@@ -174,7 +174,7 @@ func (c *cmdNetworkACLList) Run(cmd *cobra.Command, args []string) error {
 		header = append([]string{i18n.G("PROJECT")}, header...)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, acls)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, acls)
 }
 
 // Show.

--- a/cmd/incus/network_allocations.go
+++ b/cmd/incus/network_allocations.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -170,5 +171,5 @@ func (c *cmdNetworkListAllocations) Run(cmd *cobra.Command, args []string) error
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, addresses)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, addresses)
 }

--- a/cmd/incus/network_forward.go
+++ b/cmd/incus/network_forward.go
@@ -232,7 +232,7 @@ func (c *cmdNetworkForwardList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, forwards)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, forwards)
 }
 
 // Show.

--- a/cmd/incus/network_integration.go
+++ b/cmd/incus/network_integration.go
@@ -541,7 +541,7 @@ func (c *cmdNetworkIntegrationList) Run(cmd *cobra.Command, args []string) error
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, networkIntegrations)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, networkIntegrations)
 }
 
 // Rename.

--- a/cmd/incus/network_load_balancer.go
+++ b/cmd/incus/network_load_balancer.go
@@ -236,7 +236,7 @@ func (c *cmdNetworkLoadBalancerList) Run(cmd *cobra.Command, args []string) erro
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, loadBalancers)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, loadBalancers)
 }
 
 // Show.

--- a/cmd/incus/network_peer.go
+++ b/cmd/incus/network_peer.go
@@ -233,7 +233,7 @@ func (c *cmdNetworkPeerList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, peers)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, peers)
 }
 
 // Show.

--- a/cmd/incus/network_zone.go
+++ b/cmd/incus/network_zone.go
@@ -238,7 +238,7 @@ func (c *cmdNetworkZoneList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, zones)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, zones)
 }
 
 // Show.
@@ -918,7 +918,7 @@ func (c *cmdNetworkZoneRecordList) Run(cmd *cobra.Command, args []string) error 
 		i18n.G("ENTRIES"),
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, records)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, records)
 }
 
 // Show.

--- a/cmd/incus/operation.go
+++ b/cmd/incus/operation.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -272,7 +273,7 @@ func (c *cmdOperationList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, operations)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, operations)
 }
 
 // Show.

--- a/cmd/incus/profile.go
+++ b/cmd/incus/profile.go
@@ -852,7 +852,7 @@ func (c *cmdProfileList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, profiles)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, profiles)
 }
 
 // Remove.

--- a/cmd/incus/project.go
+++ b/cmd/incus/project.go
@@ -710,7 +710,7 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, projects)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, projects)
 }
 
 // Rename.
@@ -1147,7 +1147,7 @@ func (c *cmdProjectInfo) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("USAGE"),
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, projectState)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, projectState)
 }
 
 // Get current project.

--- a/cmd/incus/remote.go
+++ b/cmd/incus/remote.go
@@ -880,7 +880,7 @@ func (c *cmdRemoteList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, conf.Remotes)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, conf.Remotes)
 }
 
 // Rename.

--- a/cmd/incus/snapshot.go
+++ b/cmd/incus/snapshot.go
@@ -433,7 +433,7 @@ func (c *cmdSnapshotList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, snapshots)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, snapshots)
 }
 
 // Rename.

--- a/cmd/incus/storage.go
+++ b/cmd/incus/storage.go
@@ -808,7 +808,7 @@ func (c *cmdStorageList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, pools)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, pools)
 }
 
 // Set.

--- a/cmd/incus/storage_bucket.go
+++ b/cmd/incus/storage_bucket.go
@@ -620,7 +620,7 @@ func (c *cmdStorageBucketList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, buckets)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, buckets)
 }
 
 // Set.
@@ -1008,7 +1008,7 @@ func (c *cmdStorageBucketKeyList) Run(cmd *cobra.Command, args []string) error {
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, bucketKeys)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, bucketKeys)
 }
 
 // Create Key.

--- a/cmd/incus/storage_volume.go
+++ b/cmd/incus/storage_volume.go
@@ -1479,7 +1479,7 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 			i18n.G("Expires at"),
 		}
 
-		_ = cli.RenderTable(cli.TableFormatTable, snapHeader, snapData, volSnapshots)
+		_ = cli.RenderTable(os.Stdout, cli.TableFormatTable, snapHeader, snapData, volSnapshots)
 	}
 
 	// List backups
@@ -1531,7 +1531,7 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 			i18n.G("Optimized Storage"),
 		}
 
-		_ = cli.RenderTable(cli.TableFormatTable, backupHeader, backupData, volBackups)
+		_ = cli.RenderTable(os.Stdout, cli.TableFormatTable, backupHeader, backupData, volBackups)
 	}
 
 	return nil
@@ -1665,7 +1665,7 @@ func (c *cmdStorageVolumeList) Run(cmd *cobra.Command, args []string) error {
 		headers = append(headers, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, headers, data, rawData)
+	return cli.RenderTable(os.Stdout, c.flagFormat, headers, data, rawData)
 }
 
 func (c *cmdStorageVolumeList) parseColumns(clustered bool) ([]volumeColumn, error) {
@@ -2638,7 +2638,7 @@ func (c *cmdStorageVolumeSnapshotList) listSnapshots(d incus.InstanceServer, poo
 		header = append(header, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, header, data, snapshots)
+	return cli.RenderTable(os.Stdout, c.flagFormat, header, data, snapshots)
 }
 
 type storageVolumeSnapshotColumn struct {

--- a/cmd/incus/top.go
+++ b/cmd/incus/top.go
@@ -435,7 +435,7 @@ func (c *cmdTop) updateDisplay(d incus.InstanceServer, refreshInterval time.Dura
 	}
 
 	fmt.Print("\033[H\033[2J") // Clear the terminal on each tick
-	err = cli.RenderTable(c.flagFormat, headers, dataFormatted, nil)
+	err = cli.RenderTable(os.Stdout, c.flagFormat, headers, dataFormatted, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/incus/warning.go
+++ b/cmd/incus/warning.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -166,7 +167,7 @@ func (c *cmdWarningList) Run(cmd *cobra.Command, args []string) error {
 		headers = append(headers, column.Name)
 	}
 
-	return cli.RenderTable(c.flagFormat, headers, data, rawData)
+	return cli.RenderTable(os.Stdout, c.flagFormat, headers, data, rawData)
 }
 
 func (c *cmdWarningList) countColumnData(warning api.Warning) string {

--- a/cmd/incusd/main_cluster.go
+++ b/cmd/incusd/main_cluster.go
@@ -369,7 +369,7 @@ func (c *cmdClusterListDatabase) Run(cmd *cobra.Command, args []string) error {
 		data[i] = []string{address}
 	}
 
-	_ = cli.RenderTable(c.flagFormat, columns, data, nil)
+	_ = cli.RenderTable(os.Stdout, c.flagFormat, columns, data, nil)
 
 	return nil
 }

--- a/cmd/incusd/main_cluster.go
+++ b/cmd/incusd/main_cluster.go
@@ -351,14 +351,14 @@ func (c *cmdClusterListDatabase) Command() *cobra.Command {
 }
 
 func (c *cmdClusterListDatabase) Run(cmd *cobra.Command, args []string) error {
-	os := sys.DefaultOS()
+	defaultOS := sys.DefaultOS()
 
-	db, err := db.OpenNode(filepath.Join(os.VarDir, "database"), nil)
+	dbconn, err := db.OpenNode(filepath.Join(defaultOS.VarDir, "database"), nil)
 	if err != nil {
 		return fmt.Errorf("Failed to open local database: %w", err)
 	}
 
-	addresses, err := cluster.ListDatabaseNodes(db)
+	addresses, err := cluster.ListDatabaseNodes(dbconn)
 	if err != nil {
 		return fmt.Errorf("Failed to get database nodes: %w", err)
 	}
@@ -546,7 +546,7 @@ func textEditor(inPath string, inContent []byte) ([]byte, error) {
 			_ = os.Remove(f.Name())
 		})
 
-		err = os.Chmod(f.Name(), 0600)
+		err = os.Chmod(f.Name(), 0o600)
 		if err != nil {
 			return []byte{}, err
 		}


### PR DESCRIPTION
Makes `RenderTable` more flexible and allows to pass a different `io.Writer` instead of `os.Stdout` e.g. for testing.

This can be seen as a preparation step to replace all all direct writing to Stdout (and Stderr) with the facilities provided by `github.com/spf13/cobra`, namely [`command.Print`](https://pkg.go.dev/github.com/spf13/cobra#Command.Print) and the likes.