### PR TITLE
incusd/storage/drivers/common: Truncate/Discard ahead of sparse write

### DIFF
--- a/internal/server/storage/drivers/generic_vfs.go
+++ b/internal/server/storage/drivers/generic_vfs.go
@@ -332,6 +332,12 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 
 		defer func() { _ = to.Close() }()
 
+		// Reset the disk.
+		err = clearDiskData(path, to)
+		if err != nil {
+			return err
+		}
+
 		// Setup progress tracker.
 		fromPipe := io.ReadCloser(conn)
 		if wrapper != nil {
@@ -787,6 +793,13 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 						logMsg = "Unpacking custom block volume"
 					}
 
+					// Reset the disk.
+					err = clearDiskData(targetPath, to)
+					if err != nil {
+						return err
+					}
+
+					// Copy the data.
 					d.Logger().Debug(logMsg, logger.Ctx{"source": srcFile, "target": targetPath})
 					_, err = io.Copy(NewSparseFileWrapper(to), tr)
 					if err != nil {


### PR DESCRIPTION
As we use a sparse writer which will skip any zero blocks, we need to discard (block) or truncate (file) prior to processing the data or we risk having leftover data from a previous snapshot interfere with the new state.

Closes #1264