### PR TITLE
incusd/instance/lxc: Skip instances without idmap allocation yet

### DIFF
--- a/internal/server/instance/drivers/driver_lxc.go
+++ b/internal/server/instance/drivers/driver_lxc.go
@@ -566,12 +566,13 @@ func (d *lxc) findIdmap() (*idmap.Set, int64, error) {
 			continue
 		}
 
-		cBase := int64(0)
-		if container.ExpandedConfig()["volatile.idmap.base"] != "" {
-			cBase, err = strconv.ParseInt(container.ExpandedConfig()["volatile.idmap.base"], 10, 64)
-			if err != nil {
-				return nil, 0, err
-			}
+		if container.ExpandedConfig()["volatile.idmap.base"] == "" {
+			continue
+		}
+
+		cBase, err := strconv.ParseInt(container.ExpandedConfig()["volatile.idmap.base"], 10, 64)
+		if err != nil {
+			return nil, 0, err
 		}
 
 		cSize, err := idmapSize(container.ExpandedConfig()["security.idmap.size"])


### PR DESCRIPTION
When running findIdmap to determine the next idmap to use (in isolated mode), instances without an idmap set should be skipped.

This is needed to avoid issues on parallel instance creation on slower storage.

Closes #1483