### PR TITLE
Add `--force` flag to the console command

### DIFF
--- a/client/incus_instances.go
+++ b/client/incus_instances.go
@@ -2528,6 +2528,10 @@ func (r *ProtocolIncus) ConsoleInstance(instanceName string, console api.Instanc
 		return nil, fmt.Errorf("The server is missing the required \"console_vga_type\" API extension")
 	}
 
+	if console.Force && !r.HasExtension("console_force") {
+		return nil, fmt.Errorf(`The server is missing the required "console_force" API extension`)
+	}
+
 	// Send the request
 	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "")
 	if err != nil {
@@ -2614,6 +2618,10 @@ func (r *ProtocolIncus) ConsoleInstanceDynamic(instanceName string, console api.
 
 	if console.Type == "vga" && !r.HasExtension("console_vga_type") {
 		return nil, nil, fmt.Errorf("The server is missing the required \"console_vga_type\" API extension")
+	}
+
+	if console.Force && !r.HasExtension("console_force") {
+		return nil, nil, fmt.Errorf(`The server is missing the required "console_force" API extension`)
 	}
 
 	// Send the request.

--- a/cmd/incus/console.go
+++ b/cmd/incus/console.go
@@ -26,6 +26,7 @@ import (
 type cmdConsole struct {
 	global *cmdGlobal
 
+	flagForce   bool
 	flagShowLog bool
 	flagType    string
 }
@@ -41,6 +42,7 @@ This command allows you to interact with the boot console of an instance
 as well as retrieve past log entries from it.`))
 
 	cmd.RunE = c.Run
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Forces a connection to the console, even if there is already an active session"))
 	cmd.Flags().BoolVar(&c.flagShowLog, "show-log", false, i18n.G("Retrieve the instance's console log"))
 	cmd.Flags().StringVarP(&c.flagType, "type", "t", "console", i18n.G("Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output")+"``")
 
@@ -188,6 +190,7 @@ func (c *cmdConsole) text(d incus.InstanceServer, name string) error {
 		Width:  width,
 		Height: height,
 		Type:   "console",
+		Force:  c.flagForce,
 	}
 
 	consoleDisconnect := make(chan bool)
@@ -243,7 +246,8 @@ func (c *cmdConsole) vga(d incus.InstanceServer, name string) error {
 
 	// Prepare the remote console.
 	req := api.InstanceConsolePost{
-		Type: "vga",
+		Type:  "vga",
+		Force: c.flagForce,
 	}
 
 	chDisconnect := make(chan bool)

--- a/cmd/incusd/instance_console.go
+++ b/cmd/incusd/instance_console.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"slices"
 	"strconv"
 	"sync"
@@ -391,6 +392,26 @@ func (s *consoleWs) doVGA(op *operations.Operation) error {
 	return err
 }
 
+// Cancel is responsible for closing websocket connections.
+func (s *consoleWs) Cancel(op *operations.Operation) error {
+	s.connsLock.Lock()
+	conn := s.conns[-1]
+	s.connsLock.Unlock()
+
+	err := conn.Close()
+	if err != nil {
+		return err
+	}
+
+	// Close all dynamic connections.
+	for conn, console := range s.dynamic {
+		_ = conn.Close()
+		_ = console.Close()
+	}
+
+	return nil
+}
+
 // swagger:operation POST /1.0/instances/{name}/console instances instance_console_post
 //
 //	Connect to console
@@ -500,6 +521,40 @@ func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Instance is frozen"))
 	}
 
+	// Find any running 'ConsoleShow' operation for the instance.
+	// If the '--force' flag was used, cancel the running operation. Otherwise, notify the user about the operation.
+	for _, op := range operations.Clone() {
+		// Consider only console show operations with Running status.
+		if op.Type() != operationtype.ConsoleShow || op.Project() != projectName || op.Status() != api.Running {
+			continue
+		}
+
+		// Fetch instance name from operation.
+		r := op.Resources()
+		apiUrls := r["instances"]
+		if len(apiUrls) < 1 {
+			return response.SmartError(fmt.Errorf("Operation does not have an instance URL defined"))
+		}
+
+		urlPrefix, instanceName := path.Split(apiUrls[0].URL.Path)
+		if urlPrefix == "" || instanceName == "" {
+			return response.SmartError(fmt.Errorf("Instance URL has incorrect format"))
+		}
+
+		if instanceName != inst.Name() {
+			continue
+		}
+
+		if !post.Force {
+			return response.SmartError(fmt.Errorf("This console is already connected. Force is required to take it over."))
+		}
+
+		_, err = op.Cancel()
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
 	ws := &consoleWs{}
 	ws.fds = map[int]string{}
 	ws.conns = map[int]*websocket.Conn{}
@@ -523,7 +578,7 @@ func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 	resources := map[string][]api.URL{}
 	resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", ws.instance.Name())}
 
-	op, err := operations.OperationCreate(s, projectName, operations.OperationClassWebsocket, operationtype.ConsoleShow, resources, ws.Metadata(), ws.Do, nil, ws.Connect, r)
+	op, err := operations.OperationCreate(s, projectName, operations.OperationClassWebsocket, operationtype.ConsoleShow, resources, ws.Metadata(), ws.Do, ws.Cancel, ws.Connect, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2672,3 +2672,8 @@ Adds a new `X-Incus-aliases` HTTP header to set aliases while uploading an image
 ## `authorization_scriptlet`
 
 This adds the ability to define a scriptlet in a new configuration key, `authorization.scriptlet`, managing authorization on the Incus cluster.
+
+## `console_force`
+
+This adds support for forcing a connection to the console, even if there is already an active session.
+It introduces the new `--force` flag for connecting to the instance console.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1511,6 +1511,11 @@ definitions:
         x-go-package: github.com/lxc/incus/v6/shared/api
     InstanceConsolePost:
         properties:
+            force:
+                description: Forces a connection to the console
+                example: true
+                type: boolean
+                x-go-name: Force
             height:
                 description: Console height in rows (console type only)
                 example: 24

--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -455,6 +455,7 @@ var APIExtensions = []string{
 	"instance_console_screenshot",
 	"image_import_alias",
 	"authorization_scriptlet",
+	"console_force",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2024-10-06 20:15+0000\n"
 "Last-Translator: Jan Mittelstädter <jan@mittelstaedter.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/incus/cli/de/>\n"
@@ -1064,7 +1064,7 @@ msgstr ""
 "Sind Sie sicher, dass sie das Cluster Mitglied %q %s? (ja/nein) "
 "[default=nein]: "
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 "Da keines der genannten Programme gefunden werden konnte, finden Sie hier "
@@ -1109,11 +1109,11 @@ msgstr "Storage Volumes zu Profilen hinzufügen"
 msgid "Attach new network interfaces to instances"
 msgstr "Netzwerkschnittstellen (network interfaces) zu Instanzen hinzufügen"
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr "Konsole der Instanz öffnen"
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 #, fuzzy
 msgid ""
 "Attach to instance consoles\n"
@@ -2216,7 +2216,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -3182,7 +3182,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed parsing validation response: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3504,6 +3504,12 @@ msgid ""
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
@@ -7031,7 +7037,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 #, fuzzy
 msgid "Retrieve the instance's console log"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -8116,7 +8122,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -8147,7 +8153,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -8421,7 +8427,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8510,7 +8516,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -8612,7 +8618,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, fuzzy, c-format
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -8627,7 +8633,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, fuzzy, c-format
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -9461,7 +9467,7 @@ msgstr ""
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 #, fuzzy
 msgid "[<remote>:]<instance>"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1065,11 +1065,11 @@ msgstr "Perfil %s creado"
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2127,7 +2127,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -3009,7 +3009,7 @@ msgstr "Acepta certificado"
 msgid "Failed parsing validation response: %w"
 msgstr "Acepta certificado"
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
@@ -3328,6 +3328,12 @@ msgid ""
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
@@ -6773,7 +6779,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr "Aliases:"
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -7813,7 +7819,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7844,7 +7850,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -8112,7 +8118,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8202,7 +8208,7 @@ msgstr "Expira: %s"
 msgid "Type of certificate"
 msgstr "Acepta certificado"
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -8301,7 +8307,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -8316,7 +8322,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -9009,7 +9015,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 #, fuzzy
 msgid "[<remote>:]<instance>"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2024-11-11 22:00+0000\n"
 "Last-Translator: \"Laterria.Severino\" <Laterria.Severino@openmail.pro>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/incus/cli/fr/>\n"
@@ -1047,7 +1047,7 @@ msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "Êtes-vous sûr de %s le membre du cluster %q ? (oui/non) [défaut=non] : "
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "Aucun n'a pu être trouvé, la socket SPICE peut être trouvé à:"
 
@@ -1083,11 +1083,11 @@ msgstr "Attacher de nouveaux volumes de stockage aux profils"
 msgid "Attach new network interfaces to instances"
 msgstr "Attacher de nouvelles interfaces aux instances"
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr "Connexion aux consoles de l'instance"
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2226,7 +2226,7 @@ msgstr "Récupération de l'image : %s"
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -3215,7 +3215,7 @@ msgstr "Échec de l'analyse de la clé d'hôte SSH : %w"
 msgid "Failed parsing validation response: %w"
 msgstr "Échec de l'analyse de la réponse de validation : %w"
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "Échec de l'exécution de la commande : %w"
@@ -3567,6 +3567,12 @@ msgstr ""
 "hors-service, a été réinstallé ou n'est pas censé réintégrer le cluster.\n"
 "\n"
 "Êtes-vous vraiment sûr de vouloir forcer la suppression de %s ? (oui/non) : "
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
+msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
@@ -7219,7 +7225,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr "Création du conteneur"
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 #, fuzzy
 msgid "Retrieve the instance's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
@@ -8309,7 +8315,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -8340,7 +8346,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -8623,7 +8629,7 @@ msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 msgid "To create a new network, use: incus network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8715,7 +8721,7 @@ msgstr "Expire : %s"
 msgid "Type of certificate"
 msgstr "Accepter le certificat"
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -8817,7 +8823,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -8832,7 +8838,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -9643,7 +9649,7 @@ msgstr ""
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 #, fuzzy
 msgid "[<remote>:]<instance>"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2024-11-09 07:00+0000\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/incus/cli/id/"
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -809,11 +809,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1839,7 +1839,7 @@ msgstr "Hapus peringatan"
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -2697,7 +2697,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3015,6 +3015,12 @@ msgid ""
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
@@ -6347,7 +6353,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -7348,7 +7354,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7379,7 +7385,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7646,7 +7652,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7734,7 +7740,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -7832,7 +7838,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -7847,7 +7853,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8480,7 +8486,7 @@ msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instansi>"

--- a/po/incus.pot
+++ b/po/incus.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: incus\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2024-12-06 15:12-0500\n"
+        "POT-Creation-Date: 2024-12-11 17:46+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -734,7 +734,7 @@ msgstr  ""
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
@@ -770,11 +770,11 @@ msgstr  ""
 msgid   "Attach new network interfaces to instances"
 msgstr  ""
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid   "Attach to instance consoles"
 msgstr  ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid   "Attach to instance consoles\n"
         "\n"
         "This command allows you to interact with the boot console of an instance\n"
@@ -1672,7 +1672,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491 cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183 cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104 cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437 cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792 cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985 cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762 cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957 cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317 cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562 cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113 cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797 cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964 cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
+#: cmd/incus/action.go:32 cmd/incus/action.go:57 cmd/incus/action.go:83 cmd/incus/action.go:109 cmd/incus/action.go:134 cmd/incus/admin.go:20 cmd/incus/admin_cluster.go:25 cmd/incus/admin_init.go:45 cmd/incus/admin_other.go:20 cmd/incus/admin_recover.go:29 cmd/incus/admin_shutdown.go:30 cmd/incus/admin_sql.go:30 cmd/incus/admin_waitready.go:27 cmd/incus/alias.go:23 cmd/incus/alias.go:61 cmd/incus/alias.go:111 cmd/incus/alias.go:168 cmd/incus/alias.go:223 cmd/incus/cluster.go:35 cmd/incus/cluster.go:130 cmd/incus/cluster.go:318 cmd/incus/cluster.go:375 cmd/incus/cluster.go:434 cmd/incus/cluster.go:507 cmd/incus/cluster.go:587 cmd/incus/cluster.go:631 cmd/incus/cluster.go:689 cmd/incus/cluster.go:780 cmd/incus/cluster.go:873 cmd/incus/cluster.go:994 cmd/incus/cluster.go:1072 cmd/incus/cluster.go:1237 cmd/incus/cluster.go:1325 cmd/incus/cluster.go:1449 cmd/incus/cluster.go:1478 cmd/incus/cluster_group.go:35 cmd/incus/cluster_group.go:101 cmd/incus/cluster_group.go:186 cmd/incus/cluster_group.go:272 cmd/incus/cluster_group.go:332 cmd/incus/cluster_group.go:457 cmd/incus/cluster_group.go:609 cmd/incus/cluster_group.go:694 cmd/incus/cluster_group.go:750 cmd/incus/cluster_group.go:812 cmd/incus/cluster_group.go:888 cmd/incus/cluster_group.go:963 cmd/incus/cluster_group.go:1045 cmd/incus/cluster_role.go:24 cmd/incus/cluster_role.go:51 cmd/incus/cluster_role.go:115 cmd/incus/config.go:32 cmd/incus/config.go:95 cmd/incus/config.go:388 cmd/incus/config.go:525 cmd/incus/config.go:751 cmd/incus/config.go:883 cmd/incus/config_device.go:24 cmd/incus/config_device.go:78 cmd/incus/config_device.go:220 cmd/incus/config_device.go:317 cmd/incus/config_device.go:400 cmd/incus/config_device.go:502 cmd/incus/config_device.go:618 cmd/incus/config_device.go:625 cmd/incus/config_device.go:758 cmd/incus/config_device.go:843 cmd/incus/config_metadata.go:26 cmd/incus/config_metadata.go:54 cmd/incus/config_metadata.go:187 cmd/incus/config_template.go:26 cmd/incus/config_template.go:66 cmd/incus/config_template.go:134 cmd/incus/config_template.go:188 cmd/incus/config_template.go:288 cmd/incus/config_template.go:356 cmd/incus/config_trust.go:36 cmd/incus/config_trust.go:91 cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275 cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590 cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789 cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41 cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41 cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135 cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491 cmd/incus/file.go:719 cmd/incus/file.go:1322 cmd/incus/image.go:40 cmd/incus/image.go:148 cmd/incus/image.go:308 cmd/incus/image.go:363 cmd/incus/image.go:498 cmd/incus/image.go:667 cmd/incus/image.go:924 cmd/incus/image.go:1067 cmd/incus/image.go:1417 cmd/incus/image.go:1501 cmd/incus/image.go:1568 cmd/incus/image.go:1633 cmd/incus/image.go:1697 cmd/incus/image_alias.go:29 cmd/incus/image_alias.go:65 cmd/incus/image_alias.go:129 cmd/incus/image_alias.go:183 cmd/incus/image_alias.go:367 cmd/incus/import.go:27 cmd/incus/info.go:35 cmd/incus/launch.go:24 cmd/incus/list.go:50 cmd/incus/main.go:100 cmd/incus/manpage.go:22 cmd/incus/monitor.go:33 cmd/incus/move.go:35 cmd/incus/network.go:36 cmd/incus/network.go:143 cmd/incus/network.go:240 cmd/incus/network.go:337 cmd/incus/network.go:448 cmd/incus/network.go:506 cmd/incus/network.go:603 cmd/incus/network.go:700 cmd/incus/network.go:836 cmd/incus/network.go:917 cmd/incus/network.go:1053 cmd/incus/network.go:1251 cmd/incus/network.go:1405 cmd/incus/network.go:1465 cmd/incus/network.go:1561 cmd/incus/network.go:1633 cmd/incus/network_acl.go:28 cmd/incus/network_acl.go:94 cmd/incus/network_acl.go:190 cmd/incus/network_acl.go:251 cmd/incus/network_acl.go:307 cmd/incus/network_acl.go:380 cmd/incus/network_acl.go:477 cmd/incus/network_acl.go:565 cmd/incus/network_acl.go:608 cmd/incus/network_acl.go:747 cmd/incus/network_acl.go:804 cmd/incus/network_acl.go:861 cmd/incus/network_acl.go:876 cmd/incus/network_acl.go:1013 cmd/incus/network_allocations.go:34 cmd/incus/network_forward.go:28 cmd/incus/network_forward.go:91 cmd/incus/network_forward.go:248 cmd/incus/network_forward.go:324 cmd/incus/network_forward.go:427 cmd/incus/network_forward.go:512 cmd/incus/network_forward.go:622 cmd/incus/network_forward.go:669 cmd/incus/network_forward.go:823 cmd/incus/network_forward.go:897 cmd/incus/network_forward.go:912 cmd/incus/network_forward.go:993 cmd/incus/network_integration.go:28 cmd/incus/network_integration.go:85 cmd/incus/network_integration.go:178 cmd/incus/network_integration.go:230 cmd/incus/network_integration.go:352 cmd/incus/network_integration.go:416 cmd/incus/network_integration.go:559 cmd/incus/network_integration.go:613 cmd/incus/network_integration.go:694 cmd/incus/network_integration.go:727 cmd/incus/network_load_balancer.go:29 cmd/incus/network_load_balancer.go:100 cmd/incus/network_load_balancer.go:252 cmd/incus/network_load_balancer.go:328 cmd/incus/network_load_balancer.go:431 cmd/incus/network_load_balancer.go:499 cmd/incus/network_load_balancer.go:609 cmd/incus/network_load_balancer.go:639 cmd/incus/network_load_balancer.go:804 cmd/incus/network_load_balancer.go:877 cmd/incus/network_load_balancer.go:892 cmd/incus/network_load_balancer.go:968 cmd/incus/network_load_balancer.go:1066 cmd/incus/network_load_balancer.go:1081 cmd/incus/network_load_balancer.go:1154 cmd/incus/network_load_balancer.go:1277 cmd/incus/network_peer.go:28 cmd/incus/network_peer.go:87 cmd/incus/network_peer.go:249 cmd/incus/network_peer.go:320 cmd/incus/network_peer.go:466 cmd/incus/network_peer.go:551 cmd/incus/network_peer.go:653 cmd/incus/network_peer.go:700 cmd/incus/network_peer.go:837 cmd/incus/network_zone.go:32 cmd/incus/network_zone.go:91 cmd/incus/network_zone.go:254 cmd/incus/network_zone.go:317 cmd/incus/network_zone.go:390 cmd/incus/network_zone.go:485 cmd/incus/network_zone.go:573 cmd/incus/network_zone.go:616 cmd/incus/network_zone.go:743 cmd/incus/network_zone.go:799 cmd/incus/network_zone.go:856 cmd/incus/network_zone.go:934 cmd/incus/network_zone.go:998 cmd/incus/network_zone.go:1074 cmd/incus/network_zone.go:1172 cmd/incus/network_zone.go:1261 cmd/incus/network_zone.go:1308 cmd/incus/network_zone.go:1438 cmd/incus/network_zone.go:1499 cmd/incus/network_zone.go:1514 cmd/incus/network_zone.go:1572 cmd/incus/operation.go:29 cmd/incus/operation.go:62 cmd/incus/operation.go:113 cmd/incus/operation.go:288 cmd/incus/profile.go:34 cmd/incus/profile.go:109 cmd/incus/profile.go:184 cmd/incus/profile.go:275 cmd/incus/profile.go:357 cmd/incus/profile.go:440 cmd/incus/profile.go:498 cmd/incus/profile.go:634 cmd/incus/profile.go:710 cmd/incus/profile.go:868 cmd/incus/profile.go:956 cmd/incus/profile.go:1016 cmd/incus/profile.go:1105 cmd/incus/profile.go:1169 cmd/incus/project.go:36 cmd/incus/project.go:104 cmd/incus/project.go:203 cmd/incus/project.go:301 cmd/incus/project.go:437 cmd/incus/project.go:512 cmd/incus/project.go:727 cmd/incus/project.go:792 cmd/incus/project.go:880 cmd/incus/project.go:924 cmd/incus/project.go:985 cmd/incus/project.go:1053 cmd/incus/project.go:1164 cmd/incus/publish.go:32 cmd/incus/query.go:34 cmd/incus/rebuild.go:27 cmd/incus/remote.go:44 cmd/incus/remote.go:109 cmd/incus/remote.go:638 cmd/incus/remote.go:685 cmd/incus/remote.go:724 cmd/incus/remote.go:898 cmd/incus/remote.go:979 cmd/incus/remote.go:1044 cmd/incus/remote.go:1092 cmd/incus/remote_unix.go:37 cmd/incus/rename.go:21 cmd/incus/snapshot.go:31 cmd/incus/snapshot.go:78 cmd/incus/snapshot.go:203 cmd/incus/snapshot.go:294 cmd/incus/snapshot.go:449 cmd/incus/snapshot.go:510 cmd/incus/snapshot.go:589 cmd/incus/storage.go:37 cmd/incus/storage.go:100 cmd/incus/storage.go:212 cmd/incus/storage.go:270 cmd/incus/storage.go:402 cmd/incus/storage.go:484 cmd/incus/storage.go:665 cmd/incus/storage.go:826 cmd/incus/storage.go:930 cmd/incus/storage.go:1024 cmd/incus/storage_bucket.go:34 cmd/incus/storage_bucket.go:96 cmd/incus/storage_bucket.go:201 cmd/incus/storage_bucket.go:262 cmd/incus/storage_bucket.go:395 cmd/incus/storage_bucket.go:479 cmd/incus/storage_bucket.go:639 cmd/incus/storage_bucket.go:733 cmd/incus/storage_bucket.go:802 cmd/incus/storage_bucket.go:836 cmd/incus/storage_bucket.go:883 cmd/incus/storage_bucket.go:1027 cmd/incus/storage_bucket.go:1133 cmd/incus/storage_bucket.go:1197 cmd/incus/storage_bucket.go:1332 cmd/incus/storage_bucket.go:1404 cmd/incus/storage_bucket.go:1555 cmd/incus/storage_volume.go:56 cmd/incus/storage_volume.go:163 cmd/incus/storage_volume.go:254 cmd/incus/storage_volume.go:362 cmd/incus/storage_volume.go:579 cmd/incus/storage_volume.go:689 cmd/incus/storage_volume.go:762 cmd/incus/storage_volume.go:860 cmd/incus/storage_volume.go:957 cmd/incus/storage_volume.go:1181 cmd/incus/storage_volume.go:1317 cmd/incus/storage_volume.go:1478 cmd/incus/storage_volume.go:1562 cmd/incus/storage_volume.go:1777 cmd/incus/storage_volume.go:1870 cmd/incus/storage_volume.go:1950 cmd/incus/storage_volume.go:2113 cmd/incus/storage_volume.go:2218 cmd/incus/storage_volume.go:2276 cmd/incus/storage_volume.go:2325 cmd/incus/storage_volume.go:2458 cmd/incus/storage_volume.go:2547 cmd/incus/storage_volume.go:2553 cmd/incus/storage_volume.go:2710 cmd/incus/storage_volume.go:2797 cmd/incus/storage_volume.go:2877 cmd/incus/storage_volume.go:2964 cmd/incus/storage_volume.go:3130 cmd/incus/top.go:43 cmd/incus/version.go:22 cmd/incus/warning.go:29 cmd/incus/warning.go:72 cmd/incus/warning.go:263 cmd/incus/warning.go:304 cmd/incus/warning.go:358 cmd/incus/webui.go:19
 msgid   "Description"
 msgstr  ""
 
@@ -2360,7 +2360,7 @@ msgstr  ""
 msgid   "Failed parsing validation response: %w"
 msgstr  ""
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, c-format
 msgid   "Failed starting command: %w"
 msgstr  ""
@@ -2669,6 +2669,10 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "or is otherwise never expected to come back up.\n"
         "\n"
         "Are you really sure you want to force removing %s? (yes/no): "
+msgstr  ""
+
+#: cmd/incus/console.go:45
+msgid   "Forces a connection to the console, even if there is already an active session"
 msgstr  ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151 cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478 cmd/incus/config_template.go:290 cmd/incus/config_trust.go:422 cmd/incus/config_trust.go:609 cmd/incus/image.go:1094 cmd/incus/image_alias.go:204 cmd/incus/list.go:135 cmd/incus/network.go:1073 cmd/incus/network.go:1272 cmd/incus/network_acl.go:97 cmd/incus/network_allocations.go:59 cmd/incus/network_forward.go:114 cmd/incus/network_integration.go:437 cmd/incus/network_load_balancer.go:122 cmd/incus/network_peer.go:110 cmd/incus/network_zone.go:113 cmd/incus/network_zone.go:859 cmd/incus/operation.go:136 cmd/incus/profile.go:726 cmd/incus/project.go:533 cmd/incus/project.go:1056 cmd/incus/remote.go:749 cmd/incus/snapshot.go:315 cmd/incus/storage.go:689 cmd/incus/storage_bucket.go:500 cmd/incus/storage_bucket.go:902 cmd/incus/storage_volume.go:1578 cmd/incus/storage_volume.go:2564 cmd/incus/warning.go:94
@@ -5785,7 +5789,7 @@ msgstr  ""
 msgid   "Resume instances"
 msgstr  ""
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid   "Retrieve the instance's console log"
 msgstr  ""
 
@@ -6735,7 +6739,7 @@ msgstr  ""
 msgid   "The %s storage pool already exists"
 msgstr  ""
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid   "The --show-log flag is only supported for by 'console' output type"
 msgstr  ""
 
@@ -6759,7 +6763,7 @@ msgid   "The \"cluster\" subcommand requires access to internal server data.\n"
         "You can invoke it through \"incusd cluster\"."
 msgstr  ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid   "The client automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
@@ -7013,7 +7017,7 @@ msgstr  ""
 msgid   "To create a new network, use: incus network create"
 msgstr  ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
@@ -7097,7 +7101,7 @@ msgstr  ""
 msgid   "Type of certificate"
 msgstr  ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
@@ -7175,7 +7179,7 @@ msgstr  ""
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid   "Unknown console type %q"
 msgstr  ""
@@ -7190,7 +7194,7 @@ msgstr  ""
 msgid   "Unknown key: %s"
 msgstr  ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid   "Unknown output type %q"
 msgstr  ""
@@ -7789,7 +7793,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752 cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185 cmd/incus/config_template.go:286 cmd/incus/console.go:35 cmd/incus/snapshot.go:292
+#: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752 cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185 cmd/incus/config_template.go:286 cmd/incus/console.go:36 cmd/incus/snapshot.go:292
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2024-02-09 19:02+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/incus/cli/it/>\n"
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1064,11 +1064,11 @@ msgstr "Creazione del container in corso"
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2120,7 +2120,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -3002,7 +3002,7 @@ msgstr "Accetta certificato"
 msgid "Failed parsing validation response: %w"
 msgstr "Accetta certificato"
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
@@ -3322,6 +3322,12 @@ msgid ""
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
@@ -6769,7 +6775,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr "Creazione del container in corso"
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -7808,7 +7814,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "La periferica esiste già"
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7839,7 +7845,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -8108,7 +8114,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8197,7 +8203,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Accetta certificato"
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -8299,7 +8305,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -8314,7 +8320,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -9007,7 +9013,7 @@ msgstr "Creazione del container in corso"
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 #, fuzzy
 msgid "[<remote>:]<instance>"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2024-12-11 16:28+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/incus/cli/ja/>\n"
@@ -1026,7 +1026,7 @@ msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "本当に %s しますか? （対象: クラスターメンバー %q） (yes/no) [default=no]: "
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
@@ -1064,11 +1064,11 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Attach new network interfaces to instances"
 msgstr "新たなネットワークインターフェースをインスタンスに追加します"
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr "インスタンスのコンソールに接続します"
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2146,7 +2146,7 @@ msgstr "警告を削除します"
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -3099,7 +3099,7 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed parsing validation response: %w"
 msgstr "バリデーションレスポンスの読み取りに失敗しました: %w"
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
@@ -3434,6 +3434,12 @@ msgstr ""
 "の見込みがまったくない場合にのみ使用してください。\n"
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
+msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
 #: cmd/incus/cluster.go:1091 cmd/incus/cluster_group.go:478
@@ -7544,7 +7550,7 @@ msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 msgid "Resume instances"
 msgstr "インスタンスを再起動します"
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
@@ -8667,7 +8673,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "デバイスはすでに存在します"
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
 
@@ -8714,7 +8720,7 @@ msgstr ""
 "\n"
 "\"incusd cluster\" から呼び出すことができます。"
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 #, fuzzy
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
@@ -9019,7 +9025,7 @@ msgid "To create a new network, use: incus network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
@@ -9113,7 +9119,7 @@ msgstr "タイプ"
 msgid "Type of certificate"
 msgstr "証明書の形式"
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -9216,7 +9222,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
@@ -9231,7 +9237,7 @@ msgstr "未知のファイルタイプ '%s'"
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
@@ -9913,7 +9919,7 @@ msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2024-09-11 12:09+0000\n"
 "Last-Translator: Daniel Dybing <daniel.dybing@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/incus/"
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -812,11 +812,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1842,7 +1842,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -2700,7 +2700,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3018,6 +3018,12 @@ msgid ""
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
@@ -6351,7 +6357,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -7352,7 +7358,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7383,7 +7389,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7650,7 +7656,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7738,7 +7744,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -7836,7 +7842,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -7851,7 +7857,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8484,7 +8490,7 @@ msgstr ""
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 msgid "[<remote>:]<instance>"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2024-10-14 01:15+0000\n"
 "Last-Translator: Dklfajsjfi49wefklsf32 <nlincus@users.noreply.hosted.weblate."
 "org>\n"
@@ -1050,7 +1050,7 @@ msgstr "Wilt u lid worden (joining) van een bestaand cluster?"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr "Weet je zeker dat je %s wilt clusteren met %q ? (yes/no) "
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 "Beide konden niet worden gevonden, de directe SPICE plug (raw SPICE socket) "
@@ -1093,11 +1093,11 @@ msgstr "Toekennen nieuwe aangepaste opslag volumes aan profielen (profiles)"
 msgid "Attach new network interfaces to instances"
 msgstr "Toekennen van nieuwe netwerk interfaces aan instantiaties (instances)"
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2133,7 +2133,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -2991,7 +2991,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3309,6 +3309,12 @@ msgid ""
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
@@ -6641,7 +6647,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -7644,7 +7650,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7675,7 +7681,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7942,7 +7948,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8030,7 +8036,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -8128,7 +8134,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -8143,7 +8149,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8777,7 +8783,7 @@ msgstr ""
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 msgid "[<remote>:]<instance>"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: incus\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -769,7 +769,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -805,11 +805,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1835,7 +1835,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -2693,7 +2693,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3011,6 +3011,12 @@ msgid ""
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
@@ -6343,7 +6349,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -7344,7 +7350,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7375,7 +7381,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7642,7 +7648,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7730,7 +7736,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -7828,7 +7834,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -7843,7 +7849,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8476,7 +8482,7 @@ msgstr ""
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 msgid "[<remote>:]<instance>"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2024-01-30 13:01+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1073,12 +1073,12 @@ msgstr "Desconectar volumes de armazenamento dos containers"
 msgid "Attach new network interfaces to instances"
 msgstr "Anexar uma nova interface de rede aos containers"
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2159,7 +2159,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -3048,7 +3048,7 @@ msgstr "Aceitar certificado"
 msgid "Failed parsing validation response: %w"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
@@ -3367,6 +3367,12 @@ msgid ""
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
@@ -6836,7 +6842,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr "Editar arquivos no container"
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -7893,7 +7899,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "Alias %s já existe"
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7924,7 +7930,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -8192,7 +8198,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8281,7 +8287,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Aceitar certificado"
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -8383,7 +8389,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -8398,7 +8404,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -9085,7 +9091,7 @@ msgstr ""
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 msgid "[<remote>:]<instance>"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1049,7 +1049,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1088,11 +1088,11 @@ msgstr "Копирование образа: %s"
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2155,7 +2155,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -3044,7 +3044,7 @@ msgstr "Принять сертификат"
 msgid "Failed parsing validation response: %w"
 msgstr "Принять сертификат"
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
@@ -3363,6 +3363,12 @@ msgid ""
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
@@ -6835,7 +6841,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr "Псевдонимы:"
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -7887,7 +7893,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr "Копирование образа: %s"
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7918,7 +7924,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -8186,7 +8192,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -8275,7 +8281,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Принять сертификат"
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -8376,7 +8382,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -8391,7 +8397,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -9196,7 +9202,7 @@ msgstr ""
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 #, fuzzy
 msgid "[<remote>:]<instance>"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2024-12-06 15:12-0500\n"
+"POT-Creation-Date: 2024-12-11 17:46+0000\n"
 "PO-Revision-Date: 2024-08-14 07:23+0000\n"
 "Last-Translator: Kwok Guy <kwokjuy@163.com>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: cmd/incus/console.go:384
+#: cmd/incus/console.go:388
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -966,11 +966,11 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: cmd/incus/console.go:36
+#: cmd/incus/console.go:37
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: cmd/incus/console.go:37
+#: cmd/incus/console.go:38
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1996,7 +1996,7 @@ msgstr ""
 #: cmd/incus/config_trust.go:171 cmd/incus/config_trust.go:275
 #: cmd/incus/config_trust.go:400 cmd/incus/config_trust.go:590
 #: cmd/incus/config_trust.go:743 cmd/incus/config_trust.go:789
-#: cmd/incus/config_trust.go:860 cmd/incus/console.go:37 cmd/incus/copy.go:41
+#: cmd/incus/config_trust.go:860 cmd/incus/console.go:38 cmd/incus/copy.go:41
 #: cmd/incus/create.go:43 cmd/incus/delete.go:32 cmd/incus/exec.go:41
 #: cmd/incus/export.go:32 cmd/incus/file.go:88 cmd/incus/file.go:135
 #: cmd/incus/file.go:331 cmd/incus/file.go:413 cmd/incus/file.go:491
@@ -2854,7 +2854,7 @@ msgstr ""
 msgid "Failed parsing validation response: %w"
 msgstr ""
 
-#: cmd/incus/console.go:362
+#: cmd/incus/console.go:366
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3172,6 +3172,12 @@ msgid ""
 "or is otherwise never expected to come back up.\n"
 "\n"
 "Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
+
+#: cmd/incus/console.go:45
+msgid ""
+"Forces a connection to the console, even if there is already an active "
+"session"
 msgstr ""
 
 #: cmd/incus/admin_sql.go:55 cmd/incus/alias.go:113 cmd/incus/cluster.go:151
@@ -6514,7 +6520,7 @@ msgstr ""
 msgid "Resume instances"
 msgstr ""
 
-#: cmd/incus/console.go:44
+#: cmd/incus/console.go:46
 msgid "Retrieve the instance's console log"
 msgstr ""
 
@@ -7516,7 +7522,7 @@ msgstr ""
 msgid "The %s storage pool already exists"
 msgstr ""
 
-#: cmd/incus/console.go:134
+#: cmd/incus/console.go:136
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -7547,7 +7553,7 @@ msgid ""
 "You can invoke it through \"incusd cluster\"."
 msgstr ""
 
-#: cmd/incus/console.go:383
+#: cmd/incus/console.go:387
 msgid ""
 "The client automatically uses either spicy or remote-viewer when present."
 msgstr ""
@@ -7814,7 +7820,7 @@ msgstr ""
 msgid "To create a new network, use: incus network create"
 msgstr ""
 
-#: cmd/incus/console.go:221
+#: cmd/incus/console.go:224
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -7902,7 +7908,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: cmd/incus/console.go:45
+#: cmd/incus/console.go:47
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -8000,7 +8006,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: cmd/incus/console.go:164
+#: cmd/incus/console.go:166
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -8015,7 +8021,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: cmd/incus/console.go:113
+#: cmd/incus/console.go:115
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -8648,7 +8654,7 @@ msgstr ""
 
 #: cmd/incus/config_device.go:320 cmd/incus/config_device.go:752
 #: cmd/incus/config_metadata.go:52 cmd/incus/config_metadata.go:185
-#: cmd/incus/config_template.go:286 cmd/incus/console.go:35
+#: cmd/incus/config_template.go:286 cmd/incus/console.go:36
 #: cmd/incus/snapshot.go:292
 msgid "[<remote>:]<instance>"
 msgstr ""

--- a/shared/api/instance_console.go
+++ b/shared/api/instance_console.go
@@ -27,4 +27,10 @@ type InstanceConsolePost struct {
 	//
 	// API extension: console_vga_type
 	Type string `json:"type" yaml:"type"`
+
+	// Forces a connection to the console
+	// Example: true
+	//
+	// API extension: console_force
+	Force bool `json:"force" yaml:"force"`
 }


### PR DESCRIPTION
This PR introduces a `--force` flag to the console command. When used, it forces the connection and closes any existing ones. Without the flag, the user will receive a message about active connections. This change addresses an issue with Spice/QEMU, where connections are sometimes not properly closed after disconnection.